### PR TITLE
Refactored StringsTest to be more accurate

### DIFF
--- a/catroid/res/values-de/strings.xml
+++ b/catroid/res/values-de/strings.xml
@@ -25,10 +25,6 @@
 
     <!-- General terms -->
     <string name="app_name">Catroid</string>
-    <string name="project">Projekt</string>
-    <string name="sprite">Objekt</string>
-    <string name="script">Skript</string>
-    <string name="brick">Baustein</string>
     <string name="cancel_button">Abbrechen</string>
     <string name="rename">Umbenennen</string>
     <string name="delete">Löschen</string>
@@ -36,6 +32,9 @@
     <string name="yes">Ja</string>
     <string name="no">Nein</string>
     <string name="copy">Kopieren</string>
+    <!--  -->
+
+
     <!-- General -->
     <string name="close">Schließen</string>
     <string name="error">Fehler</string>
@@ -47,6 +46,9 @@
     <string name="ok">Ok</string>
     <string name="add">Neu</string>
     <string name="start">Starten</string>
+    <!--  -->
+
+
     <!-- Main menu activity -->
     <string name="main_menu_new">Neu</string>
     <string name="main_menu_continue">Fortsetzen</string>
@@ -56,6 +58,9 @@
     <string name="main_menu_upload">Hochladen</string>
     <string name="main_menu_settings">Einstellungen</string>
     <string name="main_menu_about_catroid">Über Catroid</string>
+    <!--  -->
+
+
     <!-- Settings activity -->
     <string name="pref_title">Einstellungen</string>
     <string name="pref_enable_ms_bricks">Mindstorm Bausteine aktivieren</string>
@@ -83,7 +88,6 @@
     <string name="backgrounds">Hintergründe</string>
     <!-- Costume activity -->
     <string name="rename_costume_dialog">Kostüm umbenennen</string>
-    <string name="edit_costume">editieren</string>
     <string name="edit_costume_paintroid">Paintroid</string>
     <string name="copy_costume">kopieren</string>
     <string name="costumename_invalid">Dieser Name ist nicht zulässig</string>
@@ -154,7 +158,6 @@
     <string name="username">Benutzername:</string>
     <string name="password">Passwort:</string>
     <string name="login_or_register">Einloggen/\nRegistrieren</string>
-    <string name="register">Registrieren</string>
     <string name="password_forgotten">Passwort\nvergessen</string>
     <string name="new_user_registered">Neuer Account wurde erstellt</string>
     <string name="register_error">Fehler aufgetreten</string>
@@ -294,7 +297,6 @@
     <string name="none_paired">Keine verbundenen Geräte gefunden</string>
     <!-- Lego Mindstorms Strings -->
     <string name="brick_motor_action">NXT bewege Motor</string>
-    <string name="motor">Motor</string>
     <string name="motor_speed">Geschwindigkeit</string>
     <string name="brick_motor_turn_angle">NXT rotiere Motor</string>
     <string name="motor_angle">Winkel</string>

--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -19,16 +19,12 @@
  *  GNU Affero General Public License for more details.
  *  
  *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <resources>
 
     <!-- General terms -->
     <string name="app_name">Catroid</string>
-    <string name="project">project</string>
-    <string name="sprite">sprite</string>
-    <string name="script">script</string>
-    <string name="brick">brick</string>
     <string name="cancel_button">Cancel</string>
     <string name="rename">Rename</string>
     <string name="delete">Delete</string>
@@ -36,6 +32,9 @@
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="copy">Copy</string>
+    <!--  -->
+
+
     <!-- General -->
     <string name="close">Close</string>
     <string name="error">Error</string>
@@ -47,6 +46,9 @@
     <string name="ok">OK</string>
     <string name="add">Add</string>
     <string name="start">Start</string>
+    <!--  -->
+
+
     <!-- Main menu activity -->
     <string name="main_menu_new">New</string>
     <string name="main_menu_continue">Continue</string>
