### PR TITLE
Upped targedSdk, removed debuggable, require Open GL ES 2.0

### DIFF
--- a/catroid/AndroidManifest.xml
+++ b/catroid/AndroidManifest.xml
@@ -29,7 +29,7 @@
 
     <uses-sdk
         android:minSdkVersion="8"
-        android:targetSdkVersion="15" />
+        android:targetSdkVersion="17" />
 
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -40,8 +40,11 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
+    <uses-feature
+        android:glEsVersion="0x00020000"
+        android:required="true" />
+
     <application
-        android:debuggable="true"
         android:icon="@drawable/ic_launcher_catroid_fat"
         android:label="@string/app_name"
         android:theme="@android:style/Theme.Light.NoTitleBar" >
@@ -88,13 +91,13 @@
             android:screenOrientation="portrait" />
         <activity
             android:name=".ui.ProjectActivity"
-            android:theme="@style/Theme.Catroid" 
-            android:windowSoftInputMode="adjustPan"
-            android:screenOrientation="portrait"/>
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.Catroid"
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".ui.ProgramMenuActivity"
-            android:theme="@style/Theme.Catroid" 
-            android:screenOrientation="portrait"/>
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.Catroid" />
         <activity
             android:name=".ui.ScriptTabActivity"
             android:theme="@style/Theme.Catroid" />


### PR DESCRIPTION
- Increased the **android:targetSdkVersion** from 15 (IceCreamSandwich) to 17 (Jelly Bean) so that no compatibility modes are used. Since we have a lot of 4.2.1 devices in our project our app implicitly gets tested on this API level.
- Removed **android:debuggable="true"**.
  Reason: Since SDK Tools, Revision 8 (from December 2010!) this is no longer needed.
  Quote from  https://developer.android.com/tools/sdk/tools-notes.html
  
  > Support for a true debug build. Developers no longer need to add the android:debuggable attribute to the <application> tag in the manifest — the build tools add the attribute automatically. In Eclipse/ADT, all incremental builds are assumed to be debug builds, so the tools insert android:debuggable="true". When exporting a signed release build, the tools do not add the attribute. In Ant, a ant debug command automatically inserts the android:debuggable="true" attribute, while ant release does not. If android:debuggable="true" is manually set, then ant release will actually do a debug build, rather than a release build.
- Require OpenGL 2.0 ES.
  Catroid now requires OpenGL ES 2.0. Please see http://goo.gl/GzZ7X for details. The main reason for us to do this is that Google Play filters apps based on - among other criteria - the **&lt;uses-feature>** elements. Since we use libgdx in OpenGL ES 2.0 mode, users without it cannot properly use Catroid and the Stage would force close. By adding this element, Catroid will not be shown in the Play Store for them, thus avoiding this issue. Please also see https://developer.android.com/about/dashboards/index.html#OpenGL for more information about the relative number of devices that support Open GL ES 2.0 (at the time of writing, almost 91%).

[Successful testrun](http://catrobatgw.ist.tugraz.at:8080/job/Catroid-custom-branch-test/40/)
