### PR TITLE
 Remove unnecessary calls to getString()

### DIFF
--- a/catroid/src/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/org/catrobat/catroid/ProjectManager.java
@@ -75,7 +75,7 @@ public class ProjectManager {
 						MessageContainer.clearBackup();
 					} catch (IOException ioException) {
 						if (errorMessage) {
-							Utils.showErrorDialog(context, context.getString(R.string.error_load_project));
+							Utils.showErrorDialog(context, R.string.error_load_project);
 						}
 						Log.e(TAG, "Cannot load project.", ioException);
 						return false;
@@ -83,14 +83,14 @@ public class ProjectManager {
 				}
 			}
 			if (errorMessage) {
-				Utils.showErrorDialog(context, context.getString(R.string.error_load_project));
+				Utils.showErrorDialog(context, R.string.error_load_project);
 			}
 			return false;
 		} else if (!Utils.isApplicationDebuggable(context)
 				&& (project.getCatrobatLanguageVersion() > Constants.SUPPORTED_CATROBAT_LANGUAGE_VERSION)) {
 			project = oldProject;
 			if (errorMessage) {
-				Utils.showErrorDialog(context, context.getString(R.string.error_project_compatability));
+				Utils.showErrorDialog(context, R.string.error_project_compatability);
 				// TODO show dialog to download latest catroid version instead
 			}
 			return false;
@@ -98,7 +98,7 @@ public class ProjectManager {
 				&& (project.getCatrobatLanguageVersion() < Constants.SUPPORTED_CATROBAT_LANGUAGE_VERSION)) {
 			project = oldProject;
 			if (errorMessage) {
-				Utils.showErrorDialog(context, context.getString(R.string.error_project_compatability));
+				Utils.showErrorDialog(context, R.string.error_project_compatability);
 				// TODO show dialog to convert project to a supported version
 			}
 			return false;
@@ -142,7 +142,7 @@ public class ProjectManager {
 			return true;
 		} catch (IOException ioException) {
 			Log.e(TAG, "Cannot initialize default project.", ioException);
-			Utils.showErrorDialog(context, context.getString(R.string.error_load_project));
+			Utils.showErrorDialog(context, R.string.error_load_project);
 			return false;
 		}
 	}
@@ -179,7 +179,7 @@ public class ProjectManager {
 
 	public boolean renameProject(String newProjectName, Context context) {
 		if (StorageHandler.getInstance().projectExistsCheckCase(newProjectName)) {
-			Utils.showErrorDialog(context, context.getString(R.string.error_project_exists));
+			Utils.showErrorDialog(context, R.string.error_project_exists);
 			return false;
 		}
 
@@ -208,7 +208,7 @@ public class ProjectManager {
 		}
 
 		if (!directoryRenamed) {
-			Utils.showErrorDialog(context, context.getString(R.string.error_rename_project));
+			Utils.showErrorDialog(context, R.string.error_rename_project);
 		}
 
 		return directoryRenamed;
@@ -216,7 +216,7 @@ public class ProjectManager {
 
 	public boolean renameProjectNameAndDescription(String newProjectName, String newProjectDescription, Context context) {
 		if (StorageHandler.getInstance().projectExistsCheckCase(newProjectName)) {
-			Utils.showErrorDialog(context, context.getString(R.string.error_project_exists));
+			Utils.showErrorDialog(context, R.string.error_project_exists);
 			return false;
 		}
 
@@ -246,7 +246,7 @@ public class ProjectManager {
 		}
 
 		if (!directoryRenamed) {
-			Utils.showErrorDialog(context, context.getString(R.string.error_rename_project));
+			Utils.showErrorDialog(context, R.string.error_rename_project);
 		}
 
 		return directoryRenamed;

--- a/catroid/src/org/catrobat/catroid/io/LoadProjectTask.java
+++ b/catroid/src/org/catrobat/catroid/io/LoadProjectTask.java
@@ -82,7 +82,7 @@ public class LoadProjectTask extends AsyncTask<Void, Void, Boolean> {
 		}
 		if (onLoadProjectCompleteListener != null) {
 			if (!success && showErrorMessage) {
-				Utils.showErrorDialog(activity, activity.getString(R.string.error_load_project));
+				Utils.showErrorDialog(activity, R.string.error_load_project);
 			} else {
 				onLoadProjectCompleteListener.onLoadProjectSuccess(startProjectActivity);
 			}

--- a/catroid/src/org/catrobat/catroid/stage/PreStageActivity.java
+++ b/catroid/src/org/catrobat/catroid/stage/PreStageActivity.java
@@ -237,8 +237,8 @@ public class PreStageActivity extends Activity {
 					}
 				} else {
 					AlertDialog.Builder builder = new AlertDialog.Builder(this);
-					builder.setMessage(getString(R.string.text_to_speech_engine_not_installed)).setCancelable(false)
-							.setPositiveButton(getString(R.string.yes), new DialogInterface.OnClickListener() {
+					builder.setMessage(R.string.text_to_speech_engine_not_installed).setCancelable(false)
+							.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
 								@Override
 								public void onClick(DialogInterface dialog, int id) {
 									Intent installIntent = new Intent();
@@ -246,7 +246,7 @@ public class PreStageActivity extends Activity {
 									startActivity(installIntent);
 									resourceFailed();
 								}
-							}).setNegativeButton(getString(R.string.no), new DialogInterface.OnClickListener() {
+							}).setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
 								@Override
 								public void onClick(DialogInterface dialog, int id) {
 									dialog.cancel();

--- a/catroid/src/org/catrobat/catroid/transfers/ProjectUploadService.java
+++ b/catroid/src/org/catrobat/catroid/transfers/ProjectUploadService.java
@@ -22,6 +22,8 @@
  */
 package org.catrobat.catroid.transfers;
 
+import static android.widget.Toast.LENGTH_SHORT;
+
 import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
@@ -140,15 +142,11 @@ public class ProjectUploadService extends IntentService {
 	@Override
 	public void onDestroy() {
 		if (!result) {
-			showToast(getString(R.string.error_project_upload));
+			Toast.makeText(this, R.string.error_project_upload, LENGTH_SHORT).show();
 			return;
 		}
-		showToast(getString(R.string.notification_upload_finished));
+		Toast.makeText(this, R.string.notification_upload_finished, LENGTH_SHORT).show();
 		super.onDestroy();
-	}
-
-	private void showToast(String message) {
-		Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
 	}
 
 }

--- a/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -336,7 +336,7 @@ public class MainMenuActivity extends BaseActivity implements OnCheckTokenComple
 			int b = path.lastIndexOf('.');
 			String projectName = path.substring(a, b);
 			if (!UtilZip.unZipFile(path, Utils.buildProjectPath(projectName))) {
-				Utils.showErrorDialog(this, getResources().getString(R.string.error_load_project));
+				Utils.showErrorDialog(this, R.string.error_load_project);
 			}
 		}
 	}

--- a/catroid/src/org/catrobat/catroid/ui/MyProjectsActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/MyProjectsActivity.java
@@ -42,7 +42,6 @@ public class MyProjectsActivity extends BaseActivity {
 
 	public static final String ACTION_PROJECT_LIST_INIT = "org.catrobat.catroid.PROJECT_LIST_INIT";
 
-	private ActionBar actionBar;
 	private Lock viewSwitchLock = new ViewSwitchLock();
 	private ProjectsListFragment projectsListFragment;
 
@@ -107,10 +106,8 @@ public class MyProjectsActivity extends BaseActivity {
 	}
 
 	private void setUpActionBar() {
-		String title = getResources().getString(R.string.my_projects_activity_title);
-
-		actionBar = getSupportActionBar();
-		actionBar.setTitle(title);
+		final ActionBar actionBar = getSupportActionBar();
+		actionBar.setTitle(R.string.my_projects_activity_title);
 		actionBar.setHomeButtonEnabled(true);
 	}
 

--- a/catroid/src/org/catrobat/catroid/ui/adapter/BrickAdapter.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/BrickAdapter.java
@@ -948,21 +948,18 @@ public class BrickAdapter extends BaseAdapter implements DragAndDropListener, On
 
 	private void showConfirmDeleteDialog(int itemPosition) {
 		this.clickItemPosition = itemPosition;
-		String yes = context.getString(R.string.yes);
-		String no = context.getString(R.string.no);
-		String title;
-		String message = context.getString(R.string.dialog_confirm_delete_brick_message);
+		int titleId;
 
 		if (getItem(clickItemPosition) instanceof ScriptBrick) {
-			title = context.getString(R.string.dialog_confirm_delete_script_title);
+			titleId = R.string.dialog_confirm_delete_script_title;
 		} else {
-			title = context.getString(R.string.dialog_confirm_delete_brick_title);
+			titleId = R.string.dialog_confirm_delete_brick_title;
 		}
 
 		AlertDialog.Builder builder = new AlertDialog.Builder(context);
-		builder.setTitle(title);
-		builder.setMessage(message);
-		builder.setPositiveButton(yes, new DialogInterface.OnClickListener() {
+		builder.setTitle(titleId);
+		builder.setMessage(R.string.dialog_confirm_delete_brick_message);
+		builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				if (getItem(clickItemPosition) instanceof ScriptBrick) {
@@ -975,7 +972,7 @@ public class BrickAdapter extends BaseAdapter implements DragAndDropListener, On
 				}
 			}
 		});
-		builder.setNegativeButton(no, new DialogInterface.OnClickListener() {
+		builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				dialog.cancel();

--- a/catroid/src/org/catrobat/catroid/ui/adapter/UserVariableAdapterWrapper.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/UserVariableAdapterWrapper.java
@@ -79,7 +79,7 @@ public class UserVariableAdapterWrapper extends BaseAdapter {
 			} else {
 				text1 = (TextView) view.findViewById(android.R.id.text1);
 			}
-			text1.setText(context.getString(R.string.brick_variable_spinner_create_new_variable));
+			text1.setText(R.string.brick_variable_spinner_create_new_variable);
 
 		} else {
 			view = userVariableAdapter.getView(position - 1, convertView, parent);
@@ -100,7 +100,7 @@ public class UserVariableAdapterWrapper extends BaseAdapter {
 			} else {
 				text1 = (TextView) view.findViewById(android.R.id.text1);
 			}
-			text1.setText(context.getString(R.string.brick_variable_spinner_create_new_variable));
+			text1.setText(R.string.brick_variable_spinner_create_new_variable);
 
 		} else {
 			view = userVariableAdapter.getDropDownView(position - 1, convertView, parent);

--- a/catroid/src/org/catrobat/catroid/ui/controller/SoundController.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/SoundController.java
@@ -428,7 +428,7 @@ public class SoundController {
 		}
 
 		if (audioPath.equalsIgnoreCase("")) {
-			Utils.showErrorDialog(activity, activity.getString(R.string.error_load_sound));
+			Utils.showErrorDialog(activity, R.string.error_load_sound);
 			audioPath = "";
 			return audioPath;
 		} else {

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/AboutDialogFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/AboutDialogFragment.java
@@ -64,9 +64,8 @@ public class AboutDialogFragment extends DialogFragment {
 		String versionName = this.getString(R.string.android_version_prefix) + Utils.getVersionName(getActivity());
 		aboutVersionNameTextView.setText(versionName);
 
-		Dialog aboutDialog = new AlertDialog.Builder(getActivity()).setView(view)
-				.setTitle(getString(R.string.dialog_about_title))
-				.setNeutralButton(getString(R.string.ok), new DialogInterface.OnClickListener() {
+		Dialog aboutDialog = new AlertDialog.Builder(getActivity()).setView(view).setTitle(R.string.dialog_about_title)
+				.setNeutralButton(R.string.ok, new DialogInterface.OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int id) {
 						dialog.cancel();

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/CopyProjectDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/CopyProjectDialog.java
@@ -66,10 +66,10 @@ public class CopyProjectDialog extends TextDialog {
 		String newProjectName = (input.getText().toString()).trim();
 
 		if (newProjectName.equalsIgnoreCase("")) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.notification_invalid_text_entered));
+			Utils.showErrorDialog(getActivity(), R.string.notification_invalid_text_entered);
 			return false;
 		} else if (Utils.checkIfProjectExistsOrIsDownloadingIgnoreCase(newProjectName)) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_project_exists));
+			Utils.showErrorDialog(getActivity(), R.string.error_project_exists);
 			return false;
 		}
 
@@ -79,7 +79,7 @@ public class CopyProjectDialog extends TextDialog {
 			this.dismiss();
 
 		} else {
-			Utils.showErrorDialog(getActivity(), getString(R.string.notification_invalid_text_entered));
+			Utils.showErrorDialog(getActivity(), R.string.notification_invalid_text_entered);
 			return false;
 		}
 		return false;

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/LoginRegisterDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/LoginRegisterDialog.java
@@ -73,9 +73,8 @@ public class LoginRegisterDialog extends DialogFragment implements OnRegistratio
 		passwordEditText.setText("");
 
 		final AlertDialog loginRegisterDialog = new AlertDialog.Builder(getActivity()).setView(rootView)
-				.setTitle(getString(R.string.login_register_dialog_title))
-				.setPositiveButton(getString(R.string.login_or_register), null)
-				.setNeutralButton(getString(R.string.password_forgotten), null).create();
+				.setTitle(R.string.login_register_dialog_title).setPositiveButton(R.string.login_or_register, null)
+				.setNeutralButton(R.string.password_forgotten, null).create();
 		loginRegisterDialog.setCanceledOnTouchOutside(true);
 		loginRegisterDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
 

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/NewProjectDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/NewProjectDialog.java
@@ -139,12 +139,12 @@ public class NewProjectDialog extends DialogFragment {
 		boolean shouldBeEmpty = emptyProjectCheckBox.isChecked();
 
 		if (projectName.isEmpty()) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_no_name_entered));
+			Utils.showErrorDialog(getActivity(), R.string.error_no_name_entered);
 			return;
 		}
 
 		if (Utils.checkIfProjectExistsOrIsDownloadingIgnoreCase(projectName)) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_project_exists));
+			Utils.showErrorDialog(getActivity(), R.string.error_project_exists);
 			return;
 		}
 
@@ -152,7 +152,7 @@ public class NewProjectDialog extends DialogFragment {
 			ProjectManager.getInstance().initializeNewProject(projectName, getActivity(), shouldBeEmpty);
 
 		} catch (IOException e) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_new_project));
+			Utils.showErrorDialog(getActivity(), R.string.error_new_project);
 			dismiss();
 			return;
 		}

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/NewSpriteDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/NewSpriteDialog.java
@@ -41,21 +41,21 @@ public class NewSpriteDialog extends TextDialog {
 
 	@Override
 	protected boolean handleOkButton() {
-		String newSpriteName = (input.getText().toString()).trim();
+		String newSpriteName = input.getText().toString().trim();
 		ProjectManager projectManager = ProjectManager.getInstance();
 
 		if (projectManager.spriteExists(newSpriteName)) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.spritename_already_exists));
+			Utils.showErrorDialog(getActivity(), R.string.spritename_already_exists);
 			return false;
 		}
 
 		if (newSpriteName == null || newSpriteName.equalsIgnoreCase("")) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.spritename_invalid));
