### PR TITLE
Remove duplicate code, cleanup when possible

### DIFF
--- a/catroid/res/menu/context_menu_default.xml
+++ b/catroid/res/menu/context_menu_default.xml
@@ -22,29 +22,30 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android" >
-	<item
+
+    <item
         android:id="@+id/context_menu_backpack"
-        android:title="@string/backpack" />
+        android:title="@string/backpack"/>
     <item
         android:id="@+id/context_menu_copy"
-        android:title="@string/copy" />
+        android:title="@string/copy"/>
     <item
         android:id="@+id/context_menu_cut"
         android:title="@string/cut"
-        android:visible="false" />
+        android:visible="false"/>
     <item
         android:id="@+id/context_menu_insert_below"
         android:title="@string/insert_below"
-        android:visible="false" />
+        android:visible="false"/>
     <item
         android:id="@+id/context_menu_move"
         android:title="@string/move"
-        android:visible="false" />
+        android:visible="false"/>
     <item
         android:id="@+id/context_menu_rename"
-        android:title="@string/rename" />
+        android:title="@string/rename"/>
     <item
         android:id="@+id/context_menu_delete"
-        android:title="@string/delete" />
+        android:title="@string/delete"/>
 
 </menu>

--- a/catroid/res/menu/context_menu_my_projects.xml
+++ b/catroid/res/menu/context_menu_my_projects.xml
@@ -20,20 +20,20 @@
  *  
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item
         android:id="@+id/context_menu_copy"
-        android:title="@string/copy" />
+        android:title="@string/copy"/>
     <item
         android:id="@+id/context_menu_rename"
-        android:title="@string/rename" />
+        android:title="@string/rename"/>
     <item
         android:id="@+id/context_menu_delete"
-        android:title="@string/delete" />
+        android:title="@string/delete"/>
     <item
         android:id="@+id/context_menu_set_description"
-        android:title="@string/set_description" />
+        android:title="@string/set_description"/>
+
 </menu>

--- a/catroid/res/menu/menu_current_project.xml
+++ b/catroid/res/menu/menu_current_project.xml
@@ -58,6 +58,6 @@
     <item
         android:id="@+id/settings"
         android:showAsAction="never"
-        android:title="@string/main_menu_settings"/>
+        android:title="@string/settings"/>
 
 </menu>

--- a/catroid/res/menu/menu_main_menu.xml
+++ b/catroid/res/menu/menu_main_menu.xml
@@ -24,10 +24,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item
-        android:id="@+id/menu_settings"
-        android:showAsAction="withText"
-        android:title="@string/main_menu_settings"/>
-    <item
         android:id="@+id/menu_rate_app"
         android:showAsAction="withText"
         android:title="@string/main_menu_rate_app"/>
@@ -35,5 +31,9 @@
         android:id="@+id/menu_about"
         android:showAsAction="withText"
         android:title="@string/main_menu_about_pocketcode"/>
+    <item
+        android:id="@+id/settings"
+        android:showAsAction="never"
+        android:title="@string/settings"/>
 
 </menu>

--- a/catroid/res/menu/menu_myprojects.xml
+++ b/catroid/res/menu/menu_myprojects.xml
@@ -43,6 +43,6 @@
     <item
         android:id="@+id/settings"
         android:showAsAction="never"
-        android:title="@string/main_menu_settings"/>
+        android:title="@string/settings"/>
 
 </menu>

--- a/catroid/res/menu/menu_program_activity.xml
+++ b/catroid/res/menu/menu_program_activity.xml
@@ -20,10 +20,12 @@
  *  
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- -->
+-->
 <menu xmlns:android="http://schemas.android.com/apk/res/android" >
+
     <item
         android:id="@+id/settings"
         android:showAsAction="never"
-        android:title="@string/main_menu_settings"/>
+        android:title="@string/settings"/>
+
 </menu>

--- a/catroid/res/menu/menu_script_activity.xml
+++ b/catroid/res/menu/menu_script_activity.xml
@@ -23,27 +23,23 @@
 -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android" >
 
-   <item
+    <item
         android:id="@+id/backpack"
         android:showAsAction="never"
