### PR TITLE
Select only NestingBricks in action mode

### DIFF
--- a/catroid/src/org/catrobat/catroid/ui/adapter/BrickAdapter.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/BrickAdapter.java
@@ -1096,9 +1096,6 @@ public class BrickAdapter extends BaseAdapter implements DragAndDropListener, On
 			notifyDataSetChanged();
 			return true;
 		} else if (brick instanceof NestingBrick) {
-			int counter = 1;
-			int from = 0;
-			int to = 0;
 			for (Brick currentBrick : ((NestingBrick) brick).getAllNestingBrickParts(true)) {
 				if (currentBrick == null) {
 					break;
@@ -1109,31 +1106,8 @@ public class BrickAdapter extends BaseAdapter implements DragAndDropListener, On
 				} else {
 					checkedBricks.remove(currentBrick);
 				}
-				if (counter == 1) {
-					from = brickList.indexOf(currentBrick);
-					counter++;
-				} else {
-					to = brickList.indexOf(currentBrick);
-				}
+
 				currentBrick.getCheckBox().setChecked(checked);
-			}
-			if (from > to) {
-				int temp = from;
-				from = to;
-				to = temp;
-			}
-			from++;
-			while (from < to) {
-				Brick currentBrick = brickList.get(from);
-				if (checked) {
-					animatedBricks.add(currentBrick);
-					addElementToCheckedBricks(currentBrick);
-				} else {
-					checkedBricks.remove(currentBrick);
-				}
-				currentBrick.getCheckBox().setChecked(checked);
-				handleBrickEnabledState(currentBrick, !checked);
-				from++;
 			}
 
 			animateSelectedBricks();

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/content/brick/IfBrickTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/content/brick/IfBrickTest.java
@@ -192,7 +192,7 @@ public class IfBrickTest extends BaseActivityInstrumentationTestCase<MainMenuAct
 		UiTestUtils.acceptAndCloseActionMode(solo);
 
 		ArrayList<Brick> projectBrickList = project.getSpriteList().get(0).getScript(0).getBrickList();
-		assertEquals("Incorrect number of bricks.", 8, projectBrickList.size());
+		assertEquals("Incorrect number of bricks.", 7, projectBrickList.size());
 		assertTrue("Wrong Brick instance.", projectBrickList.get(0) instanceof IfLogicBeginBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(1) instanceof ChangeYByNBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(2) instanceof IfLogicElseBrick);
@@ -200,7 +200,6 @@ public class IfBrickTest extends BaseActivityInstrumentationTestCase<MainMenuAct
 		assertTrue("Wrong Brick instance.", projectBrickList.get(4) instanceof IfLogicBeginBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(5) instanceof IfLogicElseBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(6) instanceof IfLogicEndBrick);
-		assertTrue("Wrong Brick instance.", projectBrickList.get(7) instanceof ChangeYByNBrick);
 	}
 
 	public void testCopyIfLogicElseBrickActionMode() {
@@ -209,7 +208,7 @@ public class IfBrickTest extends BaseActivityInstrumentationTestCase<MainMenuAct
 		UiTestUtils.acceptAndCloseActionMode(solo);
 
 		ArrayList<Brick> projectBrickList = project.getSpriteList().get(0).getScript(0).getBrickList();
-		assertEquals("Incorrect number of bricks.", 8, projectBrickList.size());
+		assertEquals("Incorrect number of bricks.", 7, projectBrickList.size());
 		assertTrue("Wrong Brick instance.", projectBrickList.get(0) instanceof IfLogicBeginBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(1) instanceof ChangeYByNBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(2) instanceof IfLogicElseBrick);
@@ -217,7 +216,6 @@ public class IfBrickTest extends BaseActivityInstrumentationTestCase<MainMenuAct
 		assertTrue("Wrong Brick instance.", projectBrickList.get(4) instanceof IfLogicBeginBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(5) instanceof IfLogicElseBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(6) instanceof IfLogicEndBrick);
-		assertTrue("Wrong Brick instance.", projectBrickList.get(7) instanceof ChangeYByNBrick);
 	}
 
 	public void testCopyIfLogicEndBrickActionMode() {
@@ -226,7 +224,7 @@ public class IfBrickTest extends BaseActivityInstrumentationTestCase<MainMenuAct
 		UiTestUtils.acceptAndCloseActionMode(solo);
 
 		ArrayList<Brick> projectBrickList = project.getSpriteList().get(0).getScript(0).getBrickList();
-		assertEquals("Incorrect number of bricks.", 8, projectBrickList.size());
+		assertEquals("Incorrect number of bricks.", 7, projectBrickList.size());
 		assertTrue("Wrong Brick instance.", projectBrickList.get(0) instanceof IfLogicBeginBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(1) instanceof ChangeYByNBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(2) instanceof IfLogicElseBrick);
@@ -234,7 +232,6 @@ public class IfBrickTest extends BaseActivityInstrumentationTestCase<MainMenuAct
 		assertTrue("Wrong Brick instance.", projectBrickList.get(4) instanceof IfLogicBeginBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(5) instanceof IfLogicElseBrick);
 		assertTrue("Wrong Brick instance.", projectBrickList.get(6) instanceof IfLogicEndBrick);
-		assertTrue("Wrong Brick instance.", projectBrickList.get(7) instanceof ChangeYByNBrick);
 	}
 
 	public void testSelectionAfterCopyActionMode() {
@@ -261,6 +258,34 @@ public class IfBrickTest extends BaseActivityInstrumentationTestCase<MainMenuAct
 		assertTrue("CheckBox is not checked but should be.", secondIfLogicElseBrickCheckBox.isChecked());
 		assertFalse("CheckBox is checked but shouldn't be.", firstIfLogicEndBrickCheckBox.isChecked());
 		assertTrue("CheckBox is not checked but should be.", secondIfLogicEndBrickCheckBox.isChecked());
+	}
+
+	public void testSelectionActionMode() {
+		UiTestUtils.openActionMode(solo, solo.getString(R.string.copy), R.id.copy, getActivity());
+		solo.clickOnCheckBox(1);
+
+		CheckBox ifLogicBeginBrickCheckbox = (CheckBox) solo.getView(R.id.brick_if_begin_checkbox);
+		CheckBox ifLogicElseBrickCheckbox = (CheckBox) solo.getView(R.id.brick_if_else_checkbox);
+		CheckBox ifLogicEndBrickCheckbox = (CheckBox) solo.getView(R.id.brick_if_end_if_checkbox);
+		CheckBox changeYByNBrickCheckbox = (CheckBox) solo.getView(R.id.brick_change_y_checkbox);
+
+		assertTrue("CheckBox is not checked but shouldn be.", ifLogicBeginBrickCheckbox.isChecked()
+				&& ifLogicElseBrickCheckbox.isChecked() && ifLogicEndBrickCheckbox.isChecked());
+		assertFalse("CheckBox is checked but shouldn't be.", changeYByNBrickCheckbox.isChecked());
+
+		UiTestUtils.acceptAndCloseActionMode(solo);
+
+		UiTestUtils.openActionMode(solo, solo.getString(R.string.delete), R.id.delete, getActivity());
+		solo.clickOnCheckBox(1);
+
+		ifLogicBeginBrickCheckbox = (CheckBox) solo.getView(R.id.brick_if_begin_checkbox);
+		ifLogicElseBrickCheckbox = (CheckBox) solo.getView(R.id.brick_if_else_checkbox);
+		ifLogicEndBrickCheckbox = (CheckBox) solo.getView(R.id.brick_if_end_if_checkbox);
+		changeYByNBrickCheckbox = (CheckBox) solo.getView(R.id.brick_change_y_checkbox);
+
+		assertTrue("CheckBox is not checked but shouldn be.", ifLogicBeginBrickCheckbox.isChecked()
+				&& ifLogicElseBrickCheckbox.isChecked() && ifLogicEndBrickCheckbox.isChecked());
+		assertFalse("CheckBox is checked but shouldn't be.", changeYByNBrickCheckbox.isChecked());
 	}
 
 	private void logBrickListForJenkins(ArrayList<Brick> projectBrickList) {

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/content/brick/LoopBrickTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/content/brick/LoopBrickTest.java
@@ -367,6 +367,32 @@ public class LoopBrickTest extends BaseActivityInstrumentationTestCase<MainMenuA
 		assertTrue("CheckBox is not checked but should be.", secondLoopEndBrickCheckBox.isChecked());
 	}
 