+			Utils.showErrorDialog(getActivity(), R.string.spritename_invalid);
 			return false;
 		}
 
 		if (projectManager.spriteExists(newSpriteName)) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.spritename_already_exists));
+			Utils.showErrorDialog(getActivity(), R.string.spritename_already_exists);
 			return false;
 		}
 

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/RenameLookDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/RenameLookDialog.java
@@ -60,7 +60,7 @@ public class RenameLookDialog extends TextDialog {
 
 	@Override
 	protected boolean handleOkButton() {
-		String newLookName = (input.getText().toString()).trim();
+		String newLookName = input.getText().toString().trim();
 
 		if (newLookName.equals(oldLookName)) {
 			dismiss();
@@ -69,7 +69,7 @@ public class RenameLookDialog extends TextDialog {
 		if (newLookName != null && !newLookName.equalsIgnoreCase("")) {
 			newLookName = Utils.getUniqueLookName(newLookName);
 		} else {
-			Utils.showErrorDialog(getActivity(), getString(R.string.lookname_invalid));
+			Utils.showErrorDialog(getActivity(), R.string.lookname_invalid);
 			dismiss();
 		}
 

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/RenameProjectDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/RenameProjectDialog.java
@@ -61,14 +61,14 @@ public class RenameProjectDialog extends TextDialog {
 
 	@Override
 	protected boolean handleOkButton() {
-		String newProjectName = (input.getText().toString()).trim();
+		String newProjectName = input.getText().toString().trim();
 
 		if (newProjectName.equalsIgnoreCase("")) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.notification_invalid_text_entered));
+			Utils.showErrorDialog(getActivity(), R.string.notification_invalid_text_entered);
 			return false;
 		} else if (Utils.checkIfProjectExistsOrIsDownloadingIgnoreCase(newProjectName)
 				&& !oldProjectName.equalsIgnoreCase(newProjectName)) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_project_exists));
+			Utils.showErrorDialog(getActivity(), R.string.error_project_exists);
 			return false;
 		}
 
