### PR TITLE
Delete duplicate rename function in ProjectManager

### DIFF
--- a/catroid/src/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/org/catrobat/catroid/ProjectManager.java
@@ -203,45 +203,7 @@ public class ProjectManager {
 
 		if (directoryRenamed) {
 			project.setName(newProjectName);
-			StorageHandler.getInstance().saveProject(project);
-		}
-
-		if (!directoryRenamed) {
-			Utils.showErrorDialog(context, R.string.error_rename_project);
-		}
-
-		return directoryRenamed;
-	}
-
-	public boolean renameProjectNameAndDescription(String newProjectName, String newProjectDescription, Context context) {
-		if (StorageHandler.getInstance().projectExists(newProjectName)) {
-			Utils.showErrorDialog(context, R.string.error_project_exists);
-			return false;
-		}
-
-		String oldProjectPath = Utils.buildProjectPath(project.getName());
-		File oldProjectDirectory = new File(oldProjectPath);
-
-		String newProjectPath = Utils.buildProjectPath(newProjectName);
-		File newProjectDirectory = new File(newProjectPath);
-
-		boolean directoryRenamed = false;
-
-		if (oldProjectPath.equalsIgnoreCase(newProjectPath)) {
-			String tmpProjectPath = Utils.buildProjectPath(createTemporaryDirectoryName(newProjectName));
-			File tmpProjectDirectory = new File(tmpProjectPath);
-			directoryRenamed = oldProjectDirectory.renameTo(tmpProjectDirectory);
-			if (directoryRenamed) {
-				directoryRenamed = tmpProjectDirectory.renameTo(newProjectDirectory);
-			}
-		} else {
-			directoryRenamed = oldProjectDirectory.renameTo(newProjectDirectory);
-		}
-
-		if (directoryRenamed) {
-			project.setName(newProjectName);
-			project.setDescription(newProjectDescription);
-			this.saveProject();
+			saveProject();
 		}
 
 		if (!directoryRenamed) {

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
@@ -224,17 +224,20 @@ public class UploadProjectDialog extends DialogFragment {
 			return;
 		}
 
-		if (!uploadName.equals(currentProjectName)) {
+		boolean needsRenaming;
+		if ((needsRenaming = !uploadName.equals(currentProjectName))
+				|| !projectDescription.equals(currentProjectDescription)) {
 
-			projectRename.setVisibility(View.VISIBLE);
-			boolean renamed = projectManager.renameProjectNameAndDescription(newProjectName, projectDescription,
-					getActivity());
-			if (!renamed) {
-				return;
-			}
-
-		} else if (uploadName.equals(currentProjectName) && (!projectDescription.equals(currentProjectDescription))) {
+			String oldDescription = currentProjectDescription;
 			projectManager.getCurrentProject().setDescription(projectDescription);
+			if (needsRenaming) {
+				projectRename.setVisibility(View.VISIBLE);
+				boolean renamed = projectManager.renameProject(newProjectName, getActivity());
+				if (!renamed) {
+					projectManager.getCurrentProject().setDescription(oldDescription);
+					return;
+				}
+			}
 		}
 
 		projectManager.getCurrentProject().setDeviceData(getActivity());

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
@@ -953,6 +953,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 
 	public void testRenameProject() {
 		createProjects();
+		Reflection.setPrivateField(ProjectManager.class, ProjectManager.getInstance(), "asynchronTask", false);
 		String currentProjectName = ProjectManager.getInstance().getCurrentProject().getName();
 		solo.sleep(200);
 		String buttonPositiveText = solo.getString(R.string.ok);


### PR DESCRIPTION
#### What I did

Got rid of a rename function that was an almost exact duplicate of another. In the sake of "single responsibility per method", I removed it and adopted the code as necessary.
#### Discussion

Currently, just like before, the project is not saved if only the description was changed and thus possibly lost. Is this on purpose, did I miss a "hidden" call to `saveProject()` (like `renameProject()` has) or is this just a plain mistakw? There's a `saveProject()` call in `MainMenuActivity#onPause()`, but I'm not sure if that can be trusted. 

i.e. I just trashed my local copy of the Hanabi program, by loading it, leaving Catroid and killing it with the Android recent apps screen (swiped it away), making me think that an AsyncTask is probably not suitable for what we do with it. We probably need a Service. But that's a completely different issue which I am not even addressing here.
#### Relevant links

[Diff of both functions before the changes](https://gist.github.com/aried3r/401ac00d65e12ebc6d12/revisions)
[Testrun](https://jenkins.catrob.at/view/All-Categories/view/Catroid/job/Catroid-Multi-Job-Custom-Branch/708/)
