### PR TITLE
Fixed NullPointerException in ForeverBrickTest

### DIFF
--- a/catroidTest/src/org/catrobat/catroid/test/content/brick/ForeverBrickTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/brick/ForeverBrickTest.java
@@ -35,25 +35,16 @@ import android.test.InstrumentationTestCase;
 
 public class ForeverBrickTest extends InstrumentationTestCase {
 
-	private Sprite testSprite;
-	private StartScript testScript;
-	private LoopEndBrick loopEndBrick;
-	private LoopBeginBrick foreverBrick;
-
-	@Override
-	protected void setUp() throws Exception {
-		testSprite = new Sprite("testSprite");
-	}
-	
 	@FlakyTest(tolerance = 3)
 	public void testForeverBrick() throws InterruptedException {
 		final int fiveIsAlmostForever = 5;
 
-		testSprite.removeAllScripts();
-		testScript = new StartScript(testSprite);
+		Sprite testSprite = new Sprite("testSprite");
 
-		foreverBrick = new ForeverBrick(testSprite);
-		loopEndBrick = new LoopEndBrick(testSprite, foreverBrick);
+		StartScript testScript = new StartScript(testSprite);
+
+		LoopBeginBrick foreverBrick = new ForeverBrick(testSprite);
+		LoopEndBrick loopEndBrick = new LoopEndBrick(testSprite, foreverBrick);
 		foreverBrick.setLoopEndBrick(loopEndBrick);
 
 		final int deltaY = -10;
@@ -82,11 +73,12 @@ public class ForeverBrickTest extends InstrumentationTestCase {
 		final int deltaY = -10;
 		final int repeatTimes = 5;
 
-		testSprite.removeAllScripts();
-		testScript = new StartScript(testSprite);
+		Sprite testSprite = new Sprite("testSprite");
 
-		foreverBrick = new ForeverBrick(testSprite);
-		loopEndBrick = new LoopEndBrick(testSprite, foreverBrick);
+		StartScript testScript = new StartScript(testSprite);
+
+		LoopBeginBrick foreverBrick = new ForeverBrick(testSprite);
+		LoopEndBrick loopEndBrick = new LoopEndBrick(testSprite, foreverBrick);
 		foreverBrick.setLoopEndBrick(loopEndBrick);
 
 		final int expectedDelay = (Integer) TestUtils.getPrivateField("LOOP_DELAY", loopEndBrick, false);
@@ -112,15 +104,15 @@ public class ForeverBrickTest extends InstrumentationTestCase {
 		final long delayByContract = 20;
 		assertEquals("Loop delay was not 20ms!", delayByContract * repeatTimes, endTime - startTime, 15);
 	}
-	
+
 	@FlakyTest(tolerance = 3)
 	public void testNoDelayAtBeginOfLoop() throws InterruptedException {
+		Sprite testSprite = new Sprite("testSprite");
 
-		testSprite.removeAllScripts();
-		testScript = new StartScript(testSprite);
+		StartScript testScript = new StartScript(testSprite);
 
-		foreverBrick = new ForeverBrick(testSprite);
-		loopEndBrick = new LoopEndBrick(testSprite, foreverBrick);
+		LoopBeginBrick foreverBrick = new ForeverBrick(testSprite);
+		LoopEndBrick loopEndBrick = new LoopEndBrick(testSprite, foreverBrick);
 		foreverBrick.setLoopEndBrick(loopEndBrick);
 
 		final int deltaY = -10;


### PR DESCRIPTION
The Nullpointer occured when the test silently failed and was executed
again due the @FlakyTest annotation. Since the Sprite was a member and
only initialized once, the already running StartScript from the first
try was still running in the background, still calling getScript() in
the LoopEndBrick, which returned null, because all Scripts had been
removed via removeAllScripts() and replaced with a new one, which did
not contain the LoopEndBrick anymore.

[Here's a testrun](http://catrobatgw.ist.tugraz.at:8080/job/Catroid-single-jUnit-test/32/console) and [logcat output](http://catrobatgw.ist.tugraz.at:8080/job/Catroid-single-jUnit-test/32/artifact/logcat.txt) of a testrun with _810_ (after that, the job was killed by Jenkins) consecutive executions of the previously failing test, not one throwing a NullPointerException.

Fixed #118 
