### PR TITLE
Broadcast Performance

### DIFF
--- a/catroid/src/org/catrobat/catroid/content/BroadcastHandler.java
+++ b/catroid/src/org/catrobat/catroid/content/BroadcastHandler.java
@@ -44,9 +44,7 @@ public final class BroadcastHandler {
 		}
 
 		for (SequenceAction action : BroadcastSequenceMap.get(broadcastMessage)) {
-			if (!handleAction(action)) {
 				addOrRestartAction(look, action);
-			}
 		}
 
 		if (BroadcastWaitSequenceMap.containsKey(broadcastMessage)) {
@@ -108,40 +106,6 @@ public final class BroadcastHandler {
 		if (actionList.size() > 0) {
 			BroadcastWaitSequenceMap.put(broadcastMessage, actionList);
 		}
-	}
-
-	private static boolean handleAction(Action action) {
-		for (Sprite sprites : ProjectManager.getInstance().getCurrentProject().getSpriteList()) {
-			for (Action actionOfLook : sprites.look.getActions()) {
-				if (actionOfLook instanceof SequenceAction && ((SequenceAction) actionOfLook).getActions().size > 0
-						&& ((SequenceAction) actionOfLook).getActions().get(0) == action) {
-					Look.actionsToRestartAdd(actionOfLook);
-					return true;
-				} else {
-					if (action instanceof SequenceAction && ((SequenceAction) action).getActions().size > 0
-							&& ((SequenceAction) action).getActions().get(0) == actionOfLook) {
-						Look.actionsToRestartAdd(action);
-						return true;
-					} else {
-						if (action == actionOfLook) {
-							Look.actionsToRestartAdd(actionOfLook);
-							return true;
-						} else {
-							if (actionOfLook instanceof SequenceAction
-									&& ((SequenceAction) actionOfLook).getActions().size > 0
-									&& action instanceof SequenceAction
-									&& ((SequenceAction) action).getActions().size > 0
-									&& ((SequenceAction) actionOfLook).getActions().get(0) == ((SequenceAction) action)
-											.getActions().get(0)) {
-								Look.actionsToRestartAdd(action);
-								return true;
-							}
-						}
-					}
-				}
-			}
-		}
-		return false;
 	}
 
 	private static boolean handleActionFromBroadcastWait(Look look,


### PR DESCRIPTION
fixes CAT-893 (Significant performance drop in Google Play 0.9.7 Version)

There's a huge overhead when broadcast events are handled. I think the method handleAction(..) is unnecessary as the actions are added or restarted anyway later during addOrRestartAction(..). 
The Air Fight program runs quite fast after this adaption and I've noticed no side-effects.

Maybe there's the same problem with handleActionFromBroadcastWait(..). I'll look into this.

I've also written a Cucumber Feature as discussed with @wslany 
(https://github.com/Catrobat/Catroid/compare/master...broadcastPerformanceTest)
However, it's not finished and I'd like to review it with @ManuelWallner . Therefore it's not part of this pull request.

Testrun:
https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch/1650/
