### PR TITLE
Fix #496, Rate app link in overflow menu

### DIFF
--- a/catroid/res/menu/menu_main_menu.xml
+++ b/catroid/res/menu/menu_main_menu.xml
@@ -28,6 +28,10 @@
         android:showAsAction="withText"
         android:title="@string/main_menu_settings"/>
     <item
+        android:id="@+id/menu_rate_app"
+        android:showAsAction="withText"
+        android:title="@string/main_menu_rate_app"/>
+    <item
         android:id="@+id/menu_about"
         android:showAsAction="withText"
         android:title="@string/main_menu_about_pocketcode"/>

--- a/catroid/res/values-de/strings.xml
+++ b/catroid/res/values-de/strings.xml
@@ -56,6 +56,8 @@
     <string name="main_menu_upload">Hochladen</string>
     <string name="main_menu_settings">Einstellungen</string>
     <string name="main_menu_about_pocketcode">Über Pocket Code</string>
+    <string name="main_menu_rate_app">Bewerte uns!</string>
+    <string name="main_menu_play_store_not_installed">Play Store App nicht gefunden</string>
     <string name="main_menu_web_dialog_title">Achtung!</string>
     <string name="main_menu_web_dialog_message">Derzeit werden keine alternativen Browser wie Firefox oder Dolphin unterstützt</string>
     <!--  -->

--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -56,6 +56,8 @@
     <string name="main_menu_upload">Upload</string>
     <string name="main_menu_settings">Settings</string>
     <string name="main_menu_about_pocketcode">About Pocket Code</string>
+    <string name="main_menu_rate_app">Rate us!</string>
+    <string name="main_menu_play_store_not_installed">Play Store app not found</string>
     <string name="main_menu_web_dialog_title">Caution!</string>
     <string name="main_menu_web_dialog_message">Currently alternative browsers like Firefox or Dolphin are not supported</string>
     <!--  -->

--- a/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -43,6 +43,7 @@ import org.catrobat.catroid.utils.Utils;
 import org.catrobat.catroid.web.ServerCalls;
 
 import android.app.AlertDialog;
+import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -59,6 +60,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.Button;
+import android.widget.Toast;
 
 import com.actionbarsherlock.app.ActionBar;
 import com.actionbarsherlock.app.SherlockFragmentActivity;
@@ -154,8 +156,8 @@ public class MainMenuActivity extends SherlockFragmentActivity implements OnChec
 		// also when you switch activities
 		if (ProjectManager.getInstance().getCurrentProject() != null) {
 			ProjectManager.getInstance().saveProject();
-			Utils.saveToPreferences(this, Constants.PREF_PROJECTNAME_KEY, ProjectManager.getInstance().getCurrentProject()
-					.getName());
+			Utils.saveToPreferences(this, Constants.PREF_PROJECTNAME_KEY, ProjectManager.getInstance()
+					.getCurrentProject().getName());
 		}
 	}
 
@@ -186,6 +188,9 @@ public class MainMenuActivity extends SherlockFragmentActivity implements OnChec
 				startActivity(intent);
 				return true;
 			}
+			case R.id.menu_rate_app:
+				launchMarket();
+				return true;
 			case R.id.menu_about: {
 				AboutDialogFragment aboutDialog = new AboutDialogFragment();
 				aboutDialog.show(getSupportFragmentManager(), AboutDialogFragment.DIALOG_FRAGMENT_TAG);
@@ -193,6 +198,17 @@ public class MainMenuActivity extends SherlockFragmentActivity implements OnChec
 			}
 		}
 		return super.onOptionsItemSelected(item);
+	}
+
+	// Taken from http://stackoverflow.com/a/11270668
+	private void launchMarket() {
+		Uri uri = Uri.parse("market://details?id=" + getPackageName());
+		Intent myAppLinkToMarket = new Intent(Intent.ACTION_VIEW, uri);
+		try {
+			startActivity(myAppLinkToMarket);
+		} catch (ActivityNotFoundException e) {
+			Toast.makeText(this, R.string.main_menu_play_store_not_installed, Toast.LENGTH_SHORT).show();
+		}
 	}
 
 	public void handleContinueButton(View v) {

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MainMenuActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MainMenuActivityTest.java
@@ -259,6 +259,12 @@ public class MainMenuActivityTest extends BaseActivityInstrumentationTestCase<Ma
 		assertEquals("Sprite at index 4 is not \"pig\"!", "pig", fourth.getName());
 	}
 
+	public void testRateAppMenuExists() {
+		solo.sendKey(Solo.MENU);
+		assertTrue("App rating menu not found in overflow menu!",
+				solo.searchText(solo.getString(R.string.main_menu_rate_app)));
+	}
+
 	public void testShouldDisplayDialogIfVersionNumberTooHigh() throws Throwable {
 		solo.waitForActivity(MainMenuActivity.class.getSimpleName());
 		// Prevent Utils from returning true in isApplicationDebuggable


### PR DESCRIPTION
The test is very minimalistic for a few reasons. On the emulator, there
is no Play Store App, on a device there probably is, but clicking the
menu would then leave Catroid. This would cause us to lose control over
the test, because we're not in Catroid anymore.

@RoxaneKoitz, please verify the wording. I implemented it using the 
imperative form _Rate us!_ and _Bewerte uns!_.