-        android:title="@string/backpack" />
-
+        android:title="@string/backpack"/>
     <item
         android:id="@+id/copy"
         android:showAsAction="never"
-        android:title="@string/copy" />
-
+        android:title="@string/copy"/>
     <item
         android:id="@+id/delete"
         android:icon="@drawable/ic_menu_delete"
         android:showAsAction="ifRoom"
         android:title="@string/delete"/>
-  
     <item
         android:id="@+id/cut"
         android:showAsAction="never"
-        android:title="@string/cut" />
-
+        android:title="@string/cut"/>
     <item
         android:id="@+id/insert_below"
         android:showAsAction="never"
@@ -65,6 +61,6 @@
     <item
         android:id="@+id/settings"
         android:showAsAction="never"
-        android:title="@string/main_menu_settings"/>
+        android:title="@string/settings"/>
 
 </menu>

--- a/catroid/res/values-de/strings.xml
+++ b/catroid/res/values-de/strings.xml
@@ -34,11 +34,6 @@
     <string name="move">Verschieben</string>
     <string name="backpack">Einpacken</string>
     <string name="copy_addition">Kopie</string>
-
-    <!--  -->
-
-
-    <!-- General -->
     <string name="close">Schließen</string>
     <string name="error">Fehler</string>
     <string name="please_wait">Bitte warten</string>
@@ -46,6 +41,7 @@
     <string name="background">Hintergrund</string>
     <string name="stage">Bühne</string>
     <string name="ok">OK</string>
+    <string name="settings">Einstellungen</string>
     <!--  -->
 
 
@@ -56,7 +52,6 @@
     <string name="main_menu_forum">Diskutieren</string>
     <string name="main_menu_web">Erkunden</string>
     <string name="main_menu_upload">Hochladen</string>
-    <string name="main_menu_settings">Einstellungen</string>
     <string name="main_menu_about_pocketcode">Über Pocket Code</string>
     <string name="main_menu_rate_app">Bewerte uns!</string>
     <string name="main_menu_play_store_not_installed">Play Store App nicht gefunden</string>
@@ -557,6 +552,7 @@
     <string name="formula_editor_discard_changes_dialog_message">Möchten Sie die Änderungen speichern?</string>
     <string name="formula_editor_discard_changes_dialog_title">Änderungen speichern?</string>
     <string name="variable_name">Variablenname:</string>
+
     <plurals name="formula_editor_variable_context_action_item_selected">
         <item quantity="one">Variable ausgewählt!</item>
         <item quantity="other">Variablen ausgewählt!</item>

--- a/catroid/res/values-nl/strings.xml
+++ b/catroid/res/values-nl/strings.xml
@@ -31,10 +31,6 @@
     <string name="copy">"Kopiëren"</string>
     <string name="cut">"Knippen"</string>
     <string name="move">"Verplaatsen"</string>
-    <!--  -->
-
-
-    <!-- General -->
     <string name="close">"Sluiten"</string>
     <string name="error">"Fout"</string>
     <string name="please_wait">"Even geduld"</string>
@@ -42,6 +38,7 @@
     <string name="background">"Achtergrond"</string>
     <string name="stage">"Speelveld"</string>
     <string name="ok">"OK"</string>
+    <string name="settings">"Instellingen"</string>
     <!--  -->
 
 
@@ -52,7 +49,6 @@
     <string name="main_menu_forum">"Forum"</string>
     <string name="main_menu_web">"Gemeenschap"</string>
     <string name="main_menu_upload">"Uploaden"</string>
-    <string name="main_menu_settings">"Instellingen"</string>
     <string name="main_menu_about_pocketcode">"Over Pocket Code"</string>
     <string name="main_menu_rate_app">"Beoordeel ons!"</string>
     <string name="main_menu_play_store_not_installed">"Play Store-app niet gevonden"</string>

--- a/catroid/res/values-pt/strings.xml
+++ b/catroid/res/values-pt/strings.xml
@@ -32,10 +32,6 @@
     <string name="cut">"Cortar"</string>
     <string name="move">"Mover"</string>
     <string name="play">"Play"</string>
