### PR TITLE
"add new look dialog" changed according to new object workflow add look.

### DIFF
--- a/catroid/res/layout/dialog_new_look.xml
+++ b/catroid/res/layout/dialog_new_look.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+ *  Catroid: An on-device visual programming system for Android devices
+ *  Copyright (C) 2010-2013 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *  
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *  
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  http://developer.catrobat.org/license_additional_term
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            style="style/DefaultDialog"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="0dp">
+
+    <LinearLayout
+        android:id="@+id/dialog_new_look"
+        style="@style/DefaultDialog.Item"
+        android:layout_marginTop="8dp"
+        android:baselineAligned="false"
+        android:weightSum="3">
+
+        <TextView
+            android:id="@+id/dialog_new_look_paintroid"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="@drawable/new_object_dialog_selector"
+            android:drawableTop="@drawable/ic_paintroid"
+            android:gravity="center"
+            android:text="@string/add_look_draw_new_image"
+            android:textSize="12sp"/>
+
+        <TextView
+            android:id="@+id/dialog_new_look_gallery"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="@drawable/new_object_dialog_selector"
+            android:drawableTop="@drawable/ic_gallery"
+            android:gravity="center"
+            android:text="@string/add_look_choose_image"
+            android:textSize="12sp"/>
+
+        <TextView
+            android:id="@+id/dialog_new_look_camera"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="@drawable/new_object_dialog_selector"
+            android:drawableTop="@drawable/ic_camera"
+            android:gravity="center"
+            android:text="@string/add_look_from_camera"
+            android:textSize="12sp"/>
+    </LinearLayout>
+</ScrollView>

--- a/catroid/res/values/arrays.xml
+++ b/catroid/res/values/arrays.xml
@@ -38,11 +38,5 @@
         <item>@string/nxt_motor_all</item>
     </string-array>
 
