### PR TITLE
fix unstable test

### DIFF
--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
@@ -1234,7 +1234,6 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		projectCodeFile = new File(Utils.buildPath(Utils.buildProjectPath(UiTestUtils.PROJECTNAME1),
 				Constants.PROJECTCODE_NAME));
 		Date now = new Date();
-		System.gc();
 		projectCodeFile.setLastModified(now.getTime() - DateUtils.DAY_IN_MILLIS);
 
 		solo.sleep(200);


### PR DESCRIPTION
since the merge of GSoC backpack, testProjectDetailsLastAccess failed from time to time (you can click on "older" to get to the first build where it failed; test never failed before)
https://jenkins.catrob.at/job/DeviceTest/592/testReport/junit/org.catrobat.catroid.uitest.ui.activity/MyProjectsActivityTest/testProjectDetailsLastAccess/history/?

System.gc() call was merged with gsoc_backpack branch and caused several unstable testruns.
single testrun without System.gc() call - https://jenkins.catrob.at/view/Catroid/job/Catroid-single-UI-device/105/console