@@ -99,7 +99,7 @@ public class RenameProjectDialog extends TextDialog {
 				onProjectRenameListener.onProjectRename(isCurrentProject);
 			}
 		} else {
-			Utils.showErrorDialog(getActivity(), getActivity().getString(R.string.notification_invalid_text_entered));
+			Utils.showErrorDialog(getActivity(), R.string.notification_invalid_text_entered);
 			return false;
 		}
 

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/RenameSoundDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/RenameSoundDialog.java
@@ -60,7 +60,7 @@ public class RenameSoundDialog extends TextDialog {
 
 	@Override
 	protected boolean handleOkButton() {
-		String newSoundTitle = (input.getText().toString()).trim();
+		String newSoundTitle = input.getText().toString().trim();
 
 		if (newSoundTitle.equals(oldSoundTitle)) {
 			dismiss();
@@ -69,7 +69,7 @@ public class RenameSoundDialog extends TextDialog {
 		if (newSoundTitle != null && !newSoundTitle.equalsIgnoreCase("")) {
 			newSoundTitle = Utils.getUniqueSoundName(newSoundTitle);
 		} else {
-			Utils.showErrorDialog(getActivity(), getString(R.string.soundname_invalid));
+			Utils.showErrorDialog(getActivity(), R.string.soundname_invalid);
 		}
 
 		Intent intent = new Intent(ScriptActivity.ACTION_SOUND_RENAMED);

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/RenameSpriteDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/RenameSpriteDialog.java
@@ -61,7 +61,7 @@ public class RenameSpriteDialog extends TextDialog {
 		ProjectManager projectManager = ProjectManager.getInstance();
 
 		if (projectManager.spriteExists(newSpriteName) && !newSpriteName.equalsIgnoreCase(oldSpriteName)) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.spritename_already_exists));
+			Utils.showErrorDialog(getActivity(), R.string.spritename_already_exists);
 			return false;
 		}
 
@@ -75,7 +75,7 @@ public class RenameSpriteDialog extends TextDialog {
 			intent.putExtra(EXTRA_NEW_SPRITE_NAME, newSpriteName);
 			getActivity().sendBroadcast(intent);
 		} else {
-			Utils.showErrorDialog(getActivity(), getString(R.string.spritename_invalid));
+			Utils.showErrorDialog(getActivity(), R.string.spritename_invalid);
 			return false;
 		}
 

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/StageDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/StageDialog.java
@@ -22,6 +22,8 @@
  */
 package org.catrobat.catroid.ui.dialogs;
 
+import static android.widget.Toast.LENGTH_SHORT;
+
 import android.app.Dialog;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -112,11 +114,9 @@ public class StageDialog extends Dialog implements View.OnClickListener {
 
 	private void makeScreenshot() {
 		if (stageListener.makeManualScreenshot()) {
-			Toast.makeText(stageActivity, stageActivity.getString(R.string.notification_screenshot_ok),
-					Toast.LENGTH_SHORT).show();
+			Toast.makeText(stageActivity, R.string.notification_screenshot_ok, LENGTH_SHORT).show();
 		} else {
-			Toast.makeText(stageActivity, stageActivity.getString(R.string.error_screenshot_failed), Toast.LENGTH_SHORT)
-					.show();
+			Toast.makeText(stageActivity, R.string.error_screenshot_failed, LENGTH_SHORT).show();
 		}
 	}
 

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
@@ -209,18 +209,18 @@ public class UploadProjectDialog extends DialogFragment {
 		String projectDescription = projectDescriptionField.getText().toString();
 
 		if (uploadName.isEmpty()) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_no_name_entered));
+			Utils.showErrorDialog(getActivity(), R.string.error_no_name_entered);
 			return;
 		}
 
 		if (uploadName.equals(getString(R.string.default_project_name))) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_upload_project_with_default_name));
