### PR TITLE
new version 0.9.2

### DIFF
--- a/catroid/AndroidManifest.xml
+++ b/catroid/AndroidManifest.xml
@@ -24,8 +24,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.catrobat.catroid"
     android:installLocation="auto"
-    android:versionCode="8"
-    android:versionName="0.9.1" >
+    android:versionCode="9"
+    android:versionName="0.9.2" >
 
     <supports-screens
         android:largeScreens="true"

--- a/catroidTest/AndroidManifest.xml
+++ b/catroidTest/AndroidManifest.xml
@@ -23,8 +23,8 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.catrobat.catroid.test"
-    android:versionCode="8"
-    android:versionName="0.9.1" >
+    android:versionCode="9"
+    android:versionName="0.9.2" >
 
     <uses-sdk
         android:minSdkVersion="10"

--- a/catroidUiTest/AndroidManifest.xml
+++ b/catroidUiTest/AndroidManifest.xml
@@ -23,8 +23,8 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.catrobat.catroid.uitest"
-    android:versionCode="8"
-    android:versionName="0.9.1" >
+    android:versionCode="9"
+    android:versionName="0.9.2" >
 
     <uses-sdk
         android:minSdkVersion="10"


### PR DESCRIPTION
Changes for 0.9.2:
- 0.9.1 build for Play was erroneous
- fixed: copying a brick may crashes the app
