### PR TITLE
Restart When script correctly when BroadcastWait is sent

### DIFF
--- a/catroid/src/org/catrobat/catroid/common/BroadcastSequenceMap.java
+++ b/catroid/src/org/catrobat/catroid/common/BroadcastSequenceMap.java
@@ -35,18 +35,18 @@ public final class BroadcastSequenceMap {
 	}
 
 	public static boolean containsKey(String key) {
-		return broadcastSequenceMap.containsKey(key);
+		return BroadcastSequenceMap.broadcastSequenceMap.containsKey(key);
 	}
 
 	public static ArrayList<SequenceAction> get(String key) {
-		return broadcastSequenceMap.get(key);
+		return BroadcastSequenceMap.broadcastSequenceMap.get(key);
 	}
 
 	public static ArrayList<SequenceAction> put(String key, ArrayList<SequenceAction> value) {
-		return broadcastSequenceMap.put(key, value);
+		return BroadcastSequenceMap.broadcastSequenceMap.put(key, value);
 	}
 
 	public static void clear() {
-		broadcastSequenceMap.clear();
+		BroadcastSequenceMap.broadcastSequenceMap.clear();
 	}
 }

--- a/catroid/src/org/catrobat/catroid/common/BroadcastWaitSequenceMap.java
+++ b/catroid/src/org/catrobat/catroid/common/BroadcastWaitSequenceMap.java
@@ -38,23 +38,23 @@ public final class BroadcastWaitSequenceMap {
 	}
 
 	public static boolean containsKey(String key) {
-		return broadcastWaitSequenceMap.containsKey(key);
+		return BroadcastWaitSequenceMap.broadcastWaitSequenceMap.containsKey(key);
 	}
 
 	public static ArrayList<SequenceAction> get(String key) {
-		return broadcastWaitSequenceMap.get(key);
+		return BroadcastWaitSequenceMap.broadcastWaitSequenceMap.get(key);
 	}
 
 	public static ArrayList<SequenceAction> put(String key, ArrayList<SequenceAction> value) {
-		return broadcastWaitSequenceMap.put(key, value);
+		return BroadcastWaitSequenceMap.broadcastWaitSequenceMap.put(key, value);
 	}
 
 	public static ArrayList<SequenceAction> remove(String key) {
-		return broadcastWaitSequenceMap.remove(key);
+		return BroadcastWaitSequenceMap.broadcastWaitSequenceMap.remove(key);
 	}
 
 	public static void clear() {
-		broadcastWaitSequenceMap.clear();
+		BroadcastWaitSequenceMap.broadcastWaitSequenceMap.clear();
 	}
 
 	public static BroadcastEvent getCurrentBroadcastEvent() {

--- a/catroid/src/org/catrobat/catroid/content/actions/BroadcastNotifyAction.java
+++ b/catroid/src/org/catrobat/catroid/content/actions/BroadcastNotifyAction.java
@@ -42,4 +42,8 @@ public class BroadcastNotifyAction extends Action {
 	public void setEvent(BroadcastEvent event) {
 		this.event = event;
 	}
+
+	public BroadcastEvent getEvent() {
+		return event;
+	}
 }

--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/BroadcastActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/BroadcastActionTest.java
@@ -139,6 +139,48 @@ public class BroadcastActionTest extends AndroidTestCase {
 				(int) sprite.look.getXInUserInterfaceDimensionUnit() > xMovement);
 	}
 