+			Utils.showErrorDialog(getActivity(), R.string.error_upload_project_with_default_name);
 			return;
 		}
 
 		Context context = getActivity().getApplicationContext();
 		if (Utils.isStandardProject(projectManager.getCurrentProject(), context)) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_upload_default_project));
+			Utils.showErrorDialog(getActivity(), R.string.error_upload_default_project);
 			return;
 		}
 

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSoundFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSoundFragment.java
@@ -413,19 +413,17 @@ public class BackPackSoundFragment extends BackPackActivityFragment implements S
 	};
 
 	private void showConfirmDeleteDialog() {
-		String title = "";
+		int titleId;
 		if (adapter.getAmountOfCheckedItems() == 1) {
-			title = getActivity().getString(R.string.dialog_confirm_delete_sound_title);
+			titleId = R.string.dialog_confirm_delete_sound_title;
 		} else {
-			title = getActivity().getString(R.string.dialog_confirm_delete_multiple_sounds_title);
+			titleId = R.string.dialog_confirm_delete_multiple_sounds_title;
 		}
 
-		String message = getActivity().getString(R.string.dialog_confirm_delete_sound_message);
-
 		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-		builder.setTitle(title);
-		builder.setMessage(message);
-		builder.setPositiveButton(getActivity().getString(R.string.yes), new DialogInterface.OnClickListener() {
+		builder.setTitle(titleId);
+		builder.setMessage(R.string.dialog_confirm_delete_sound_message);
+		builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				SoundController.getInstance().deleteCheckedSounds(getActivity(), adapter,
@@ -433,7 +431,7 @@ public class BackPackSoundFragment extends BackPackActivityFragment implements S
 				clearCheckedSoundsAndEnableButtons();
 			}
 		});
-		builder.setNegativeButton(getActivity().getString(R.string.no), new DialogInterface.OnClickListener() {
+		builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				dialog.cancel();

--- a/catroid/src/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -84,12 +84,11 @@ public class FormulaEditorFragment extends SherlockFragment implements OnKeyList
 	private LinearLayout formulaEditorKeyboard;
 	private ImageButton formularEditorFieldDeleteButton;
 	private LinearLayout formulaEditorBrick;
+	private Toast toast;
 	private View brickView;
 	private long[] confirmSwitchEditTextTimeStamp = { 0, 0 };
 	private int confirmSwitchEditTextCounter = 0;
 	private CharSequence previousActionBarTitle;
-
-	private Toast formularEditorToast;
 
 	public boolean restoreInstance = false;
 	private View fragmentView;
@@ -111,7 +110,7 @@ public class FormulaEditorFragment extends SherlockFragment implements OnKeyList
 		ActionBar actionBar = getSherlockActivity().getSupportActionBar();
 		previousActionBarTitle = ProjectManager.getInstance().getCurrentSprite().getName();
 		actionBar.setDisplayShowTitleEnabled(true);
-		actionBar.setTitle(getString(R.string.formula_editor_title));
+		actionBar.setTitle(R.string.formula_editor_title);
 	}
 
 	private void resetActionBar() {
@@ -408,20 +407,17 @@ public class FormulaEditorFragment extends SherlockFragment implements OnKeyList
 
 	}
 
-	private void showToast(int ressourceId) {
-		if (formularEditorToast != null) {
-			View toastView = formularEditorToast.getView();
-			if (toastView != null) {
-				formularEditorToast.setText(getString(ressourceId));
-				if (!toastView.isShown()) {
-					formularEditorToast.show();
-				}
-				return;
-			}
+	/*
+	 * TODO Remove Toasts from this class and replace them with something useful
+	 * This is a hack more than anything else. We shouldn't use Toasts if we're going to change the message all the time
+	 */
+	private void showToast(int resourceId) {
+		if (toast == null || toast.getView().getWindowVisibility() != View.VISIBLE) {
+			toast = Toast.makeText(getActivity().getApplicationContext(), resourceId, Toast.LENGTH_SHORT);
+		} else {
+			toast.setText(resourceId);
 		}
-		formularEditorToast = Toast.makeText(context, getString(ressourceId), Toast.LENGTH_LONG);
-		formularEditorToast.show();
-
+		toast.show();
 	}
 
 	@Override

--- a/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
@@ -381,7 +381,7 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 		}
 
 		if (catchedExpetion || (data == null && originalImagePath.equals(""))) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_load_image));
+			Utils.showErrorDialog(getActivity(), R.string.error_load_image);
 			return;
 		}
 		copyImageToCatroid(originalImagePath);
