### PR TITLE
add additional checkstyle rules

### DIFF
--- a/catroid/checkstyle.xml
+++ b/catroid/checkstyle.xml
@@ -3,29 +3,37 @@
  *  Catroid: An on-device visual programming system for Android devices
  *  Copyright (C) 2010-2013 The Catrobat Team
  *  (<http://developer.catrobat.org/credits>)
- *
+ *  
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
  *  published by the Free Software Foundation, either version 3 of the
  *  License, or (at your option) any later version.
- *
+ *  
  *  An additional term exception under section 7 of the GNU Affero
  *  General Public License, version 3, is available at
  *  http://developer.catrobat.org/license_additional_term
- *
+ *  
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU Affero General Public License for more details.
- *
+ *  
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
+<!--
+    This configuration file was written by the eclipse-cs plugin configuration editor
+-->
+<!--
+    Checkstyle-Configuration: Catroid Checkstyle
+    Description: none
+-->
 <module name="Checker">
   <property name="severity" value="warning"/>
   <module name="TreeWalker">
+    <module name="FileContentsHolder"/>
     <module name="ClassTypeParameterName">
       <message key="name.invalidPattern" value="Class type parameter not following naming convention - Name ''{0}'' must match pattern ''{1}''."/>
     </module>
@@ -74,13 +82,38 @@
     </module>
     <module name="UnusedImports"/>
     <module name="RedundantImport"/>
-    <!-- needed for SuppressWithNearbyCommentFilter -->
-    <module name="FileContentsHolder"/>
+    <module name="GenericWhitespace"/>
+    <module name="AvoidNestedBlocks"/>
+    <module name="NeedBraces"/>
+    <module name="ArrayTypeStyle"/>
+    <module name="UpperEll"/>
+    <module name="OuterTypeFilename"/>
+    <module name="HideUtilityClassConstructor"/>
+    <module name="InterfaceIsType"/>
+    <module name="FinalClass"/>
+    <module name="OneStatementPerLine"/>
+    <module name="SuperFinalize"/>
+    <module name="NoFinalizer"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="DefaultComesLast"/>
+    <module name="EmptyStatement"/>
   </module>
-
+  
+  <!-- For each spacing -->
+  <module name="RegexpSingleline">
+    <property name="format" value="^\s*for \(.*?([^ ]:|:[^ ])"/>
+    <property name="message" value="Space needed around ':' character."/>
+  </module>
+  
+  <!-- Space after 'for' and 'if' -->
+  <module name="RegexpSingleline">
+    <property name="format" value="^\s*(for\(|if\()"/>
+    <property name="message" value="Space needed before opening parenthesis."/>
+  </module>
+  
   <module name="SuppressWithNearbyCommentFilter">
-   <property name="commentFormat" value="CHECKSTYLE DISABLE ([\w\|]+) FOR (-?\d+) LINES"/>
-   <property name="checkFormat" value="$1"/>
-   <property name="influenceFormat" value="$2"/>
+    <property name="commentFormat" value="CHECKSTYLE DISABLE ([\w\|]+) FOR (-?\d+) LINES"/>
+    <property name="checkFormat" value="$1"/>
+    <property name="influenceFormat" value="$2"/>
   </module>
 </module>

--- a/catroid/src/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/org/catrobat/catroid/ProjectManager.java
@@ -49,7 +49,7 @@ import org.catrobat.catroid.web.ServerCalls;
 import java.io.File;
 import java.io.IOException;
 
-public class ProjectManager implements OnLoadProjectCompleteListener, OnCheckTokenCompleteListener {
+public final class ProjectManager implements OnLoadProjectCompleteListener, OnCheckTokenCompleteListener {
 	private static final ProjectManager INSTANCE = new ProjectManager();
 	private static final String TAG = ProjectManager.class.getSimpleName();
 

--- a/catroid/src/org/catrobat/catroid/common/BrickValues.java
+++ b/catroid/src/org/catrobat/catroid/common/BrickValues.java
@@ -22,7 +22,7 @@
  */
 package org.catrobat.catroid.common;
 
-public class BrickValues {
+public final class BrickValues {
 
 	public static final int X_POSITION = 100;
 	public static final int Y_POSITION = 200;
@@ -57,4 +57,9 @@ public class BrickValues {
 	public static final int LEGO_SPEED = 100;
 	public static final int LEGO_DURATION = 1;
 	public static final int LEGO_FREQUENCY = 2;
+
+	// Suppress default constructor for noninstantiability
+	private BrickValues() {
+		throw new AssertionError();
+	}
 }

--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -89,4 +89,9 @@ public final class Constants {
 	public static final int UPLOAD_NOTIFICATION = 102;
 	public static final int DOWNLOAD_NOTIFICATION = 103;
 	public static final int COPY_NOTIFICATION = 104;
+
+	// Suppress default constructor for noninstantiability
+	private Constants() {
+		throw new AssertionError();
+	}
 }

--- a/catroid/src/org/catrobat/catroid/common/MessageContainer.java
+++ b/catroid/src/org/catrobat/catroid/common/MessageContainer.java
@@ -33,11 +33,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class MessageContainer {
+public final class MessageContainer {
 
 	private static Map<String, List<BroadcastScript>> receiverMap = new HashMap<String, List<BroadcastScript>>();
 	private static Map<String, List<BroadcastScript>> backupReceiverMap = null;
 	private static ArrayAdapter<String> messageAdapter = null;
+
+	// Suppress default constructor for noninstantiability
+	private MessageContainer() {
+		throw new AssertionError();
+	}
 
 	public static void clear() {
 		receiverMap.clear();

--- a/catroid/src/org/catrobat/catroid/common/ScreenValues.java
+++ b/catroid/src/org/catrobat/catroid/common/ScreenValues.java
@@ -22,8 +22,13 @@
  */
 package org.catrobat.catroid.common;
 
-public class ScreenValues {
+public final class ScreenValues {
 	// CHECKSTYLE DISABLE StaticVariableNameCheck FOR 2 LINES
 	public static int SCREEN_WIDTH;
 	public static int SCREEN_HEIGHT;
+
+	// Suppress default constructor for noninstantiability
+	private ScreenValues() {
+		throw new AssertionError();
+	}
 }

--- a/catroid/src/org/catrobat/catroid/common/StandardProjectHandler.java
+++ b/catroid/src/org/catrobat/catroid/common/StandardProjectHandler.java
@@ -56,9 +56,14 @@ import org.catrobat.catroid.utils.UtilFile;
 import java.io.File;
 import java.io.IOException;
 
-public class StandardProjectHandler {
+public final class StandardProjectHandler {
 
 	private static double backgroundImageScaleFactor = 1;
+
+	// Suppress default constructor for noninstantiability
+	private StandardProjectHandler() {
+		throw new AssertionError();
+	}
 
 	public static Project createAndSaveStandardProject(Context context) throws IOException {
 		String projectName = context.getString(R.string.default_project_name);

--- a/catroid/src/org/catrobat/catroid/content/actions/GlideToAction.java
+++ b/catroid/src/org/catrobat/catroid/content/actions/GlideToAction.java
@@ -29,9 +29,12 @@ import org.catrobat.catroid.formulaeditor.Formula;
 
 public class GlideToAction extends TemporalAction {
 
-	private float startX, startY;
-	private float currentX, currentY;
-	private Formula endX, endY;
+	private float startX;
+	private float startY;
+	private float currentX;
+	private float currentY;
+	private Formula endX;
+	private Formula endY;
 	private Sprite sprite;
 	private Formula duration;
 	private float endXValue;

--- a/catroid/src/org/catrobat/catroid/content/bricks/PointToBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PointToBrick.java
@@ -252,7 +252,7 @@ public class PointToBrick extends BrickBaseType {
 		return arrayAdapter;
 	}
 
-	public class SpinnerAdapterWrapper implements SpinnerAdapter {
+	public final class SpinnerAdapterWrapper implements SpinnerAdapter {
 
 		protected Context context;
 		protected Spinner spinner;

--- a/catroid/src/org/catrobat/catroid/formulaeditor/InternFormulaUtils.java
+++ b/catroid/src/org/catrobat/catroid/formulaeditor/InternFormulaUtils.java
@@ -28,7 +28,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Stack;
 
-public class InternFormulaUtils {
+public final class InternFormulaUtils {
+
+	// Suppress default constructor for noninstantiability
+	private InternFormulaUtils() {
+		throw new AssertionError();
+	}
 
 	public static List<InternToken> getFunctionByFunctionBracketClose(List<InternToken> internTokenList,
 			int functionBracketCloseInternTokenListIndex) {

--- a/catroid/src/org/catrobat/catroid/formulaeditor/SensorHandler.java
+++ b/catroid/src/org/catrobat/catroid/formulaeditor/SensorHandler.java
@@ -28,7 +28,7 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.util.Log;
 
-public class SensorHandler implements SensorEventListener, SensorCustomEventListener {
+public final class SensorHandler implements SensorEventListener, SensorCustomEventListener {
 	private static final String TAG = SensorHandler.class.getSimpleName();
 	private static SensorHandler instance = null;
 	private SensorManagerInterface sensorManager = null;

--- a/catroid/src/org/catrobat/catroid/formulaeditor/SensorLoudness.java
+++ b/catroid/src/org/catrobat/catroid/formulaeditor/SensorLoudness.java
@@ -30,7 +30,7 @@ import org.catrobat.catroid.soundrecorder.SoundRecorder;
 import java.io.IOException;
 import java.util.ArrayList;
 
-public class SensorLoudness {
+public final class SensorLoudness {
 
 	private static SensorLoudness instance = null;
 	private static final int UPDATE_INTERVAL = 50;

--- a/catroid/src/org/catrobat/catroid/io/SoundManager.java
+++ b/catroid/src/org/catrobat/catroid/io/SoundManager.java
@@ -33,10 +33,10 @@ import java.util.List;
  * synchronized.
  */
 public class SoundManager {
+	public static final int MAX_MEDIA_PLAYERS = 7;
+
 	private static final String TAG = SoundManager.class.getSimpleName();
 	private static final SoundManager INSTANCE = new SoundManager();
-
-	public static final int MAX_MEDIA_PLAYERS = 7;
 
 	private final List<MediaPlayer> mediaPlayers = new ArrayList<MediaPlayer>(MAX_MEDIA_PLAYERS);
 	private float volume = 70.0f;

--- a/catroid/src/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/org/catrobat/catroid/io/StorageHandler.java
@@ -124,12 +124,11 @@ import java.util.Locale;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class StorageHandler {
+public final class StorageHandler {
+	private static final StorageHandler INSTANCE;
 	private static final String TAG = StorageHandler.class.getSimpleName();
 	private static final String XML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?>\n";
 	private static final int JPG_COMPRESSION_SETTING = 95;
-
-	private static final StorageHandler INSTANCE;
 
 	private XStream xstream;
 

--- a/catroid/src/org/catrobat/catroid/legonxt/LCPMessage.java
+++ b/catroid/src/org/catrobat/catroid/legonxt/LCPMessage.java
@@ -46,7 +46,7 @@ package org.catrobat.catroid.legonxt;
  * Class for composing the proper messages for simple
  * communication over bluetooth
  */
-public class LCPMessage {
+public final class LCPMessage {
 
 	// the folowing constants were taken from the leJOS project (http://www.lejos.org) 
 
@@ -125,6 +125,11 @@ public class LCPMessage {
 	public static final byte[] FIRMWARE_VERSION_LEJOSMINDDROID = { 0x6c, 0x4d, 0x49, 0x64 };
 
 	private static boolean requestConfirmFromDevice = false;
+
+	// Suppress default constructor for noninstantiability
+	private LCPMessage() {
+		throw new AssertionError();
+	}
 
 	public static void enableRequestConfirmFromDevice() {
 		//this request will only return a small error message, not the actually executed command!

--- a/catroid/src/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/org/catrobat/catroid/stage/StageListener.java
@@ -431,7 +431,8 @@ public class StageListener implements ApplicationListener {
 
 	private boolean saveScreenshot(byte[] screenshot, String fileName) {
 		int length = screenshot.length;
-		Bitmap fullScreenBitmap, centerSquareBitmap;
+		Bitmap fullScreenBitmap;
+		Bitmap centerSquareBitmap;
 		int[] colors = new int[length / 4];
 
 		for (int i = 0; i < length; i += 4) {

--- a/catroid/src/org/catrobat/catroid/ui/BaseActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/BaseActivity.java
@@ -46,18 +46,18 @@ public class BaseActivity extends SherlockFragmentActivity {
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
 		switch (item.getItemId()) {
-			case android.R.id.home: {
+			case android.R.id.home:
 				Intent intent = new Intent(this, MainMenuActivity.class);
 				intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 				BackPackListManager.setBackPackFlag(true);
 				startActivity(intent);
 				break;
-			}
-			case R.id.settings: {
+
+			case R.id.settings:
 				Intent settingsIntent = new Intent(this, SettingsActivity.class);
 				startActivity(settingsIntent);
 				break;
-			}
+
 		}
 		return super.onOptionsItemSelected(item);
 	}

--- a/catroid/src/org/catrobat/catroid/ui/BottomBar.java
+++ b/catroid/src/org/catrobat/catroid/ui/BottomBar.java
@@ -27,7 +27,12 @@ import android.view.View;
 
 import org.catrobat.catroid.R;
 
-public class BottomBar {
+public final class BottomBar {
+
+	// Suppress default constructor for noninstantiability
+	private BottomBar() {
+		throw new AssertionError();
+	}
 
 	public static void showBottomBar(Activity activity) {
 		activity.findViewById(R.id.bottom_bar).setVisibility(View.VISIBLE);

--- a/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -143,11 +143,11 @@ public class MainMenuActivity extends BaseActivity implements OnLoadProjectCompl
 			case R.id.menu_rate_app:
 				launchMarket();
 				return true;
-			case R.id.menu_about: {
+			case R.id.menu_about:
 				AboutDialogFragment aboutDialog = new AboutDialogFragment();
 				aboutDialog.show(getSupportFragmentManager(), AboutDialogFragment.DIALOG_FRAGMENT_TAG);
 				return true;
-			}
+
 		}
 		return super.onOptionsItemSelected(item);
 	}

--- a/catroid/src/org/catrobat/catroid/ui/MyProjectsActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/MyProjectsActivity.java
@@ -80,22 +80,22 @@ public class MyProjectsActivity extends BaseActivity {
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
 		switch (item.getItemId()) {
-			case R.id.copy: {
+			case R.id.copy:
 				projectsListFragment.startCopyActionMode();
 				break;
-			}
-			case R.id.delete: {
+
+			case R.id.delete:
 				projectsListFragment.startDeleteActionMode();
 				break;
-			}
-			case R.id.rename: {
+
+			case R.id.rename:
 				projectsListFragment.startRenameActionMode();
 				break;
-			}
-			case R.id.show_details: {
+
+			case R.id.show_details:
 				handleShowDetails(!projectsListFragment.getShowDetails(), item);
 				break;
-			}
+
 		}
 		return super.onOptionsItemSelected(item);
 	}

--- a/catroid/src/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/ProjectActivity.java
@@ -85,41 +85,35 @@ public class ProjectActivity extends BaseActivity {
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
 		switch (item.getItemId()) {
-			case R.id.show_details: {
+			case R.id.show_details:
 				handleShowDetails(!spritesListFragment.getShowDetails(), item);
 				break;
-			}
 
-			case R.id.copy: {
+			case R.id.copy:
 				spritesListFragment.startCopyActionMode();
 				break;
-			}
 
-			case R.id.cut: {
+			case R.id.cut:
 				break;
-			}
 
-			case R.id.insert_below: {
+			case R.id.insert_below:
 				break;
-			}
 
-			case R.id.move: {
+			case R.id.move:
 				break;
-			}
 
-			case R.id.rename: {
+			case R.id.rename:
 				spritesListFragment.startRenameActionMode();
 				break;
-			}
 
-			case R.id.delete: {
+			case R.id.delete:
 				spritesListFragment.startDeleteActionMode();
 				break;
-			}
 
-			case R.id.upload: {
+			case R.id.upload:
 				ProjectManager.getInstance().uploadProject(Utils.getCurrentProjectName(this), this);
-			}
+				break;
+
 		}
 		return super.onOptionsItemSelected(item);
 	}

--- a/catroid/src/org/catrobat/catroid/ui/adapter/BrickAdapter.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/BrickAdapter.java
@@ -85,7 +85,8 @@ public class BrickAdapter extends BaseAdapter implements DragAndDropListener, On
 	private Script scriptToDelete;
 
 	private boolean firstDrag;
-	private int fromBeginDrag, toEndDrag;
+	private int fromBeginDrag;
+	private int toEndDrag;
 	private boolean retryScriptDragging;
 	private boolean showDetails = false;
 
@@ -614,7 +615,7 @@ public class BrickAdapter extends BaseAdapter implements DragAndDropListener, On
 		if (addingNewBrick) {
 			brickList.remove(draggedBrick);
 		} else {
-			int temp[] = getScriptAndBrickIndexFromProject(index);
+			int[] temp = getScriptAndBrickIndexFromProject(index);
 			Script script = ProjectManager.getInstance().getCurrentSprite().getScript(temp[0]);
 			if (script != null) {
 

--- a/catroid/src/org/catrobat/catroid/ui/controller/BackPackListManager.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/BackPackListManager.java
@@ -27,11 +27,11 @@ import org.catrobat.catroid.ui.adapter.SoundBaseAdapter;
 
 import java.util.ArrayList;
 
-public class BackPackListManager {
-
+public final class BackPackListManager {
 	private static final BackPackListManager INSTANCE = new BackPackListManager();
 	private static final ArrayList<SoundInfo> SOUND_INFO_ARRAY_LIST = new ArrayList<SoundInfo>();
 	private static final ArrayList<SoundInfo> ACTION_BAR_SOUND_INFO_ARRAY_LIST = new ArrayList<SoundInfo>();
+
 	private static SoundInfo currentSoundInfo;
 	private static ArrayList<SoundInfo> currentSoundInfoArrayList;
 	private static SoundBaseAdapter currentAdapter;

--- a/catroid/src/org/catrobat/catroid/ui/controller/LookController.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/LookController.java
@@ -64,8 +64,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class LookController {
-
+public final class LookController {
 	public static final int REQUEST_SELECT_OR_DRAW_IMAGE = 0;
 	public static final int REQUEST_POCKET_PAINT_EDIT_IMAGE = 1;
 	public static final int REQUEST_TAKE_PICTURE = 2;
@@ -74,13 +73,14 @@ public class LookController {
 	public static final String BUNDLE_ARGUMENTS_URI_IS_SET = "uri_is_set";
 	public static final String LOADER_ARGUMENTS_IMAGE_URI = "image_uri";
 	public static final String SHARED_PREFERENCE_NAME = "showDetailsLooks";
-	private static LookController instance;
+
+	private static final LookController INSTANCE = new LookController();
+
+	private LookController() {
+	}
 
 	public static LookController getInstance() {
-		if (instance == null) {
-			instance = new LookController();
-		}
-		return instance;
+		return INSTANCE;
 	}
 
 	public void updateLookLogic(final int position, final LookViewHolder holder, final LookBaseAdapter lookAdapter) {

--- a/catroid/src/org/catrobat/catroid/ui/controller/SoundController.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/SoundController.java
@@ -65,21 +65,20 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.SortedSet;
 
-public class SoundController {
-
+public final class SoundController {
 	public static final String BUNDLE_ARGUMENTS_SELECTED_SOUND = "selected_sound";
 	public static final String SHARED_PREFERENCE_NAME = "showDetailsSounds";
 	public static final int ID_LOADER_MEDIA_IMAGE = 1;
 	public static final int REQUEST_SELECT_MUSIC = 0;
+
+	private static final SoundController INSTANCE = new SoundController();
 	private static final String TAG = SoundController.class.getSimpleName();
-	private static SoundController instance;
+
+	private SoundController() {
+	}
 
 	public static SoundController getInstance() {
-		if (instance == null) {
-			instance = new SoundController();
-		}
-
-		return instance;
+		return INSTANCE;
 	}
 
 	public void updateSoundLogic(Context context, final int position, final SoundViewHolder holder,

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/OverwriteRenameDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/OverwriteRenameDialog.java
@@ -46,8 +46,10 @@ import org.catrobat.catroid.utils.DownloadUtil;
 import org.catrobat.catroid.utils.Utils;
 
 public class OverwriteRenameDialog extends DialogFragment implements OnClickListener {
-	protected RadioButton replaceButton, renameButton;
-	protected String programName, url;
+	protected RadioButton replaceButton;
+	protected RadioButton renameButton;
+	protected String programName;
+	protected String url;
 	protected Context context;
 	protected EditText projectText;
 	protected TextView projectTextView;

--- a/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
@@ -430,11 +430,10 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 	public boolean onContextItemSelected(MenuItem item) {
 
 		switch (item.getItemId()) {
-			case R.id.context_menu_copy: {
+			case R.id.context_menu_copy:
 				LookController.getInstance().copyLook(selectedLookPosition, lookDataList, getActivity(),
 						LookFragment.this);
 				break;
-			}
 
 			case R.id.context_menu_cut:
 				break;
@@ -445,15 +444,14 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 			case R.id.context_menu_move:
 				break;
 
-			case R.id.context_menu_rename: {
+			case R.id.context_menu_rename:
 				showRenameDialog();
 				break;
-			}
 
-			case R.id.context_menu_delete: {
+			case R.id.context_menu_delete:
 				showConfirmDeleteDialog();
 				break;
-			}
+
 		}
 		return super.onContextItemSelected(item);
 	}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/SoundFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/SoundFragment.java
@@ -529,16 +529,15 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 		if (soundInfoListChangedAfterNewListener != null) {
 			soundInfoListChangedAfterNewListener.onSoundInfoListChangedAfterNew(newSoundInfo);
 		}
+
 		//scroll down the list to the new item:
-		{
-			final ListView listView = getListView();
-			listView.post(new Runnable() {
-				@Override
-				public void run() {
-					listView.setSelection(listView.getCount() - 1);
-				}
-			});
-		}
+		final ListView listView = getListView();
+		listView.post(new Runnable() {
+			@Override
+			public void run() {
+				listView.setSelection(listView.getCount() - 1);
+			}
+		});
 
 		if (isResultHandled) {
 			isResultHandled = false;
@@ -957,16 +956,15 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 				if (soundInfoListChangedAfterNewListener != null) {
 					soundInfoListChangedAfterNewListener.onSoundInfoListChangedAfterNew(newSoundInfo);
 				}
+
 				//scroll down the list to the new item:
-				{
-					final ListView listView = getListView();
-					listView.post(new Runnable() {
-						@Override
-						public void run() {
-							listView.setSelection(listView.getCount() - 1);
-						}
-					});
-				}
+				final ListView listView = getListView();
+				listView.post(new Runnable() {
+					@Override
+					public void run() {
+						listView.setSelection(listView.getCount() - 1);
+					}
+				});
 
 				if (isResultHandled) {
 					isResultHandled = false;

--- a/catroid/src/org/catrobat/catroid/utils/DownloadUtil.java
+++ b/catroid/src/org/catrobat/catroid/utils/DownloadUtil.java
@@ -42,23 +42,19 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-public class DownloadUtil {
-	private static DownloadUtil instance;
-	private Set<String> programDownloadQueue;
-
+public final class DownloadUtil {
+	private static final DownloadUtil INSTANCE = new DownloadUtil();
 	private static final String TAG = DownloadUtil.class.getSimpleName();
 	private static final String PROJECTNAME_TAG = "fname=";
 
+	private Set<String> programDownloadQueue;
+
 	private DownloadUtil() {
 		programDownloadQueue = Collections.synchronizedSet(new HashSet<String>());
-
 	}
 
 	public static DownloadUtil getInstance() {
-		if (instance == null) {
-			instance = new DownloadUtil();
-		}
-		return instance;
+		return INSTANCE;
 	}
 
 	public void prepareDownloadAndStartIfPossible(FragmentActivity activity, String url) {

--- a/catroid/src/org/catrobat/catroid/utils/ImageEditing.java
+++ b/catroid/src/org/catrobat/catroid/utils/ImageEditing.java
@@ -33,14 +33,15 @@ import org.catrobat.catroid.io.StorageHandler;
 import java.io.File;
 import java.io.FileNotFoundException;
 
-public class ImageEditing {
+public final class ImageEditing {
 
 	public enum ResizeType {
 		STRETCH_TO_RECTANGLE, STAY_IN_RECTANGLE_WITH_SAME_ASPECT_RATIO, FILL_RECTANGLE_WITH_SAME_ASPECT_RATIO
 	}
 
-	public ImageEditing() {
-
+	// Suppress default constructor for noninstantiability
+	private ImageEditing() {
+		throw new AssertionError();
 	}
 
 	/**

--- a/catroid/src/org/catrobat/catroid/utils/StatusBarNotificationManager.java
+++ b/catroid/src/org/catrobat/catroid/utils/StatusBarNotificationManager.java
@@ -32,7 +32,8 @@ import android.util.SparseArray;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.ui.MainMenuActivity;
 
-public class StatusBarNotificationManager {
+public final class StatusBarNotificationManager {
+	public static final String EXTRA_PROJECT_NAME = "projectName";
 
 	private static final StatusBarNotificationManager INSTANCE = new StatusBarNotificationManager();
 
@@ -40,8 +41,6 @@ public class StatusBarNotificationManager {
 	private SparseArray<NotificationData> notificationDataMap = new SparseArray<NotificationData>();
 
 	private NotificationManager notificationManager;
-
-	public static final String EXTRA_PROJECT_NAME = "projectName";
 
 	private StatusBarNotificationManager() {
 	}

--- a/catroid/src/org/catrobat/catroid/utils/UtilCamera.java
+++ b/catroid/src/org/catrobat/catroid/utils/UtilCamera.java
@@ -36,9 +36,11 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-public class UtilCamera {
+public final class UtilCamera {
 
+	// Suppress default constructor for noninstantiability
 	private UtilCamera() {
+		throw new AssertionError();
 	}
 
 	public static Uri getDefaultLookFromCameraUri(String defLookName) {

--- a/catroid/src/org/catrobat/catroid/utils/UtilDeviceInfo.java
+++ b/catroid/src/org/catrobat/catroid/utils/UtilDeviceInfo.java
@@ -28,8 +28,13 @@ import android.content.Context;
 
 import java.util.Locale;
 
-public class UtilDeviceInfo {
+public final class UtilDeviceInfo {
 	public static final String SERVER_VALUE_FOR_UNDEFINED_COUNTRY = "undef";
+
+	// Suppress default constructor for noninstantiability
+	private UtilDeviceInfo() {
+		throw new AssertionError();
+	}
 
 	public static String getUserEmail(Context context) {
 		if (context == null) {

--- a/catroid/src/org/catrobat/catroid/utils/UtilFile.java
+++ b/catroid/src/org/catrobat/catroid/utils/UtilFile.java
@@ -41,9 +41,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-public class UtilFile {
+public final class UtilFile {
 	public enum FileType {
 		TYPE_IMAGE_FILE, TYPE_SOUND_FILE
+	}
+
+	// Suppress default constructor for noninstantiability
+	private UtilFile() {
+		throw new AssertionError();
 	}
 
 	private static long getSizeOfFileOrDirectoryInByte(File fileOrDirectory) {

--- a/catroid/src/org/catrobat/catroid/utils/UtilZip.java
+++ b/catroid/src/org/catrobat/catroid/utils/UtilZip.java
@@ -36,10 +36,15 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-public class UtilZip {
+public final class UtilZip {
 	private static final int QUICKEST_COMPRESSION = 0;
 
 	private static ZipOutputStream zipOutputStream;
+
+	// Suppress default constructor for noninstantiability
+	private UtilZip() {
+		throw new AssertionError();
+	}
 
 	public static boolean writeToZipFile(String[] filePaths, String zipFile) {
 		try {
@@ -96,7 +101,7 @@ public class UtilZip {
 			ZipEntry zipEntry = null;
 
 			BufferedOutputStream destinationOutputStream = null;
-			byte data[] = new byte[Constants.BUFFER_8K];
+			byte[] data = new byte[Constants.BUFFER_8K];
 			ZipFile zipfile = new ZipFile(zipFile);
 			Enumeration<? extends ZipEntry> e = zipfile.entries();
 			while (e.hasMoreElements()) {

--- a/catroid/src/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/org/catrobat/catroid/utils/Utils.java
@@ -77,7 +77,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-public class Utils {
+public final class Utils {
 
 	private static final String TAG = Utils.class.getSimpleName();
 	public static final int PICTURE_INTENT = 1;
@@ -85,6 +85,11 @@ public class Utils {
 	public static final int TRANSLATION_PLURAL_OTHER_INTEGER = 767676;
 	private static final int DEFAULT_SCREEN_WIDTH = 1280;
 	private static final int DEFAULT_SCREEN_HEIGHT = 768;
+
+	// Suppress default constructor for noninstantiability
+	private Utils() {
+		throw new AssertionError();
+	}
 
 	public static boolean externalStorageAvailable() {
 		String externalStorageState = Environment.getExternalStorageState();

--- a/catroid/src/org/catrobat/catroid/web/ServerCalls.java
+++ b/catroid/src/org/catrobat/catroid/web/ServerCalls.java
@@ -40,7 +40,7 @@ import java.util.HashMap;
 
 //web status codes are on: https://github.com/Catrobat/Catroweb/blob/master/statusCodes.php
 
-public class ServerCalls {
+public final class ServerCalls {
 
 	private static final String TAG = "ServerCalls";
 
@@ -91,7 +91,7 @@ public class ServerCalls {
 	private String emailForUiTests;
 	private int uploadStatusCode;
 
-	protected ServerCalls() {
+	private ServerCalls() {
 		connection = new ConnectionWrapper();
 	}
 

--- a/catroidLegoNXTBTTest/src/org/catrobat/catroid/bluetoothtestserver/BTServer.java
+++ b/catroidLegoNXTBTTest/src/org/catrobat/catroid/bluetoothtestserver/BTServer.java
@@ -33,78 +33,75 @@ import javax.microedition.io.Connector;
 import javax.microedition.io.StreamConnection;
 import javax.microedition.io.StreamConnectionNotifier;
 
-public class BTServer
-{
-  private boolean run = true;
-  private static boolean gui = false;
-  static StreamConnection connection = null;
-  static BTServer btServer;
-  private static Writer out = null;
+public final class BTServer {
+	private boolean run = true;
+	private static boolean gui = false;
+	static StreamConnection connection = null;
+	static BTServer btServer;
+	private static Writer out = null;
 
-  private void startServer() throws IOException
-  {
-    UUID uuid = new UUID("1101", true);
+	// Suppress default constructor for noninstantiability
+	private BTServer() {
+	}
 
-    String connectionString = "btspp://localhost:" + uuid + ";name=BT Test Server";
+	private void startServer() throws IOException {
+		UUID uuid = new UUID("1101", true);
 
-    StreamConnectionNotifier streamConnNotifier = (StreamConnectionNotifier)Connector.open(connectionString);
+		String connectionString = "btspp://localhost:" + uuid
+				+ ";name=BT Test Server";
 
-    writeMessage("Bluetooth Server started. Waiting for Bluetooth test clients... \n");
+		StreamConnectionNotifier streamConnNotifier = (StreamConnectionNotifier) Connector
+				.open(connectionString);
 
-    while (this.run) {
-      connection = streamConnNotifier.acceptAndOpen();
-      BTClientHandler btc = new BTClientHandler(connection);
-      btc.start();
-    }
+		writeMessage("Bluetooth Server started. Waiting for Bluetooth test clients... \n");
 
-    streamConnNotifier.close();
-  }
-
-  public static void writeMessage(String arg)
-  {
-	  if(gui == false){
-	    try {
-	      out.write(arg);
-	      out.flush();
-	    }
-	    catch (Exception localException)
-	    {
-	    }
-	  }
-	  else{
-		  GUI.writeMessage(arg);
-	  }
-  }
-
-  public static void main(String[] args)
-  {
-	  if(args.length == 0){
-		  gui = true;
-		  GUI.startGUI();
-	      btServer = new BTServer();
-	      try {
-			btServer.startServer();
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+		while (this.run) {
+			connection = streamConnNotifier.acceptAndOpen();
+			BTClientHandler btc = new BTClientHandler(connection);
+			btc.start();
 		}
-	  }
-	  else{
-	    try {
-	      out = new OutputStreamWriter(new FileOutputStream(args[0]));
-	
-	      LocalDevice localDevice = LocalDevice.getLocalDevice();
-	      writeMessage("Local System:\n");
-	      writeMessage("Address: " + localDevice.getBluetoothAddress() + "\n");
-	      writeMessage("Name: " + localDevice.getFriendlyName() + "\n");
-	
-	      btServer = new BTServer();
-	      btServer.startServer();
-    } 
-    catch (IOException e)
-    {
-      e.printStackTrace();
-    }
-	  }
-  }
+
+		streamConnNotifier.close();
+	}
+
+	public static void writeMessage(String arg) {
+		if (gui == false) {
+			try {
+				out.write(arg);
+				out.flush();
+			} catch (Exception localException) {
+			}
+		} else {
+			GUI.writeMessage(arg);
+		}
+	}
+
+	public static void main(String[] args) {
+		if (args.length == 0) {
+			gui = true;
+			GUI.startGUI();
+			btServer = new BTServer();
+			try {
+				btServer.startServer();
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		} else {
+			try {
+				out = new OutputStreamWriter(new FileOutputStream(args[0]));
+
+				LocalDevice localDevice = LocalDevice.getLocalDevice();
+				writeMessage("Local System:\n");
+				writeMessage("Address: " + localDevice.getBluetoothAddress()
+						+ "\n");
+				writeMessage("Name: " + localDevice.getFriendlyName() + "\n");
+
+				btServer = new BTServer();
+				btServer.startServer();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+	}
 }

--- a/catroidSourceTest/src/org/catrobat/catroid/test/code/CheckForAssertionsTest.java
+++ b/catroidSourceTest/src/org/catrobat/catroid/test/code/CheckForAssertionsTest.java
@@ -36,7 +36,7 @@ import java.util.List;
 public class CheckForAssertionsTest extends TestCase {
 	private StringBuffer errorMessages;
 	private boolean assertionNotFound;
-	private static final String[] DIRECTORIES = { "../catroidUiTest", "../catroidTest", "../catroidCucumberTest", };
+	private static final String[] DIRECTORIES = { "../catroidUiTest", "../catroidTest", "../catroidCucumberTest" };
 	private static final String[] IGNORED_FILES = { "MockGalleryActivity.java", "UiTestUtils.java",
 			"SimulatedSensorManager.java", "SimulatedSoundRecorder.java", "TestUtils.java",
 			"MockPaintroidActivity.java", "TestMainMenuActivity.java", "TestErrorListenerInterface.java",

--- a/catroidSourceTest/src/org/catrobat/catroid/test/license/LicenseTest.java
+++ b/catroidSourceTest/src/org/catrobat/catroid/test/license/LicenseTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 public class LicenseTest extends TestCase {
 	private static final String[] DIRECTORIES = { ".", "../catroid", "../catroidTest", "../catroidUiTest",
-			"../catroidCucumberTest", };
+			"../catroidCucumberTest" };
 
 	private ArrayList<String> agplLicenseText;
 	private boolean allLicenseTextsPresentAndCorrect;

--- a/catroidSourceTest/src/org/catrobat/catroid/test/utils/Utils.java
+++ b/catroidSourceTest/src/org/catrobat/catroid/test/utils/Utils.java
@@ -31,7 +31,12 @@ import java.util.List;
 
 // Ignored, so JUnit won't try to test this class.
 @Ignore
-public class Utils {
+public final class Utils {
+
+	// Suppress default constructor for noninstantiability
+	private Utils() {
+		throw new AssertionError();
+	}
 
 	public static List<File> getFilesFromDirectoryByExtension(File directory, String extension) {
 		String[] extensions = { extension };

--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/RepeatActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/RepeatActionTest.java
@@ -49,7 +49,8 @@ public class RepeatActionTest extends InstrumentationTestCase {
 
 	public void testLoopDelay() throws InterruptedException {
 		final int deltaY = -10;
-		final float delta = 0.005f, delayByContract = 0.020f;
+		final float delta = 0.005f;
+		final float delayByContract = 0.020f;
 		Sprite testSprite = new Sprite("sprite");
 		Script testScript = new StartScript(testSprite);
 

--- a/catroidTest/src/org/catrobat/catroid/test/ui/ViewSwitchLockTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/ui/ViewSwitchLockTest.java
@@ -67,7 +67,7 @@ public class ViewSwitchLockTest extends AndroidTestCase {
 	}
 
 	public void testDefaultSettings() {
-		assertEquals("Wrong default setting", 200l, Reflection.getPrivateField(ViewSwitchLock.class, "UNLOCK_TIMEOUT"));
+		assertEquals("Wrong default setting", 200L, Reflection.getPrivateField(ViewSwitchLock.class, "UNLOCK_TIMEOUT"));
 	}
 
 	public void testUnsupportedMethods() {
@@ -97,7 +97,7 @@ public class ViewSwitchLockTest extends AndroidTestCase {
 		}
 
 		try {
-			viewSwitchLock.tryLock(1l, null);
+			viewSwitchLock.tryLock(1L, null);
 			fail("Method is supported");
 		} catch (UnsupportedOperationException unsupportedOperationException) {
 			// Expected behavior

--- a/catroidTest/src/org/catrobat/catroid/test/utils/Reflection.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utils/Reflection.java
@@ -25,7 +25,12 @@ package org.catrobat.catroid.test.utils;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-public class Reflection {
+public final class Reflection {
+
+	// Suppress default constructor for noninstantiability
+	private Reflection() {
+		throw new AssertionError();
+	}
 
 	public static Object getPrivateField(Object object, String fieldName) {
 		if (object == null) {

--- a/catroidTest/src/org/catrobat/catroid/test/utils/TestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utils/TestUtils.java
@@ -49,13 +49,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-public class TestUtils {
+public final class TestUtils {
 	public static final int TYPE_IMAGE_FILE = 0;
 	public static final int TYPE_SOUND_FILE = 1;
 	public static final String DEFAULT_TEST_PROJECT_NAME = "testProject";
 
+	// Suppress default constructor for noninstantiability
 	private TestUtils() {
-	};
+		throw new AssertionError();
+	}
 
 	/**
 	 * saves a file into the project folder

--- a/catroidTest/src/org/catrobat/catroid/test/utils/XMLValidationUtil.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utils/XMLValidationUtil.java
@@ -39,10 +39,15 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
 
-public class XMLValidationUtil {
+public final class XMLValidationUtil {
 	// TODO: change to new XML schema
 	private static final String XML_VALIDATING_URL = "http://catroid.org/CatrobatLanguage/xmlSchema/version-0.3/validateXmlVersion3.php";
 	private static final String LOG_TAG = XMLValidationUtil.class.getSimpleName();
+
+	// Suppress default constructor for noninstantiability
+	private XMLValidationUtil() {
+		throw new AssertionError();
+	}
 
 	public static void sendProjectXMLToServerForValidating(Project projectToValidate) throws IOException,
 			JSONException, WebconnectionException {

--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/ImageEditingTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/ImageEditingTest.java
@@ -68,7 +68,7 @@ public class ImageEditingTest extends TestCase {
 			e.printStackTrace();
 		}
 
-		int dimensions[] = new int[2];
+		int[] dimensions = new int[2];
 
 		dimensions = ImageEditing.getImageDimensions(testImageFile.getAbsolutePath());
 

--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/ReflectionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/ReflectionTest.java
@@ -272,7 +272,7 @@ public class ReflectionTest extends AndroidTestCase {
 
 	public void testConvertObjectsIntoPrimitives() {
 		ParameterList parameterList = new ParameterList(Boolean.valueOf(true), Byte.valueOf((byte) 1),
-				Character.valueOf('c'), Double.valueOf(1.0), Float.valueOf(1.0f), Integer.valueOf(1), Long.valueOf(1l),
+				Character.valueOf('c'), Double.valueOf(1.0), Float.valueOf(1.0f), Integer.valueOf(1), Long.valueOf(1L),
 				Short.valueOf((short) 1));
 
 		Class<?>[] primitiveObjectsClass = (Class<?>[]) Reflection.getPrivateField(parameterList, "types");

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
@@ -1258,7 +1258,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 	public void testProjectDetailsLastAccess() {
 		String showDetailsText = solo.getString(R.string.show_details);
 
-		Date date = new Date(1357038000000l);
+		Date date = new Date(1357038000000L);
 		DateFormat mediumDateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM);
 
 		// sometimes standard project is not created for some reason!

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/util/Reflection.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/util/Reflection.java
@@ -25,7 +25,12 @@ package org.catrobat.catroid.uitest.util;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-public class Reflection {
+public final class Reflection {
+
+	// Suppress default constructor for noninstantiability
+	private Reflection() {
+		throw new AssertionError();
+	}
 
 	public static Object getPrivateField(Object object, String fieldName) {
 		if (object == null) {

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -156,7 +156,7 @@ import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
 
-public class UiTestUtils {
+public final class UiTestUtils {
 	private static ProjectManager projectManager = ProjectManager.getInstance();
 	private static SparseIntArray brickCategoryMap;
 	private static List<InternToken> internTokenList = new ArrayList<InternToken>();
@@ -191,9 +191,10 @@ public class UiTestUtils {
 		IMAGE, SOUND, ROOT
 	};
 
+	// Suppress default constructor for noninstantiability
 	private UiTestUtils() {
-
-	};
+		throw new AssertionError();
+	}
 
 	public static void enterText(Solo solo, int editTextIndex, String text) {
 

--- a/catroidUiTest/src/org/catrobat/catroid/uitest/util/XMLValidationUtil.java
+++ b/catroidUiTest/src/org/catrobat/catroid/uitest/util/XMLValidationUtil.java
@@ -39,10 +39,15 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
 
-public class XMLValidationUtil {
+public final class XMLValidationUtil {
 	// TODO: add new XML schema
 	private static final String XML_VALIDATING_URL = "http://catroid.org/CatrobatLanguage/xmlSchema/version-0.3/validateXmlVersion3.php";
 	private static final String LOG_TAG = XMLValidationUtil.class.getSimpleName();
+
+	// Suppress default constructor for noninstantiability
+	private XMLValidationUtil() {
+		throw new AssertionError();
+	}
 
 	public static void sendProjectXMLToServerForValidating(Project projectToValidate) throws IOException,
 			JSONException, WebconnectionException {


### PR DESCRIPTION
### open for discussion

in this branch I enabled some more checkstyle rules which didn't raise any warnings or could be fixed easily!
have a look at the changes in catroid/checkstyle.xml - further infos for the added checks: http://checkstyle.sourceforge.net/availablechecks.html

some of these rules like GenericWhitespace were automatically resolved by our Eclipse settings when a file is saved and so did not need any code refactoring!
others like HideUtilityClassConstructor raised warnings and were resolved - see commit message for additional info!

also refactored some singletons to match our "convention" for singleton classes!

update # 1 - testrun: https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/783/

update # 2 - rebased; removed ArrayTrailingCommaCheck

update # 3 (29.11.) - newest testrun after rebase: https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/840/
