### PR TITLE
Quickfix for SoundRecorderTest

### DIFF
--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/SoundRecorderTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/SoundRecorderTest.java
@@ -125,7 +125,9 @@ public class SoundRecorderTest extends ActivityInstrumentationTestCase2<MainMenu
 		UiTestUtils.waitForFragment(solo, R.id.fragment_sound_relative_layout);
 
 		UiTestUtils.clickOnBottomBar(solo, R.id.button_add);
-		String soundRecorderText = solo.getString(R.string.soundrecorder_name);
+		// quickfix for Jenkins to get rid of Resources$NotFoundException: String resource
+		// String soundRecorderText = solo.getString(R.string.soundrecorder_name);
+		String soundRecorderText = "Catroid Sound Recorder";
 		solo.waitForText(soundRecorderText);
 		assertTrue("Catroid Sound Recorder is not present", solo.searchText(soundRecorderText));
 


### PR DESCRIPTION
for over 2 months we had problems with the SoundRecorderTest.
Most of the time, a string ressource is not found (although it is there :D)
a sample console output can be found here [1].
the history of the last runs can be found here [2] - pretty annoying...

with the quickfix the test is working [3].

of course, it is a quickfix and the problem with the ressource should be figured out - but we also need "green" builds on jenkins :)

[1]http://catrobatgw.ist.tugraz.at:8080/job/Catroid/1290/testReport/junit/org.catrobat.catroid.uitest.ui/SoundRecorderTest/testRecordMultipleSounds/
[2]http://catrobatgw.ist.tugraz.at:8080/job/Catroid/1290/testReport/junit/org.catrobat.catroid.uitest.ui/SoundRecorderTest/testRecordMultipleSounds/history/?
[3]http://catrobatgw.ist.tugraz.at:8080/job/Catroid-single-UI-test/183/console
