### PR TITLE
Fix UploadDialogTest

### DIFF
--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/dialog/UploadDialogTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/dialog/UploadDialogTest.java
@@ -90,9 +90,14 @@ public class UploadDialogTest extends ActivityInstrumentationTestCase2<MainMenuA
 		solo.sleep(200);
 		UiTestUtils.createValidUser(getActivity());
 		solo.clickOnText(solo.getString(R.string.main_menu_upload));
-		solo.waitForDialogToClose(5000);
+		solo.sleep(5000);
 
-		View renameView = solo.getText(solo.getString(R.string.project_rename));
+		// robotium updated getText with RegularExpressions
+		// need to escape brackets for test to work
+		String projectRenameString = solo.getString(R.string.project_rename);
+		projectRenameString.replaceAll("\\(", "");
+		projectRenameString.replaceAll("\\)", "");
+		View renameView = solo.getText("\\(" + projectRenameString + "\\)");
 		assertNotNull("View for rename project could not be found", renameView);
 		assertEquals("rename View is visible.", renameView.getVisibility(), View.GONE);
 


### PR DESCRIPTION
the latest nightly build of robotium changed the solo.getText() method to accept regular expressions as string. in the testclass UploadDialogTest.java a string (containing brackets) was used to get a certain textview - we have to escape these brackets in order to get the correct textview!

refactored solo.waitForDialogToClose() to solo.sleep() - there is no dialog closing...

last master build on Jenkins: http://catrobatgw.ist.tugraz.at:8080/job/Catroid/1339/testReport/org.catrobat.catroid.uitest.ui.dialog/UploadDialogTest/testUploadDialog/

successful run with bugfix (tested UploadDialogTest 5 times): http://catrobatgw.ist.tugraz.at:8080/job/Catroid-single-UI-test/245/
