### PR TITLE
Remove unused methods and their tests

### DIFF
--- a/catroid/src/org/catrobat/catroid/utils/ImageEditing.java
+++ b/catroid/src/org/catrobat/catroid/utils/ImageEditing.java
@@ -60,7 +60,8 @@ public class ImageEditing {
 		return newBitmap;
 	}
 
-	public static Bitmap getScaledBitmapFromPath(String imagePath, int outputWidth, int outputHeight, boolean justScaleDown) {
+	public static Bitmap getScaledBitmapFromPath(String imagePath, int outputWidth, int outputHeight,
+			boolean justScaleDown) {
 		if (imagePath == null) {
 			return null;
 		}
@@ -101,12 +102,6 @@ public class ImageEditing {
 		imageDimensions[1] = options.outHeight;
 
 		return imageDimensions;
-	}
-
-	public static Bitmap createSingleColorBitmap(int width, int height, int color) {
-		Bitmap newBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-		newBitmap.eraseColor(color);
-		return newBitmap;
 	}
 
 	public static void overwriteImageFileWithNewBitmap(File imageFile) throws FileNotFoundException {

--- a/catroid/src/org/catrobat/catroid/utils/UtilFile.java
+++ b/catroid/src/org/catrobat/catroid/utils/UtilFile.java
@@ -164,33 +164,16 @@ public class UtilFile {
 	 */
 	public static List<String> getProjectNames(File directory) {
 		List<String> projectList = new ArrayList<String>();
-		File[] sdFileList = directory.listFiles();
-		for (File file : sdFileList) {
-			FilenameFilter filenameFilter = new FilenameFilter() {
-				@Override
-				public boolean accept(File dir, String filename) {
-					return filename.contentEquals(Constants.PROJECTCODE_NAME);
-				}
-			};
-			if (file.isDirectory() && file.list(filenameFilter).length != 0) {
-				projectList.add(file.getName());
-			}
-		}
-		return projectList;
-	}
-
-	public static List<File> getProjectFiles(File directory) {
-		List<File> projectList = new ArrayList<File>();
-		File[] sdFileList = directory.listFiles();
+		File[] fileList = directory.listFiles();
 		FilenameFilter filenameFilter = new FilenameFilter() {
 			@Override
 			public boolean accept(File dir, String filename) {
 				return filename.contentEquals(Constants.PROJECTCODE_NAME);
 			}
 		};
-		for (File file : sdFileList) {
+		for (File file : fileList) {
 			if (file.isDirectory() && file.list(filenameFilter).length != 0) {
-				projectList.add(file);
+				projectList.add(file.getName());
 			}
 		}
 		return projectList;

--- a/catroid/src/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/org/catrobat/catroid/utils/Utils.java
@@ -78,13 +78,10 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.Semaphore;
 
 public class Utils {
 
 	private static final String TAG = Utils.class.getSimpleName();
-	private static long uniqueLong = 0;
-	private static Semaphore uniqueNameLock = new Semaphore(1);
 	public static final int PICTURE_INTENT = 1;
 	public static final int FILE_INTENT = 2;
 	public static final int TRANSLATION_PLURAL_OTHER_INTEGER = 767676;
@@ -224,13 +221,6 @@ public class Utils {
 		messageDigest.update(string.getBytes());
 
 		return toHex(messageDigest.digest()).toLowerCase(Locale.US);
-	}
-
-	public static String getUniqueName() {
-		uniqueNameLock.acquireUninterruptibly();
-		String uniqueName = String.valueOf(uniqueLong++);
-		uniqueNameLock.release();
-		return uniqueName;
 	}
 
 	private static String toHex(byte[] messageDigest) {

--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/ImageEditingTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/ImageEditingTest.java
@@ -26,7 +26,6 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.BitmapFactory;
-import android.graphics.Color;
 import android.os.Environment;
 
 import junit.framework.TestCase;
@@ -173,24 +172,6 @@ public class ImageEditingTest extends TestCase {
 
 		assertEquals("Loaded and scaled bitmap has incorrect height", bitmap.getHeight(), loadedBitmap.getHeight());
 		assertEquals("Loaded and scaled bitmap has incorrect width", bitmap.getWidth(), loadedBitmap.getWidth());
-	}
-
-	public void testCreateSingleColorBitmap() {
-		int expectedWidth = 100;
-		int expectedHeight = 200;
-		int expectedColor = Color.CYAN;
-
-		Bitmap testBitmap = ImageEditing.createSingleColorBitmap(expectedWidth, expectedHeight, expectedColor);
-
-		assertEquals("The Bitmap has the wrong width", expectedWidth, testBitmap.getWidth());
-		assertEquals("The Bitmap has the wrong height", expectedHeight, testBitmap.getHeight());
-
-		assertEquals("The color of the Pixel is wrong", expectedColor, testBitmap.getPixel(0, 0));
-		assertEquals("The color of the Pixel is wrong", expectedColor,
-				testBitmap.getPixel(expectedWidth - 1, expectedHeight - 1));
-		assertEquals("The color of the Pixel is wrong", expectedColor,
-				testBitmap.getPixel(expectedWidth / 2, expectedHeight / 2));
-
 	}
 
 	public void testRotatePicture() {

--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilFileTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilFileTest.java
@@ -132,7 +132,7 @@ public class UtilFileTest extends InstrumentationTestCase {
 		UtilFile.deleteDirectory(testDirectory);
 	}
 
-	public void testGetProjectFiles() {
+	public void testGetProjectNames() {
 		Project project = new Project(null, projectName);
 		ProjectManager.getInstance().setProject(project);
 		Sprite sprite = new Sprite("new sprite");
@@ -142,11 +142,11 @@ public class UtilFileTest extends InstrumentationTestCase {
 		File catroidDirectoryFile = new File(CATROID_DIRECTORY);
 		File project1Directory = new File(catroidDirectoryFile + "/" + projectName);
 
-		List<File> projectList = UtilFile.getProjectFiles(catroidDirectoryFile);
+		List<String> projectList = UtilFile.getProjectNames(catroidDirectoryFile);
 
 		assertTrue("project1 should be in Projectlist - is a valid Catroid project",
-				projectList.contains(project1Directory));
+				projectList.contains(project1Directory.getName()));
 		assertFalse("testDirectory should not be in Projectlist - not a Catroid project",
-				projectList.contains(testDirectory));
+				projectList.contains(testDirectory.getName()));
 	}
 }

--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilsTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilsTest.java
@@ -159,15 +159,6 @@ public class UtilsTest extends AndroidTestCase {
 		assertEquals(Utils.buildPath(first, second), result);
 	}
 
-	public void testUniqueName() {
-		String first = Utils.getUniqueName();
-		String second = Utils.getUniqueName();
-		String third = Utils.getUniqueName();
-		assertFalse("Same unique name!", first.equals(second));
-		assertFalse("Same unique name!", first.equals(third));
-		assertFalse("Same unique name!", second.equals(third));
-	}
-
 	public void testDeleteSpecialCharactersFromString() {
 		String testString = "This:IsA-\" */ :<Very>?|Very\\\\Long_Test_String";
 		String newString = Utils.deleteSpecialCharactersInString(testString);


### PR DESCRIPTION
Pretty much self explaining. 

But one thing should be mentioned, for clarity: `getProjectFiles()` which was unused but had tests has been removed, but the test has been adapted to test `getProjectNames()` which _is_ used but had no tests.

[Testrun](https://jenkins.catrob.at/view/All-Categories/view/Catroid/job/Catroid-Multi-Job-Custom-Branch/688/)
