### PR TITLE
Setting page design

### DIFF
--- a/catroid/res/layout/checkbox_preference.xml
+++ b/catroid/res/layout/checkbox_preference.xml
@@ -24,7 +24,7 @@
 <TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:paddingLeft="8dp"
+    android:paddingLeft="15dp"
     android:minHeight="?android:attr/listPreferredItemHeight"
     android:gravity="center_vertical"
     android:paddingRight="?android:attr/scrollbarSize" >


### PR DESCRIPTION
Bigger padding on the left side. The description text was already multi-lined with a maximum number of 4 lines, which should be enough space for any description text.
