### PR TITLE
fixed pocket paint link in test case

### DIFF
--- a/catroidSourceTest/src/org/catrobat/catroid/test/code/ImportantValuesTest.java
+++ b/catroidSourceTest/src/org/catrobat/catroid/test/code/ImportantValuesTest.java
@@ -22,14 +22,14 @@
  */
 package org.catrobat.catroid.test.code;
 
-import org.catrobat.catroid.common.Constants;
-
 import junit.framework.TestCase;
+
+import org.catrobat.catroid.common.Constants;
 
 public class ImportantValuesTest extends TestCase {
 
 	public void testPaintroidDownloadLink() {
-		assertEquals("wrong paintroid download link", "https://github.com/Catrobat/Paintroid/downloads",
+		assertEquals("wrong paintroid download link", "market://details?id=org.catrobat.paintroid.pocketpaint",
 				Constants.POCKET_PAINT_DOWNLOAD_LINK);
 	}
 }


### PR DESCRIPTION
This request fixes one test case where the download link of pocket paint is tested. 

Jenkins:
[test-source-and-jUnit-tests-only - #71](http://catrobatgw.ist.tugraz.at:8080/job/Catroid-custom-branch-test-source-and-jUnit-tests-only/71/)
