### PR TITLE
fixed issue #797: handle audio focus in StageActivity

### DIFF
--- a/catroid/src/org/catrobat/catroid/io/StageAudioFocus.java
+++ b/catroid/src/org/catrobat/catroid/io/StageAudioFocus.java
@@ -1,0 +1,70 @@
+/**
+ *  Catroid: An on-device visual programming system for Android devices
+ *  Copyright (C) 2010-2013 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  http://developer.catrobat.org/license_additional_term
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.io;
+
+import android.content.Context;
+import android.media.AudioManager;
+import android.media.AudioManager.OnAudioFocusChangeListener;
+
+public class StageAudioFocus implements OnAudioFocusChangeListener {
+
+	private AudioManager audioManager = null;
+	private boolean isAudioFocusGranted = false;
+
+	public static final String TAG = StageAudioFocus.class.getSimpleName();
+
+	public StageAudioFocus(Context context) {
+		audioManager = (AudioManager)context.getSystemService(Context.AUDIO_SERVICE);
+	}
+
+	public void requestAudioFocus() {
+		if (isAudioFocusGranted()) {
+			return;
+		}
+
+		int result = audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+
+		if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+			isAudioFocusGranted = true;
+		}
+		else {
+			isAudioFocusGranted = false;
+		}
+	}
+
+	public void releaseAudioFocus() {
+		audioManager.abandonAudioFocus(this);
+		isAudioFocusGranted = false;
+	}
+
+	public boolean isAudioFocusGranted() {
+		return isAudioFocusGranted;
+	}
+
+	@Override
+	public void onAudioFocusChange(int focusChange) {
+		if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
+			releaseAudioFocus();
+		}
+	}
+}

--- a/catroid/src/org/catrobat/catroid/stage/StageActivity.java
+++ b/catroid/src/org/catrobat/catroid/stage/StageActivity.java
@@ -35,6 +35,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.ScreenValues;
 import org.catrobat.catroid.drone.DroneInitializer;
 import org.catrobat.catroid.formulaeditor.SensorHandler;
+import org.catrobat.catroid.io.StageAudioFocus;
 import org.catrobat.catroid.ui.dialogs.StageDialog;
 
 public class StageActivity extends AndroidApplication {
@@ -46,6 +47,9 @@ public class StageActivity extends AndroidApplication {
 	private DroneConnection droneConnection = null;
 
 	public static final int STAGE_ACTIVITY_FINISH = 7777;
+
+	private StageAudioFocus stageAudioFocus;
+
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -61,6 +65,7 @@ public class StageActivity extends AndroidApplication {
 		calculateScreenSizes();
 
 		initialize(stageListener, true);
+
 		if (droneConnection != null) {
 			try {
 				droneConnection.initialise();
@@ -70,6 +75,8 @@ public class StageActivity extends AndroidApplication {
 				this.finish();
 			}
 		}
+
+		stageAudioFocus = new StageAudioFocus(this);
 	}
 
 	@Override
@@ -88,6 +95,7 @@ public class StageActivity extends AndroidApplication {
 	@Override
 	public void onPause() {
 		SensorHandler.stopSensorListeners();
+		stageAudioFocus.releaseAudioFocus();
 		super.onPause();
 
 		if (droneConnection != null) {
@@ -98,6 +106,7 @@ public class StageActivity extends AndroidApplication {
 	@Override
 	public void onResume() {
 		SensorHandler.startSensorListener(this);
+		stageAudioFocus.requestAudioFocus();
 		super.onResume();
 
 		if (droneConnection != null) {

--- a/catroidSourceTest/src/org/catrobat/catroid/test/code/CheckForVerifiesOrAssertionsTest.java
+++ b/catroidSourceTest/src/org/catrobat/catroid/test/code/CheckForVerifiesOrAssertionsTest.java
@@ -39,7 +39,7 @@ public class CheckForVerifiesOrAssertionsTest extends TestCase {
 			"SimulatedSensorManager.java", "SimulatedSoundRecorder.java", "TestUtils.java",
 			"MockPaintroidActivity.java", "TestMainMenuActivity.java", "TestErrorListenerInterface.java",
 			"XmlTestUtils.java", "MockSoundActivity.java", "Reflection.java", "Utils.java",
-			"BaseActivityInstrumentationTestCase.java", "Device.java", "Callback.java", "CallbackBrick.java",
+			"BaseActivityInstrumentationTestCase.java", "BaseActivityUnitTestCase.java", "Device.java", "Callback.java", "CallbackBrick.java",
 			"Util.java", "BeforeAfterSteps.java", "Cucumber.java", "CallbackAction.java", "ObjectSteps.java",
 			"CucumberAnnotation.java", "CatroidExampleSteps.java", "PrintBrick.java", "DroneTestUtils.java" };
 

--- a/catroidTest/src/org/catrobat/catroid/test/io/StageAudioFocusTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/io/StageAudioFocusTest.java
@@ -1,0 +1,61 @@
+/**
+ *  Catroid: An on-device visual programming system for Android devices
+ *  Copyright (C) 2010-2013 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  http://developer.catrobat.org/license_additional_term
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.io;
+
+import android.media.AudioManager;
+import android.test.InstrumentationTestCase;
+
+import org.catrobat.catroid.io.StageAudioFocus;
+
+public class StageAudioFocusTest extends InstrumentationTestCase
+{
+	private StageAudioFocus audioFocus = null;
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		audioFocus = new StageAudioFocus(getInstrumentation().getTargetContext());
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		audioFocus = null;
+	}
+
+	public void testRequestAndReleaseAudioFocus()
+	{
+		assertFalse("AudioFocus is held before requesting it", audioFocus.isAudioFocusGranted());
+		audioFocus.requestAudioFocus();
+		assertTrue("AudioFocus is not held, although it was requested", audioFocus.isAudioFocusGranted());
+		audioFocus.releaseAudioFocus();
+		assertFalse("Audio Focus is still held, although it is released", audioFocus.isAudioFocusGranted());
+	}
+
+	public void testIfAudioFocusGetsAbandonedOnAudioFocusLossEvent() {
+		audioFocus.requestAudioFocus();
+		assertTrue("AudioFocus is not held, although it was requested", audioFocus.isAudioFocusGranted());
+		audioFocus.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS);
+		assertFalse("AudioFocus should be abandoned after focus is lost", audioFocus.isAudioFocusGranted());
+	}
+}

--- a/catroidTest/src/org/catrobat/catroid/test/stage/StageActivityAudioFocusTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/stage/StageActivityAudioFocusTest.java
@@ -1,0 +1,68 @@
+/**
+ *  Catroid: An on-device visual programming system for Android devices
+ *  Copyright (C) 2010-2013 The Catrobat Team
+ *  (<http://developer.catrobat.org/credits>)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  http://developer.catrobat.org/license_additional_term
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.stage;
+
+import android.app.Instrumentation;
+import android.content.Intent;
+
+import org.catrobat.catroid.io.StageAudioFocus;
+import org.catrobat.catroid.stage.StageActivity;
+import org.catrobat.catroid.test.utils.BaseActivityUnitTestCase;
+import org.catrobat.catroid.uitest.util.Reflection;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+
+public class StageActivityAudioFocusTest extends BaseActivityUnitTestCase<StageActivity> {
+
+	public StageActivityAudioFocusTest() {
+		super(StageActivity.class);
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		UiTestUtils.createTestProject();
+	}
+
+	public void testAudioFocusAcquisitionInStageActivityLifecycle() throws InterruptedException {
+
+		StageActivity activity = startActivity(new Intent(Intent.ACTION_MAIN), null, null);
+		Instrumentation instrumentation = getInstrumentation();
+		StageAudioFocus stageAudioFocus = (StageAudioFocus)Reflection.getPrivateField(StageActivity.class, activity, "stageAudioFocus");
+
+		Thread.sleep(400);
+		instrumentation.callActivityOnStart(activity);
+		assertFalse("AudioFocus granted after Stage is started, but not resumed", stageAudioFocus.isAudioFocusGranted());
+
+		Thread.sleep(400);
+		instrumentation.callActivityOnResume(activity);
+		assertTrue("AudioFocus not granted after Stage has resumed", stageAudioFocus.isAudioFocusGranted());
+
+		Thread.sleep(400);
+		instrumentation.callActivityOnPause(activity);
+		assertFalse("AudioFocus still granted, although the stage is paused", stageAudioFocus.isAudioFocusGranted());
+
+		Thread.sleep(400);
+		instrumentation.callActivityOnStop(activity);
+		assertFalse("AudioFocus granted, although the stage already should be paused and abandoned the audio focus", stageAudioFocus.isAudioFocusGranted());
+	}
+}

--- a/catroidTest/src/org/catrobat/catroid/test/utils/BaseActivityUnitTestCase.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utils/BaseActivityUnitTestCase.java
@@ -1,0 +1,54 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2013 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.utils;
+
+import android.app.Activity;
+import android.test.ActivityUnitTestCase;
+import android.util.Log;
+
+import org.catrobat.catroid.stage.StageListener;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+
+public abstract class BaseActivityUnitTestCase<T extends Activity> extends ActivityUnitTestCase<T> {
+
+	public static final String TAG = BaseActivityUnitTestCase.class.getSimpleName();
+
+	public BaseActivityUnitTestCase(Class<T> activityClass) {
+		super(activityClass);
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		Log.v(TAG, "setUp");
+		super.setUp();
+		UiTestUtils.clearAllUtilTestProjects();
+		Reflection.setPrivateField(StageListener.class, "checkIfAutomaticScreenshotShouldBeTaken", false);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		Log.v(TAG, "tearDown");
+		UiTestUtils.clearAllUtilTestProjects();
+		super.tearDown();
+	}
+}


### PR DESCRIPTION
AudioFocus is now acquired when the stage is resumed and released if it gets paused

https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/1556/
