### PR TITLE
paintroid changed package names - catroid has to adapt

### DIFF
--- a/catroid/src/at/tugraz/ist/catroid/common/Constants.java
+++ b/catroid/src/at/tugraz/ist/catroid/common/Constants.java
@@ -41,13 +41,13 @@ public final class Constants {
 	public static final String TOKEN = "token";
 
 	// Paintroid
-	public static final String EXTRA_PICTURE_PATH_PAINTROID = "at.tugraz.ist.extra.PAINTROID_PICTURE_PATH";
-	public static final String EXTRA_PICTURE_NAME_PAINTROID = "at.tugraz.ist.extra.PAINTROID_PICTURE_NAME";
-	public static final String EXTRA_X_VALUE_PAINTROID = "at.tugraz.ist.extra.PAINTROID_X";
-	public static final String EXTRA_Y_VALUE_PAINTROID = "at.tugraz.ist.extra.PAINTROID_Y";
+	public static final String EXTRA_PICTURE_PATH_PAINTROID = "org.catrobat.extra.PAINTROID_PICTURE_PATH";
+	public static final String EXTRA_PICTURE_NAME_PAINTROID = "org.catrobat.extra.PAINTROID_PICTURE_NAME";
+	public static final String EXTRA_X_VALUE_PAINTROID = "org.catrobat.extra.PAINTROID_X";
+	public static final String EXTRA_Y_VALUE_PAINTROID = "org.catrobat.extra.PAINTROID_Y";
 
 	//Various:
 	public static final int BUFFER_8K = 8 * 1024;
-	public static final String PAINTROID_DOWNLOAD_LINK = "http://code.google.com/p/catroid/downloads";
+	public static final String PAINTROID_DOWNLOAD_LINK = "https://github.com/Catrobat/Paintroid/downloads";
 	public static final String PREF_PROJECTNAME_KEY = "projectName";
 }

--- a/catroid/src/at/tugraz/ist/catroid/ui/fragment/CostumeFragment.java
+++ b/catroid/src/at/tugraz/ist/catroid/ui/fragment/CostumeFragment.java
@@ -562,7 +562,7 @@ public class CostumeFragment extends SherlockListFragment implements OnCostumeEd
 
 	private void handleEditCostumeButton(View v) {
 		Intent intent = new Intent("android.intent.action.MAIN");
-		intent.setComponent(new ComponentName("at.tugraz.ist.paintroid", "at.tugraz.ist.paintroid.MainActivity"));
+		intent.setComponent(new ComponentName("org.catrobat.paintroid", "org.catrobat.paintroid.MainActivity"));
 
 		// Confirm if paintroid is installed else start dialog --------------------------
 		List<ResolveInfo> packageList = getActivity().getPackageManager().queryIntentActivities(intent,
@@ -597,7 +597,7 @@ public class CostumeFragment extends SherlockListFragment implements OnCostumeEd
 		bundleForPaintroid.putString(Constants.EXTRA_PICTURE_PATH_PAINTROID, costumeDataList.get(position)
 				.getAbsolutePath());
 		bundleForPaintroid.putInt(Constants.EXTRA_X_VALUE_PAINTROID, 0);
-		bundleForPaintroid.putInt(Constants.EXTRA_X_VALUE_PAINTROID, 0);
+		bundleForPaintroid.putInt(Constants.EXTRA_Y_VALUE_PAINTROID, 0);
 		intent.putExtras(bundleForPaintroid);
 		intent.addCategory("android.intent.category.LAUNCHER");
 		startActivityForResult(intent, REQUEST_PAINTROID_EDIT_IMAGE);

--- a/catroidLicenseTest/src/at/tugraz/ist/catroid/test/code/ImportantValuesTest.java
+++ b/catroidLicenseTest/src/at/tugraz/ist/catroid/test/code/ImportantValuesTest.java
@@ -28,7 +28,7 @@ import at.tugraz.ist.catroid.common.Constants;
 public class ImportantValuesTest extends TestCase {
 
 	public void testPaintroidDownloadLink() {
-		assertEquals("wrong paintroid download link", "http://code.google.com/p/catroid/downloads",
+		assertEquals("wrong paintroid download link", "https://github.com/Catrobat/Paintroid/downloads",
 				Constants.PAINTROID_DOWNLOAD_LINK);
 	}
 }

--- a/catroidUiTest/src/at/tugraz/ist/catroid/uitest/mockups/MockPaintroidActivity.java
+++ b/catroidUiTest/src/at/tugraz/ist/catroid/uitest/mockups/MockPaintroidActivity.java
@@ -42,8 +42,8 @@ public class MockPaintroidActivity extends Activity {
 			return;
 		}
 
-		if (bundle.containsKey("at.tugraz.ist.extra.PAINTROID_PICTURE_PATH")) {
-			pathToImage = bundle.getString("at.tugraz.ist.extra.PAINTROID_PICTURE_PATH");
+		if (bundle.containsKey("org.catrobat.extra.PAINTROID_PICTURE_PATH")) {
+			pathToImage = bundle.getString("org.catrobat.extra.PAINTROID_PICTURE_PATH");
 			imageFile = new File(pathToImage);
 		}
 
@@ -62,9 +62,9 @@ public class MockPaintroidActivity extends Activity {
 	public void sendBundleBackToCatroidAndFinish() {
 		Bundle bundle = new Bundle();
 		if (secondImageFile != null) {
-			bundle.putString("at.tugraz.ist.extra.PAINTROID_PICTURE_PATH", secondImageFile.getAbsolutePath());
+			bundle.putString("org.catrobat.extra.PAINTROID_PICTURE_PATH", secondImageFile.getAbsolutePath());
 		} else {
-			bundle.putString("at.tugraz.ist.extra.PAINTROID_PICTURE_PATH", imageFile.getAbsolutePath());
+			bundle.putString("org.catrobat.extra.PAINTROID_PICTURE_PATH", imageFile.getAbsolutePath());
 		}
 
 		Intent intent = new Intent();


### PR DESCRIPTION
adaptions to new paintroid package names!
successful jenkins run: http://catroidtestserver.ist.tugraz.at:8080/job/Catroid-ABS/201/

howto test:
- deinstall catroid and paintroid
- install catroid NewPaintroidPackage branch
- add new costume from gallery - paintroid should not appear
- edit existing costume -> alertdialog should appear, and download page for paintroid should be github
- download latest paintroid build http://catroidtestserver.ist.tugraz.at:8080/job/Paintroid/lastSuccessfulBuild/artifact/Paintroid/bin/ or https://github.com/Catrobat/Paintroid/downloads
- test adding and editing costumes from/with paintroid

CostumeFragment.java#600 was a copy-and-paste error, I think - fixed for future support of rotation point
