### PR TITLE
Refactor more testcases to run on the Emulator rather than on the Device

### DIFF
--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
@@ -408,7 +408,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 				viewBitmap = viewToTest.getDrawingCache();
 				int testPixelX = viewBitmap.getWidth() / 2;
 				int testPixelY = viewBitmap.getHeight() / 2;
-				//the following equals ARGB value #fff8fcf8, which is 
+				//the following equals ARGB value #fff8fcf8, which is
 				//the white value on the test device
 				int expectedWhite = -459528;
 				switch (counter) {
@@ -436,7 +436,6 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		}
 	}
 
-	@Device
 	public void testImageCache() {
 		deleteCacheProjects = true;
 
@@ -530,9 +529,9 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 				int testPixelX = viewBitmap.getWidth() / 2;
 				int testPixelY = viewBitmap.getHeight() / 2;
 
-				//the following equals ARGB value #fff8fcf8, which is 
-				//the white value on the test device
-				int expectedWhite = -459528;
+				//the following equals ARGB value #ffffffff, which is
+				//the white value on the emulated test device
+				int expectedWhite = -1;
 				switch (counter) {
 					case 1:
 						pixelColor = viewBitmap.getPixel(testPixelX, testPixelY);
@@ -724,7 +723,6 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 				.getCurrentProject().getName());
 	}
 
-	@Device
 	public void testDeleteProjectViaActionBar() {
 		String delete = solo.getString(R.string.delete);
 		createProjects();
@@ -1158,11 +1156,6 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		solo.goBack();
 	}
 
-	// this test MUST run on Device
-	// otherwise testProjectDetailsLastAccess fails
-	// TODO
-	// tests should run without dependencies - should be fixed
-	@Device
 	public void testProjectDetails() {
 		String showDetailsText = solo.getString(R.string.show_details);
 		String hideDetailsText = solo.getString(R.string.hide_details);
@@ -1211,7 +1204,6 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		assertTrue("Menu item still says \"Hide Details\"!", solo.searchText(showDetailsText));
 	}
 
-	@Device
 	public void testProjectDetailsLastAccess() {
 		String showDetailsText = solo.getString(R.string.show_details);
 

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/dialog/UploadDialogTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/dialog/UploadDialogTest.java
@@ -29,8 +29,6 @@ import android.preference.PreferenceManager;
 import android.view.View;
 import android.widget.EditText;
 
-import com.jayway.android.robotium.solo.Solo;
-
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
@@ -38,7 +36,6 @@ import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.ui.MyProjectsActivity;
-import org.catrobat.catroid.uitest.annotation.Device;
 import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
 import org.catrobat.catroid.uitest.util.UiTestUtils;
 import org.catrobat.catroid.utils.UtilFile;
@@ -120,7 +117,6 @@ public class UploadDialogTest extends BaseActivityInstrumentationTestCase<MainMe
 		solo.clickOnButton(solo.getString(R.string.cancel_button));
 	}
 
-	@Device
 	public void testUploadingProjectDescriptionDefaultValue() throws Throwable {
 		String testDescription = "Test description";
 		String actionSetDescriptionText = solo.getString(R.string.set_description);
@@ -137,9 +133,7 @@ public class UploadDialogTest extends BaseActivityInstrumentationTestCase<MainMe
 		assertTrue("dialog not loaded in 5 seconds", solo.waitForText(actionSetDescriptionText, 0, 5000));
 		solo.sleep(300);
 
-		// workaround - Ok button not clickable
-		solo.sendKey(Solo.ENTER);
-		solo.sendKey(Solo.ENTER);
+		solo.clickOnText(solo.getString(R.string.ok));
 
 		solo.waitForDialogToClose(500);
 		solo.goBack();

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -682,8 +682,8 @@ public class UiTestUtils {
 		brickList.add(new SetGhostEffectBrick(firstSprite, 0));
 		brickList.add(new SetLookBrick(firstSprite));
 		brickList.add(new SetSizeToBrick(firstSprite, 0));
-		brickList.add(new SetVolumeToBrick(firstSprite, 0));
 		brickList.add(new SetVariableBrick(firstSprite, 0));
+		brickList.add(new SetVolumeToBrick(firstSprite, 0));
 		brickList.add(new SetXBrick(firstSprite, 0));
 		brickList.add(new SetYBrick(firstSprite, 0));
 		brickList.add(new ShowBrick(firstSprite));

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/web/ProjectUpAndDownloadTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/web/ProjectUpAndDownloadTest.java
@@ -40,7 +40,6 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.WaitBrick;
 import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.ui.MainMenuActivity;
-import org.catrobat.catroid.uitest.annotation.Device;
 import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
 import org.catrobat.catroid.uitest.util.Reflection;
 import org.catrobat.catroid.uitest.util.UiTestUtils;
@@ -100,7 +99,6 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 		});
 	}
 
