### PR TITLE
Actionbar title not updated

### DIFF
--- a/catroid/src/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -51,6 +51,7 @@ import com.actionbarsherlock.app.SherlockFragment;
 import com.actionbarsherlock.app.SherlockFragmentActivity;
 import com.actionbarsherlock.view.Menu;
 
+import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.formulaeditor.Formula;
@@ -107,8 +108,8 @@ public class FormulaEditorFragment extends SherlockFragment implements OnKeyList
 
 	private void setUpActionBar() {
 		ActionBar actionBar = getSherlockActivity().getSupportActionBar();
+		previousActionBarTitle = ProjectManager.getInstance().getCurrentSprite().getName();
 		actionBar.setDisplayShowTitleEnabled(true);
-		previousActionBarTitle = actionBar.getTitle();
 		actionBar.setTitle(getString(R.string.formula_editor_title));
 	}
 

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ScriptActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ScriptActivityTest.java
@@ -37,6 +37,7 @@ import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.ui.ProgramMenuActivity;
 import org.catrobat.catroid.ui.ScriptActivity;
 import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.uitest.annotation.Device;
 import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
 import org.catrobat.catroid.uitest.util.UiTestUtils;
 
@@ -134,6 +135,17 @@ public class ScriptActivityTest extends BaseActivityInstrumentationTestCase<Main
 		assertEquals("Current sprite name is not shown as actionbar title or is wrong", "cat", currentSprite);
 
 		checkSettingsAndGoBack();
+	}
+
+	//regression test for issue#626; Android version < 4.2
+	@Device
+	public void testActionBarTitle() {
+		assertTrue("Sprite name not found", solo.waitForText("cat"));
+		solo.waitForView(solo.getView(R.id.brick_set_size_to_edit_text));
+		solo.clickOnView(solo.getView(R.id.brick_set_size_to_edit_text));
+		assertTrue("FormulaEditor title not found", solo.waitForText(solo.getString(R.string.formula_editor_title)));
+		solo.goBack();
+		assertTrue("Sprite name not found", solo.waitForText("cat"));
 	}
 
 	private void checkplayProgramButton() {


### PR DESCRIPTION
When leaving the formula editor back to the script, the title in the Actionbar wasn't updated and still said "Formula Editor"
- the previous Actionbar title is now delivered by the ProjectManager (currentSprite)
- added Testcase to check the title in the Actionbar

Fix Issue #626 

Test: https://jenkins.catrob.at/view/Catroid/job/Catroid-Multi-Job-Custom-Branch/292/
