### PR TITLE
.gitattributes file added to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files we want to always be normalized and converted 
+# to native line endings on checkout.
+*.java text
+*.xml  text
+*.txt  text
+*.md   text
+
+# Denote all files that are truly binary and should not be modified.
+# (binary is a macro for -text -diff)
+*.jar  binary
+*.so   binary
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.bmp  binary
+*.mp3  binary
+*.zip  binary
+
+# For more info see
+# https://timclem.wordpress.com/2012/03/01/mind-the-end-of-your-line/


### PR DESCRIPTION
In today's meeting it was decided that we normalize the line endings
over the course of time instead of normalizing the whole repo at once.

This _will_ break git blame in the future.
