### PR TITLE
brick_nxt_play_tone.xml  (NXT play tone brick)

### DIFF
--- a/catroid/res/layout/brick_nxt_play_tone.xml
+++ b/catroid/res/layout/brick_nxt_play_tone.xml
@@ -68,7 +68,7 @@
             <EditText
                 android:id="@+id/nxt_tone_duration_edit_text"
                 style="@style/BrickEditText"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:clickable="false"
                 android:inputType="number|numberDecimal|numberSigned" >
@@ -97,7 +97,7 @@
             <EditText
                 android:id="@+id/nxt_tone_freq_edit_text"
                 style="@style/BrickEditText"
-                android:layout_width="60dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:clickable="false"
                 android:inputType="number|numberDecimal|numberSigned" >


### PR DESCRIPTION
Catroid / catroid / res / layout / brick_nxt_play_tone.xml

1) Size of " NXT play tone brick" increases abnormally when used.
2) Line -71....  android:layout_width="fill_parent" results into disappear of the next TextView (seconds).
3) Line -100... android:layout_width="60dp" is not the recommended way.

Please guide me if I am wrong.
