### PR TITLE
Correctly start Pocket Paint or Paintroid, depending on our build

### DIFF
--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -74,6 +74,7 @@ public final class Constants {
 	//Various:
 	public static final int BUFFER_8K = 8 * 1024;
 	public static final String POCKET_PAINT_DOWNLOAD_LINK = "market://details?id=" + POCKET_PAINT_PACKAGE_NAME;
+	public static final String POCKET_PAINT_DOWNLOAD_LINK_NIGHTLY = "http://files.catrob.at/pocketpaint_nightly.apk";
 	public static final String PREF_PROJECTNAME_KEY = "projectName";
 
 	//Services + Notifications

--- a/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
@@ -65,6 +65,7 @@ import com.actionbarsherlock.view.ActionMode;
 import com.actionbarsherlock.view.Menu;
 import com.badlogic.gdx.graphics.Pixmap;
 
+import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
@@ -740,9 +741,16 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 					.setPositiveButton(getString(R.string.yes), new DialogInterface.OnClickListener() {
 						@Override
 						public void onClick(DialogInterface dialog, int id) {
-							Intent downloadPocketPaintIntent = new Intent(Intent.ACTION_VIEW, Uri
-									.parse(Constants.POCKET_PAINT_DOWNLOAD_LINK));
-							startActivity(downloadPocketPaintIntent);
+
+							if (BuildConfig.DEBUG) {
+								Intent downloadPocketPaintIntent = new Intent(Intent.ACTION_VIEW, Uri
+										.parse(Constants.POCKET_PAINT_DOWNLOAD_LINK_NIGHTLY));
+								startActivity(downloadPocketPaintIntent);
+							} else {
+								Intent downloadPocketPaintIntent = new Intent(Intent.ACTION_VIEW, Uri
+										.parse(Constants.POCKET_PAINT_DOWNLOAD_LINK));
+								startActivity(downloadPocketPaintIntent);
+							}
 						}
 					}).setNegativeButton(getString(R.string.no), new DialogInterface.OnClickListener() {
 						@Override


### PR DESCRIPTION
Depending on the build (release or debug) either a debug version of Paintdroid (debug) or the store version of Pocket Paint is offered as download. The download is only offered if there is no version of Pocket Paint or Paintdroid installed.
- added download of debug version of Paintdroid to checkIfPocketPaintIsInstalled() in LookFragment.
- added POCKET_PAINT_DOWNLOAD_LINK_NIGHTLY to constants.

Issue #586 

test: https://jenkins.catrob.at/view/Catroid/job/Catroid-Multi-Job-Custom-Branch/332/
