### PR TITLE
refactor junitTest cleanup

### DIFF
--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilsTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilsTest.java
@@ -39,6 +39,7 @@ import org.catrobat.catroid.content.bricks.SetLookBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.test.utils.Reflection;
+import org.catrobat.catroid.test.utils.TestUtils;
 import org.catrobat.catroid.utils.UtilFile;
 import org.catrobat.catroid.utils.Utils;
 
@@ -56,6 +57,7 @@ public class UtilsTest extends AndroidTestCase {
 	private static final String MD5_EMPTY = "D41D8CD98F00B204E9800998ECF8427E";
 	private static final String MD5_CATROID = "4F982D927F4784F69AD6D6AF38FD96AD";
 	private static final String MD5_HELLO_WORLD = "ED076287532E86365E841E92BFC50D8C";
+	private static final String NEW_PROGRAM_NAME = "new name";
 	private File testFile;
 	private File copiedFile;
 
@@ -90,6 +92,7 @@ public class UtilsTest extends AndroidTestCase {
 		if (copiedFile != null && copiedFile.exists()) {
 			copiedFile.delete();
 		}
+		TestUtils.deleteTestProjects(NEW_PROGRAM_NAME);
 		super.tearDown();
 	}
 
@@ -196,7 +199,7 @@ public class UtilsTest extends AndroidTestCase {
 			assertTrue("Failed to recognize the standard project",
 					Utils.isStandardProject(standardProject, getContext()));
 
-			standardProject.setName("new name");
+			standardProject.setName(NEW_PROGRAM_NAME);
 			assertTrue("Failed to recognize renamed standard project",
 					Utils.isStandardProject(standardProject, getContext()));
 

--- a/catroidTest/src/org/catrobat/catroid/test/web/ServerCallsTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/web/ServerCallsTest.java
@@ -59,7 +59,7 @@ public class ServerCallsTest extends AndroidTestCase {
 
 	@Override
 	protected void tearDown() throws Exception {
-		TestUtils.clearProject("uploadtestProject");
+		TestUtils.deleteTestProjects("uploadtestProject");
 		ServerCalls.useTestUrl = false;
 		super.tearDown();
 	}


### PR DESCRIPTION
after executing the whole catroidTest package there were two testprojects in pocketcode folder.
calling TestUtils.deleteTestProjects deletes the project with DEFAULT_TEST_PROJECT name, and can be used with additional parameter to delete a certain project (https://github.com/Catrobat/Catroid/blob/master/catroidTest/src/org/catrobat/catroid/test/utils/TestUtils.java#L195)
