### PR TITLE
Test nesting brick references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ Thumbs.db
 # Gradle
 .gradle/
 build/
-

--- a/catroid/src/org/catrobat/catroid/ui/adapter/BrickAdapter.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/BrickAdapter.java
@@ -155,6 +155,7 @@ public class BrickAdapter extends BaseAdapter implements DragAndDropListener, On
 	@Override
 	public void drag(int from, int to) {
 
+		int toOriginal = to;
 		if (to < 0 || to >= brickList.size()) {
 			to = brickList.size() - 1;
 		}
@@ -188,7 +189,6 @@ public class BrickAdapter extends BaseAdapter implements DragAndDropListener, On
 				retryScriptDragging = false;
 			}
 		}
-
 		to = getNewPositionIfEndingBrickIsThere(to, draggedBrick);
 
 		if (!(draggedBrick instanceof ScriptBrick)) {
@@ -201,9 +201,13 @@ public class BrickAdapter extends BaseAdapter implements DragAndDropListener, On
 		}
 
 		brickList.remove(draggedBrick);
-		brickList.add(dragTargetPosition, draggedBrick);
-
-		toEndDrag = to;
+		if (dragTargetPosition >= 0 && dragTargetPosition <= brickList.size()) {
+			brickList.add(dragTargetPosition, draggedBrick);
+			toEndDrag = to;
+		} else {
+			brickList.add(toOriginal, draggedBrick);
+			toEndDrag = toOriginal;
+		}
 
 		animatedBricks.clear();
 

--- a/catroidTest/src/org/catrobat/catroid/test/content/project/ProjectTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/project/ProjectTest.java
@@ -95,4 +95,5 @@ public class ProjectTest extends AndroidTestCase {
 		platform = (String) Reflection.getPrivateField(header, "platform");
 		assertEquals("Platform should be the current one", Constants.PLATFORM_NAME, platform);
 	}
+
 }

--- a/catroidTest/src/org/catrobat/catroid/test/utils/TestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utils/TestUtils.java
@@ -34,7 +34,12 @@ import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.content.bricks.ComeToFrontBrick;
 import org.catrobat.catroid.content.bricks.HideBrick;
+import org.catrobat.catroid.content.bricks.IfLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.IfLogicElseBrick;
+import org.catrobat.catroid.content.bricks.IfLogicEndBrick;
+import org.catrobat.catroid.content.bricks.ShowBrick;
 import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.utils.NotificationData;
 import org.catrobat.catroid.utils.StatusBarNotificationManager;
