### PR TITLE
refactored Angle Calculation in Catroid and Physics

### DIFF
--- a/catroid/src/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/org/catrobat/catroid/content/Look.java
@@ -352,21 +352,15 @@ public class Look extends Image {
 	}
 
 	public float getDirectionInUserInterfaceDimensionUnit() {
-		float direction = (getRotation() + DEGREE_UI_OFFSET) % 360;
-		if (direction < 0) {
-			direction += 360f;
-		}
-		direction = 180f - direction;
-
-		return direction;
+		return convertStageAngleToCatroidAngle(getRotation());
 	}
 
 	public void setDirectionInUserInterfaceDimensionUnit(float degrees) {
-		setRotation((-degrees + DEGREE_UI_OFFSET) % 360);
+		setRotation(convertCatroidAngleToStageAngle(degrees));
 	}
 
 	public void changeDirectionInUserInterfaceDimensionUnit(float changeDegrees) {
-		setRotation((getRotation() - changeDegrees) % 360);
+		setRotation(getRotation() - changeDegrees);
 	}
 
 	public float getSizeInUserInterfaceDimensionUnit() {
@@ -428,6 +422,30 @@ public class Look extends Image {
 
 	public void changeBrightnessInUserInterfaceDimensionUnit(float changePercent) {
 		setBrightnessInUserInterfaceDimensionUnit(getBrightnessInUserInterfaceDimensionUnit() + changePercent);
+	}
+
+	private boolean isAngleInCatroidIntervall(float catroidAngle) {
+		return (catroidAngle > -180 && catroidAngle <= 180);
+	}
+
+	private float breakDownCatroidAngle(float catroidAngle) { //TODO[physics]: add method
+		catroidAngle = catroidAngle % 360;
+		if (catroidAngle >= 0 && !isAngleInCatroidIntervall(catroidAngle)) {
+			return catroidAngle - 360;
+		} else if (catroidAngle < 0 && !isAngleInCatroidIntervall(catroidAngle)) {
+			return catroidAngle + 360;
+		}
+		return catroidAngle;
+	}
+
+	protected float convertCatroidAngleToStageAngle(float catroidAngle) { //TODO[physics]: add method
+		catroidAngle = breakDownCatroidAngle(catroidAngle);
+		return -catroidAngle + DEGREE_UI_OFFSET;
+	}
+
+	protected float convertStageAngleToCatroidAngle(float stageAngle) { //TODO[physics]: add method
+		float catroidAngle = -stageAngle + DEGREE_UI_OFFSET;
+		return breakDownCatroidAngle(catroidAngle);
 	}
 
 	private class BrightnessContrastShader extends ShaderProgram {

--- a/catroid/src/org/catrobat/catroid/physics/PhysicsBoundaryBox.java
+++ b/catroid/src/org/catrobat/catroid/physics/PhysicsBoundaryBox.java
@@ -47,9 +47,9 @@ public class PhysicsBoundaryBox {
 	 * @param width
 	 */
 	public void create(int width, int height) {
-		float boxWidth = PhysicsWorldConverter.toBox2dCoordinate(width);
-		float boxHeight = PhysicsWorldConverter.toBox2dCoordinate(height);
-		float boxElementSize = PhysicsWorldConverter.toBox2dCoordinate(PhysicsBoundaryBox.FRAME_SIZE);
+		float boxWidth = PhysicsWorldConverter.convertNormalToBox2dCoordinate(width);
+		float boxHeight = PhysicsWorldConverter.convertNormalToBox2dCoordinate(height);
+		float boxElementSize = PhysicsWorldConverter.convertNormalToBox2dCoordinate(PhysicsBoundaryBox.FRAME_SIZE);
 		float halfBoxElementSize = boxElementSize / 2.0f;
 
 		// Top

--- a/catroid/src/org/catrobat/catroid/physics/PhysicsLook.java
+++ b/catroid/src/org/catrobat/catroid/physics/PhysicsLook.java
@@ -111,7 +111,7 @@ public class PhysicsLook extends Look {
 
 	@Override
 	public float getRotation() {
-		super.setRotation(-physicsObject.getDirection() + getDegreeUserInterfaceOffset());
+		super.setRotation((physicsObject.getDirection() % 360));
 		return super.getRotation();
 	}
 
@@ -119,7 +119,7 @@ public class PhysicsLook extends Look {
 	public void setRotation(float degrees) {
 		super.setRotation(degrees);
 		if (null != physicsObject) {
-			physicsObject.setDirection(super.getRotation() + getDegreeUserInterfaceOffset());
+			physicsObject.setDirection(super.getRotation() % 360);
 		}
 	}
 

--- a/catroid/src/org/catrobat/catroid/physics/PhysicsObject.java
+++ b/catroid/src/org/catrobat/catroid/physics/PhysicsObject.java
@@ -138,36 +138,38 @@ public class PhysicsObject {
 	}
 
 	public float getDirection() {
-		return PhysicsWorldConverter.toCatroidAngle(body.getAngle());
+		return PhysicsWorldConverter.convertBox2dToNormalAngle(body.getAngle());
 	}
 
 	public void setDirection(float degrees) {
-		body.setTransform(body.getPosition(), PhysicsWorldConverter.toBox2dAngle(degrees));
+		body.setTransform(body.getPosition(), PhysicsWorldConverter.convertNormalToBox2dAngle(degrees));
 	}
 
 	public float getX() {
-		return PhysicsWorldConverter.toCatroidCoordinate(body.getPosition().x);
+		return PhysicsWorldConverter.convertBox2dToNormalCoordinate(body.getPosition().x);
 	}
 
 	public float getY() {
-		return PhysicsWorldConverter.toCatroidCoordinate(body.getPosition().y);
+		return PhysicsWorldConverter.convertBox2dToNormalCoordinate(body.getPosition().y);
 	}
 
 	public Vector2 getPosition() {
-		return PhysicsWorldConverter.toCatroidVector(body.getPosition());
+		return PhysicsWorldConverter.convertBox2dToNormalVector(body.getPosition());
 	}
 
 	public void setX(float x) {
-		body.setTransform(PhysicsWorldConverter.toBox2dCoordinate(x), body.getPosition().y, body.getAngle());
+		body.setTransform(PhysicsWorldConverter.convertNormalToBox2dCoordinate(x), body.getPosition().y,
+				body.getAngle());
 	}
 
 	public void setY(float y) {
-		body.setTransform(body.getPosition().x, PhysicsWorldConverter.toBox2dCoordinate(y), body.getAngle());
+		body.setTransform(body.getPosition().x, PhysicsWorldConverter.convertNormalToBox2dCoordinate(y),
+				body.getAngle());
 	}
 
 	public void setPosition(float x, float y) {
-		x = PhysicsWorldConverter.toBox2dCoordinate(x);
-		y = PhysicsWorldConverter.toBox2dCoordinate(y);
+		x = PhysicsWorldConverter.convertNormalToBox2dCoordinate(x);
+		y = PhysicsWorldConverter.convertNormalToBox2dCoordinate(y);
 		body.setTransform(x, y, body.getAngle());
 	}
 
@@ -184,11 +186,12 @@ public class PhysicsObject {
 	}
 
 	public Vector2 getVelocity() {
-		return PhysicsWorldConverter.toCatroidVector(body.getLinearVelocity());
+		return PhysicsWorldConverter.convertBox2dToNormalVector(body.getLinearVelocity());
 	}
 
 	public void setVelocity(float x, float y) {
-		body.setLinearVelocity(PhysicsWorldConverter.toBox2dCoordinate(x), PhysicsWorldConverter.toBox2dCoordinate(y));
+		body.setLinearVelocity(PhysicsWorldConverter.convertNormalToBox2dCoordinate(x),
+				PhysicsWorldConverter.convertNormalToBox2dCoordinate(y));
 	}
 
 	public float getMass() {
@@ -336,10 +339,10 @@ public class PhysicsObject {
 
 	public void getBoundaryBox(Vector2 lower, Vector2 upper) {
 		calcAABB();
-		lower.x = PhysicsWorldConverter.toCatroidVector(bodyAABBlower).x;
-		lower.y = PhysicsWorldConverter.toCatroidVector(bodyAABBlower).y;
-		upper.x = PhysicsWorldConverter.toCatroidVector(bodyAABBupper).x;
-		upper.y = PhysicsWorldConverter.toCatroidVector(bodyAABBupper).y;
+		lower.x = PhysicsWorldConverter.convertBox2dToNormalVector(bodyAABBlower).x;
+		lower.y = PhysicsWorldConverter.convertBox2dToNormalVector(bodyAABBlower).y;
+		upper.x = PhysicsWorldConverter.convertBox2dToNormalVector(bodyAABBupper).x;
+		upper.y = PhysicsWorldConverter.convertBox2dToNormalVector(bodyAABBupper).y;
 	}
 
 	private void calcAABB() {

--- a/catroid/src/org/catrobat/catroid/physics/PhysicsWorldConverter.java
+++ b/catroid/src/org/catrobat/catroid/physics/PhysicsWorldConverter.java
@@ -24,37 +24,30 @@ package org.catrobat.catroid.physics;
 
 import com.badlogic.gdx.math.Vector2;
 
-import org.catrobat.catroid.content.Look;
-
 public final class PhysicsWorldConverter {
 
-	public static float toCatroidAngle(float box2dAngle) {
-		float direction = (float) (Math.toDegrees(box2dAngle) + Look.getDegreeUserInterfaceOffset()) % 360;
-		if (direction < 0) {
-			direction += 360f;
-		}
-		direction = 180f - direction;
-
-		return direction;
+	public static float convertBox2dToNormalAngle(float box2dAngle) {
+		return (float) Math.toDegrees(box2dAngle);
 	}
 
-	public static float toBox2dAngle(float catroidAngle) {
-		return (float) Math.toRadians((catroidAngle - Look.getDegreeUserInterfaceOffset()) % 360);
+	public static float convertNormalToBox2dAngle(float catroidAngle) {
+		return (float) Math.toRadians(catroidAngle);
 	}
 
-	public static float toCatroidCoordinate(float box2dCoordinate) {
+	public static float convertBox2dToNormalCoordinate(float box2dCoordinate) {
 		return box2dCoordinate * PhysicsWorld.RATIO;
 	}
 
-	public static float toBox2dCoordinate(float catroidCoordinate) {
+	public static float convertNormalToBox2dCoordinate(float catroidCoordinate) {
 		return catroidCoordinate / PhysicsWorld.RATIO;
 	}
 
-	public static Vector2 toCatroidVector(Vector2 box2DVector) {
-		return new Vector2(toCatroidCoordinate(box2DVector.x), toCatroidCoordinate(box2DVector.y));
+	public static Vector2 convertBox2dToNormalVector(Vector2 box2DVector) {
+		return new Vector2(convertBox2dToNormalCoordinate(box2DVector.x), convertBox2dToNormalCoordinate(box2DVector.y));
 	}
 
-	public static Vector2 toBox2dVector(Vector2 catroidVector) {
-		return new Vector2(toBox2dCoordinate(catroidVector.x), toBox2dCoordinate(catroidVector.y));
+	public static Vector2 convertCatroidToBox2dVector(Vector2 catroidVector) {
+		return new Vector2(convertNormalToBox2dCoordinate(catroidVector.x),
+				convertNormalToBox2dCoordinate(catroidVector.y));
 	}
 }

--- a/catroid/src/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilderStrategyFastHull.java
+++ b/catroid/src/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilderStrategyFastHull.java
@@ -129,7 +129,7 @@ public final class PhysicsShapeBuilderStrategyFastHull implements PhysicsShapeBu
 			Vector2 point = convexpoints[index];
 			point.x -= width / 2;
 			point.y = height - point.y - height / 2;
-			convexpoints[index] = PhysicsWorldConverter.toBox2dVector(point);
+			convexpoints[index] = PhysicsWorldConverter.convertCatroidToBox2dVector(point);
 		}
 
 		if (convexpoints.length < 9) {

--- a/catroid/src/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilderStrategyRectangle.java
+++ b/catroid/src/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilderStrategyRectangle.java
@@ -81,10 +81,10 @@ public class PhysicsShapeBuilderStrategyRectangle implements PhysicsShapeBuilder
 			height = 1;
 		}
 
-		float box2dWidth = PhysicsWorldConverter.toBox2dCoordinate(width) / 2.0f;
-		float box2dHeight = PhysicsWorldConverter.toBox2dCoordinate(height) / 2.0f;
-		Vector2 center = new Vector2(box2dWidth - PhysicsWorldConverter.toBox2dCoordinate(pixmap.getWidth() / 2.0f),
-				box2dHeight - PhysicsWorldConverter.toBox2dCoordinate(pixmap.getHeight() / 2.0f));
+		float box2dWidth = PhysicsWorldConverter.convertNormalToBox2dCoordinate(width) / 2.0f;
+		float box2dHeight = PhysicsWorldConverter.convertNormalToBox2dCoordinate(height) / 2.0f;
+		Vector2 center = new Vector2(box2dWidth - PhysicsWorldConverter.convertNormalToBox2dCoordinate(pixmap.getWidth() / 2.0f),
+				box2dHeight - PhysicsWorldConverter.convertNormalToBox2dCoordinate(pixmap.getHeight() / 2.0f));
 		PolygonShape polygonShape = new PolygonShape();
 		polygonShape.setAsBox(box2dWidth, box2dHeight, center, 0.0f);
 

--- a/catroidTest/src/org/catrobat/catroid/test/content/sprite/LookTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/sprite/LookTest.java
@@ -34,6 +34,7 @@ import org.catrobat.catroid.content.Look;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.test.utils.Reflection;
+import org.catrobat.catroid.test.utils.Reflection.ParameterList;
 
 public class LookTest extends InstrumentationTestCase {
 	private Look look;
@@ -120,6 +121,163 @@ public class LookTest extends InstrumentationTestCase {
 		assertEquals("Wrong alpha value!", y - height / 2, look.getY());
 	}
 
+	public void testAngleInCatroidIntervall() {
+		float[] angles = { -360.0f, -180.0f, -179.5f, -90.0f, 0.0f, 90.0f, 180.0f, 180.5f, 360.0f };
+		boolean[] expectedResults = { false, false, true, true, true, true, true, false, false };
+		for (int index = 0; index < angles.length; index++) {
+			ParameterList params = new ParameterList(angles[index]);
+			boolean result = (Boolean) Reflection.invokeMethod(look, "isAngleInCatroidIntervall", params);
+			assertEquals("wrong result for angle " + angles[index], expectedResults[index], result);
+		}
+	}
+
+	private float convertNegativeZeroToPosigiveZero(float value) {
+		if (value == 0.0f) {
+			return 0.0f;
+		}
+		return value;
+	}
+
+	public void testBreakDownCatroidAngle() {
+		Look look = new Look(new Sprite("testsprite"));
+
+		float[] posigiveInputAngles = { 0.0f, 45.0f, 90.0f, 135.0f, 180.0f, 225.0f, 270.0f, 315.0f, 360.0f };
+		float[] posigiveHighInputAngles = { 360.0f, 405.0f, 450.0f, 495.0f, 540.0f, 585.0f, 630.0f, 675.0f, 720.0f };
+		float[] posigiveHigherInputAngles = { 720.0f, 765.0f, 810.0f, 855.0f, 900.0f, 945.0f, 990.0f, 1035.0f, 1080.0f };
+
+		float[] expectedPosigiveCatroidAngles = { 0.0f, 45.0f, 90.0f, 135.0f, 180.0f, -135.0f, -90.0f, -45.0f, 0.0f };
+
+		for (int index = 0; index < posigiveInputAngles.length; index++) {
+			ParameterList params = new ParameterList(posigiveInputAngles[index]);
+			float catroidAngle = (Float) Reflection.invokeMethod(look, "breakDownCatroidAngle", params);
+			assertEquals("positive angle break down to wrong angle", expectedPosigiveCatroidAngles[index],
+					convertNegativeZeroToPosigiveZero(catroidAngle));
+		}
+		for (int index = 0; index < posigiveHighInputAngles.length; index++) {
+			ParameterList params = new ParameterList(posigiveHighInputAngles[index]);
+			float catroidAngle = (Float) Reflection.invokeMethod(look, "breakDownCatroidAngle", params);
+			assertEquals("high positive angle break down to wrong angle", expectedPosigiveCatroidAngles[index],
+					convertNegativeZeroToPosigiveZero(catroidAngle));
+		}
+		for (int index = 0; index < posigiveHigherInputAngles.length; index++) {
+			ParameterList params = new ParameterList(posigiveHigherInputAngles[index]);
+			float catroidAngle = (Float) Reflection.invokeMethod(look, "breakDownCatroidAngle", params);
+			assertEquals("higher positive angle break down to wrong angle", expectedPosigiveCatroidAngles[index],
+					convertNegativeZeroToPosigiveZero(catroidAngle));
+		}
+
+		float[] negativeInputAngles = { -0.0f, -45.0f, -90.0f, -135.0f, -180.0f, -225.0f, -270.0f, -315.0f, -360.0f };
+		float[] negativeHighInputAngles = { -360.0f, -405.0f, -450.0f, -495.0f, -540.0f, -585.0f, -630.0f, -675.0f,
+				-720.0f };
+		float[] negativeHigherInputAngles = { -720.0f, -765.0f, -810.0f, -855.0f, -900.0f, -945.0f, -990.0f, -1035.0f,
+				-1080.0f };
+
+		float[] expectedNegativeCatroidAngles = { 0.0f, -45.0f, -90.0f, -135.0f, 180.0f, 135.0f, 90.0f, 45.0f, 0.0f };
+
+		for (int index = 0; index < negativeInputAngles.length; index++) {
+			ParameterList params = new ParameterList(negativeInputAngles[index]);
+			float catroidAngle = (Float) Reflection.invokeMethod(look, "breakDownCatroidAngle", params);
+			assertEquals("negative angle break down to wrong angle", expectedNegativeCatroidAngles[index],
+					convertNegativeZeroToPosigiveZero(catroidAngle), 0.1);
+		}
+
+		for (int index = 0; index < negativeHighInputAngles.length; index++) {
+			ParameterList params = new ParameterList(negativeHighInputAngles[index]);
+			float catroidAngle = (Float) Reflection.invokeMethod(look, "breakDownCatroidAngle", params);
+			assertEquals("high negative angle break down to wrong angle", expectedNegativeCatroidAngles[index],
+					convertNegativeZeroToPosigiveZero(catroidAngle));
+		}
+
+		for (int index = 0; index < negativeHigherInputAngles.length; index++) {
+			ParameterList params = new ParameterList(negativeHigherInputAngles[index]);
+			float catroidAngle = (Float) Reflection.invokeMethod(look, "breakDownCatroidAngle", params);
+			assertEquals("higher negative angle break down to wrong angle", expectedNegativeCatroidAngles[index],
+					convertNegativeZeroToPosigiveZero(catroidAngle));
+		}
+
+	}
+
+	public void testCatroidAngleToStageAngle() {
+		float[] posigiveCatroidAngles = { 0.0f, 45.0f, 90.0f, 135.0f, 180.0f, 225.0f, 270.0f, 315.0f, 360.0f };
+		float[] posigiveHighCatroidAngles = { 360.0f, 405.0f, 450.0f, 495.0f, 540.0f, 585.0f, 630.0f, 675.0f, 720.0f };
+		//float[] expectedPosigiveStageAngles = { 90.0f, 45.0f, 0.0f, 315.0f, 270.0f, 225.0f, 180.0f, 135.0f, 90.0f };
+		float[] expectedPosigiveStageAngles = { 90.0f, 45.0f, 0.0f, -45.0f, -90.0f, 225.0f, 180.0f, 135.0f, 90.0f };
+
+		for (int index = 0; index < posigiveCatroidAngles.length; index++) {
+			ParameterList params = new ParameterList(posigiveCatroidAngles[index]);
+			float stageAngle = (Float) Reflection.invokeMethod(look, "convertCatroidAngleToStageAngle", params);
+			assertEquals("positive catroid angle converted to wrong stage angle", expectedPosigiveStageAngles[index],
+					convertNegativeZeroToPosigiveZero(stageAngle));
+		}
+
+		for (int index = 0; index < posigiveHighCatroidAngles.length; index++) {
+			ParameterList params = new ParameterList(posigiveHighCatroidAngles[index]);
+			float stageAngle = (Float) Reflection.invokeMethod(look, "convertCatroidAngleToStageAngle", params);
+			assertEquals("high positive catroid angle converted to wrong stage angle",
+					expectedPosigiveStageAngles[index], convertNegativeZeroToPosigiveZero(stageAngle));
+		}
+
+		float[] negativeCatroidAngles = { -0.0f, -45.0f, -90.0f, -135.0f, -180.0f, -225.0f, -270.0f, -315.0f, -360.0f };
+		float[] negativeHighCatroidAngles = { -360.0f, -405.0f, -450.0f, -495.0f, -540.0f, -585.0f, -630.0f, -675.0f,
+				-720.0f };
+		//float[] expectedNegativeStageAngles = { 90.0f, 135.0f, 180.0f, 225.0f, 270.0f, 315.0f, 0.0f, 45.0f, 90.0f };
+		float[] expectedNegativeStageAngles = { 90.0f, 135.0f, 180.0f, 225.0f, -90.0f, -45.0f, 0.0f, 45.0f, 90.0f };
+
+		for (int index = 0; index < negativeCatroidAngles.length; index++) {
+			ParameterList params = new ParameterList(negativeCatroidAngles[index]);
+			float stageAngle = (Float) Reflection.invokeMethod(look, "convertCatroidAngleToStageAngle", params);
+			assertEquals("negative catroid angle converted to wrong stage angle", expectedNegativeStageAngles[index],
+					convertNegativeZeroToPosigiveZero(stageAngle));
+		}
+
+		for (int index = 0; index < negativeHighCatroidAngles.length; index++) {
+			ParameterList params = new ParameterList(negativeHighCatroidAngles[index]);
+			float stageAngle = (Float) Reflection.invokeMethod(look, "convertCatroidAngleToStageAngle", params);
+			assertEquals("high negative catroid angle converted to wrong stage angle",
+					expectedNegativeStageAngles[index], convertNegativeZeroToPosigiveZero(stageAngle));
+		}
+	}
+
+	public void testStageAngleToCatroidAngle() {
+		float[] posigiveStageAngles = { 0.0f, 45.0f, 90.0f, 135.0f, 180.0f, 225.0f, 270.0f, 315.0f, 360.0f };
+		float[] posigiveHighCatroiStagedAngles = { 360.0f, 405.0f, 450.0f, 495.0f, 540.0f, 585.0f, 630.0f, 675.0f,
+				720.0f };
+		float[] expectedPosigiveCatroidAngles = { 90.0f, 45.0f, 0.0f, -45.0f, -90.0f, -135.0f, 180.0f, 135.0f, 90.0f };
+
+		for (int index = 0; index < posigiveStageAngles.length; index++) {
+			ParameterList params = new ParameterList(posigiveStageAngles[index]);
+			float stageAngle = (Float) Reflection.invokeMethod(look, "convertStageAngleToCatroidAngle", params);
+			assertEquals("positive stage angle converted to wrong catroid angle", expectedPosigiveCatroidAngles[index],
+					convertNegativeZeroToPosigiveZero(stageAngle));
+		}
+
+		for (int index = 0; index < posigiveHighCatroiStagedAngles.length; index++) {
+			ParameterList params = new ParameterList(posigiveHighCatroiStagedAngles[index]);
+			float stageAngle = (Float) Reflection.invokeMethod(look, "convertStageAngleToCatroidAngle", params);
+			assertEquals("high positive stage angle converted to wrong catroid angle",
+					expectedPosigiveCatroidAngles[index], convertNegativeZeroToPosigiveZero(stageAngle));
+		}
+
+		float[] negativeStageAngles = { -0.0f, -45.0f, -90.0f, -135.0f, -180.0f, -225.0f, -270.0f, -315.0f, -360.0f };
+		float[] negativeHighStageAngles = { -360.0f, -405.0f, -450.0f, -495.0f, -540.0f, -585.0f, -630.0f, -675.0f,
+				-720.0f };
+		float[] expectedNegativeCatroidAngles = { 90.0f, 135.0f, 180.0f, -135.0f, -90.0f, -45.0f, 0.0f, 45.0f, 90.0f };
+
+		for (int index = 0; index < negativeStageAngles.length; index++) {
+			ParameterList params = new ParameterList(negativeStageAngles[index]);
+			float stageAngle = (Float) Reflection.invokeMethod(look, "convertStageAngleToCatroidAngle", params);
+			assertEquals("negative stage angle converted to wrong catroid angle", expectedNegativeCatroidAngles[index],
+					convertNegativeZeroToPosigiveZero(stageAngle));
+		}
+
+		for (int index = 0; index < negativeHighStageAngles.length; index++) {
+			ParameterList params = new ParameterList(negativeHighStageAngles[index]);
+			float stageAngle = (Float) Reflection.invokeMethod(look, "convertStageAngleToCatroidAngle", params);
+			assertEquals("high negative stage angle converted to wrong catroid angle",
+					expectedNegativeCatroidAngles[index], convertNegativeZeroToPosigiveZero(stageAngle));
+		}
+	}
+
 	public void testDirection() {
 		float[] degreesInUserInterfaceDimensionUnit = { 90f, 60f, 30f, 0f, -30f, -60f, -90f, -120f, -150f, 180f, 150f,
 				120f };
@@ -135,8 +293,14 @@ public class LookTest extends InstrumentationTestCase {
 
 		look.setDirectionInUserInterfaceDimensionUnit(90f);
 		look.changeDirectionInUserInterfaceDimensionUnit(10f);
-		assertEquals("Wrong alpha value!", 100f, look.getDirectionInUserInterfaceDimensionUnit());
-		assertEquals("Wrong alpha value!", -10f, look.getRotation());
+		assertEquals("Wrong degrees value!", 100f, look.getDirectionInUserInterfaceDimensionUnit());
+		assertEquals("Wrong degrees value!", -10f, look.getRotation());
+
+		look.setDirectionInUserInterfaceDimensionUnit(90f);
+		look.changeDirectionInUserInterfaceDimensionUnit(360f);
+		assertEquals("Wrong degrees value!", 90f, look.getDirectionInUserInterfaceDimensionUnit());
+		assertEquals("Wrong degrees value!", -360f, look.getRotation());
+
 	}
 
 	public void testWidthAndHeight() {

--- a/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsObjectTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsObjectTest.java
@@ -185,8 +185,8 @@ public class PhysicsObjectTest extends AndroidTestCase {
 	}
 
 	public void testSetCollisionBits() {
-		PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld, PhysicsObject.Type.NONE, 10.0f,
-				5.0f);
+		PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld, PhysicsObject.Type.NONE,
+				10.0f, 5.0f);
 		checkCollisionMask(physicsObject, PhysicsWorld.CATEGORY_PHYSICSOBJECT, PhysicsWorld.MASK_NOCOLLISION);
 
 		physicsObject.setType(PhysicsObject.Type.FIXED);
@@ -230,8 +230,8 @@ public class PhysicsObjectTest extends AndroidTestCase {
 				//angle = computeScratchCompatibleAngleForDirectSetting(angle);
 
 				physicsObject.setDirection(angle);
-				float physicsObjectCatroidAngle = PhysicsWorldConverter.toCatroidAngle(PhysicsTestUtils.getBody(
-						physicsObject).getAngle());
+				float physicsObjectCatroidAngle = PhysicsWorldConverter.convertBox2dToNormalAngle(PhysicsTestUtils
+						.getBody(physicsObject).getAngle());
 				physicsObjectCatroidAngle = physicsObject.getDirection();
 
 				assertEquals("Wrong catroid angle", expectedDegrees[idx], physicsObjectCatroidAngle, TestUtils.DELTA);
@@ -252,8 +252,8 @@ public class PhysicsObjectTest extends AndroidTestCase {
 			for (Vector2 position : positions) {
 				physicsObject.setPosition(position.x, position.y);
 
-				Vector2 physicsObjectCatroidPosition = PhysicsWorldConverter.toCatroidVector(PhysicsTestUtils.getBody(
-						physicsObject).getPosition());
+				Vector2 physicsObjectCatroidPosition = PhysicsWorldConverter
+						.convertBox2dToNormalVector(PhysicsTestUtils.getBody(physicsObject).getPosition());
 				assertEquals("Wrong catroid position", position, physicsObjectCatroidPosition);
 				assertEquals("Wrong box2d position", position, physicsObject.getPosition());
 			}
@@ -261,8 +261,8 @@ public class PhysicsObjectTest extends AndroidTestCase {
 			for (Vector2 position : positions) {
 				physicsObject.setPosition(position);
 
-				Vector2 physicsObjectCatroidPosition = PhysicsWorldConverter.toCatroidVector(PhysicsTestUtils.getBody(
-						physicsObject).getPosition());
+				Vector2 physicsObjectCatroidPosition = PhysicsWorldConverter
+						.convertBox2dToNormalVector(PhysicsTestUtils.getBody(physicsObject).getPosition());
 				assertEquals("Wrong catroid position", position, physicsObjectCatroidPosition);
 				assertEquals("Wrong box2d position", position, physicsObject.getPosition());
 			}
@@ -276,16 +276,15 @@ public class PhysicsObjectTest extends AndroidTestCase {
 			assertEquals("initialization", new Vector2(), PhysicsTestUtils.getBody(physicsObject).getPosition());
 
 			float angle = 15.6f;
-			//float angle = computeScratchCompatibleAngleForDirectSetting(15.6f);
 			float expectedAngle = 15.6f;
 			Vector2 position = new Vector2(12.34f, 56.78f);
 			physicsObject.setDirection(angle);
 			physicsObject.setPosition(position.x, position.y);
 
-			float physicsObjectCatroidAngle = PhysicsWorldConverter.toCatroidAngle(PhysicsTestUtils.getBody(
+			float physicsObjectCatroidAngle = PhysicsWorldConverter.convertBox2dToNormalAngle(PhysicsTestUtils.getBody(
 					physicsObject).getAngle());
-			Vector2 physicsObjectCatroidPosition = PhysicsWorldConverter.toCatroidVector(PhysicsTestUtils.getBody(
-					physicsObject).getPosition());
+			Vector2 physicsObjectCatroidPosition = PhysicsWorldConverter.convertBox2dToNormalVector(PhysicsTestUtils
+					.getBody(physicsObject).getPosition());
 
 			assertEquals("Wrong catroid angle", expectedAngle, physicsObjectCatroidAngle, TestUtils.DELTA);
 			assertEquals("Wrong catroid position", position, physicsObjectCatroidPosition);
@@ -466,10 +465,6 @@ public class PhysicsObjectTest extends AndroidTestCase {
 		assertEquals("Wrong initialization", 0.0f, body.getAngularVelocity());
 		float rotationSpeed = 20.0f;
 		physicsObject.setRotationSpeed(rotationSpeed);
-
-		// TODO [Physics] check if toCatroidAngle(...) is needed
-
-		//float physicsObjectCatroidRotationSpeed = PhysicsWorldConverter.toCatroidAngle(body.getAngularVelocity());
 		float physicsObjectCatroidRotationSpeed = (float) Math.toDegrees(body.getAngularVelocity());
 		assertEquals("Set wrong rotation speed", rotationSpeed, physicsObjectCatroidRotationSpeed);
 	}
@@ -482,7 +477,7 @@ public class PhysicsObjectTest extends AndroidTestCase {
 		Vector2 velocity = new Vector2(12.3f, 45.6f);
 		physicsObject.setVelocity(velocity.x, velocity.y);
 
-		Vector2 physicsObjectCatVelocity = PhysicsWorldConverter.toCatroidVector(body.getLinearVelocity());
+		Vector2 physicsObjectCatVelocity = PhysicsWorldConverter.convertBox2dToNormalVector(body.getLinearVelocity());
 		assertEquals("Set wrong velocity", velocity, physicsObjectCatVelocity);
 	}
 

--- a/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsShapeBuilderTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsShapeBuilderTest.java
@@ -154,7 +154,6 @@ public class PhysicsShapeBuilderTest extends InstrumentationTestCase {
 		} catch (NullPointerException e) {
 			// expected behavior
 		}
-
 	}
 
 	public void testSimpleSingleConvexPolygon() {
@@ -170,6 +169,7 @@ public class PhysicsShapeBuilderTest extends InstrumentationTestCase {
 	}
 
 	public void testComplexSingleConvexPolygon() {
+		// TODO[Physics] rework or delete (algorithm works different)
 		LookData lookData = PhysicsTestUtils.generateLookData(complexSingleConvexPolygonFile);
 		physicsLook.setLookData(lookData);
 
@@ -182,6 +182,7 @@ public class PhysicsShapeBuilderTest extends InstrumentationTestCase {
 	}
 
 	public void testMultibleConvexPolygons() {
+		// TODO[Physics] rework or delete (algorithm detects no multiple)
 		LookData lookData = PhysicsTestUtils.generateLookData(multibleConvexPolygonsFile);
 		physicsLook.setLookData(lookData);
 
@@ -194,6 +195,7 @@ public class PhysicsShapeBuilderTest extends InstrumentationTestCase {
 	}
 
 	public void testSingleConcavePolygon() {
+		// TODO[Physics] rework or delete (algorithm detects no concave polygons)
 		LookData lookData = PhysicsTestUtils.generateLookData(singleConcavePolygonFile);
 		physicsLook.setLookData(lookData);
 
@@ -206,6 +208,7 @@ public class PhysicsShapeBuilderTest extends InstrumentationTestCase {
 	}
 
 	public void testMultibleConcavePolygons() {
+		// TODO[Physics] rework or delete (algorithm detects no multiple)
 		LookData lookData = PhysicsTestUtils.generateLookData(multibleConvexPolygonsFile);
 		physicsLook.setLookData(lookData);
 
@@ -218,6 +221,7 @@ public class PhysicsShapeBuilderTest extends InstrumentationTestCase {
 	}
 
 	public void testMultibleMixedPolygons() {
+		// TODO[Physics] rework or delete (algorithm detects no multiple)
 		LookData lookData = PhysicsTestUtils.generateLookData(multibleMixedPolygonsFile);
 		physicsLook.setLookData(lookData);
 

--- a/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsWorldConverterTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsWorldConverterTest.java
@@ -28,7 +28,6 @@ import com.badlogic.gdx.math.Vector2;
 
 import junit.framework.Assert;
 
-import org.catrobat.catroid.content.Look;
 import org.catrobat.catroid.physics.PhysicsWorld;
 import org.catrobat.catroid.physics.PhysicsWorldConverter;
 import org.catrobat.catroid.test.utils.TestUtils;
@@ -46,50 +45,48 @@ public class PhysicsWorldConverterTest extends AndroidTestCase {
 	}
 
 	public void testAngleConversion() {
-		// TODO[Physics] refactor test
 		float angle = 0.0f;
-		//float angle = PhysicsWorldTest.computeScratchCompatibleAngleForDirectSetting(0.0f);
-		Assert.assertEquals(angle + Look.getDegreeUserInterfaceOffset(), PhysicsWorldConverter.toCatroidAngle(angle));
-		Assert.assertEquals(angle - Math.toRadians(Look.getDegreeUserInterfaceOffset()),
-				PhysicsWorldConverter.toBox2dAngle(angle), TestUtils.DELTA);
+		Assert.assertEquals("convertBox2dToNormalAngle(0) should be zero", angle,
+				PhysicsWorldConverter.convertBox2dToNormalAngle(angle));
+		Assert.assertEquals("convertNormalToBox2dAngle(0) should be zero", angle,
+				PhysicsWorldConverter.convertNormalToBox2dAngle(angle), TestUtils.DELTA);
 
-		Assert.assertEquals((float) (Math.PI / 2.0) - Math.toRadians(Look.getDegreeUserInterfaceOffset()),
-				PhysicsWorldConverter.toBox2dAngle(90.0f), TestUtils.DELTA);
-		Assert.assertEquals((float) Math.PI - Math.toRadians(Look.getDegreeUserInterfaceOffset()),
-				PhysicsWorldConverter.toBox2dAngle(180.0f), TestUtils.DELTA);
-		//angle = PhysicsObjectTest.computeScratchCompatibleAngleForDirectSetting(90.0f);
-		angle = 90.0f;
-		Assert.assertEquals(angle + Look.getDegreeUserInterfaceOffset(),
-				PhysicsWorldConverter.toCatroidAngle((float) (Math.PI / 2.0)), TestUtils.DELTA);
-		//angle = PhysicsObjectTest.computeScratchCompatibleAngleForDirectSetting(180.0f);
-		angle = 180.0f;
-		Assert.assertEquals(angle + Look.getDegreeUserInterfaceOffset(),
-				PhysicsWorldConverter.toCatroidAngle((float) Math.PI), TestUtils.DELTA);
+		Assert.assertEquals("PI/2 should be convertNormalToBox2dAngle(90°)", (float) (Math.PI / 2.0),
+				PhysicsWorldConverter.convertNormalToBox2dAngle(90.0f), TestUtils.DELTA);
+		Assert.assertEquals("PI should be convertNormalToBox2dAngle(180°)", (float) Math.PI,
+				PhysicsWorldConverter.convertNormalToBox2dAngle(180.0f), TestUtils.DELTA);
+		Assert.assertEquals("90° should be convertBox2dToNormalAngle(PI/2)", 90.0f,
+				PhysicsWorldConverter.convertBox2dToNormalAngle((float) (Math.PI / 2.0)), TestUtils.DELTA);
+		Assert.assertEquals("180° should be convertBox2dToNormalAngle(PI)", 180.0f,
+				PhysicsWorldConverter.convertBox2dToNormalAngle((float) Math.PI), TestUtils.DELTA);
 
 		float[] angles = { 123.456f, -123.456f, 1024.0f };
 		for (float currentAngle : angles) {
 			Assert.assertEquals((float) Math.toDegrees(currentAngle),
-					PhysicsWorldConverter.toCatroidAngle(currentAngle));
-			Assert.assertEquals((float) Math.toRadians(currentAngle), PhysicsWorldConverter.toBox2dAngle(currentAngle));
+					PhysicsWorldConverter.convertBox2dToNormalAngle(currentAngle));
+			Assert.assertEquals((float) Math.toRadians(currentAngle),
+					PhysicsWorldConverter.convertNormalToBox2dAngle(currentAngle));
 		}
 	}
 
 	public void testLengthConversion() {
 		float length = 0.0f;
-		Assert.assertEquals(length, PhysicsWorldConverter.toCatroidCoordinate(length));
-		Assert.assertEquals(length, PhysicsWorldConverter.toBox2dCoordinate(length));
+		Assert.assertEquals(length, PhysicsWorldConverter.convertBox2dToNormalCoordinate(length));
+		Assert.assertEquals(length, PhysicsWorldConverter.convertNormalToBox2dCoordinate(length));
 
 		float[] lengths = { 123.456f, -654.321f };
 		for (float currentLength : lengths) {
-			Assert.assertEquals(currentLength * ratio, PhysicsWorldConverter.toCatroidCoordinate(currentLength));
-			Assert.assertEquals(currentLength / ratio, PhysicsWorldConverter.toBox2dCoordinate(currentLength));
+			Assert.assertEquals(currentLength * ratio,
+					PhysicsWorldConverter.convertBox2dToNormalCoordinate(currentLength));
+			Assert.assertEquals(currentLength / ratio,
+					PhysicsWorldConverter.convertNormalToBox2dCoordinate(currentLength));
 		}
 	}
 
 	public void testVectorConversation() {
 		Vector2 vector = new Vector2();
-		Assert.assertEquals(vector, PhysicsWorldConverter.toCatroidVector(vector));
-		Assert.assertEquals(vector, PhysicsWorldConverter.toBox2dVector(vector));
+		Assert.assertEquals(vector, PhysicsWorldConverter.convertBox2dToNormalVector(vector));
+		Assert.assertEquals(vector, PhysicsWorldConverter.convertCatroidToBox2dVector(vector));
 
 		Vector2[] vectors = { new Vector2(123.456f, 123.456f), new Vector2(654.321f, -123.456f),
 				new Vector2(-654.321f, 0.0f), new Vector2(-123.456f, -654.321f) };
@@ -97,10 +94,10 @@ public class PhysicsWorldConverterTest extends AndroidTestCase {
 		Vector2 expected;
 		for (Vector2 currentVector : vectors) {
 			expected = new Vector2(currentVector.x * ratio, currentVector.y * ratio);
-			Assert.assertEquals(expected, PhysicsWorldConverter.toCatroidVector(currentVector));
+			Assert.assertEquals(expected, PhysicsWorldConverter.convertBox2dToNormalVector(currentVector));
 
 			expected = new Vector2(currentVector.x / ratio, currentVector.y / ratio);
-			Assert.assertEquals(expected, PhysicsWorldConverter.toBox2dVector(currentVector));
+			Assert.assertEquals(expected, PhysicsWorldConverter.convertCatroidToBox2dVector(currentVector));
 		}
 	}
 }


### PR DESCRIPTION
Look:
Convertes between scratch angle and stage angle.
The catroid angle is all the time in ]-180,+180] the stage is between [-90, +270[. So there is no normalization of the stage angle, due to performance saving.
PhysicsLook: 
Converts between stage and normal values. 
Getter and Setter in the physics look work with the overwritten Methodes of the Actor class, that are called by libgdx in the stage. So there is the conversion between the stage values and the “normal” values.
PhysicsObject:
Converts between normal values and Physics values (via PhysicsWorldConverter)
The anlges of the Body are no longer normalized by PhysicsObject (due to performance saving)
