### PR TITLE
fix WebViewActivityTest

### DIFF
--- a/catroid/AndroidManifest.xml
+++ b/catroid/AndroidManifest.xml
@@ -25,14 +25,14 @@
     package="org.catrobat.catroid"
     android:installLocation="auto"
     android:versionCode="6"
-    android:versionName="0.8.5">
-	
-    <supports-screens 
-        android:smallScreens="true"
-        android:normalScreens="true"
+    android:versionName="0.8.5" >
+
+    <supports-screens
         android:largeScreens="true"
-        android:xlargeScreens="false"/>
-    
+        android:normalScreens="true"
+        android:smallScreens="true"
+        android:xlargeScreens="false" />
+
     <uses-sdk
         android:minSdkVersion="10"
         android:targetSdkVersion="17" />
@@ -68,25 +68,23 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                
+
                 <data
                     android:host="*"
                     android:pathPattern="@string/catroid_extension_pathPattern"
                     android:scheme="http" />
             </intent-filter>
-            
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                
+
                 <data
                     android:host="*"
                     android:pathPattern="@string/catroid_extension_pathPattern"
                     android:scheme="https" />
             </intent-filter>
-            
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -99,12 +97,10 @@
                     android:scheme="file" />
             </intent-filter>
         </activity>
-        
         <activity
             android:name=".ui.WebViewActivity"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.Catroid" />
-        
         <activity
             android:name=".stage.StageActivity"
             android:configChanges="orientation"
@@ -125,9 +121,9 @@
             android:theme="@style/Theme.Catroid" />
         <activity
             android:name=".ui.ScriptActivity"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.Catroid"
-            android:windowSoftInputMode="adjustPan"
-            android:screenOrientation="portrait" />
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".ui.MyProjectsActivity"
             android:noHistory="true"

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/WebViewActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/WebViewActivityTest.java
@@ -26,25 +26,21 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.ui.WebViewActivity;
-import org.catrobat.catroid.uitest.annotation.Device;
 import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
 
 import android.webkit.WebView;
 
-import com.jayway.android.robotium.solo.By;
-
 public class WebViewActivityTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
+	private static final String COPYRIGHT_CHARACTER = "\u00A9";
 
 	public WebViewActivityTest() {
 		super(MainMenuActivity.class);
 	}
 
-	@Device
-	public void testWebViewSimple() {
-
+	public void testWebView() {
 		solo.clickOnButton(solo.getString(R.string.main_menu_web));
-
-		solo.waitForWebElement(By.id(solo.getString(R.id.webView)));
+		solo.waitForView(solo.getView(R.id.webView));
+		solo.sleep(2000);
 
 		assertEquals("Current Activity is not WebViewActivity", WebViewActivity.class, solo.getCurrentActivity()
 				.getClass());
@@ -52,21 +48,6 @@ public class WebViewActivityTest extends BaseActivityInstrumentationTestCase<Mai
 		WebView webView = (WebView) solo.getCurrentActivity().findViewById(R.id.webView);
 		assertEquals("URL is not correct", Constants.BASE_URL_HTTPS, webView.getUrl());
 
+		assertTrue("website hasn't been loaded properly", solo.searchText(COPYRIGHT_CHARACTER + " Catrobat"));
 	}
-
-	@Device
-	public void testWebViewCheckIfPageHasLoaded() {
-
-		solo.clickOnButton(solo.getString(R.string.main_menu_web));
-
-		solo.waitForWebElement(By.id(solo.getString(R.id.webView)));
-
-		assertEquals("Current Activity is not WebViewActivity", WebViewActivity.class, solo.getCurrentActivity()
-				.getClass());
-
-		String copyright = "\u00A9";
-		assertTrue("website hasn't been loaded properly", solo.searchText(copyright + " Catrobat"));
-
-	}
-
 }


### PR DESCRIPTION
one test was failing on Device!
solo.waitForWebElement cannot be used in that context to wait for the webview to appear (it waits for Webelements such as "HTML", "BODY", "DIV",...)

since both tests tested nearly the same, they were merged into one testcase, that can be run on the Emulator
http://jenkins.catrob.at/job/Catroid-single-UI-emulator/111/console
