### PR TITLE
Fixed Issue#423 - Can't add image from camera

### DIFF
--- a/catroid/src/org/catrobat/catroid/utils/UtilCamera.java
+++ b/catroid/src/org/catrobat/catroid/utils/UtilCamera.java
@@ -42,7 +42,7 @@ public class UtilCamera {
 	}
 
 	public static Uri getDefaultLookFromCameraUri(String defLookName) {
-		File pictureFile = new File(Constants.TMP_PATH, defLookName + ".jpg");
+		File pictureFile = new File(Constants.DEFAULT_ROOT, defLookName + ".jpg");
 		return Uri.fromFile(pictureFile);
 	}
 
@@ -58,7 +58,7 @@ public class UtilCamera {
 			Bitmap fullSizeBitmap = ImageEditing.getScaledBitmapFromPath(fullSizeImage.getAbsolutePath(),
 					project.getXmlHeader().virtualScreenHeight, project.getXmlHeader().virtualScreenWidth, true);
 			Bitmap rotatedBitmap = ImageEditing.rotateBitmap(fullSizeBitmap, rotate);
-			File downScaledCameraPicture = new File(Constants.TMP_PATH, defLookName + ".jpg");
+			File downScaledCameraPicture = new File(Constants.DEFAULT_ROOT, defLookName + ".jpg");
 			rotatedPictureUri = Uri.fromFile(downScaledCameraPicture);
 			try {
 				StorageHandler.saveBitmapToImageFile(downScaledCameraPicture, rotatedBitmap);


### PR DESCRIPTION
This issue was unrelated to the type of device or the Android version running on it.
The camera images could only be added if the tmp/ folder inside the root folder existed.
Since the tmp/ folder could potentially contain a users project, I fixed this issue by saving the temporary image in the root folder.

Jenkins runs:

https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/184/#showFailuresLink
https://jenkins.catrob.at/job/Catroid-single-UI-device/25/console
