### PR TITLE
Removed second definition of actionbar_title_color resource

### DIFF
--- a/catroid/res/values/colors.xml
+++ b/catroid/res/values/colors.xml
@@ -34,7 +34,7 @@
     <color name="dark_gray">#5a5858</color>
     <color name="gray">#808080</color>
     <color name="actionbar_background">#002534</color>
-    <color name="actionbar_title_color">#FCBB20</color>
+    <color name="actionbar_title_color">#6F8E9B</color>
     <color name="fragment_background_color">#03222C</color>
     <color name="transparent">#00000000 </color>
     <color name="formula_editor_background">#FFFFFF</color>


### PR DESCRIPTION
Fixes #220.

Removed second definition of `actionbar_title_color` from _catroid/res/values/colors.xml_. Left color `#FCBB20` because it is used in [interface mockups](https://github.com/Catrobat/DesignAndUsability/blob/master/catroid/interface_mockups.pdf).
