### PR TITLE
Removed warnings from ABS

### DIFF
--- a/libraryProjects/actionbarsherlock/src/com/actionbarsherlock/app/ActionBar.java
+++ b/libraryProjects/actionbarsherlock/src/com/actionbarsherlock/app/ActionBar.java
@@ -930,6 +930,7 @@ public abstract class ActionBar {
             this.gravity = gravity;
         }
 
+        @SuppressWarnings("deprecation")
         public LayoutParams(int gravity) {
             this(WRAP_CONTENT, FILL_PARENT, gravity);
         }

--- a/libraryProjects/actionbarsherlock/src/com/actionbarsherlock/internal/widget/IcsLinearLayout.java
+++ b/libraryProjects/actionbarsherlock/src/com/actionbarsherlock/internal/widget/IcsLinearLayout.java
@@ -199,7 +199,6 @@ public class IcsLinearLayout extends NineLinearLayout {
             if (child == null) {
                 bottom = getHeight() - getPaddingBottom() - mDividerHeight;
             } else {
-                final LayoutParams lp = (LayoutParams) child.getLayoutParams();
                 bottom = child.getBottom()/* + lp.bottomMargin*/;
             }
             drawHorizontalDivider(canvas, bottom);
@@ -226,7 +225,6 @@ public class IcsLinearLayout extends NineLinearLayout {
             if (child == null) {
                 right = getWidth() - getPaddingRight() - mDividerWidth;
             } else {
-                final LayoutParams lp = (LayoutParams) child.getLayoutParams();
                 right = child.getRight()/* + lp.rightMargin*/;
             }
             drawVerticalDivider(canvas, right);


### PR DESCRIPTION
- One deprecation warning with @SuppressWarnings
- Two unused variables. These remain unused even in 4.2.0, see
  https://github.com/JakeWharton/ActionBarSherlock/blob/master/library/src/com/actionbarsherlock/internal/widget/IcsLinearLayout.java#L208

This is so we have a workspace without warnings, since these are not
even our warnings.