-    <!--  -->
-
-
-    <!-- General -->
     <string name="close">"Fechar"</string>
     <string name="error">"Erro"</string>
     <string name="please_wait">"Por favor, aguarde…"</string>
@@ -44,6 +40,7 @@
     <string name="stage">"Etapa"</string>
     <string name="ok">"Ok"</string>
     <string name="add">"Adicionar"</string>
+    <string name="settings">"Configurações"</string>
     <!--  -->
 
 
@@ -54,7 +51,6 @@
     <string name="main_menu_forum">"Fórum"</string>
     <string name="main_menu_web">"Comunidade"</string>
     <string name="main_menu_upload">"Upload"</string>
-    <string name="main_menu_settings">"Configurações"</string>
     <string name="main_menu_about_pocketcode">"Sobre Catroid"</string>
     <!--  -->
 
@@ -94,7 +90,7 @@
     <string name="pocket_paint_not_installed">"Paintroid não instalado!\nVocê deseja instalá-lo?"</string>
     <string name="default_look_name">"traje"</string>
     <string name="delete_look_dialog">"Excluir traje?"</string>
-    <string name="add_look_from_camera">"Da Câmera"</string> 
+    <string name="add_look_from_camera">"Da Câmera"</string>
     <string name="add_look_draw_new_image">"Da Câmera"</string>
     <string name="add_look_choose_image">"Da Galeria"</string>
     <string name="select_look_from_gallery">"Selecione uma imagem"</string>

--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -34,10 +34,6 @@
     <string name="move">Move</string>
     <string name="backpack">Backpack</string>
     <string name="copy_addition">copy</string>
-    <!--  -->
-
-
-    <!-- General -->
     <string name="close">Close</string>
     <string name="error">Error</string>
     <string name="please_wait">Please wait</string>
@@ -45,6 +41,7 @@
     <string name="background">Background</string>
     <string name="stage">Stage</string>
     <string name="ok">OK</string>
+    <string name="settings">Settings</string>
     <!--  -->
 
 
@@ -55,7 +52,6 @@
     <string name="main_menu_forum">Discuss</string>
     <string name="main_menu_web">Explore</string>
     <string name="main_menu_upload">Upload</string>
-    <string name="main_menu_settings">Settings</string>
     <string name="main_menu_about_pocketcode">About Pocket Code</string>
     <string name="main_menu_rate_app">Rate us!</string>
     <string name="main_menu_play_store_not_installed">Play Store app not found</string>
@@ -557,6 +553,7 @@
     <string name="formula_editor_discard_changes_dialog_message">Do you want to save your changes?</string>
     <string name="formula_editor_discard_changes_dialog_title">Save changes?</string>
     <string name="variable_name">variable name:</string>
+
     <plurals name="formula_editor_variable_context_action_item_selected">
         <item quantity="one">Variable selected!</item>
         <item quantity="other">Variables selected!</item>

--- a/catroid/src/org/catrobat/catroid/ui/BackPackActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/BackPackActivity.java
@@ -22,7 +22,6 @@
  */
 package org.catrobat.catroid.ui;
 
-import android.content.Intent;
 import android.media.AudioManager;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
@@ -155,12 +154,6 @@ public class BackPackActivity extends BaseActivity {
 			case R.id.delete:
 				currentFragment.startDeleteActionMode();
 				break;
-
-			case R.id.settings:
-				Intent settingsIntent = new Intent(BackPackActivity.this, SettingsActivity.class);
-				startActivity(settingsIntent);
-				break;
-
 		}
 		return super.onOptionsItemSelected(item);
 	}

--- a/catroid/src/org/catrobat/catroid/ui/BaseActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/BaseActivity.java
@@ -30,6 +30,8 @@ import android.widget.AdapterView;
 import com.actionbarsherlock.app.SherlockFragmentActivity;
 import com.actionbarsherlock.view.MenuItem;
 
