### PR TITLE
'Refactor' Manifest. (Themes, targetSdk)

### DIFF
--- a/catroid/AndroidManifest.xml
+++ b/catroid/AndroidManifest.xml
@@ -35,7 +35,7 @@
 
     <uses-sdk
         android:minSdkVersion="10"
-        android:targetSdkVersion="17" />
+        android:targetSdkVersion="18" />
 
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -53,12 +53,11 @@
     <application
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@android:style/Theme.Light.NoTitleBar" >
+        android:theme="@style/Theme.Catroid" >
         <activity
             android:name=".ui.MainMenuActivity"
-            android:screenOrientation="portrait"
-            android:theme="@style/Theme.Catroid" 
-            android:launchMode="standard">
+            android:launchMode="standard"
+            android:screenOrientation="portrait" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -100,8 +99,7 @@
         </activity>
         <activity
             android:name=".ui.WebViewActivity"
-            android:screenOrientation="portrait"
-            android:theme="@style/Theme.Catroid" />
+            android:screenOrientation="portrait" />
         <activity
             android:name=".stage.StageActivity"
             android:configChanges="orientation"
@@ -114,28 +112,23 @@
         <activity
             android:name=".ui.ProjectActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.Catroid"
             android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".ui.ProgramMenuActivity"
-            android:screenOrientation="portrait"
-            android:theme="@style/Theme.Catroid" />
+            android:screenOrientation="portrait" />
         <activity
             android:name=".ui.ScriptActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.Catroid"
             android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".ui.MyProjectsActivity"
             android:noHistory="true"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.Catroid"
             android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".ui.SettingsActivity"
             android:noHistory="true"
-            android:screenOrientation="portrait"
-            android:theme="@style/Theme.Catroid" />
+            android:screenOrientation="portrait" />
         <activity
             android:name=".bluetooth.DeviceListActivity"
             android:theme="@android:style/Theme.Dialog" />
@@ -143,8 +136,7 @@
             android:name=".soundrecorder.SoundRecorderActivity"
             android:exported="false"
             android:label="@string/soundrecorder_name"
-            android:screenOrientation="portrait"
-            android:theme="@style/Theme.Catroid" >
+            android:screenOrientation="portrait" >
             <intent-filter>
                 <action android:name="android.intent.action.GET_CONTENT" />
 

--- a/catroid/project.properties
+++ b/catroid/project.properties
@@ -8,5 +8,5 @@
 # project structure.
 
 # Project target.
-target=android-15
+target=android-18
 android.library.reference.1=../libraryProjects/actionbarsherlock

--- a/catroidTest/AndroidManifest.xml
+++ b/catroidTest/AndroidManifest.xml
@@ -28,7 +28,7 @@
 
     <uses-sdk
         android:minSdkVersion="10"
-        android:targetSdkVersion="17" />
+        android:targetSdkVersion="18" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 

--- a/catroidTest/project.properties
+++ b/catroidTest/project.properties
@@ -8,4 +8,4 @@
 # project structure.
 
 # Project target.
-target=android-15
+target=android-18

--- a/catroidUiTest/AndroidManifest.xml
+++ b/catroidUiTest/AndroidManifest.xml
@@ -28,7 +28,7 @@
 
     <uses-sdk
         android:minSdkVersion="10"
-        android:targetSdkVersion="17" />
+        android:targetSdkVersion="18" />
 
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH" />

--- a/catroidUiTest/project.properties
+++ b/catroidUiTest/project.properties
@@ -8,4 +8,4 @@
 # project structure.
 
 # Project target.
-target=android-15
+target=android-18


### PR DESCRIPTION
- Updated Manifest to use `targetSdkVersion="18"`
  Quote:
  "To better optimize your app for devices running Android 4.3, you
  should set your `targetSdkVersion` to `"18"`, install it on an Android 4.3
  system image, test it, then publish an update with this change."
  https://developer.android.com/about/versions/android-4.3.html.
  
  Also I want to force people to update their SDK.
- Updated Manifest to use `Theme.Catroid` application-wide and not for
  every activity individually. Removes clutter.
- Updated `project.properties` to use `target=android-18`. This does not
  affect the final APK, it's just what Eclipse offers us as APIs.

Testrun incoming.
