### PR TITLE
Fixes #686

### DIFF
--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -28,7 +28,7 @@ public final class Constants {
 
 	// Reflection in testcases needed
 	// http://stackoverflow.com/questions/1615163/modifying-final-fields-in-java?answertab=votes#tab-top
-	public static final float SUPPORTED_CATROBAT_LANGUAGE_VERSION = Float.valueOf(0.9f);
+	public static final float SUPPORTED_CATROBAT_LANGUAGE_VERSION = Float.valueOf(0.91f);
 
 	public static final String PLATFORM_NAME = "Android";
 	public static final int APPLICATION_BUILD_NUMBER = 0; // updated from jenkins nightly/release build

--- a/catroid/src/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/org/catrobat/catroid/stage/StageListener.java
@@ -260,7 +260,7 @@ public class StageListener implements ApplicationListener {
 
 	@Override
 	public void render() {
-
+		Gdx.gl.glClearColor(1f, 1f, 1f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		if (reloadProject) {

--- a/catroid/src/org/catrobat/catroid/ui/BrickLayout.java
+++ b/catroid/src/org/catrobat/catroid/ui/BrickLayout.java
@@ -151,7 +151,7 @@ public class BrickLayout extends ViewGroup {
 		int modeWidth = MeasureSpec.getMode(widthMeasureSpec);
 		int modeHeight = MeasureSpec.getMode(heightMeasureSpec);
 
-		int lineThicknessWithorizontalSpacing = 0;
+		int lineThicknessWithHorizontalSpacing = 0;
 		int lineThickness = 0;
 		int lineLengthWithHorizontalSpacing = 0;
 		int lineLength = 0;
@@ -267,7 +267,7 @@ public class BrickLayout extends ViewGroup {
 
 		// ************************ BEGIN LAYOUT ************************
 
-		lineThicknessWithorizontalSpacing = 0;
+		lineThicknessWithHorizontalSpacing = 0;
 		lineThickness = 0;
 		lineLengthWithHorizontalSpacing = 0;
 		lineLength = 0;
@@ -319,17 +319,17 @@ public class BrickLayout extends ViewGroup {
 
 				if (newLine) {
 					newLine = false;
-					prevLinePosition = prevLinePosition + lineThicknessWithorizontalSpacing;
+					prevLinePosition = prevLinePosition + lineThicknessWithHorizontalSpacing;
 
 					currentLine = getNextLine(currentLine);
 
 					lineThickness = childHeight;
 					lineLength = childWidth;
-					lineThicknessWithorizontalSpacing = childHeight + verticalSpacing;
+					lineThicknessWithHorizontalSpacing = childHeight + verticalSpacing;
 					lineLengthWithHorizontalSpacing = lineLength + horizontalSpacing;
 				}
 
-				lineThicknessWithorizontalSpacing = Math.max(lineThicknessWithorizontalSpacing, childHeight
+				lineThicknessWithHorizontalSpacing = Math.max(lineThicknessWithHorizontalSpacing, childHeight
 						+ verticalSpacing);
 				lineThickness = Math.max(lineThickness, childHeight);
 

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/stage/StageTestComplex.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/stage/StageTestComplex.java
@@ -56,7 +56,7 @@ public class StageTestComplex extends BaseActivityInstrumentationTestCase<MainMe
 	private static final byte[] BLUE_PIXEL = { 0, (byte) 162, (byte) 232, (byte) 255 };
 	private static final byte[] WHITE_PIXEL = { (byte) 255, (byte) 255, (byte) 255, (byte) 255 };
 	private static final byte[] BLACK_PIXEL = { (byte) 0, (byte) 0, (byte) 0, (byte) 255 };
-	private static final byte[] BLACK_BRIGHTNESS_PIXEL = { (byte) 127, (byte) 127, (byte) 127, (byte) 255 };
+	private static final byte[] BLACK_BRIGHTNESS_PIXEL = { (byte) -124, (byte) -124, (byte) -124, (byte) 255 };
 
 	private Project project;
 
@@ -78,6 +78,9 @@ public class StageTestComplex extends BaseActivityInstrumentationTestCase<MainMe
 		solo.waitForActivity(StageActivity.class.getSimpleName());
 		solo.sleep(1400);
 		byte[] screenArray = StageActivity.stageListener.getPixels(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+		UiTestUtils.comparePixelArrayWithPixelScreenArrayWithTolerance(WHITE_PIXEL, screenArray, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT,
+				0);
 
 		UiTestUtils
 				.comparePixelArrayWithPixelScreenArray(RED_PIXEL, screenArray, -41, -41, SCREEN_WIDTH, SCREEN_HEIGHT);
@@ -154,7 +157,7 @@ public class StageTestComplex extends BaseActivityInstrumentationTestCase<MainMe
 		screenArray = StageActivity.stageListener.getPixels(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
 		UiTestUtils.comparePixelArrayWithPixelScreenArray(BLACK_BRIGHTNESS_PIXEL, screenArray, -54, 55, SCREEN_WIDTH,
 				SCREEN_HEIGHT);
-		assertTrue("Just for FileTest", true);
+
 	}
 
 	public void testBehaviourWithoutBricks() {

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -1151,6 +1151,11 @@ public class UiTestUtils {
 
 	public static void comparePixelArrayWithPixelScreenArray(byte[] pixelArray, byte[] screenArray, int x, int y,
 			int screenWidth, int screenHeight) {
+		comparePixelArrayWithPixelScreenArrayWithTolerance(pixelArray, screenArray, x, y, screenWidth, screenHeight, 10);
+	}
+
+	public static void comparePixelArrayWithPixelScreenArrayWithTolerance(byte[] pixelArray, byte[] screenArray, int x, int y,
+			int screenWidth, int screenHeight, int tolerance) {
 		assertEquals("Length of pixel array not 4", 4, pixelArray.length);
 		int convertedX = x + (screenWidth / 2);
 		int convertedY = y + (screenHeight / 2);
@@ -1158,10 +1163,10 @@ public class UiTestUtils {
 		for (int i = 0; i < 4; i++) {
 			screenPixel[i] = screenArray[(convertedX * 3 + convertedX + convertedY * screenWidth * 4) + i];
 		}
-		assertEquals("Pixels don't have same content.", pixelArray[0], screenPixel[0], 10);
-		assertEquals("Pixels don't have same content.", pixelArray[1], screenPixel[1], 10);
-		assertEquals("Pixels don't have same content.", pixelArray[2], screenPixel[2], 10);
-		assertEquals("Pixels don't have same content.", pixelArray[3], screenPixel[3], 10);
+		assertEquals("Pixels don't have same content.", pixelArray[0], screenPixel[0], tolerance);
+		assertEquals("Pixels don't have same content.", pixelArray[1], screenPixel[1], tolerance);
+		assertEquals("Pixels don't have same content.", pixelArray[2], screenPixel[2], tolerance);
+		assertEquals("Pixels don't have same content.", pixelArray[3], screenPixel[3], tolerance);
 	}
 
 	/**


### PR DESCRIPTION
The default background is now always white.
- new method comparePixelArrayWithPixelScreenArrayWithTolerance
- adapted tests accordingly
- Catrobat language version was increased, due to a semantic change

Jenkins:
https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/490/
