### PR TITLE
Fix for Issue#307

### DIFF
--- a/catroid/src/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/org/catrobat/catroid/stage/StageListener.java
@@ -82,7 +82,7 @@ public class StageListener implements ApplicationListener {
 	private int screenshotHeight;
 	private int screenshotX;
 	private int screenshotY;
-	private byte[] screenshot;
+	private byte[] screenshot = null;
 	// in first frame, framebuffer could be empty and screenshot
 	// would be white
 	private boolean skipFirstFrameForAutomaticScreenshot;
@@ -242,8 +242,10 @@ public class StageListener implements ApplicationListener {
 			sprite.resume();
 			sprite.resetSprite();
 		}
-		prepareScreenshotFiles();
-		saveScreenshot(thumbnail);
+		if (thumbnail != null) {
+			prepareScreenshotFiles();
+			saveScreenshot(thumbnail);
+		}
 
 	}
 


### PR DESCRIPTION
Concerning #307 

The screenshot is now created at the beginning and it is saved when the user exits the stage.

I haven't done the saving in an asnyc task, because working with Libgdx methods in background threads is very evil.

Jenkins Tesrun (these tests fail also randomly on the current master):
http://catrobatgw.ist.tugraz.at:8080/job/Catroid-custom-branch-test/1019/
