### PR TITLE
reintegrate commented assert

### DIFF
--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
@@ -1413,7 +1413,6 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 
 	public void testSetDescription() {
 		createProjects();
-
 		Reflection.setPrivateField(ProjectManager.class, ProjectManager.getInstance(), "asynchronTask", false);
 
 		solo.waitForActivity(MainMenuActivity.class.getSimpleName());
@@ -1443,10 +1442,8 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		//		assertTrue("description is not shown in activity", solo.searchText("Lorem ipsum"));
 		//		assertTrue("description is not shown in activity", solo.searchText("ultricies"));
 
-		//TODO: 
-		// throws random exceptions, because Listview cant be found
-		//		assertEquals("The project is not first in list", UiTestUtils.PROJECTNAME1, ((ProjectData) (solo
-		//				.getCurrentViews(ListView.class).get(0).getAdapter().getItem(0))).projectName);
+		assertEquals("The project is not first in list", UiTestUtils.PROJECTNAME1, ((ProjectData) (solo
+				.getCurrentViews(ListView.class).get(0).getAdapter().getItem(0))).projectName);
 
 		solo.waitForText(UiTestUtils.PROJECTNAME1);
 		UiTestUtils.longClickOnTextInList(solo, UiTestUtils.PROJECTNAME1);


### PR DESCRIPTION
this assert did not work when saving with asynctask - list was not updated.
now it's possible to disable async saving, which is done at the top of this testmethod.

jenkins run of testclass: https://jenkins.catrob.at/job/Catroid-single-UI-emulator/304/
failing test is annotated with '@'Device and can be ignored in Emulatorrun.

jenkins run of single test: https://jenkins.catrob.at/job/Catroid-single-UI-emulator/305/console

after this is merged, issue #646 can be closed!