-	@Device
 	public void testUploadProjectSuccessAndTokenReplacementAfterUpload() throws Throwable {
 		setServerURLToTestUrl();
 		UiTestUtils.createTestProject(testProject);
@@ -126,7 +124,6 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 		//downloadProject();
 	}
 
-	@Device
 	public void testUploadProjectOldCatrobatLanguageVersion() throws Throwable {
 		setServerURLToTestUrl();
 
@@ -173,7 +170,6 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 	// TODO
 	// test fails all the time - must be fixed as soon as possible
 
-	//	@Device
 	//	public void testRenameProjectNameAndDescriptionWhenUploading() throws Throwable {
 	//		setServerURLToTestUrl();
 	//
@@ -218,7 +214,6 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 	//				serverProjectDescription.equalsIgnoreCase(projectDescriptionSetWhenUploading));
 	//	}
 
-	@Device
 	public void testRenameProjectDescriptionWhenUploading() throws Throwable {
 		setServerURLToTestUrl();
 
@@ -251,7 +246,6 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 				downloadedProject.getDescription());
 	}
 
-	@Device
 	public void testUpAndDownloadJapaneseUnicodeProject() throws Throwable {
 		setServerURLToTestUrl();
 
@@ -281,7 +275,6 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 	// TODO
 	// test fails all the time - must be fixed as soon as possible
 
-	//	@Device
 	//	public void testDownload() throws Throwable {
 	//		setServerURLToTestUrl();
 	//
@@ -322,7 +315,6 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 	//		assertTrue("Project was successfully downloaded", serverProjectName.equalsIgnoreCase(projectName));
 	//	}
 
-	@Device
 	public void testUploadStandardProject() throws Throwable {
 		if (!createAndSaveStandardProject() || this.standardProject == null) {
 			fail("Standard project not created");
@@ -336,7 +328,6 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 		String uploadButtonText = solo.getString(R.string.upload_button);
 		assertTrue("Upload button not found within 5 secs!", solo.waitForText(uploadButtonText, 0, 5000));
 
-		solo.goBack();
 		solo.sleep(500);
 		solo.clickOnButton(uploadButtonText);
 
@@ -347,7 +338,6 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 
 		solo.clickOnButton(solo.getString(R.string.main_menu_upload));
 		solo.waitForText(uploadButtonText);
-		solo.goBack();
 		solo.sleep(500);
 
 		while (solo.scrollUp()) {
@@ -366,7 +356,6 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 	// TODO
 	// test fails all the time - must be fixed as soon as possible
 
-	//	@Device
 	//	public void testUploadModifiedStandardProject() throws Throwable {
 	//		if (!createAndSaveStandardProject() || this.standardProject == null) {
 	//			fail("Standard project not created");


### PR DESCRIPTION
Continuing #719 (issue #704)

Jenkins testruns: [547](https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/547/) [549](https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/549/)

The remaining `@Device` annotations are as follows:
- SetLookBrickTest.testAddNewLook: problems with mock activity; LookFragment not attached to Activity
- FormulaEditorEditTextTest.testComputeDialog: Sensor required
- LegoNXTTest.testNXTFunctionality: This test requires the NXTBTTestServer to be running or a LegoNXT Robot to run
- LegoNXTTest.testNXTPersistentConnection: This test requires the NXTBTTestServer to be running or a LegoNXT Robot to run
- LegoNXTTest.testNXTConnectionDialogGoBack: Bluetooth required
- SpeakStageTest.testNormalBehaviour: speechFileTestText does not exist
- SpeakStageTest.testNullText: speechFileNullText does not exist
- SpeakStageTest.testMultiSpeech: speechFileSimultaneousText does not exist
- SpeakStageTest.testDeleteSpeechFiles: speechFileLongText does not exist
- StageTestComplex.testShowTexture: GLThread NullPointerException
- MyProjectsActivityTest.testProjectsAndImagesVisible: test checks for a specific ARGB code which is specific to the device
- ScriptActivityTest.testActionBarTitle: https://github.com/Catrobat/Catroid/issues/626
- WebViewActivityTest.testWebOnOldDevices: This test is made for API 10 or lower
- ProjectUpAndDownloadTest: some testcases are still open for refactoring (#720)
