### PR TITLE
Fix Layout Editor Rendering of Bricks

### DIFF
--- a/catroid/res/values/styles.xml
+++ b/catroid/res/values/styles.xml
@@ -151,6 +151,7 @@
 
     <style name="BrickContainer">
         <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
     </style>
 
     <style name="BrickContainer.Motion">


### PR DESCRIPTION
In a recent commit to master I forgot to add the layout_height attribute in one of the styles and mistakenly assumed that the SDK was at fault, disabling the rendering of brick layouts in the Eclipse Layout Editor. This commit corrects this error.

**Before**
![Screen Shot 2013-01-09 at 20 21 48](https://f.cloud.github.com/assets/1301152/54426/e3c54202-5a92-11e2-8156-54f68dd85715.png)

**After**
![Screen Shot 2013-01-09 at 20 23 03](https://f.cloud.github.com/assets/1301152/54428/efc8b890-5a92-11e2-9079-c75538ba4a42.png)

Optionally I recommend you select the Catroid Style to get even more accurate rendering.
![Screen Shot 2013-01-09 at 20 23 54](https://f.cloud.github.com/assets/1301152/54431/0ca43994-5a93-11e2-9523-6980011dbeb3.png)