+import org.catrobat.catroid.R;
+
 public class BaseActivity extends SherlockFragmentActivity {
 
 	@Override
@@ -47,6 +49,11 @@ public class BaseActivity extends SherlockFragmentActivity {
 				Intent intent = new Intent(this, MainMenuActivity.class);
 				intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 				startActivity(intent);
+				break;
+			}
+			case R.id.settings: {
+				Intent settingsIntent = new Intent(this, SettingsActivity.class);
+				startActivity(settingsIntent);
 				break;
 			}
 		}

--- a/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -72,7 +72,6 @@ public class MainMenuActivity extends BaseActivity implements OnCheckTokenComple
 	private static final String TYPE_FILE = "file";
 	private static final String TYPE_HTTP = "http";
 
-	private ActionBar actionBar;
 	private Lock viewSwitchLock = new ViewSwitchLock();
 
 	@Override
@@ -85,7 +84,7 @@ public class MainMenuActivity extends BaseActivity implements OnCheckTokenComple
 
 		setContentView(R.layout.activity_main_menu);
 
-		actionBar = getSupportActionBar();
+		final ActionBar actionBar = getSupportActionBar();
 		actionBar.setDisplayUseLogoEnabled(true);
 		actionBar.setTitle(R.string.app_name);
 
@@ -126,21 +125,10 @@ public class MainMenuActivity extends BaseActivity implements OnCheckTokenComple
 			return;
 		}
 
-		// onPause is sufficient --> gets called before "process_killed",
-		// onStop(), onDestroy(), onRestart()
-		// also when you switch activities
 		if (ProjectManager.getInstance().getCurrentProject() != null) {
 			ProjectManager.getInstance().saveProject();
 			Utils.saveToPreferences(this, Constants.PREF_PROJECTNAME_KEY, ProjectManager.getInstance()
 					.getCurrentProject().getName());
-		}
-	}
-
-	@Override
-	protected void onDestroy() {
-		super.onDestroy();
-		if (!Utils.externalStorageAvailable()) {
-			return;
 		}
 	}
 
@@ -153,11 +141,6 @@ public class MainMenuActivity extends BaseActivity implements OnCheckTokenComple
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
 		switch (item.getItemId()) {
-			case R.id.menu_settings: {
-				Intent intent = new Intent(MainMenuActivity.this, SettingsActivity.class);
-				startActivity(intent);
-				return true;
-			}
 			case R.id.menu_rate_app:
 				launchMarket();
 				return true;
@@ -260,7 +243,7 @@ public class MainMenuActivity extends BaseActivity implements OnCheckTokenComple
 		builder.setTitle(getText(R.string.main_menu_web_dialog_title));
 		builder.setView(checkboxView);
 
-		builder.setPositiveButton(getText(R.string.ok), new DialogInterface.OnClickListener() {
+		builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				CheckBox dontShowAgainCheckBox = (CheckBox) checkboxView
@@ -273,7 +256,7 @@ public class MainMenuActivity extends BaseActivity implements OnCheckTokenComple
 				startActivity(browserIntent);
 			}
 		});
