### PR TITLE
RepeatAction fix

### DIFF
--- a/catroid/src/org/catrobat/catroid/content/actions/RepeatAction.java
+++ b/catroid/src/org/catrobat/catroid/content/actions/RepeatAction.java
@@ -31,6 +31,7 @@ public class RepeatAction extends com.badlogic.gdx.scenes.scene2d.actions.Repeat
 	private Formula repeatCount;
 	private Sprite sprite;
 	private boolean isCurrentLoopInitialized = false;
+	private boolean isRepeatActionInitialized = false;
 	private int repeatCountValue;
 	private static final float LOOP_DELAY = 0.02f;
 	private float currentTime = 0f;
@@ -39,10 +40,13 @@ public class RepeatAction extends com.badlogic.gdx.scenes.scene2d.actions.Repeat
 	@Override
 	public boolean act(float delta) {
 
+		if (!isRepeatActionInitialized) {
+			isRepeatActionInitialized = true;
+			repeatCountValue = repeatCount == null ? 0 : repeatCount.interpretInteger(sprite);
+		}
 		if (!isCurrentLoopInitialized) {
 			currentTime = 0f;
 			isCurrentLoopInitialized = true;
-			repeatCountValue = repeatCount == null ? 0 : repeatCount.interpretInteger(sprite);
 		}
 
 		currentTime += delta;
@@ -71,6 +75,7 @@ public class RepeatAction extends com.badlogic.gdx.scenes.scene2d.actions.Repeat
 	@Override
 	public void restart() {
 		isCurrentLoopInitialized = false;
+		isRepeatActionInitialized = false;
 		executedCount = 0;
 		super.restart();
 	}

--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/RepeatActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/RepeatActionTest.java
@@ -31,6 +31,9 @@ import org.catrobat.catroid.content.bricks.ChangeYByNBrick;
 import org.catrobat.catroid.content.bricks.LoopEndBrick;
 import org.catrobat.catroid.content.bricks.RepeatBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
+import org.catrobat.catroid.formulaeditor.Sensors;
 import org.catrobat.catroid.test.utils.Reflection;
 
 import android.test.InstrumentationTestCase;
@@ -107,6 +110,33 @@ public class RepeatActionTest extends InstrumentationTestCase {
 		}
 
 		assertEquals("Executed the wrong number of times!", REPEAT_TIMES * deltaY, (int) testSprite.look.getYPosition());
+	}
+
+	public void testRepeatCount() {
+		testSprite.removeAllScripts();
+		Script testScript = new StartScript(testSprite);
+
+		Formula repeatFormula = new Formula(new FormulaElement(ElementType.SENSOR, Sensors.LOOK_Y.name(), null));
+		RepeatBrick repeatBrick = new RepeatBrick(testSprite, repeatFormula);
+		LoopEndBrick loopEndBrick = new LoopEndBrick(testSprite, repeatBrick);
+		repeatBrick.setLoopEndBrick(loopEndBrick);
+
+		final int deltaY = -10;
+
+		testScript.addBrick(new ChangeYByNBrick(testSprite, 10));
+		testScript.addBrick(repeatBrick);
+		testScript.addBrick(new ChangeYByNBrick(testSprite, deltaY));
+		testScript.addBrick(loopEndBrick);
+
+		testSprite.addScript(testScript);
+		testSprite.createStartScriptActionSequence();
+
+		while (!testSprite.look.getAllActionsAreFinished()) {
+			testSprite.look.act(1.0f);
+		}
+
+		assertEquals("Executed the wrong number of times!", deltaY * 9, (int) testSprite.look.getYPosition());
+
 	}
 
 	public void testNestedRepeatBrick() throws InterruptedException {


### PR DESCRIPTION
Fixed an error, which occured when the repeat counter formula is modified within its repeat block.

Consider the following When tapped script:
- **Expected output:** Execute 10 times and set object to Y-Position -90 (= 10 - 100)
- **Current master-branch output:** Execute 1 time and set object to Y-Position 0

![repeatActionTestProgram](https://f.cloud.github.com/assets/1931620/371598/d87e0da4-a33d-11e2-9d6d-ca5b784ddd4c.png)
