### PR TITLE
fix webtests

### DIFF
--- a/catroidUiTest/src/org/catrobat/catroid/uitest/web/ProjectUpAndDownloadTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/web/ProjectUpAndDownloadTest.java
@@ -50,6 +50,7 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.test.ActivityInstrumentationTestCase2;
+import android.test.FlakyTest;
 import android.test.UiThreadTest;
 import android.util.Log;
 import android.widget.EditText;
@@ -104,6 +105,7 @@ public class ProjectUpAndDownloadTest extends ActivityInstrumentationTestCase2<M
 		});
 	}
 
+	@FlakyTest(tolerance = 4)
 	public void testUploadProjectSuccessAndTokenReplacementAfterUpload() throws Throwable {
 		setServerURLToTestUrl();
 		createTestProject(testProject);
@@ -130,6 +132,7 @@ public class ProjectUpAndDownloadTest extends ActivityInstrumentationTestCase2<M
 		//downloadProject();
 	}
 
+	@FlakyTest(tolerance = 4)
 	public void testUploadProjectOldCatrobatLanguageVersion() throws Throwable {
 		setServerURLToTestUrl();
 
@@ -175,6 +178,7 @@ public class ProjectUpAndDownloadTest extends ActivityInstrumentationTestCase2<M
 		UiTestUtils.clearAllUtilTestProjects();
 	}
 
+	@FlakyTest(tolerance = 4)
 	public void testRenameProjectNameAndDescriptionWhenUploading() throws Throwable {
 		setServerURLToTestUrl();
 
@@ -219,6 +223,7 @@ public class ProjectUpAndDownloadTest extends ActivityInstrumentationTestCase2<M
 				serverProjectDescription.equalsIgnoreCase(projectDescriptionSetWhenUploading));
 	}
 
+	@FlakyTest(tolerance = 4)
 	public void testRenameProjectDescriptionWhenUploading() throws Throwable {
 		setServerURLToTestUrl();
 
@@ -260,6 +265,7 @@ public class ProjectUpAndDownloadTest extends ActivityInstrumentationTestCase2<M
 				serverProjectDescription.equalsIgnoreCase(projectDescriptionSetWhenUploading));
 	}
 
+	@FlakyTest(tolerance = 4)
 	public void testUpAndDownloadJapaneseUnicodeProject() throws Throwable {
 		setServerURLToTestUrl();
 
@@ -287,6 +293,7 @@ public class ProjectUpAndDownloadTest extends ActivityInstrumentationTestCase2<M
 		assertTrue("Project name on server was changed", serverProjectName.equalsIgnoreCase(testProject));
 	}
 
+	@FlakyTest(tolerance = 4)
 	public void testDownload() throws Throwable {
 		setServerURLToTestUrl();
 
@@ -327,6 +334,7 @@ public class ProjectUpAndDownloadTest extends ActivityInstrumentationTestCase2<M
 		assertTrue("Project was successfully downloaded", serverProjectName.equalsIgnoreCase(projectName));
 	}
 
+	@FlakyTest(tolerance = 4)
 	public void testUploadStandardProject() throws Throwable {
 		if (!createAndSaveStandardProject() || this.standardProject == null) {
 			fail("Standard project not created");
@@ -367,6 +375,7 @@ public class ProjectUpAndDownloadTest extends ActivityInstrumentationTestCase2<M
 
 	}
 
+	@FlakyTest(tolerance = 4)
 	public void testUploadModifiedStandardProject() throws Throwable {
 		if (!createAndSaveStandardProject() || this.standardProject == null) {
 			fail("Standard project not created");


### PR DESCRIPTION
some webtests are unstable - they fail randomly, e.g.
http://catrobatgw.ist.tugraz.at:8080/job/Catroid-no-emma/59/

I did a testrun of ProjectUpAndDownloadTest with 10 iterations:
http://catrobatgw.ist.tugraz.at:8080/job/Catroid-single-UI-test/913/console
sometimes there are 4 and 2 errors

after adding FlakyTest with tolerance 4, the console output looks way better:
http://catrobatgw.ist.tugraz.at:8080/job/Catroid-single-UI-test/915/console

only one testcase is failing - but this test will be fixed separately.
I think it is worth a try to get closer to "green" builds on Jenkins :)
