### PR TITLE
add possibility to use our checkstyle config within eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ gen/
 # Local configuration file (sdk path, etc)
 local.properties
 proguard-project.txt
-.checkstyle

--- a/catroid/.checkstyle
+++ b/catroid/.checkstyle
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
+  <local-check-config name="Catroid Checkstyle" location="checkstyle.xml" type="project" description="">
+    <additional-data name="protect-config-file" value="true"/>
+  </local-check-config>
+  <fileset name="all" enabled="true" check-config-name="Catroid Checkstyle" local="true">
+    <file-match-pattern match-pattern="." include-pattern="true"/>
+  </fileset>
+  <filter name="FilesFromPackage" enabled="true">
+    <filter-data value="gen"/>
+  </filter>
+</fileset-config>

--- a/catroid/checkstyle.xml
+++ b/catroid/checkstyle.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *  Catroid: An on-device visual programming system for Android devices
+ *  Copyright (C) 2010-2013 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  http://developer.catrobat.org/license_additional_term
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+  <property name="severity" value="warning"/>
+  <module name="TreeWalker">
+    <module name="ClassTypeParameterName">
+      <message key="name.invalidPattern" value="Class type parameter not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="TypeName">
+      <message key="name.invalidPattern" value="Class name not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+      <message key="name.invalidPattern" value="Package name not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ParameterName">
+      <message key="name.invalidPattern" value="Parameter name not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="StaticVariableName">
+      <property name="format" value="^(([a-z]{2})|([x-z][A-Z]))[a-zA-Z0-9]*$"/>
+      <message key="name.invalidPattern" value="Static member variable not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MethodTypeParameterName">
+      <message key="name.invalidPattern" value="Method type parameter not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MethodName">
+      <message key="name.invalidPattern" value="Method name not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MemberName">
+      <property name="format" value="^(([a-z]{2})|([x-z][A-Z]))[a-zA-Z0-9]*$"/>
+      <message key="name.invalidPattern" value="Member name not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LocalVariableName">
+      <message key="name.invalidPattern" value="Local variable name not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LocalFinalVariableName">
+      <message key="name.invalidPattern" value="Local final variable name not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ConstantName">
+      <message key="name.invalidPattern" value="Constant name not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ModifierOrder">
+      <message key="mod.order" value="{0}'' modifier out of order with the JLS suggestions"/>
+    </module>
+    <module name="PackageDeclaration"/>
+    <module name="ImportOrder">
+      <property name="option" value="top"/>
+      <property name="groups" value="android,com,edu,junit,net,org,java,javax"/>
+      <property name="ordered" value="true"/>
+      <property name="separated" value="true"/>
+    </module>
+    <module name="UnusedImports"/>
+    <module name="RedundantImport"/>
+    <!-- needed for SuppressWithNearbyCommentFilter -->
+    <module name="FileContentsHolder"/>
+  </module>
+
+  <module name="SuppressWithNearbyCommentFilter">
+   <property name="commentFormat" value="CHECKSTYLE DISABLE ([\w\|]+) FOR (-?\d+) LINES"/>
+   <property name="checkFormat" value="$1"/>
+   <property name="influenceFormat" value="$2"/>
+  </module>
+</module>

--- a/catroidLegoNXTBTTest/.checkstyle
+++ b/catroidLegoNXTBTTest/.checkstyle
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
+  <local-check-config name="Catroid Checkstyle" location="/catroid/checkstyle.xml" type="project" description="">
+    <additional-data name="protect-config-file" value="true"/>
+  </local-check-config>
+  <fileset name="all" enabled="true" check-config-name="Catroid Checkstyle" local="true">
+    <file-match-pattern match-pattern="." include-pattern="true"/>
+  </fileset>
+</fileset-config>

--- a/catroidSourceTest/.checkstyle
+++ b/catroidSourceTest/.checkstyle
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
+  <local-check-config name="Catroid Checkstyle" location="/catroid/checkstyle.xml" type="project" description="">
+    <additional-data name="protect-config-file" value="true"/>
+  </local-check-config>
+  <fileset name="all" enabled="true" check-config-name="Catroid Checkstyle" local="true">
+    <file-match-pattern match-pattern="." include-pattern="true"/>
+  </fileset>
+</fileset-config>

--- a/catroidTest/.checkstyle
+++ b/catroidTest/.checkstyle
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
+  <local-check-config name="Catroid Checkstyle" location="/catroid/checkstyle.xml" type="project" description="">
+    <additional-data name="protect-config-file" value="true"/>
+  </local-check-config>
+  <fileset name="all" enabled="true" check-config-name="Catroid Checkstyle" local="true">
+    <file-match-pattern match-pattern="." include-pattern="true"/>
+  </fileset>
+  <filter name="FilesFromPackage" enabled="true">
+    <filter-data value="gen"/>
+  </filter>
+</fileset-config>

--- a/catroidUiTest/.checkstyle
+++ b/catroidUiTest/.checkstyle
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
+  <local-check-config name="Catroid Checkstyle" location="/catroid/checkstyle.xml" type="project" description="">
+    <additional-data name="protect-config-file" value="true"/>
+  </local-check-config>
+  <fileset name="all" enabled="true" check-config-name="Catroid Checkstyle" local="true">
+    <file-match-pattern match-pattern="." include-pattern="true"/>
+  </fileset>
+  <filter name="FilesFromPackage" enabled="true">
+    <filter-data value="gen"/>
+  </filter>
+</fileset-config>


### PR DESCRIPTION
I committed our checkstyle.xml config file (which is used on our Jenkins server) to the catroid project and all of our projects (catroid, catroidTest, ...) use this config (project relative checkstyle mode).
To check a project within Eclipse, rightclick on project name (multiselect possible), select checkstyle-check code with checkstyle.
Automatic check is disabled because it slows down the build process (project properties-checkstyle-activate will change the .checkstyle file) - but this behavior can be easily activated in the future!
Changes in project properties-checkstyle are not required, but will lead to a change of the corresponding .checkstyle file. Additionally the checkstyle config is protected against unintentional changes within project-properties->checkstyle->configure (Catroid Checkstyle local).
New checkstyle rules can be added either by adapting catroid/checkstyle.xml manually or by disabling the protection (project properties->checkstyle->Local check configurations->select->properties->disable protect checkstyle file - then you'll be able to configure Catroid Checkstyle local (but do not forget to "lock" the file afterwards); after modifying checkstyle.xml with configure steps, all comments/license header have to be added manually, because .xml file is formatted with checkstyle plugin!!

Feel free to test it out - might be useful for developers to check their code before committing/pushing.
