### PR TITLE
quickfix for WebViewActivityTest

### DIFF
--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/WebViewActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/WebViewActivityTest.java
@@ -46,7 +46,7 @@ public class WebViewActivityTest extends BaseActivityInstrumentationTestCase<Mai
 				.getClass());
 
 		WebView webView = (WebView) solo.getCurrentActivity().findViewById(R.id.webView);
-		assertEquals("URL is not correct", Constants.BASE_URL_HTTPS, webView.getUrl());
+		assertEquals("URL is not correct", Constants.CATROBAT_WEBVIEW_URL, webView.getUrl());
 
 		assertTrue("website hasn't been loaded properly", solo.searchText(COPYRIGHT_CHARACTER + " Catrobat"));
 	}


### PR DESCRIPTION
URL for Webview was recently updated and must be
adapted for testcase

failing testcase: https://jenkins.catrob.at/job/Catroid-Multi-Job/84/testReport/junit/org.catrobat.catroid.uitest.ui.activity/WebViewActivityTest/testWebView/
single ui test on emulator: https://jenkins.catrob.at/job/Catroid-single-UI-emulator/138/