@@ -572,7 +572,7 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 		int[] imageDimensions = ImageEditing.getImageDimensions(originalImagePath);
 
 		if (imageDimensions[0] < 0 || imageDimensions[1] < 0) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_load_image));
+			Utils.showErrorDialog(getActivity(), R.string.error_load_image);
 			return;
 		}
 
@@ -605,7 +605,7 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 				pixmap = Utils.getPixmapFromFile(imageFile);
 
 				if (pixmap == null) {
-					Utils.showErrorDialog(getActivity(), getString(R.string.error_load_image));
+					Utils.showErrorDialog(getActivity(), R.string.error_load_image);
 					StorageHandler.getInstance().deleteFile(imageFile.getAbsolutePath());
 					return;
 				}
@@ -613,7 +613,7 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 			pixmap = null;
 			updateLookAdapter(imageName, imageFileName);
 		} catch (IOException e) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_load_image));
+			Utils.showErrorDialog(getActivity(), R.string.error_load_image);
 		}
 		getLoaderManager().destroyLoader(ID_LOADER_MEDIA_IMAGE);
 		getActivity().sendBroadcast(new Intent(ScriptActivity.ACTION_BRICK_LIST_CHANGED));
@@ -650,7 +650,7 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 
 		int[] imageDimensions = ImageEditing.getImageDimensions(pathOfPocketPaintImage);
 		if (imageDimensions[0] < 0 || imageDimensions[1] < 0) {
-			Utils.showErrorDialog(getActivity(), this.getString(R.string.error_load_image));
+			Utils.showErrorDialog(getActivity(), R.string.error_load_image);
 			return;
 		}
 