-		builder.setNegativeButton(getText(R.string.cancel_button), new DialogInterface.OnClickListener() {
+		builder.setNegativeButton(R.string.cancel_button, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				dialog.cancel();

--- a/catroid/src/org/catrobat/catroid/ui/MyProjectsActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/MyProjectsActivity.java
@@ -96,11 +96,6 @@ public class MyProjectsActivity extends BaseActivity {
 				handleShowDetails(!projectsListFragment.getShowDetails(), item);
 				break;
 			}
-			case R.id.settings: {
-				Intent intent = new Intent(MyProjectsActivity.this, SettingsActivity.class);
-				startActivity(intent);
-				break;
-			}
 		}
 		return super.onOptionsItemSelected(item);
 	}
@@ -133,12 +128,6 @@ public class MyProjectsActivity extends BaseActivity {
 	private void handleShowDetails(boolean showDetails, MenuItem item) {
 		projectsListFragment.setShowDetails(showDetails);
 
-		String menuItemText = "";
-		if (showDetails) {
-			menuItemText = getString(R.string.hide_details);
-		} else {
-			menuItemText = getString(R.string.show_details);
-		}
-		item.setTitle(menuItemText);
+		item.setTitle(showDetails ? R.string.hide_details : R.string.show_details);
 	}
 }

--- a/catroid/src/org/catrobat/catroid/ui/ProgramMenuActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/ProgramMenuActivity.java
@@ -30,7 +30,6 @@ import android.widget.Button;
 
 import com.actionbarsherlock.app.ActionBar;
 import com.actionbarsherlock.view.Menu;
-import com.actionbarsherlock.view.MenuItem;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
@@ -44,7 +43,6 @@ public class ProgramMenuActivity extends BaseActivity {
 
 	private static final String TAG = ProgramMenuActivity.class.getSimpleName();
 
-	private ActionBar actionBar;
 	private Lock viewSwitchLock = new ViewSwitchLock();
 
 	@Override
@@ -55,7 +53,7 @@ public class ProgramMenuActivity extends BaseActivity {
 
 		BottomBar.hideAddButton(this);
 
-		actionBar = getSupportActionBar();
+		final ActionBar actionBar = getSupportActionBar();
 
 		//The try-catch block is a fix for this bug: https://github.com/Catrobat/Catroid/issues/618
 		try {
@@ -94,17 +92,6 @@ public class ProgramMenuActivity extends BaseActivity {
 	public boolean onCreateOptionsMenu(Menu menu) {
 		getSupportMenuInflater().inflate(R.menu.menu_program_activity, menu);
 		return super.onCreateOptionsMenu(menu);
-	}
-
-	@Override
-	public boolean onOptionsItemSelected(MenuItem item) {
-		switch (item.getItemId()) {
-			case R.id.settings: {
-				Intent intent = new Intent(this, SettingsActivity.class);
-				startActivity(intent);
-			}
-		}
-		return super.onOptionsItemSelected(item);
 	}
 
 	public void handleScriptsButton(View view) {

--- a/catroid/src/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/ProjectActivity.java
@@ -112,12 +112,6 @@ public class ProjectActivity extends BaseActivity {
 				spritesListFragment.startDeleteActionMode();
 				break;
 			}
-
-			case R.id.settings: {
-				Intent intent = new Intent(ProjectActivity.this, SettingsActivity.class);
-				startActivity(intent);
-				break;
-			}
 		}
 		return super.onOptionsItemSelected(item);
 	}
@@ -178,12 +172,6 @@ public class ProjectActivity extends BaseActivity {
 	public void handleShowDetails(boolean showDetails, MenuItem item) {
 		spritesListFragment.setShowDetails(showDetails);
 
-		String menuItemText = "";
-		if (showDetails) {
-			menuItemText = getString(R.string.hide_details);
-		} else {
-			menuItemText = getString(R.string.show_details);
-		}
-		item.setTitle(menuItemText);
+		item.setTitle(showDetails ? R.string.hide_details : R.string.show_details);
 	}
 }

--- a/catroid/src/org/catrobat/catroid/ui/ScriptActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/ScriptActivity.java
@@ -28,7 +28,6 @@ import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -96,7 +95,7 @@ public class ScriptActivity extends BaseActivity {
 	private boolean isLookFragmentFromSetLookBrickNew = false;
 	private boolean isLookFragmentHandleAddButtonHandled = false;
 
-	private ImageButton buttonAdd = null;
+	private ImageButton buttonAdd;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -248,11 +247,6 @@ public class ScriptActivity extends BaseActivity {
 			case R.id.delete:
 				currentFragment.startDeleteActionMode();
 				break;
-
-			case R.id.settings:
-				Intent settingsIntent = new Intent(ScriptActivity.this, SettingsActivity.class);
-				startActivity(settingsIntent);
-				break;
 		}
 		return super.onOptionsItemSelected(item);
 	}
@@ -275,9 +269,6 @@ public class ScriptActivity extends BaseActivity {
 
 	@Override
 	public boolean onKeyDown(int keyCode, KeyEvent event) {
-
-		Log.i("info", "onKeyDown() ScriptActivity.... keyCode: " + keyCode);
-
 		FragmentManager fragmentManager = getSupportFragmentManager();
 
 		for (String tag : FormulaEditorListFragment.TAGS) {
@@ -439,13 +430,7 @@ public class ScriptActivity extends BaseActivity {
 	public void handleShowDetails(boolean showDetails, MenuItem item) {
 		currentFragment.setShowDetails(showDetails);
 
-		String menuItemText = "";
-		if (showDetails) {
-			menuItemText = getString(R.string.hide_details);
-		} else {
-			menuItemText = getString(R.string.show_details);
-		}
-		item.setTitle(menuItemText);
+		item.setTitle(showDetails ? R.string.hide_details : R.string.show_details);
 	}
 
 	public ScriptActivityFragment getFragment(int fragmentPosition) {

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
@@ -215,7 +215,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		solo.clickOnButton(solo.getString(R.string.main_menu_programs));
 		solo.waitForActivity(MyProjectsActivity.class.getSimpleName());
 		solo.waitForFragmentById(R.id.fragment_projects_list);
-		solo.clickOnMenuItem(solo.getString(R.string.main_menu_settings));
+		solo.clickOnMenuItem(solo.getString(R.string.settings));
 		solo.assertCurrentActivity("Not in SettingsActivity", SettingsActivity.class);
 	}
 

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ProgramMenuActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ProgramMenuActivityTest.java
@@ -169,7 +169,7 @@ public class ProgramMenuActivityTest extends BaseActivityInstrumentationTestCase
 		solo.clickOnText(solo.getString(R.string.main_menu_continue));
 		solo.waitForActivity(ProjectActivity.class.getSimpleName());
 		solo.clickOnText(backgroundName);
-		solo.clickOnMenuItem(solo.getString(R.string.main_menu_settings));
+		solo.clickOnMenuItem(solo.getString(R.string.settings));
 		solo.assertCurrentActivity("Not in SettingsActivity", SettingsActivity.class);
 	}
 

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ProjectActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ProjectActivityTest.java
@@ -1151,7 +1151,7 @@ public class ProjectActivityTest extends BaseActivityInstrumentationTestCase<Mai
 	public void testOverFlowMenuSettings() {
 		UiTestUtils.getIntoSpritesFromMainMenu(solo);
 
-		solo.clickOnMenuItem(solo.getString(R.string.main_menu_settings));
+		solo.clickOnMenuItem(solo.getString(R.string.settings));
 		solo.assertCurrentActivity("Not in SettingsActivity", SettingsActivity.class);
 	}
 

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ScriptActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/ScriptActivityTest.java
@@ -174,7 +174,7 @@ public class ScriptActivityTest extends BaseActivityInstrumentationTestCase<Main
 	}
 
 	private void checkSettingsAndGoBack() {
-		solo.clickOnMenuItem(solo.getString(R.string.main_menu_settings), true);
+		solo.clickOnMenuItem(solo.getString(R.string.settings), true);
 		solo.assertCurrentActivity("Not in " + SettingsActivity.class.getSimpleName(), SettingsActivity.class);
 		solo.goBack();
 		solo.assertCurrentActivity("Not in " + ScriptActivity.class.getSimpleName(), ScriptActivity.class);

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/SettingsActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/SettingsActivityTest.java
@@ -45,7 +45,7 @@ public class SettingsActivityTest extends BaseActivityInstrumentationTestCase<Ma
 	}
 
 	public void testToggleMindstormBricks() {
-		String settings = solo.getString(R.string.main_menu_settings);
+		String settings = solo.getString(R.string.settings);
 		String mindstormsPreferenceString = solo.getString(R.string.preference_title_enable_mindstorm_bricks);
 		String categoryLegoNXTLabel = solo.getString(R.string.category_lego_nxt);
 		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());


### PR DESCRIPTION
- Settings menu moved to BaseActivity
- Moved strings around where necessary
- Adapted tests
- Various little refactorings

As you can see, the XML Formatter actually **removed** the spaces before the > and /> in the opening tags. From what I can tell, this only happens in the `res/menu/` directory and not for the layouts. What do?

[Testrun](https://jenkins.catrob.at/view/Catroid/job/Catroid-Multi-Job-Custom-Branch/554/)