-    <!-- New Look Dialog -->
-    <string-array name="new_look_chooser">
-        <item>@string/add_look_from_camera</item>
-        <item>@string/add_look_choose_image</item>
-        <item>@string/add_look_draw_new_image</item>
-    </string-array>
 
 </resources>

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/NewLookDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/NewLookDialog.java
@@ -2,21 +2,21 @@
  *  Catroid: An on-device visual programming system for Android devices
  *  Copyright (C) 2010-2013 The Catrobat Team
  *  (<http://developer.catrobat.org/credits>)
- *  
+ *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
  *  published by the Free Software Foundation, either version 3 of the
  *  License, or (at your option) any later version.
- *  
+ *
  *  An additional term exception under section 7 of the GNU Affero
  *  General Public License, version 3, is available at
  *  http://developer.catrobat.org/license_additional_term
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU Affero General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,56 +24,98 @@ package org.catrobat.catroid.ui.dialogs;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
-import android.content.DialogInterface;
+import android.content.ComponentName;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
-import android.support.v4.app.FragmentManager;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
 
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.ui.controller.LookController;
 import org.catrobat.catroid.ui.fragment.LookFragment;
 
 public class NewLookDialog extends DialogFragment {
 
-	public static final String DIALOG_FRAGMENT_TAG = "dialog_new_look";
+	public static final String TAG = "dialog_new_look";
 
-	public static final int FROM_CAMERA_INDEX = 0;
-	public static final int CHOOSE_IMAGE_INDEX = 1;
-	public static final int DRAW_NEW_IMAGE = 2;
+	private LookFragment fragment = null;
 
-	private LookFragment lookFragment = null;
+	public static NewLookDialog newInstance() {
+		return new NewLookDialog();
+	}
 
-	public void showDialog(FragmentManager fragmentManager, LookFragment fragment) {
-		lookFragment = fragment;
-		show(fragmentManager, DIALOG_FRAGMENT_TAG);
+	public void showDialog(Fragment fragment) {
+		if (!(fragment instanceof LookFragment)) {
+			throw new RuntimeException("This dialog (NewLookDialog) can only be called by the LookFragment.");
+		}
+		this.fragment = (LookFragment) fragment;
+		show(fragment.getActivity().getSupportFragmentManager(), TAG);
 	}
 
 	@Override
 	public Dialog onCreateDialog(Bundle savedInstanceState) {
-		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+		View dialogView = LayoutInflater.from(getActivity()).inflate(R.layout.dialog_new_look, null);
+		setupPaintroidButton(dialogView);
+		setupGalleryButton(dialogView);
+		setupCameraButton(dialogView);
 
-		builder.setTitle(R.string.new_look_dialog_title).setItems(R.array.new_look_chooser,
-				new DialogInterface.OnClickListener() {
-					@Override
-					public void onClick(DialogInterface dialog, int index) {
-						if (lookFragment == null) {
-							return;
-						}
-						switch (index) {
-							case FROM_CAMERA_INDEX:
-								lookFragment.addLookFromCamera();
-								break;
-							case CHOOSE_IMAGE_INDEX:
-								lookFragment.addLookChooseImage();
-								break;
-							case DRAW_NEW_IMAGE:
-								lookFragment.addLookDrawNewImage();
-								break;
-							default:
-								break;
-						}
-					}
-				});
+		AlertDialog dialog;
+		AlertDialog.Builder dialogBuilder = new CustomAlertDialogBuilder(getActivity()).setView(dialogView).setTitle(
+				R.string.new_look_dialog_title);
 
-		return builder.create();
+		dialog = createDialog(dialogBuilder);
+		dialog.setCanceledOnTouchOutside(true);
+		return dialog;
+	}
+
+	private AlertDialog createDialog(AlertDialog.Builder dialogBuilder) {
+		return dialogBuilder.create();
+	}
+
+	private void setupPaintroidButton(View parentView) {
+		View paintroidButton = parentView.findViewById(R.id.dialog_new_look_paintroid);
+
+		final Intent intent = new Intent("android.intent.action.MAIN");
+		intent.setComponent(new ComponentName(Constants.POCKET_PAINT_PACKAGE_NAME,
+				Constants.POCKET_PAINT_INTENT_ACTIVITY_NAME));
+
+		paintroidButton.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View view) {
+				if (LookController.getInstance().checkIfPocketPaintIsInstalled(intent, getActivity())) {
+					fragment.addLookDrawNewImage();
+					NewLookDialog.this.dismiss();
+				}
+			}
+		});
+	}
+
+	private void setupGalleryButton(View parentView) {
+		View galleryButton = parentView.findViewById(R.id.dialog_new_look_gallery);
+
+		galleryButton.setOnClickListener(new View.OnClickListener() {
+
+			@Override
+			public void onClick(View view) {
+				fragment.addLookChooseImage();
+				NewLookDialog.this.dismiss();
+			}
+		});
+	}
+
+	private void setupCameraButton(View parentView) {
+		View cameraButton = parentView.findViewById(R.id.dialog_new_look_camera);
+
+		cameraButton.setOnClickListener(new View.OnClickListener() {
+
+			@Override
+			public void onClick(View view) {
+				fragment.addLookFromCamera();
+				NewLookDialog.this.dismiss();
+			}
+		});
 	}
 }

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/NewSpriteDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/NewSpriteDialog.java
@@ -2,21 +2,21 @@
  *  Catroid: An on-device visual programming system for Android devices
  *  Copyright (C) 2010-2013 The Catrobat Team
  *  (<http://developer.catrobat.org/credits>)
- *  
+ *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
  *  published by the Free Software Foundation, either version 3 of the
  *  License, or (at your option) any later version.
- *  
+ *
  *  An additional term exception under section 7 of the GNU Affero
  *  General Public License, version 3, is available at
  *  http://developer.catrobat.org/license_additional_term
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU Affero General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -39,7 +39,6 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
@@ -64,29 +63,31 @@ public class NewSpriteDialog extends DialogFragment {
 	private static final int REQUEST_SELECT_IMAGE = 0;
 	private static final int REQUEST_CREATE_POCKET_PAINT_IMAGE = 1;
 	private static final int REQUEST_TAKE_PICTURE = 2;
-
-	public enum ActionAfterFinished {
-		ACTION_FORWARD_TO_NEW_OBJECT, ACTION_UPDATE_SPINNER;
-		static final String KEY = "action";
-	};
-
-	public enum DialogWizardStep {
-		STEP_1, STEP_2;
-		static final String KEY = "step";
-	}
-
 	private final ActionAfterFinished requestedAction;
 	private final DialogWizardStep wizardStep;
-
 	private Uri lookUri;
 	private View dialogView;
-
 	private String newObjectName = null;
 	private SpinnerAdapterWrapper spinnerAdapter;
 
 	public NewSpriteDialog() {
 		this.requestedAction = ActionAfterFinished.ACTION_FORWARD_TO_NEW_OBJECT;
 		this.wizardStep = DialogWizardStep.STEP_1;
+	}
+
+	public NewSpriteDialog(SpinnerAdapterWrapper spinnerAdapter) {
+		this.requestedAction = ActionAfterFinished.ACTION_UPDATE_SPINNER;
+		this.spinnerAdapter = spinnerAdapter;
+		this.wizardStep = DialogWizardStep.STEP_1;
+	}
+
+	private NewSpriteDialog(DialogWizardStep wizardStep, Uri lookUri, String newObjectName,
+							ActionAfterFinished requestedAction, SpinnerAdapterWrapper spinnerAdapter) {
+		this.requestedAction = requestedAction;
+		this.wizardStep = wizardStep;
+		this.lookUri = lookUri;
+		this.newObjectName = newObjectName;
+		this.spinnerAdapter = spinnerAdapter;
 	}
 
 	static NewSpriteDialog newInstance() {
@@ -97,21 +98,6 @@ public class NewSpriteDialog extends DialogFragment {
 		arguments.putInt(DialogWizardStep.KEY, DialogWizardStep.STEP_1.ordinal());
 		newSpriteDialog.setArguments(arguments);
 		return newSpriteDialog;
-	}
-
-	public NewSpriteDialog(SpinnerAdapterWrapper spinnerAdapter) {
-		this.requestedAction = ActionAfterFinished.ACTION_UPDATE_SPINNER;
-		this.spinnerAdapter = spinnerAdapter;
-		this.wizardStep = DialogWizardStep.STEP_1;
-	}
-
-	private NewSpriteDialog(DialogWizardStep wizardStep, Uri lookUri, String newObjectName,
-			ActionAfterFinished requestedAction, SpinnerAdapterWrapper spinnerAdapter) {
-		this.requestedAction = requestedAction;
-		this.wizardStep = wizardStep;
-		this.lookUri = lookUri;
-		this.newObjectName = newObjectName;
-		this.spinnerAdapter = spinnerAdapter;
 	}
 
 	@Override
@@ -215,7 +201,7 @@ public class NewSpriteDialog extends DialogFragment {
 	}
 
 	private Uri decodeUri(Uri uri) {
-		String[] filePathColumn = { MediaStore.Images.Media.DATA };
+		String[] filePathColumn = {MediaStore.Images.Media.DATA};
 		Cursor cursor = getActivity().getContentResolver().query(uri, filePathColumn, null, null, null);
 		cursor.moveToFirst();
 		int columnIndex = cursor.getColumnIndexOrThrow(filePathColumn[0]);
@@ -228,14 +214,14 @@ public class NewSpriteDialog extends DialogFragment {
 	private void setupPaintroidButton(View parentView) {
 		View paintroidButton = parentView.findViewById(R.id.dialog_new_object_paintroid);
 
-		Intent intent = new Intent("android.intent.action.MAIN");
+		final Intent intent = new Intent("android.intent.action.MAIN");
 		intent.setComponent(new ComponentName(Constants.POCKET_PAINT_PACKAGE_NAME,
 				Constants.POCKET_PAINT_INTENT_ACTIVITY_NAME));
-		if (LookController.getInstance().checkIfPocketPaintIsInstalled(intent, getActivity())) {
-			paintroidButton.setOnClickListener(new View.OnClickListener() {
 
-				@Override
-				public void onClick(View view) {
+		paintroidButton.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View view) {
+				if (LookController.getInstance().checkIfPocketPaintIsInstalled(intent, getActivity())) {
 					Intent intent = new Intent("android.intent.action.MAIN");
 					intent.setComponent(new ComponentName(Constants.POCKET_PAINT_PACKAGE_NAME,
 							Constants.POCKET_PAINT_INTENT_ACTIVITY_NAME));
@@ -250,12 +236,10 @@ public class NewSpriteDialog extends DialogFragment {
 					intent.addCategory("android.intent.category.LAUNCHER");
 					startActivityForResult(intent, REQUEST_CREATE_POCKET_PAINT_IMAGE);
 				}
-			});
-		} else {
-			LinearLayout linearLayout = (LinearLayout) parentView.findViewById(R.id.dialog_new_object_step_1_layout);
-			paintroidButton.setVisibility(View.GONE);
-			linearLayout.setWeightSum(2f);
-		}
+			}
+
+		});
+
 	}
 
 	private void setupGalleryButton(View parentView) {
@@ -357,5 +341,15 @@ public class NewSpriteDialog extends DialogFragment {
 		}
 		dismiss();
 		return true;
+	}
+
+	public enum ActionAfterFinished {
+		ACTION_FORWARD_TO_NEW_OBJECT, ACTION_UPDATE_SPINNER;
+		static final String KEY = "action";
+	}
+
+	public enum DialogWizardStep {
+		STEP_1, STEP_2;
+		static final String KEY = "step";
 	}
 }

--- a/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
@@ -585,8 +585,8 @@ public class LookFragment extends ScriptActivityFragment implements OnLookEditLi
 		if (!viewSwitchLock.tryLock()) {
 			return;
 		}
-		NewLookDialog dialog = new NewLookDialog();
-		dialog.showDialog(getActivity().getSupportFragmentManager(), this);
+		NewLookDialog dialog = NewLookDialog.newInstance();
+		dialog.showDialog(this);
 	}
 
 	@Override


### PR DESCRIPTION
- own xml file
- pocketPaintButton allways visible
- pocketPaintInstallDialog moved to the front. (NewObject and NewLook)

jenkins successful:
https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/1252/
source check:
https://jenkins.catrob.at/view/All-Categories/view/Catroid/job/Catroid-build-and-test-source/1624/