@@ -690,7 +690,7 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 
 			int[] imageDimensions = ImageEditing.getImageDimensions(originalImagePath);
 			if (imageDimensions[0] < 0 || imageDimensions[1] < 0) {
-				Utils.showErrorDialog(getActivity(), getString(R.string.error_load_image));
+				Utils.showErrorDialog(getActivity(), R.string.error_load_image);
 				return;
 			}
 			copyImageToCatroid(originalImagePath);
@@ -722,8 +722,8 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 
 		if (packageList.size() <= 0) {
 			AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-			builder.setMessage(getString(R.string.pocket_paint_not_installed)).setCancelable(false)
-					.setPositiveButton(getString(R.string.yes), new DialogInterface.OnClickListener() {
+			builder.setMessage(R.string.pocket_paint_not_installed).setCancelable(false)
+					.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
 						@Override
 						public void onClick(DialogInterface dialog, int id) {
 
@@ -737,7 +737,7 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 								startActivity(downloadPocketPaintIntent);
 							}
 						}
-					}).setNegativeButton(getString(R.string.no), new DialogInterface.OnClickListener() {
+					}).setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
 						@Override
 						public void onClick(DialogInterface dialog, int id) {
 							dialog.cancel();
@@ -860,7 +860,7 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 		@Override
 		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
 			setSelectMode(ListView.CHOICE_MODE_SINGLE);
-			mode.setTitle(getString(R.string.rename));
+			mode.setTitle(R.string.rename);
 
 			setActionModeActive(true);
 
@@ -941,28 +941,24 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 	}
 
 	private void showConfirmDeleteDialog() {
-		String yes = getActivity().getString(R.string.yes);
-		String no = getActivity().getString(R.string.no);
-		String title = "";
+		int titleId;
 		if (adapter.getAmountOfCheckedItems() == 1) {
-			title = getActivity().getString(R.string.dialog_confirm_delete_look_title);
+			titleId = R.string.dialog_confirm_delete_look_title;
 		} else {
-			title = getActivity().getString(R.string.dialog_confirm_delete_multiple_looks_title);
+			titleId = R.string.dialog_confirm_delete_multiple_looks_title;
 		}
 
-		String message = getActivity().getString(R.string.dialog_confirm_delete_look_message);
-
 		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-		builder.setTitle(title);
-		builder.setMessage(message);
-		builder.setPositiveButton(yes, new DialogInterface.OnClickListener() {
+		builder.setTitle(titleId);
+		builder.setMessage(R.string.dialog_confirm_delete_look_message);
+		builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				deleteCheckedLooks();
 				clearCheckedLooksAndEnableButtons();
 			}
 		});
