### PR TITLE
fixed NullPointerException in ProjectUploadService

### DIFF
--- a/catroid/src/org/catrobat/catroid/transfers/ProjectUploadService.java
+++ b/catroid/src/org/catrobat/catroid/transfers/ProjectUploadService.java
@@ -83,10 +83,18 @@ public class ProjectUploadService extends IntentService {
 	protected void onHandleIntent(Intent intent) {
 		receiver = (ResultReceiver) intent.getParcelableExtra("receiver");
 		try {
+			if (projectPath == null) {
+				result = false;
+				Log.e(TAG, "project path is null");
+				return;
+			}
+
 			File directoryPath = new File(projectPath);
 			String[] paths = directoryPath.list();
 
 			if (paths == null) {
+				result = false;
+				Log.e(TAG, "project path is not valid");
 				return;
 			}
 
@@ -102,6 +110,7 @@ public class ProjectUploadService extends IntentService {
 			}
 			if (!UtilZip.writeToZipFile(paths, zipFileString)) {
 				zipFile.delete();
+				result = false;
 				return;
 			}
 
@@ -116,7 +125,7 @@ public class ProjectUploadService extends IntentService {
 			zipFile.delete();
 		} catch (IOException e) {
 			e.printStackTrace();
-
+			result = false;
 		} catch (WebconnectionException webException) {
 			serverAnswer = webException.getMessage();
 			Log.e(TAG, serverAnswer);


### PR DESCRIPTION
Testruns:
[branch test](http://catrobatgw.ist.tugraz.at:8080/job/Catroid-custom-branch-test/1038/)
[single UI](http://catrobatgw.ist.tugraz.at:8080/job/Catroid-single-UI-test/700/)

This will fix errors like [there](http://catrobatgw.ist.tugraz.at:8080/job/Catroid-custom-branch-test/1031/artifact/logcat.txt):

```
05-17 10:14:16.410 E/AndroidRuntime( 4794): FATAL EXCEPTION: IntentService[ProjectUploadService]
05-17 10:14:16.410 E/AndroidRuntime( 4794): java.lang.NullPointerException
05-17 10:14:16.410 E/AndroidRuntime( 4794):     at java.io.File.fixSlashes(File.java:205)
05-17 10:14:16.410 E/AndroidRuntime( 4794):     at java.io.File.init(File.java:189)
05-17 10:14:16.410 E/AndroidRuntime( 4794):     at java.io.File.<init>(File.java:139)
05-17 10:14:16.410 E/AndroidRuntime( 4794):     at org.catrobat.catroid.transfers.ProjectUploadService.onHandleIntent(ProjectUploadService.java:86)
05-17 10:14:16.410 E/AndroidRuntime( 4794):     at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:59)
05-17 10:14:16.410 E/AndroidRuntime( 4794):     at android.os.Handler.dispatchMessage(Handler.java:99)
05-17 10:14:16.410 E/AndroidRuntime( 4794):     at android.os.Looper.loop(Looper.java:130)
05-17 10:14:16.410 E/AndroidRuntime( 4794):     at android.os.HandlerThread.run(HandlerThread.java:60)
```
