### PR TITLE
SettingPageRedesign

### DIFF
--- a/catroid/res/layout/checkbox_preference.xml
+++ b/catroid/res/layout/checkbox_preference.xml
@@ -24,10 +24,7 @@
 <TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="15dp"
-    android:layout_marginRight="6dp"
-    android:layout_marginTop="6dp"
-    android:layout_marginBottom="6dp"
+    android:paddingLeft="8dp"
     android:minHeight="?android:attr/listPreferredItemHeight"
     android:gravity="center_vertical"
     android:paddingRight="?android:attr/scrollbarSize" >


### PR DESCRIPTION
The text in the individual settings items has now a bigger padding on the left side.

The description text was already multi-lined with a maximum number of 4 lines.
