### PR TITLE
Fix testProjectDetailsLastAccess

### DIFF
--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
@@ -115,7 +115,6 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 
 	@Override
 	public void tearDown() throws Exception {
-		UiTestUtils.goBackToHome(getInstrumentation());
 		UtilFile.deleteDirectory(new File(Utils.buildProjectPath(WHITELISTED_CHARACTER_STRING)));
 		UtilFile.deleteDirectory(new File(Utils.buildProjectPath(BLACKLISTED_CHARACTER_STRING)));
 		UtilFile.deleteDirectory(new File(Utils.buildProjectPath(BLACKLISTED_ONLY_CHARACTER_STRING)));
@@ -1221,8 +1220,13 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 
 		Date date = new Date(1357038000000l);
 		DateFormat mediumDateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM);
-		createProjects();
 
+		// sometimes standard project is not created for some reason!
+		// this test needs at least 3 projects in list!
+		// creating standard project if no project is loaded on test start
+		createStandardProgramIfNeeded();
+
+		createProjectsWithoutSprites();
 		String projectFilePath = Utils.buildPath(Utils.buildProjectPath(UiTestUtils.DEFAULT_TEST_PROJECT_NAME),
 				Constants.PROJECTCODE_NAME);
 		File projectCodeFile = new File(projectFilePath);
@@ -1235,7 +1239,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		succeededInSettingModifiedDate = projectCodeFile.setLastModified(now.getTime() - DateUtils.DAY_IN_MILLIS);
 		assertTrue("Failed to set last modified on " + projectFilePath, succeededInSettingModifiedDate);
 
-		solo.sleep(2000);
+		solo.sleep(200);
 		solo.clickOnButton(solo.getString(R.string.main_menu_programs));
 		solo.waitForActivity(MyProjectsActivity.class.getSimpleName());
 		solo.waitForFragmentById(R.id.fragment_projects_list);
@@ -1585,45 +1589,6 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		solo.clickOnButton(solo.getString(R.string.close));
 	}
 
-	public void createProjects() {
-
-		Project project2 = new Project(getActivity(), UiTestUtils.PROJECTNAME1);
-		StorageHandler.getInstance().saveProject(project2);
-
-		solo.sleep(4000);
-
-		Project project1 = new Project(getActivity(), UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
-		StorageHandler.getInstance().saveProject(project1);
-		ProjectManager.getInstance().setProject(project1);
-		ProjectManager projectManager = ProjectManager.getInstance();
-
-		Sprite testSprite = new Sprite("sprite1");
-		projectManager.addSprite(testSprite);
-		projectManager.setCurrentSprite(testSprite);
-
-		File imageFile = UiTestUtils.saveFileToProject(UiTestUtils.DEFAULT_TEST_PROJECT_NAME, "catroid_sunglasses.png",
-				IMAGE_RESOURCE_1, getActivity(), UiTestUtils.FileTypes.IMAGE);
-
-		ArrayList<LookData> lookDataList = projectManager.getCurrentSprite().getLookDataList();
-		LookData lookData = new LookData();
-		lookData.setLookFilename(imageFile.getName());
-		lookData.setLookName("testname");
-		lookDataList.add(lookData);
-		projectManager.getFileChecksumContainer().addChecksum(lookData.getChecksum(), lookData.getAbsolutePath());
-
-		StorageHandler.getInstance().saveProject(project1);
-
-		//-------------------------------------------------
-
-		UiTestUtils.saveFileToProject(UiTestUtils.DEFAULT_TEST_PROJECT_NAME, StageListener.SCREENSHOT_MANUAL_FILE_NAME,
-				IMAGE_RESOURCE_2, getInstrumentation().getContext(), UiTestUtils.FileTypes.ROOT);
-
-		UiTestUtils.saveFileToProject(UiTestUtils.PROJECTNAME1, StageListener.SCREENSHOT_MANUAL_FILE_NAME,
-				IMAGE_RESOURCE_3, getInstrumentation().getContext(), UiTestUtils.FileTypes.ROOT);
-
-		solo.sleep(1000);
-	}
-
 	public void testBottombarElementsVisibilty() {
 		solo.clickOnButton(solo.getString(R.string.main_menu_programs));
 
@@ -1635,6 +1600,10 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 	}
 
 	public void testLongProjectName() {
+		// create standard program if needed
+		// missing default program caused testing errors
+		createStandardProgramIfNeeded();
+
 		String longProjectName = "veryveryveryverylongprojectname";
 		UiTestUtils.waitForText(solo, solo.getString(R.string.main_menu_programs));
 		solo.clickOnButton(solo.getString(R.string.main_menu_programs));
@@ -1837,4 +1806,64 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		}
 	}
 
