### PR TITLE
Fix for the testRestartProjectWithSound test

### DIFF
--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/dialog/StageDialogTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/dialog/StageDialogTest.java
@@ -261,14 +261,14 @@ public class StageDialogTest extends ActivityInstrumentationTestCase2<MainMenuAc
 		solo.waitForActivity(ProjectActivity.class.getSimpleName());
 		UiTestUtils.clickOnBottomBar(solo, R.id.button_play);
 		solo.waitForActivity(StageActivity.class.getSimpleName());
-		solo.sleep(2000);
+		solo.sleep(4000);
 		assertTrue("Sound not playing.", mediaPlayer.isPlaying());
 		int positionBeforeRestart = mediaPlayer.getCurrentPosition();
 		solo.goBack();
 		solo.sleep(500);
 		assertFalse("Sound playing but should be paused.", mediaPlayer.isPlaying());
 		solo.clickOnButton(solo.getString(R.string.stage_dialog_restart));
-		solo.sleep(800);
+		solo.sleep(2000);
 		@SuppressWarnings("unchecked")
 		ArrayList<MediaPlayer> mediaPlayerArrayList = (ArrayList<MediaPlayer>) Reflection.getPrivateField(
 				SoundManager.getInstance(), "mediaPlayers");


### PR DESCRIPTION
Final fix for the testRestartProjectWithSound test.

10 iterations of the StageDialogTest (including the testRestartProjectWithSound test):
http://catrobatgw.ist.tugraz.at:8080/job/Catroid-single-UI-test/478/