+	public void testSelectionActionMode() {
+		UiTestUtils.openActionMode(solo, solo.getString(R.string.copy), R.id.copy, getActivity());
+		solo.clickOnCheckBox(1);
+
+		CheckBox repeatBrickCheckbox = (CheckBox) solo.getView(R.id.brick_repeat_checkbox);
+		CheckBox loopEndBrickCheckbox = (CheckBox) solo.getView(R.id.brick_loop_end_checkbox);
+		CheckBox changeYByNBrickCheckbox = (CheckBox) solo.getView(R.id.brick_change_y_checkbox);
+
+		assertTrue("CheckBox is not checked but should be.",
+				repeatBrickCheckbox.isChecked() && loopEndBrickCheckbox.isChecked());
+		assertFalse("CheckBox is checked but shouldn't be.", changeYByNBrickCheckbox.isChecked());
+
+		UiTestUtils.acceptAndCloseActionMode(solo);
+
+		UiTestUtils.openActionMode(solo, solo.getString(R.string.delete), R.id.delete, getActivity());
+		solo.clickOnCheckBox(1);
+
+		repeatBrickCheckbox = (CheckBox) solo.getView(R.id.brick_repeat_checkbox);
+		loopEndBrickCheckbox = (CheckBox) solo.getView(R.id.brick_loop_end_checkbox);
+		changeYByNBrickCheckbox = (CheckBox) solo.getView(R.id.brick_change_y_checkbox);
+
+		assertTrue("CheckBox is not checked but should be.",
+				repeatBrickCheckbox.isChecked() && loopEndBrickCheckbox.isChecked());
+		assertFalse("CheckBox is checked but shouldn't be.", changeYByNBrickCheckbox.isChecked());
+	}
+
 	private void createProject() {
 		LoopBeginBrick beginBrick;
 		LoopEndBrick endBrick;

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/fragment/ScriptFragmentTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/fragment/ScriptFragmentTest.java
@@ -382,8 +382,8 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 
 		assertTrue("Bottom bar is visible", solo.getView(R.id.bottom_bar).getVisibility() == View.GONE);
 
-		String expectedTitle = getActivity().getResources()
-				.getQuantityString(R.plurals.number_of_bricks_to_delete, 0, 0);
+		String expectedTitle = getActivity().getResources().getQuantityString(R.plurals.number_of_bricks_to_delete, 0,
+				0);
 		assertTrue("Title not as expected", solo.waitForText(expectedTitle, 0, 300, false, true));
 
 		solo.clickOnCheckBox(0);
@@ -510,8 +510,8 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 		assertTrue("Bottom bar is visible", solo.getView(R.id.bottom_bar).getVisibility() == View.GONE);
 
 		solo.clickOnCheckBox(3);
-		String expectedTitle = getActivity().getResources()
-				.getQuantityString(R.plurals.number_of_bricks_to_delete, 3, 3);
+		String expectedTitle = getActivity().getResources().getQuantityString(R.plurals.number_of_bricks_to_delete, 2,
+				2);
 		assertTrue("Title not as expected", solo.waitForText(expectedTitle, 0, 300, false, true));
 
 		solo.clickOnCheckBox(4);
@@ -519,11 +519,10 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 
 		solo.sleep(500);
 		solo.clickOnCheckBox(1);
-		expectedTitle = getActivity().getResources().getQuantityString(R.plurals.number_of_bricks_to_delete, 6, 6);
+		expectedTitle = getActivity().getResources().getQuantityString(R.plurals.number_of_bricks_to_delete, 5, 5);
 		assertTrue("Title not as expected", solo.waitForText(expectedTitle, 0, 300, false, true));
 
 		solo.clickOnCheckBox(1);
-		solo.clickOnCheckBox(3);
 
 		UiTestUtils.acceptAndCloseActionMode(solo);
 		solo.clickOnButton(solo.getString(R.string.yes));
@@ -566,18 +565,19 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 
 		solo.clickOnCheckBox(2);
 		solo.clickOnCheckBox(5);
-		String expectedTitle = getActivity().getResources()
-				.getQuantityString(R.plurals.number_of_bricks_to_delete, 5, 5);
+		String expectedTitle = getActivity().getResources().getQuantityString(R.plurals.number_of_bricks_to_delete, 4,
+				4);
 		assertTrue("Title not as expected", solo.waitForText(expectedTitle, 0, 300, false, true));
 
 		solo.sleep(500);
 		solo.clickOnCheckBox(5);
-		expectedTitle = solo.getString(R.string.delete);
+		solo.clickOnCheckBox(2);
+		expectedTitle = getActivity().getResources().getQuantityString(R.plurals.number_of_bricks_to_delete, 0, 0);
 		assertTrue("Title not as expected", solo.waitForText(expectedTitle, 0, 300, false, true));
 
 		solo.sleep(300);
 		solo.clickOnCheckBox(3);
-		expectedTitle = getActivity().getResources().getQuantityString(R.plurals.number_of_bricks_to_delete, 5, 5);
+		expectedTitle = getActivity().getResources().getQuantityString(R.plurals.number_of_bricks_to_delete, 3, 3);
 		assertTrue("Title not as expected", solo.waitForText(expectedTitle, 0, 300, false, true));
 
 		UiTestUtils.acceptAndCloseActionMode(solo);
@@ -594,7 +594,7 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 			currentBrickList.add((Brick) dragAndDropListView.getItemAtPosition(position));
 		}
 
-		assertEquals("Wrong number of bricks left", 0, numberOfBricks);
+		assertEquals("Wrong number of bricks left", 2, numberOfBricks);
 	}
 
 	public void testDeleteItem() {


### PR DESCRIPTION
Just depending `NestingBricks` are selected and all other bricks remain untouched and are not grayed out.
This applies for copy as well as for delete.

Fix #755 

Jenkins testrun: [742](https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/742/)
