### PR TITLE
fix failing testcase

### DIFF
--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ProjectActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ProjectActivityTest.java
@@ -319,7 +319,7 @@ public class ProjectActivityTest extends BaseActivityInstrumentationTestCase<Mai
 
 	@Device
 	public void testBackgroundSprite() {
-		String sometext = "something" + System.currentTimeMillis();
+		String sometext = UiTestUtils.PROJECTNAME1;
 
 		solo.clickOnText(solo.getString(R.string.main_menu_new));
 		solo.waitForText(solo.getString(R.string.new_project_dialog_title));

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ScriptActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ScriptActivityTest.java
@@ -144,7 +144,14 @@ public class ScriptActivityTest extends BaseActivityInstrumentationTestCase<Main
 		solo.waitForView(solo.getView(R.id.brick_set_size_to_edit_text));
 		solo.clickOnView(solo.getView(R.id.brick_set_size_to_edit_text));
 		assertTrue("FormulaEditor title not found", solo.waitForText(solo.getString(R.string.formula_editor_title)));
+
 		solo.goBack();
+		// workaround for testdevice - Bug in Catroid-multi-job
+		// for some reason the discard changes dialog appears without changing anything
+		if (solo.searchText(solo.getString(R.string.formula_editor_discard_changes_dialog_title))) {
+			solo.clickOnText(solo.getString(R.string.no));
+		}
+		solo.sleep(200);
 		assertTrue("Sprite name not found", solo.waitForText("cat"));
 	}
 


### PR DESCRIPTION
one testcase in our multi-job failed but is working in single runs.
https://jenkins.catrob.at/job/Catroid-Multi-Job/134/testReport/org.catrobat.catroid.uitest.ui.activity/ScriptActivityTest/testActionBarTitle/history/?

test was refactored - a green build is possible ^^
testrun: https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/319/ 

I also refactored the testBackgroundSprite; this testcase created projects with a custom name: a prefix ("something") and a timestamp, but these projects are not deleted in tearDown (never :D). good practise is to use programnames from UiTestUtils if possible, because programs with these names are handled by the tearDown of the basetestclass.