-		builder.setNegativeButton(no, new DialogInterface.OnClickListener() {
+		builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				dialog.cancel();
@@ -998,7 +994,7 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 
 			updateLookAdapter(imageName, imageFileName);
 		} catch (IOException e) {
-			Utils.showErrorDialog(getActivity(), getString(R.string.error_load_image));
+			Utils.showErrorDialog(getActivity(), R.string.error_load_image);
 			e.printStackTrace();
 		}
 		getActivity().sendBroadcast(new Intent(ScriptActivity.ACTION_BRICK_LIST_CHANGED));

--- a/catroid/src/org/catrobat/catroid/ui/fragment/ProjectsListFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/ProjectsListFragment.java
@@ -363,28 +363,24 @@ public class ProjectsListFragment extends SherlockListFragment implements OnProj
 	}
 
 	private void showConfirmDeleteDialog() {
-		String yes = getActivity().getString(R.string.yes);
-		String no = getActivity().getString(R.string.no);
-		String title = "";
+		int titleId;
 		if (adapter.getAmountOfCheckedProjects() == 1) {
-			title = getActivity().getString(R.string.dialog_confirm_delete_program_title);
+			titleId = R.string.dialog_confirm_delete_program_title;
 		} else {
-			title = getActivity().getString(R.string.dialog_confirm_delete_multiple_programs_title);
+			titleId = R.string.dialog_confirm_delete_multiple_programs_title;
 		}
 
-		String message = getActivity().getString(R.string.dialog_confirm_delete_program_message);
-
 		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-		builder.setTitle(title);
-		builder.setMessage(message);
-		builder.setPositiveButton(yes, new DialogInterface.OnClickListener() {
+		builder.setTitle(titleId);
+		builder.setMessage(R.string.dialog_confirm_delete_program_message);
+		builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				deleteCheckedProjects();
 				clearCheckedProjectsAndEnableButtons();
 			}
 		});
-		builder.setNegativeButton(no, new DialogInterface.OnClickListener() {
+		builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				clearCheckedProjectsAndEnableButtons();
@@ -501,7 +497,7 @@ public class ProjectsListFragment extends SherlockListFragment implements OnProj
 		@Override
 		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
 			setSelectMode(ListView.CHOICE_MODE_SINGLE);
-			mode.setTitle(getString(R.string.rename));
+			mode.setTitle(R.string.rename);
 
 			actionModeActive = true;
 
@@ -536,7 +532,7 @@ public class ProjectsListFragment extends SherlockListFragment implements OnProj
 		@Override
 		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
 			setSelectMode(ListView.CHOICE_MODE_SINGLE);
-			mode.setTitle(getString(R.string.copy));
+			mode.setTitle(R.string.copy);
 
 			actionModeActive = true;
 

--- a/catroid/src/org/catrobat/catroid/ui/fragment/ScriptFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/ScriptFragment.java
@@ -556,22 +556,18 @@ public class ScriptFragment extends ScriptActivityFragment implements OnCategory
 
 	private void showConfirmDeleteDialog(boolean fromContextMenu) {
 		this.deleteScriptFromContextMenu = fromContextMenu;
-		String yes = getActivity().getString(R.string.yes);
-		String no = getActivity().getString(R.string.no);
-		String title = "";
+		int titleId;
 		if ((deleteScriptFromContextMenu && scriptToEdit.getBrickList().size() == 0)
 				|| adapter.getAmountOfCheckedItems() == 1) {
-			title = getActivity().getString(R.string.dialog_confirm_delete_brick_title);
+			titleId = R.string.dialog_confirm_delete_brick_title;
 		} else {
-			title = getActivity().getString(R.string.dialog_confirm_delete_multiple_bricks_title);
+			titleId = R.string.dialog_confirm_delete_multiple_bricks_title;
 		}
 
-		String message = getActivity().getString(R.string.dialog_confirm_delete_brick_message);
-
 		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-		builder.setTitle(title);
-		builder.setMessage(message);
-		builder.setPositiveButton(yes, new DialogInterface.OnClickListener() {
+		builder.setTitle(titleId);
+		builder.setMessage(R.string.dialog_confirm_delete_brick_message);
+		builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				if (deleteScriptFromContextMenu) {
@@ -582,7 +578,7 @@ public class ScriptFragment extends ScriptActivityFragment implements OnCategory
 				}
 			}
 		});
-		builder.setNegativeButton(no, new DialogInterface.OnClickListener() {
+		builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				dialog.cancel();

--- a/catroid/src/org/catrobat/catroid/ui/fragment/SoundFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/SoundFragment.java
@@ -644,7 +644,7 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 		@Override
 		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
 			setSelectMode(ListView.CHOICE_MODE_SINGLE);
-			mode.setTitle(getString(R.string.rename));
+			mode.setTitle(R.string.rename);
 
 			setActionModeActive(true);
 
@@ -784,28 +784,24 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 	}
 
 	private void showConfirmDeleteDialog() {
-		String yes = getActivity().getString(R.string.yes);
-		String no = getActivity().getString(R.string.no);
-		String title = "";
+		int titleId;
 		if (adapter.getAmountOfCheckedItems() == 1) {
-			title = getActivity().getString(R.string.dialog_confirm_delete_sound_title);
+			titleId = R.string.dialog_confirm_delete_sound_title;
 		} else {
-			title = getActivity().getString(R.string.dialog_confirm_delete_multiple_sounds_title);
+			titleId = R.string.dialog_confirm_delete_multiple_sounds_title;
 		}
 
-		String message = getActivity().getString(R.string.dialog_confirm_delete_sound_message);
-
 		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-		builder.setTitle(title);
-		builder.setMessage(message);
-		builder.setPositiveButton(yes, new DialogInterface.OnClickListener() {
+		builder.setTitle(titleId);
+		builder.setMessage(R.string.dialog_confirm_delete_sound_message);
+		builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				SoundController.getInstance().deleteCheckedSounds(getActivity(), adapter, soundInfoList, mediaPlayer);
 				clearCheckedSoundsAndEnableButtons();
 			}
 		});
-		builder.setNegativeButton(no, new DialogInterface.OnClickListener() {
+		builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				dialog.cancel();
@@ -918,7 +914,7 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 		@Override
 		protected void onPreExecute() {
 			progressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
-			progressDialog.setTitle(getString(R.string.loading));
+			progressDialog.setTitle(R.string.loading);
 			progressDialog.show();
 		}
 
@@ -967,7 +963,7 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 					}
 				}
 			} else {
-				Utils.showErrorDialog(getActivity(), getString(R.string.error_load_sound));
+				Utils.showErrorDialog(getActivity(), R.string.error_load_sound);
 			}
 		}
 

--- a/catroid/src/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
@@ -360,28 +360,24 @@ public class SpritesListFragment extends SherlockListFragment implements OnSprit
 	}
 
 	private void showConfirmDeleteDialog() {
-		String yes = getActivity().getString(R.string.yes);
-		String no = getActivity().getString(R.string.no);
-		String title = "";
+		int titleId;
 		if (spriteAdapter.getAmountOfCheckedSprites() == 1) {
-			title = getActivity().getString(R.string.dialog_confirm_delete_object_title);
+			titleId = R.string.dialog_confirm_delete_object_title;
 		} else {
-			title = getActivity().getString(R.string.dialog_confirm_delete_multiple_objects_title);
+			titleId = R.string.dialog_confirm_delete_multiple_objects_title;
 		}
 
-		String message = getActivity().getString(R.string.dialog_confirm_delete_object_message);
-
 		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-		builder.setTitle(title);
-		builder.setMessage(message);
-		builder.setPositiveButton(yes, new DialogInterface.OnClickListener() {
+		builder.setTitle(titleId);
+		builder.setMessage(R.string.dialog_confirm_delete_object_message);
+		builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				deleteCheckedSprites();
 				clearCheckedSpritesAndEnableButtons();
 			}
 		});
