### PR TITLE
no bricks are required to show the first look

### DIFF
--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -26,7 +26,7 @@ import android.os.Environment;
 
 public final class Constants {
 
-	public static final float SUPPORTED_CATROBAT_LANGUAGE_VERSION = 0.8f;
+	public static final float SUPPORTED_CATROBAT_LANGUAGE_VERSION = 0.9f;
 	public static final String PLATFORM_NAME = "Android";
 	public static final int APPLICATION_BUILD_NUMBER = 0; // updated from jenkins nightly/release build
 	public static final String APPLICATION_BUILD_NAME = ""; // updated from jenkins nightly/release build

--- a/catroid/src/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/org/catrobat/catroid/stage/StageListener.java
@@ -276,10 +276,10 @@ public class StageListener implements ApplicationListener {
 			sprites = project.getSpriteList();
 			if (spriteSize > 0) {
 				sprites.get(0).look.setLookData(createWhiteBackgroundLookData());
-				sprites.get(0).pause();
 			}
+			Sprite sprite;
 			for (int i = 0; i < spriteSize; i++) {
-				Sprite sprite = sprites.get(i);
+				sprite = sprites.get(i);
 				sprite.resetSprite();
 				sprite.look.createBrightnessContrastShader();
 				stage.addActor(sprite.look);
@@ -324,8 +324,13 @@ public class StageListener implements ApplicationListener {
 			if (spriteSize > 0) {
 				sprites.get(0).look.setLookData(createWhiteBackgroundLookData());
 			}
+			Sprite sprite;
 			for (int i = 0; i < spriteSize; i++) {
-				sprites.get(i).createStartScriptActionSequence();
+				sprite = sprites.get(i);
+				sprite.createStartScriptActionSequence();
+				if (!sprite.getLookDataList().isEmpty()) {
+					sprite.look.setLookData(sprite.getLookDataList().get(0));
+				}
 			}
 			firstStart = false;
 		}

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/stage/StageTestComplex.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/stage/StageTestComplex.java
@@ -34,7 +34,6 @@ import org.catrobat.catroid.content.bricks.ComeToFrontBrick;
 import org.catrobat.catroid.content.bricks.PlaceAtBrick;
 import org.catrobat.catroid.content.bricks.SetBrightnessBrick;
 import org.catrobat.catroid.content.bricks.SetGhostEffectBrick;
-import org.catrobat.catroid.content.bricks.SetLookBrick;
 import org.catrobat.catroid.content.bricks.SetSizeToBrick;
 import org.catrobat.catroid.content.bricks.TurnLeftBrick;
 import org.catrobat.catroid.io.StorageHandler;
@@ -46,13 +45,22 @@ import org.catrobat.catroid.uitest.util.UiTestUtils;
 
 import java.io.File;
 
-public class ComplexStageTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
-	private final int screenWidth = 480;
-	private final int screenHeight = 800;
+public class StageTestComplex extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
+	private static final int SCREEN_WIDTH = 480;
+	private static final int SCREEN_HEIGHT = 800;
+
+	private static final byte[] RED_PIXEL = { (byte) 237, 28, 36, (byte) 255 };
+	private static final byte[] RED_BRIGHTNESS_PIXEL = { (byte) 109, 0, 0, (byte) 255 };
+	private static final byte[] GREEN_PIXEL = { 34, (byte) 177, 76, (byte) 255 };
+	private static final byte[] YELLOW_PIXEL = { (byte) 255, (byte) 242, 0, (byte) 255 };
+	private static final byte[] BLUE_PIXEL = { 0, (byte) 162, (byte) 232, (byte) 255 };
+	private static final byte[] WHITE_PIXEL = { (byte) 255, (byte) 255, (byte) 255, (byte) 255 };
+	private static final byte[] BLACK_PIXEL = { (byte) 0, (byte) 0, (byte) 0, (byte) 255 };
+	private static final byte[] BLACK_BRIGHTNESS_PIXEL = { (byte) 127, (byte) 127, (byte) 127, (byte) 255 };
 
 	private Project project;
 
-	public ComplexStageTest() {
+	public StageTestComplex() {
 		super(MainMenuActivity.class);
 	}
 
@@ -67,92 +75,126 @@ public class ComplexStageTest extends BaseActivityInstrumentationTestCase<MainMe
 
 	@Device
 	public void testShowTexture() {
-		byte[] redPixel = { (byte) 237, 28, 36, (byte) 255 };
-		byte[] redBrightnessPixel = { (byte) 109, 0, 0, (byte) 255 };
-		byte[] greenPixel = { 34, (byte) 177, 76, (byte) 255 };
-		byte[] yellowPixel = { (byte) 255, (byte) 242, 0, (byte) 255 };
-		byte[] bluePixel = { 0, (byte) 162, (byte) 232, (byte) 255 };
-		byte[] whitePixel = { (byte) 255, (byte) 255, (byte) 255, (byte) 255 };
-		byte[] blackPixel = { (byte) 0, (byte) 0, (byte) 0, (byte) 255 };
-		byte[] blackBrightnessPixel = { (byte) 127, (byte) 127, (byte) 127, (byte) 255 };
-
 		solo.waitForActivity(StageActivity.class.getSimpleName());
 		solo.sleep(1400);
-		byte[] screenArray = StageActivity.stageListener.getPixels(0, 0, screenWidth, screenHeight);
+		byte[] screenArray = StageActivity.stageListener.getPixels(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
 
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(redPixel, screenArray, -41, -41, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(redPixel, screenArray, -41, -2, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(redPixel, screenArray, -2, -41, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(redPixel, screenArray, -2, -2, screenWidth, screenHeight);
+		UiTestUtils
+				.comparePixelArrayWithPixelScreenArray(RED_PIXEL, screenArray, -41, -41, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(RED_PIXEL, screenArray, -41, -2, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(RED_PIXEL, screenArray, -2, -41, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(RED_PIXEL, screenArray, -2, -2, SCREEN_WIDTH, SCREEN_HEIGHT);
 
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 1, -2, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 40, -2, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 1, -41, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 40, -41, screenWidth, screenHeight);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 1, -2, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils
+				.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 40, -2, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils
+				.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 1, -41, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 40, -41, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
 
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(yellowPixel, screenArray, -21, 21, screenWidth, screenHeight);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(YELLOW_PIXEL, screenArray, -21, 21, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
 
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(whitePixel, screenArray, 0, 0, screenWidth, screenHeight);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(WHITE_PIXEL, screenArray, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
 
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(blackPixel, screenArray, -80, -80, screenWidth, screenHeight);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(BLACK_PIXEL, screenArray, -80, -80, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
 
-		solo.clickOnScreen((screenWidth / 2) + 21, (screenHeight / 2) - 21);
+		solo.clickOnScreen((SCREEN_WIDTH / 2) + 21, (SCREEN_HEIGHT / 2) - 21);
 		solo.sleep(300);
-		screenArray = StageActivity.stageListener.getPixels(0, 0, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(bluePixel, screenArray, 21, 21, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(bluePixel, screenArray, 0, 0, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(bluePixel, screenArray, 21 - 40, 21 - 40, screenWidth,
-				screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(redPixel, screenArray, 21 - 41, 21 - 41, screenWidth,
-				screenHeight);
+		screenArray = StageActivity.stageListener.getPixels(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(BLUE_PIXEL, screenArray, 21, 21, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(BLUE_PIXEL, screenArray, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(BLUE_PIXEL, screenArray, 21 - 40, 21 - 40, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(RED_PIXEL, screenArray, 21 - 41, 21 - 41, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
 
-		solo.clickOnScreen((screenWidth / 2) - 21, (screenHeight / 2) - 21);
+		solo.clickOnScreen((SCREEN_WIDTH / 2) - 21, (SCREEN_HEIGHT / 2) - 21);
 		solo.sleep(300);
-		screenArray = StageActivity.stageListener.getPixels(0, 0, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(whitePixel, screenArray, -31, 21, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(bluePixel, screenArray, 21, 21, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(redPixel, screenArray, -41, -41, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 40, -41, screenWidth, screenHeight);
+		screenArray = StageActivity.stageListener.getPixels(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(WHITE_PIXEL, screenArray, -31, 21, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(BLUE_PIXEL, screenArray, 21, 21, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils
+				.comparePixelArrayWithPixelScreenArray(RED_PIXEL, screenArray, -41, -41, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 40, -41, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
 
-		solo.clickOnScreen((screenWidth / 2) + 21, (screenHeight / 2) + 21);
+		solo.clickOnScreen((SCREEN_WIDTH / 2) + 21, (SCREEN_HEIGHT / 2) + 21);
 		solo.sleep(300);
-		screenArray = StageActivity.stageListener.getPixels(0, 0, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 1, -2, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 40, -2, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 1, -41, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 40, -41, screenWidth, screenHeight);
+		screenArray = StageActivity.stageListener.getPixels(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 1, -2, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils
+				.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 40, -2, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils
+				.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 1, -41, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 40, -41, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
 
-		solo.clickOnScreen((screenWidth / 2) - 21, (screenHeight / 2) + 21);
+		solo.clickOnScreen((SCREEN_WIDTH / 2) - 21, (SCREEN_HEIGHT / 2) + 21);
 		solo.sleep(300);
-		screenArray = StageActivity.stageListener.getPixels(0, 0, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(redBrightnessPixel, screenArray, -21, -21, screenWidth,
-				screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(redBrightnessPixel, screenArray, -21, -21 + 27, screenWidth,
-				screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 1, -2, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 40, -2, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 1, -41, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(greenPixel, screenArray, 40, -41, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(bluePixel, screenArray, 21, 21, screenWidth, screenHeight);
+		screenArray = StageActivity.stageListener.getPixels(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(RED_BRIGHTNESS_PIXEL, screenArray, -21, -21, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(RED_BRIGHTNESS_PIXEL, screenArray, -21, -21 + 27,
+				SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 1, -2, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils
+				.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 40, -2, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils
+				.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 1, -41, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(GREEN_PIXEL, screenArray, 40, -41, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(BLUE_PIXEL, screenArray, 21, 21, SCREEN_WIDTH, SCREEN_HEIGHT);
 
-		solo.clickOnScreen((screenWidth / 2) - 50, (screenHeight / 2) - 50);
+		solo.clickOnScreen((SCREEN_WIDTH / 2) - 50, (SCREEN_HEIGHT / 2) - 50);
 		solo.sleep(300);
-		screenArray = StageActivity.stageListener.getPixels(0, 0, screenWidth, screenHeight);
-		UiTestUtils.comparePixelArrayWithPixelScreenArray(blackBrightnessPixel, screenArray, -54, 55, screenWidth,
-				screenHeight);
+		screenArray = StageActivity.stageListener.getPixels(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(BLACK_BRIGHTNESS_PIXEL, screenArray, -54, 55, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
 		assertTrue("Just for FileTest", true);
 	}
 
+	public void testBehaviourWithoutBricks() {
+		Project project = ProjectManager.getInstance().getCurrentProject();
+		assertNotNull("current project was null", project);
+
+		Sprite blueSprite = project.getSpriteList().get(4);
+		while (blueSprite.getNumberOfScripts() > 0) {
+			blueSprite.removeScript(blueSprite.getScript(0));
+		}
+
+		assertEquals("there shouldn't be any script left", 0, blueSprite.getNumberOfScripts());
+		assertEquals("there shouldn't be any script left", 0, blueSprite.getNumberOfBricks());
+		StorageHandler.getInstance().loadProject(project.getName());
+
+		solo.waitForActivity(StageActivity.class.getSimpleName());
+		solo.sleep(1400);
+
+		byte[] screenArray = StageActivity.stageListener.getPixels(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(BLUE_PIXEL, screenArray, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(BLUE_PIXEL, screenArray, -19, -19, SCREEN_WIDTH,
+				SCREEN_HEIGHT);
+		UiTestUtils
+				.comparePixelArrayWithPixelScreenArray(BLUE_PIXEL, screenArray, -19, 19, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils
+				.comparePixelArrayWithPixelScreenArray(BLUE_PIXEL, screenArray, 19, -19, SCREEN_WIDTH, SCREEN_HEIGHT);
+		UiTestUtils.comparePixelArrayWithPixelScreenArray(BLUE_PIXEL, screenArray, 19, 19, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+		solo.sleep(2000);
+	}
+
 	private void createProject() {
-		ScreenValues.SCREEN_HEIGHT = screenHeight;
-		ScreenValues.SCREEN_WIDTH = screenWidth;
+		ScreenValues.SCREEN_HEIGHT = SCREEN_HEIGHT;
+		ScreenValues.SCREEN_WIDTH = SCREEN_WIDTH;
 
 		project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 
 		// yellow Sprite
 		Sprite yellowSprite = new Sprite("yellowSprite");
 		StartScript yellowStartScript = new StartScript(yellowSprite);
-		SetLookBrick yellowLookBrick = new SetLookBrick(yellowSprite);
 		LookData yellowLookData = new LookData();
 		String yellowImageName = "yellow_image.bmp";
 
@@ -160,8 +202,6 @@ public class ComplexStageTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		yellowSprite.getLookDataList().add(yellowLookData);
 
-		yellowLookBrick.setLook(yellowLookData);
-		yellowStartScript.addBrick(yellowLookBrick);
 		yellowStartScript.addBrick(new PlaceAtBrick(yellowSprite, -21, 21));
 
 		yellowSprite.addScript(yellowStartScript);
@@ -175,7 +215,6 @@ public class ComplexStageTest extends BaseActivityInstrumentationTestCase<MainMe
 		// blue Sprite
 		Sprite blueSprite = new Sprite("blueSprite");
 		StartScript blueStartScript = new StartScript(blueSprite);
-		SetLookBrick blueLookBrick = new SetLookBrick(blueSprite);
 		LookData blueLookData = new LookData();
 		String blueImageName = "blue_image.bmp";
 
@@ -183,8 +222,6 @@ public class ComplexStageTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		blueSprite.getLookDataList().add(blueLookData);
 
-		blueLookBrick.setLook(blueLookData);
-		blueStartScript.addBrick(blueLookBrick);
 		blueStartScript.addBrick(new PlaceAtBrick(blueSprite, 21, 21));
 
 		blueSprite.addScript(blueStartScript);
@@ -198,7 +235,6 @@ public class ComplexStageTest extends BaseActivityInstrumentationTestCase<MainMe
 		// green Sprite
 		Sprite greenSprite = new Sprite("greenSprite");
 		StartScript greenStartScript = new StartScript(greenSprite);
-		SetLookBrick greenLookBrick = new SetLookBrick(greenSprite);
 		LookData greenLookData = new LookData();
 		String greenImageName = "green_image.bmp";
 
@@ -206,8 +242,6 @@ public class ComplexStageTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		greenSprite.getLookDataList().add(greenLookData);
 
-		greenLookBrick.setLook(greenLookData);
-		greenStartScript.addBrick(greenLookBrick);
 		greenStartScript.addBrick(new PlaceAtBrick(greenSprite, 21, -21));
 
 		greenSprite.addScript(greenStartScript);
@@ -221,7 +255,6 @@ public class ComplexStageTest extends BaseActivityInstrumentationTestCase<MainMe
 		// red Sprite
 		Sprite redSprite = new Sprite("redSprite");
 		StartScript redStartScript = new StartScript(redSprite);
-		SetLookBrick redLookBrick = new SetLookBrick(redSprite);
 		LookData redLookData = new LookData();
 		String redImageName = "red_image.bmp";
 
@@ -229,8 +262,6 @@ public class ComplexStageTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		redSprite.getLookDataList().add(redLookData);
 
-		redLookBrick.setLook(redLookData);
-		redStartScript.addBrick(redLookBrick);
 		redStartScript.addBrick(new PlaceAtBrick(redSprite, -21, -21));
 
 		redSprite.addScript(redStartScript);
@@ -248,7 +279,6 @@ public class ComplexStageTest extends BaseActivityInstrumentationTestCase<MainMe
 		// black Sprite
 		Sprite blackSprite = new Sprite("blackSprite");
 		StartScript blackStartScript = new StartScript(blackSprite);
-		SetLookBrick blackLookBrick = new SetLookBrick(blackSprite);
 		LookData blackLookData = new LookData();
 		String blackImageName = "black_image.bmp";
 
@@ -256,8 +286,6 @@ public class ComplexStageTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		blackSprite.getLookDataList().add(blackLookData);
 
-		blackLookBrick.setLook(blackLookData);
-		blackStartScript.addBrick(blackLookBrick);
 		blackStartScript.addBrick(new PlaceAtBrick(blackSprite, -50, 50));
 
 		blackSprite.addScript(blackStartScript);

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/stage/StageTestSimple.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/stage/StageTestSimple.java
@@ -31,9 +31,9 @@ import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
 import org.catrobat.catroid.uitest.util.UiTestUtils;
 
-public class SimpleStageTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
+public class StageTestSimple extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
 
-	public SimpleStageTest() {
+	public StageTestSimple() {
 		super(MainMenuActivity.class);
 	}
 


### PR DESCRIPTION
This semantic change seems to be more straightforward and easier to use.

Changed in this commit:
- Catrobat-Language version update to 0.9
- If there's a look in the object it will be shown by default
- Adapted and refactored test case plus a new one

**Jenkins:**
https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/281/

SetVariableTest.testCreateNewUserVariableAndDeletion:
https://jenkins.catrob.at/view/Catroid/job/Catroid-single-UI-emulator/163/
(seems to be unstable - 1/3)