+	private void createProjects() {
+		Project project2 = new Project(getActivity(), UiTestUtils.PROJECTNAME1);
+		StorageHandler.getInstance().saveProject(project2);
+
+		solo.sleep(2000);
+
+		Project project1 = new Project(getActivity(), UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
+		StorageHandler.getInstance().saveProject(project1);
+		ProjectManager.getInstance().setProject(project1);
+		ProjectManager projectManager = ProjectManager.getInstance();
+
+		Sprite testSprite = new Sprite("sprite1");
+		projectManager.addSprite(testSprite);
+		projectManager.setCurrentSprite(testSprite);
+
+		File imageFile = UiTestUtils.saveFileToProject(UiTestUtils.DEFAULT_TEST_PROJECT_NAME, "catroid_sunglasses.png",
+				IMAGE_RESOURCE_1, getActivity(), UiTestUtils.FileTypes.IMAGE);
+
+		ArrayList<LookData> lookDataList = projectManager.getCurrentSprite().getLookDataList();
+		LookData lookData = new LookData();
+		lookData.setLookFilename(imageFile.getName());
+		lookData.setLookName("testname");
+		lookDataList.add(lookData);
+		projectManager.getFileChecksumContainer().addChecksum(lookData.getChecksum(), lookData.getAbsolutePath());
+
+		StorageHandler.getInstance().saveProject(project1);
+
+		//-------------------------------------------------
+
+		UiTestUtils.saveFileToProject(UiTestUtils.DEFAULT_TEST_PROJECT_NAME, StageListener.SCREENSHOT_MANUAL_FILE_NAME,
+				IMAGE_RESOURCE_2, getInstrumentation().getContext(), UiTestUtils.FileTypes.ROOT);
+
+		UiTestUtils.saveFileToProject(UiTestUtils.PROJECTNAME1, StageListener.SCREENSHOT_MANUAL_FILE_NAME,
+				IMAGE_RESOURCE_3, getInstrumentation().getContext(), UiTestUtils.FileTypes.ROOT);
+
+		solo.sleep(1000);
+	}
+
+	private void createProjectsWithoutSprites() {
+		Project project1 = new Project(getActivity(), UiTestUtils.PROJECTNAME1);
+		StorageHandler.getInstance().saveProject(project1);
+		solo.sleep(2000);
+
+		Project project2 = new Project(getActivity(), UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
+		StorageHandler.getInstance().saveProject(project2);
+		solo.sleep(2000);
+	}
+
+	private void createStandardProgramIfNeeded() {
+		File rootDirectory = new File(Constants.DEFAULT_ROOT);
+		if (UtilFile.getProjectNames(rootDirectory).isEmpty()) {
+			Log.v(MY_PROJECTS_ACTIVITY_TEST_TAG, "projectlist empty - creating standard project");
+			try {
+				StandardProjectHandler.createAndSaveStandardProject(getActivity());
+			} catch (IOException e) {
+				e.printStackTrace();
+				fail("Standard Project could not be not created");
+			}
+		}
+	}
 }


### PR DESCRIPTION
this test failed most of the time since gsoc_backpack merge - https://jenkins.catrob.at/job/DeviceTest/597/testReport/org.catrobat.catroid.uitest.ui.activity/MyProjectsActivityTest/testProjectDetailsLastAccess/history/?

two problems caused this failure: sometimes there were only 2 instead of 3 projects visible, but the test checks for today, yesterday and 1st january as last modification time.
and sometimes, since programs are saved within asynctask when switching from main to programlist, modificationtime was overwritten if the asynctask took longer than expected!
removing UiTestUtils.goBackToHome solved a possible problem with IOException which occurred in MyProjectsActivityTest cases - https://jenkins.catrob.at/view/Catroid/job/Catroid-single-UI-device/111/artifact/logcat.txt

multirun: https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/506/ (seems that webserver was down)
single run of failing testcase (testEqualLookNames): https://jenkins.catrob.at/view/Catroid/job/Catroid-single-UI-emulator/283/
single run with 20 iterations (testProjectDetails + testProjectDetailsLastAccess): https://jenkins.catrob.at/view/Catroid/job/Catroid-single-UI-device/115/console