-		builder.setNegativeButton(no, new DialogInterface.OnClickListener() {
+		builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int id) {
 				dialog.cancel();
@@ -546,7 +542,7 @@ public class SpritesListFragment extends SherlockListFragment implements OnSprit
 		@Override
 		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
 			setSelectMode(ListView.CHOICE_MODE_SINGLE);
-			mode.setTitle(getString(R.string.rename));
+			mode.setTitle(R.string.rename);
 
 			actionModeActive = true;
 

--- a/catroid/src/org/catrobat/catroid/utils/CopyProjectTask.java
+++ b/catroid/src/org/catrobat/catroid/utils/CopyProjectTask.java
@@ -89,7 +89,7 @@ public class CopyProjectTask extends AsyncTask<String, Long, Boolean> {
 		}
 
 		if (!result) {
-			Utils.showErrorDialog(parentFragment.getActivity(), parentFragment.getString(R.string.error_copy_project));
+			Utils.showErrorDialog(parentFragment.getActivity(), R.string.error_copy_project);
 			return;
 		}
 

--- a/catroid/src/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/org/catrobat/catroid/utils/Utils.java
@@ -102,9 +102,9 @@ public class Utils {
 		if (!externalStorageAvailable()) {
 			Builder builder = new AlertDialog.Builder(context);
 
-			builder.setTitle(context.getString(R.string.error));
-			builder.setMessage(context.getString(R.string.error_no_writiable_external_storage_available));
-			builder.setNeutralButton(context.getString(R.string.close), new OnClickListener() {
+			builder.setTitle(R.string.error);
+			builder.setMessage(R.string.error_no_writiable_external_storage_available);
+			builder.setNeutralButton(R.string.close, new OnClickListener() {
 				@Override
 				public void onClick(DialogInterface dialog, int which) {
 					((Activity) context).moveTaskToBack(true);
@@ -160,11 +160,11 @@ public class Utils {
 		return buildPath(Constants.DEFAULT_ROOT, deleteSpecialCharactersInString(projectName));
 	}
 
-	public static void showErrorDialog(Context context, String errorMessage) {
+	public static void showErrorDialog(Context context, int errorMessageId) {
 		Builder builder = new AlertDialog.Builder(context);
-		builder.setTitle(context.getString(R.string.error));
-		builder.setMessage(errorMessage);
-		builder.setNeutralButton(context.getString(R.string.close), new OnClickListener() {
+		builder.setTitle(R.string.error);
+		builder.setMessage(errorMessageId);
+		builder.setNeutralButton(R.string.close, new OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int which) {
 			}


### PR DESCRIPTION
Where possible, I remove calls to `getString()`, including our own Utility method `showErrorMessage()`.

[Testrun](https://jenkins.catrob.at/view/Catroid/job/Catroid-Multi-Job-Custom-Branch/562/)
