### PR TITLE
quick fix for #614 (no webview on old devices)

### DIFF
--- a/catroid/res/layout/dialog_web_warning.xml
+++ b/catroid/res/layout/dialog_web_warning.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ *  Catroid: An on-device visual programming system for Android devices
+ *  Copyright (C) 2010-2013 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *  
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *  
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  http://developer.catrobat.org/license_additional_term
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:theme="@android:style/Theme.Light" >
+
+    <CheckBox
+        android:id="@+id/main_menu_web_dialog_dont_show_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checked="false"
+        android:text="@string/main_menu_web_dialog_dont_show" />
+
+</LinearLayout>

--- a/catroid/res/values-de/strings.xml
+++ b/catroid/res/values-de/strings.xml
@@ -58,6 +58,9 @@
     <string name="main_menu_about_pocketcode">Über Pocket Code</string>
     <string name="main_menu_rate_app">Bewerte uns!</string>
     <string name="main_menu_play_store_not_installed">Play Store App nicht gefunden</string>
+    <string name="main_menu_web_dialog_title">Achtung!</string>
+    <string name="main_menu_web_dialog_message">Derzeit werden keine alternativen Browser wie Firefox oder Dolphin unterstützt</string>
+    <string name="main_menu_web_dialog_dont_show">Nicht mehr anzeigen</string>
     <!--  -->
 
 

--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -58,6 +58,9 @@
     <string name="main_menu_about_pocketcode">About Pocket Code</string>
     <string name="main_menu_rate_app">Rate us!</string>
     <string name="main_menu_play_store_not_installed">Play Store app not found</string>
+    <string name="main_menu_web_dialog_title">Caution!</string>
+    <string name="main_menu_web_dialog_message">Currently alternative browsers like Firefox or Dolphin are not supported</string>
+    <string name="main_menu_web_dialog_dont_show">Don\'t show again</string>
     <!--  -->
 
 

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/WebViewActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/WebViewActivityTest.java
@@ -22,32 +22,95 @@
  */
 package org.catrobat.catroid.uitest.ui.activity;
 
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.preference.PreferenceManager;
 import android.webkit.WebView;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.ui.WebViewActivity;
+import org.catrobat.catroid.uitest.annotation.Device;
 import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
 
 public class WebViewActivityTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
 	private static final String COPYRIGHT_CHARACTER = "\u00A9";
+	private boolean containsSetting;
+	private boolean showWarning;
+	private SharedPreferences preferences;
 
 	public WebViewActivityTest() {
 		super(MainMenuActivity.class);
 	}
 
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+
+		preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
+		containsSetting = preferences.contains(MainMenuActivity.SHARED_PREFERENCES_SHOW_BROWSER_WARNING);
+		showWarning = preferences.getBoolean(MainMenuActivity.SHARED_PREFERENCES_SHOW_BROWSER_WARNING, true);
+		preferences.edit().remove(MainMenuActivity.SHARED_PREFERENCES_SHOW_BROWSER_WARNING).commit();
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		if (containsSetting) {
+			preferences.edit().putBoolean(MainMenuActivity.SHARED_PREFERENCES_SHOW_BROWSER_WARNING, showWarning)
+					.commit();
+		}
+
+		super.tearDown();
+	}
+
 	public void testWebView() {
-		solo.clickOnButton(solo.getString(R.string.main_menu_web));
-		solo.waitForView(solo.getView(R.id.webView));
-		solo.sleep(2000);
+		String webButtonText = solo.getString(R.string.main_menu_web);
 
-		assertEquals("Current Activity is not WebViewActivity", WebViewActivity.class, solo.getCurrentActivity()
-				.getClass());
+		solo.clickOnButton(webButtonText);
 
-		WebView webView = (WebView) solo.getCurrentActivity().findViewById(R.id.webView);
-		assertEquals("URL is not correct", Constants.CATROBAT_WEBVIEW_URL, webView.getUrl());
+		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.GINGERBREAD_MR1) {
+			solo.waitForView(solo.getView(R.id.webView));
+			solo.sleep(2000);
 
-		assertTrue("website hasn't been loaded properly", solo.searchText(COPYRIGHT_CHARACTER + " Catrobat"));
+			assertEquals("Current Activity is not WebViewActivity", WebViewActivity.class, solo.getCurrentActivity()
+					.getClass());
+
+			WebView webView = (WebView) solo.getCurrentActivity().findViewById(R.id.webView);
+			assertEquals("URL is not correct", Constants.CATROBAT_WEBVIEW_URL, webView.getUrl());
+
+			assertTrue("website hasn't been loaded properly", solo.searchText(COPYRIGHT_CHARACTER + " Catrobat"));
+		} else {
+			fail("This test is made for API 11 or above");
+		}
+	}
+
+	@Device
+	public void testWebOnOldDevices() {
+		String webButtonText = solo.getString(R.string.main_menu_web);
+		String cancelButtonText = solo.getString(R.string.cancel_button);
+		String dialogTitleText = solo.getString(R.string.main_menu_web_dialog_title);
+
+		solo.clickOnButton(webButtonText);
+
+		if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.GINGERBREAD_MR1) {
+			solo.sleep(300);
+			assertTrue("Alert dialog title not found", solo.searchText(dialogTitleText));
+			assertTrue("Alert dialog message not found",
+					solo.searchText(solo.getString(R.string.main_menu_web_dialog_message)));
+			assertTrue("OK button not found", solo.searchText(solo.getString(R.string.ok)));
+			assertTrue("Cancel button not found", solo.searchText(cancelButtonText));
+
+			solo.clickOnButton(cancelButtonText);
+			solo.sleep(200);
+			assertFalse("Dialog was not closed when pressing cancel", solo.searchText(dialogTitleText));
+			solo.clickOnButton(webButtonText);
+			solo.sleep(300);
+			solo.goBack();
+			assertFalse("Dialog was not closed when clicked back button", solo.searchText(dialogTitleText));
+		} else {
+			fail("This test is made for API 10 or lower");
+		}
+
 	}
 }


### PR DESCRIPTION
- fixes #614 by invoking the browser intent on old devices again
- also the alert dialog warning will be shown
- new option to disable this dialog
## Jenkins testruns
### Multi-Job

https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/210/
### Changed WebViewActivityTest

Both tests of WebViewActivityTest are made for Jenkins Multi-Job to test them on the correct devices. Forced to test it either on emulator or device will fail on those tests where the API does not match.
https://jenkins.catrob.at/view/Catroid/job/Catroid-single-UI-device/32/
https://jenkins.catrob.at/view/Catroid/job/Catroid-single-UI-emulator/148/