+	public void testRestartingOfWhenScriptWithBroadcastWaitBrick() {
+		String messageOne = "messageOne";
+		String messageTwo = "messageTwo";
+		final int xMovement = 1;
+
+		Sprite sprite = new Sprite("cat");
+		Script startScript = new StartScript(sprite);
+		BroadcastBrick startBroadcastBrick = new BroadcastBrick(sprite, messageOne);
+		startScript.addBrick(startBroadcastBrick);
+		sprite.addScript(startScript);
+
+		BroadcastScript broadcastScriptMessageOne = new BroadcastScript(sprite, messageOne);
+		ChangeXByNBrick changeXByNBrickOne = new ChangeXByNBrick(sprite, xMovement);
+		BroadcastWaitBrick broadcastWaitBrickOne = new BroadcastWaitBrick(sprite, messageTwo);
+		broadcastScriptMessageOne.addBrick(changeXByNBrickOne);
+		broadcastScriptMessageOne.addBrick(broadcastWaitBrickOne);
+		sprite.addScript(broadcastScriptMessageOne);
+
+		BroadcastScript broadcastScriptMessageTwo = new BroadcastScript(sprite, messageTwo);
+		ChangeXByNBrick changeXByNBrickTwo = new ChangeXByNBrick(sprite, xMovement);
+		BroadcastWaitBrick broadcastWaitBrickTwo = new BroadcastWaitBrick(sprite, messageOne);
+		broadcastScriptMessageTwo.addBrick(changeXByNBrickTwo);
+		broadcastScriptMessageTwo.addBrick(broadcastWaitBrickTwo);
+		sprite.addScript(broadcastScriptMessageTwo);
+
+		Project project = new Project(getContext(), UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
+		project.addSprite(sprite);
+		ProjectManager.getInstance().setProject(project);
+
+		sprite.createStartScriptActionSequence();
+
+		int loopCounter = 0;
+		while (!allActionsOfAllSpritesAreFinished() && loopCounter++ < 20) {
+			for (Sprite spriteOfList : ProjectManager.getInstance().getCurrentProject().getSpriteList()) {
+				spriteOfList.look.act(1.0f);
+			}
+		}
+
+		assertTrue("When script does not restart itself when a BroadcastWait is sent! ",
+				(int) sprite.look.getXInUserInterfaceDimensionUnit() > 5 * xMovement);
+	}
+
 	public boolean allActionsOfAllSpritesAreFinished() {
 		for (Sprite spriteOfList : ProjectManager.getInstance().getCurrentProject().getSpriteList()) {
 			if (!spriteOfList.look.getAllActionsAreFinished()) {

--- a/catroidTest/src/org/catrobat/catroid/uitest/stage/BroadCastReceiverRegressionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/stage/BroadCastReceiverRegressionTest.java
@@ -28,6 +28,7 @@ import org.catrobat.catroid.content.BroadcastScript;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.BroadcastBrick;
+import org.catrobat.catroid.content.bricks.BroadcastWaitBrick;
 import org.catrobat.catroid.content.bricks.ChangeXByNBrick;
 import org.catrobat.catroid.stage.StageActivity;
 import org.catrobat.catroid.ui.MainMenuActivity;
@@ -111,5 +112,40 @@ public class BroadCastReceiverRegressionTest extends BaseActivityInstrumentation
 
 		assertTrue("When script does not restart itself!",
 				(int) sprite.look.getXInUserInterfaceDimensionUnit() > xMovement);
+	}
+
+	public void testRestartingOfWhenScriptWithBroadcastWaitBrick() {
+		String messageOne = "messageOne";
+		String messageTwo = "messageTwo";
+		final int xMovement = 1;
+
+		UiTestUtils.createEmptyProject();
+		Sprite sprite = ProjectManager.getInstance().getCurrentProject().getSpriteList().get(0);
+		Script startScript = sprite.getScript(0);
+		BroadcastBrick startBroadcastBrick = new BroadcastBrick(sprite, messageOne);
+		startScript.addBrick(startBroadcastBrick);
+
+		BroadcastScript broadcastScriptMessageOne = new BroadcastScript(sprite, messageOne);
+		ChangeXByNBrick changeXByNBrickOne = new ChangeXByNBrick(sprite, xMovement);
+		BroadcastWaitBrick broadcastWaitBrickOne = new BroadcastWaitBrick(sprite, messageTwo);
+		broadcastScriptMessageOne.addBrick(changeXByNBrickOne);
+		broadcastScriptMessageOne.addBrick(broadcastWaitBrickOne);
+		sprite.addScript(broadcastScriptMessageOne);
+
+		BroadcastScript broadcastScriptMessageTwo = new BroadcastScript(sprite, messageTwo);
+		ChangeXByNBrick changeXByNBrickTwo = new ChangeXByNBrick(sprite, xMovement);
+		BroadcastWaitBrick broadcastWaitBrickTwo = new BroadcastWaitBrick(sprite, messageOne);
+		broadcastScriptMessageTwo.addBrick(changeXByNBrickTwo);
+		broadcastScriptMessageTwo.addBrick(broadcastWaitBrickTwo);
+		sprite.addScript(broadcastScriptMessageTwo);
+
+		UiTestUtils.getIntoScriptActivityFromMainMenu(solo);
+
+		UiTestUtils.clickOnBottomBar(solo, R.id.button_play);
+		solo.waitForActivity(StageActivity.class.getSimpleName());
+		solo.sleep(3000);
+
+		assertTrue("When script does not restart itself when a BroadcastWait is sent!",
+				(int) sprite.look.getXInUserInterfaceDimensionUnit() > 5 * xMovement);
 	}
 }


### PR DESCRIPTION
A `When` script was not correctly restarted if a `BroadcastWait` was sent. See regression tests in `BroadcastActionTest.java` and `BroadCastReceiverRegressionTest.java` for examples.

This fixes issue #876 

Successful Jenkins testrun: ~~[1241](https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/1241/)~~ [1260](https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/1260/)