@@ -48,11 +53,14 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class TestUtils {
 	public static final int TYPE_IMAGE_FILE = 0;
 	public static final int TYPE_SOUND_FILE = 1;
 	public static final String DEFAULT_TEST_PROJECT_NAME = "testProject";
+	public static final String CORRUPT_PROJECT_NAME = "copiedProject";
 
 	// Suppress default constructor for noninstantiability
 	private TestUtils() {
@@ -191,6 +199,57 @@ public final class TestUtils {
 
 		StorageHandler.getInstance().saveProject(project);
 		return project;
+	}
+
+	public static List<Brick> createTestProjectWithWrongIfClauseReferences() {
+		ProjectManager projectManager = ProjectManager.getInstance();
+		Project project = new Project(null, CORRUPT_PROJECT_NAME);
+		Sprite firstSprite = new Sprite("corruptReferences");
+
+		Script testScript = new StartScript(firstSprite);
+
+		ArrayList<Brick> brickList = new ArrayList<Brick>();
+
+		IfLogicBeginBrick ifBeginBrick = new IfLogicBeginBrick(firstSprite, 0);
+		IfLogicElseBrick ifElseBrick = new IfLogicElseBrick(firstSprite, ifBeginBrick);
+		ifElseBrick.setIfBeginBrick(null);
+
+		IfLogicBeginBrick ifBeginBrickNested = new IfLogicBeginBrick(firstSprite, 0);
+		//reference shouldn't be null:
+		IfLogicElseBrick ifElseBrickNested = new IfLogicElseBrick(firstSprite, ifBeginBrickNested);
+		ifElseBrickNested.setIfBeginBrick(null);
+		//reference shouldn't be null + wrong ifElseBrickReference:
+		IfLogicEndBrick ifEndBrickNested = new IfLogicEndBrick(firstSprite, ifElseBrick, ifBeginBrickNested);
+		ifEndBrickNested.setIfBeginBrick(null);
+
+		//reference to wrong ifBegin and ifEnd-Bricks:
+		IfLogicEndBrick ifEndBrick = new IfLogicEndBrick(firstSprite, ifElseBrickNested, ifBeginBrickNested);
+
+		brickList.add(ifBeginBrick);
+		brickList.add(new ShowBrick(firstSprite));
+		brickList.add(ifElseBrick);
+		brickList.add(new ComeToFrontBrick(firstSprite));
+		brickList.add(ifBeginBrickNested);
+		brickList.add(new ComeToFrontBrick(firstSprite));
+		brickList.add(ifElseBrickNested);
+		brickList.add(new ShowBrick(firstSprite));
+		brickList.add(ifEndBrickNested);
+		brickList.add(ifEndBrick);
+
+		for (Brick brick : brickList) {
+			testScript.addBrick(brick);
+		}
+
+		firstSprite.addScript(testScript);
+
+		project.addSprite(firstSprite);
+
+		projectManager.setFileChecksumContainer(new FileChecksumContainer());
+		projectManager.setProject(project);
+		projectManager.setCurrentSprite(firstSprite);
+		projectManager.setCurrentScript(testScript);
+
+		return brickList;
 	}
 
 	public static Project createTestProjectOnLocalStorageWithCatrobatLanguageVersion(float catrobatLanguageVersion) {

--- a/catroidTest/src/org/catrobat/catroid/uitest/content/brick/IfBrickTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/content/brick/IfBrickTest.java
@@ -95,7 +95,7 @@ public class IfBrickTest extends BaseActivityInstrumentationTestCase<MainMenuAct
 		int dragAndDropSteps = 100;
 		ArrayList<Integer> yPosition;
 		ArrayList<Brick> projectBrickList = project.getSpriteList().get(0).getScript(0).getBrickList();
-		Log.e(TAG, "Befor drag item 1 to item 4 + 20");
+		Log.e(TAG, "Before drag item 1 to item 4 + 20");
 		logBrickListForJenkins(projectBrickList);
 
 		yPosition = UiTestUtils.getListItemYPositions(solo, 0);
@@ -103,7 +103,7 @@ public class IfBrickTest extends BaseActivityInstrumentationTestCase<MainMenuAct
 		assertEquals("Incorrect number of bricks.", 4, projectBrickList.size());
 		assertTrue("Wrong Brick instance.", (projectBrickList.get(1) instanceof IfLogicBeginBrick));
 
-		Log.e(TAG, "Befor drag item 2 to item 0");
+		Log.e(TAG, "Before drag item 2 to item 0");
 		logBrickListForJenkins(projectBrickList);
 
 		yPosition = UiTestUtils.getListItemYPositions(solo, 0);
@@ -126,7 +126,7 @@ public class IfBrickTest extends BaseActivityInstrumentationTestCase<MainMenuAct
 				+ projectBrickList.get(2).getClass().getSimpleName(),
 				projectBrickList.get(2) instanceof ChangeYByNBrick);
 
-		Log.e(TAG, "Befor drag item 4 to item 0");
+		Log.e(TAG, "Before drag item 4 to item 0");
 		logBrickListForJenkins(projectBrickList);
 
 		yPosition = UiTestUtils.getListItemYPositions(solo, 0);


### PR DESCRIPTION
fixes #827 

Added bricks sometimes disappeared because they were accessed with an invalid negative index in the brick list. This index was the result of wrong nesting brick references (e.g. with the old version of Tic-Tac-Toe), which are due to our former faulty CopySprite-implementation.

The PR fixes it twice:
1. Correct wrong references directly while projects are loaded (autocorrect mode)
2. Checking index bounds on long click in BrickAdapter (if somehow the index is still wrong) 

Testrun:
https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/989/
Only WebviewTest timed out due to some reason --> Internet connection?

Please review with me before merging ;)