@@ -56,6 +58,9 @@
     <string name="main_menu_upload">Upload</string>
     <string name="main_menu_settings">Settings</string>
     <string name="main_menu_about_catroid">About Catroid</string>
+    <!--  -->
+
+
     <!-- Settings activity -->
     <string name="pref_title">Settings</string>
     <string name="pref_enable_ms_bricks">Enable Lego Mindstorms bricks</string>
@@ -84,7 +89,6 @@
     <string name="backgrounds">Backgrounds</string>
     <!-- Costume activity -->
     <string name="rename_costume_dialog">Rename costume</string>
-    <string name="edit_costume">edit</string>
     <string name="edit_costume_paintroid">Paintroid</string>
     <string name="copy_costume">copy</string>
     <string name="costumename_invalid">This costume\'s name is invalid</string>
@@ -149,7 +153,6 @@
     <string name="username">Username:</string>
     <string name="password">Password:</string>
     <string name="login_or_register">Login or Register</string>
-    <string name="register">Register</string>
     <string name="password_forgotten">Password forgotten</string>
     <string name="new_user_registered">new account created</string>
     <string name="register_error">Error occurred</string>
@@ -299,7 +302,6 @@
     <string name="none_paired">No paired devices found</string>
     <!-- Lego Mindstorms Strings -->
     <string name="brick_motor_action">NXT move motor</string>
-    <string name="motor">motor</string>
     <string name="motor_speed">Speed</string>
     <string name="brick_motor_turn_angle">NXT turn motor</string>
     <string name="motor_angle">Angle</string>

--- a/catroidLicenseTest/src/org/catrobat/catroid/test/code/StringsTest.java
+++ b/catroidLicenseTest/src/org/catrobat/catroid/test/code/StringsTest.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -46,7 +47,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-
 /**
  * @author pete
  * 
@@ -57,7 +57,6 @@ public class StringsTest extends TestCase {
 	private static final String SOURCE_DIRECTORY = "../catroid/src";
 	private static final String RESOURCES_DIRECTORY = "../catroid/res";
 	private static final String ANDROID_MANIFEST = "../catroid/AndroidManifest.xml";
-	private static final String JAVA_STRING_PREFIX = "R.string.";
 	private static final String XML_STRING_PREFIX = "@string/";
 
 	private List<File> getStringFiles() throws IOException {
@@ -196,9 +195,11 @@ public class StringsTest extends TestCase {
 		Map<String, List<String>> languageStrings = getStringNamesPerLanguage();
 
 		for (String string : allStringNames) {
-			String stringReferenceJava = JAVA_STRING_PREFIX + string;
-			String stringReferenceXml = XML_STRING_PREFIX + string;
-			if (!javaSourceCode.contains(stringReferenceJava) && !xmlSourceCode.contains(stringReferenceXml)) {
+			Pattern javaReferencePattern = Pattern.compile("R\\.string\\." + string + "[^\\w]");
+			Pattern xmlReferencePattern = Pattern.compile("@string/" + string + "[^\\w]");
+
+			if (!javaReferencePattern.matcher(javaSourceCode).find()
+					&& !xmlReferencePattern.matcher(xmlSourceCode).find()) {
 				unusedStringsFound = true;
 
 				errorMessage.append("\nString with name " + string + " is unused (found in ");


### PR DESCRIPTION
Previously, StringsTest.java, when looking for a string like
'R.string.no', would also match 'R.string.notification'. Thus, falsly
thnking that 'R.string.no' was indeed a used string, when there was no
occurance of it.
I corrected it via a Regex pattern in the hopes to get more accurate
results in the future. A few strings were removed after the test found
a few of these cases.

values/strings.xml was modified as a whole, changing line endings from
\r\n to \n.

I added <!-- --> after string categories because it makes a much nicer
formatting, categories are now visibly separated from each other.

Edit:
[Successful testrun](http://catroidtestserver.ist.tugraz.at:8080/job/Catroid-ABS/301/testReport/)
