### PR TITLE
make Bluetooth not required #841

### DIFF
--- a/catroid/AndroidManifest.xml
+++ b/catroid/AndroidManifest.xml
@@ -41,10 +41,12 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+    <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
 
     <uses-feature
         android:glEsVersion="0x00020000"


### PR DESCRIPTION
as stated in issue #841 BT is currently required for Catroid. Because we only need it for NXT (Albert, Ardoino) a BT-module should not be required for app installation.

Not tested on physical device yet, will be done tomorrow.

successful Test run https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/1143/
