### PR TITLE
Update gradle, android plugin, support library,...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,23 +2,25 @@ import java.util.regex.Pattern
 
 buildscript {
     repositories {
-        mavenLocal()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:0.11.+'
+        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.10.+'
     }
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
 }
 
+apply plugin: 'android-sdk-manager'
 apply plugin: 'android'
 //apply plugin: 'findbugs'
 apply plugin: 'checkstyle'
 //apply plugin: 'pmd'
+
+check.dependsOn 'checkstyle'
 
 ext {
     projectVersion = "0.9"
@@ -36,11 +38,10 @@ ext {
 
 dependencies {
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
-    compile 'com.android.support:support-v4:18.0.+'
-    compile fileTree(dir: 'catroid/libs', include: '*.jar')
-    compile fileTree(dir: 'catroid/libs-natives', include: '*.jar')
-
-    androidTestCompile fileTree(dir: 'catroidTest/libs', include: '*.jar')
+    compile 'com.android.support:support-v4:19.1.0'
+    compile fileTree(include: '*.jar', dir: 'catroid/libs')
+    compile fileTree(include: '*.jar', dir: 'catroid/libs-natives')
+    androidTestCompile fileTree(include: '*.jar', dir: 'catroidTest/libs')
 }
 
 
@@ -78,14 +79,13 @@ def getCurrentGitBranch() {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19"
-
+    buildToolsVersion '19.1.0'
     defaultConfig {
         minSdkVersion 10
         targetSdkVersion 19
-        packageName "org.catrobat.catroid"
-        testPackageName "org.catrobat.catroid.test"
-        testInstrumentationRunner "pl.polidea.instrumentation.PolideaInstrumentationTestRunner"
+        applicationId 'org.catrobat.catroid'
+        testApplicationId "org.catrobat.catroid.test"
+        testInstrumentationRunner 'pl.polidea.instrumentation.PolideaInstrumentationTestRunner'
         versionCode getBuildNumberParameter()
         println "VersionCode is " + versionCode
         versionName generateVersionName(projectVersion, versionCode)
@@ -93,7 +93,6 @@ android {
         buildConfigField "String", "GIT_DESCRIBE", "\"${getGitDescribe()}\""
         buildConfigField "String", "GIT_CURRENT_BRANCH", "\"${getCurrentGitBranch()}\""
     }
-
     sourceSets {
         main {
             manifest.srcFile 'catroid/AndroidManifest.xml'
@@ -112,18 +111,17 @@ android {
             renderscript.srcDirs = ['catroidTest/src']
             res.srcDirs = ['catroidTest/res']
             assets.srcDirs = ['catroidTest/assets']
-            if(file('testexclusions.txt').exists()){
+            if (file('testexclusions.txt').exists()) {
                 java.exclude file('testexclusions.txt').readLines()
             }
         }
     }
-
     lintOptions {
         //lintConfig file('catroid/lint.xml')
         textReport true
         ignore 'ContentDescription', 'ExtraTranslation', 'MissingTranslation', 'UnusedResources'
         //these should be fixed soon:
-        ignore 'ValidFragment', 'IconDensities', 'InvalidPackage', 'GradleOverrides', 'GradleDependency'
+        ignore 'ValidFragment', 'IconDensities', 'InvalidPackage', 'GradleOverrides', 'GradleDependency', 'ClickableViewAccessibility', 'InflateParams', 'UnusedAttribute'
     }
 }
 
@@ -141,9 +139,9 @@ task checkstyle(type: Checkstyle) {
     configFile file('catroid/checkstyle.xml')
     source '.'
     include '**/*.java'
-    exclude 'build/**', 'libraryProjects/**'
+    exclude '**/gen/**','**/build/**','**/res/**', 'libraryProjects/**'
 
-    classpath = files(project.configurations.compile.asPath)
+    classpath = files()
 }
 
 // Doesn't work atm. Maybe if the pmd plugin gets updated.
@@ -184,7 +182,7 @@ task featuresToBuildconfig << {
 
 task testManifestHack << {
     def origManifest = file('catroidTest/AndroidManifest.xml')
-    def generatedManifest = file("build/manifests/test/debug/AndroidManifest.xml")
+    def generatedManifest = file("build/intermediates/manifests/test/debug/AndroidManifest.xml")
     def origContent = origManifest.getText()
     def generatedContent = generatedManifest.getText()
     def pattern = Pattern.compile("<application.*?>.*?</application>", Pattern.DOTALL)
@@ -225,3 +223,4 @@ task gitNoSkipWorktreeForIntellijConfigFiles << {
         throw new UnsupportedOperationException("Could not find git! Maybe it is not in \$PATH variable?", exception)
     }
 }
+

--- a/catroid/src/org/catrobat/catroid/ui/adapter/BrickAdapter.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/BrickAdapter.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.ui.adapter;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -727,7 +728,7 @@ public class BrickAdapter extends BaseAdapter implements DragAndDropListener, On
 
 		// Hack!!!
 		// if wrapper isn't used the longClick event won't be triggered
-		ViewGroup wrapper = (ViewGroup) View.inflate(context, R.layout.brick_wrapper, null);
+		@SuppressLint("ViewHolder") ViewGroup wrapper = (ViewGroup) View.inflate(context, R.layout.brick_wrapper, null);
 		if (currentBrickView.getParent() != null) {
 			((ViewGroup) currentBrickView.getParent()).removeView(currentBrickView);
 		}

--- a/catroidSourceTest/build.gradle
+++ b/catroidSourceTest/build.gradle
@@ -1,21 +1,18 @@
 repositories{
-    mavenLocal()
     mavenCentral()
 }
 
-
 apply plugin: 'java'
 
-
 dependencies {
-	testCompile files( project(":").buildDir.getPath()+'/classes/debug')
-	testCompile 'junit:junit:4.10'
+    testCompile files( project(":").buildDir.getPath() + '/intermediates/classes/debug' )
+    testCompile 'junit:junit:4.10'
 }
 
 sourceSets {
     main {
         test {
-	    java.srcDir 'src'
+            java.srcDir 'src'
         }
         resources {
             srcDir 'res'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.daemon=true
+org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 07 14:46:38 CET 2014
+#Tue Jun 03 22:51:12 CEST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip


### PR DESCRIPTION
#### Requires Android Studio 0.6!
- Gradle (wrapper) updated from 1.11 to 1.12
- Gradle Android plugin updated from 0.9.+ to 0.11.+
- Support Library updated from 18.0.+ to 19.1.0
- Build Tools updated from 19 to 19.1.0
- NEW plugin android-sdk-manager, will download new build tools, SDK
  versions,... as declared in `build.gradle` on demand
- Checkstyle is now part of the `build` lifecycle
- `gradle.properties` file added, includes the daemon and parallel
  execution. AFAIK this is not honoured by AS as it has its own settings
  and uses the daemon by default, but it speeds up commandline builds
  (not clean builds but incremental ones). Benchmarks below.
- Had to change the classpath variable of the checkstyle task because
  otherwise it wouldn't compile for me. Works on my machine doing `gw
  checkstyle`.
## Benchmarks:
### Not parallel:

```
gw clean:
Total time: 13.921 secs

gw assDe:
Total time: 1 mins 32.123 secs

gw clean:
Total time: 12.841 secs

gw assDe:
Total time: 1 mins 19.26 secs

gw clean:
Total time: 13.316 secs

gw assDe:
Total time: 1 mins 26.894 secs

gw assDe:
Total time: 12.774 secs

gw assDe:
Total time: 13.149 secs
```
### Parallel + Daemon

```
gw clean:
Total time: 12.18 secs

gw assDe:
Total time: 1 mins 10.839 secs

gw clean:
Total time: 4.368 secs

gw assDe:
Total time: 1 mins 27.029 secs

gw clean:
Total time: 4.055 secs

gw assDe:
Total time: 1 mins 6.845 secs

gw assDe:
Total time: 5.357 secs

gw assDe:
Total time: 3.644 secs
```
### Results:

`gw clean build` is a bit faster, but not by a lot, `clean` is a
lot faster, as are subsequent incremental builds (note: not really an
incremental build in this case, because the source wasn't modified at
all). I use these settings at work on the console and did not encounter
any problems so far. For parallel builds in Android Studio, see the
compiler settings there.

![screen shot 2014-06-09 at 19 41 11](https://cloud.githubusercontent.com/assets/1301152/3220198/99910796-effd-11e3-8192-dcb623280f44.png)

As you can see, parallel execution is no magic bullet, only works for decoupled projects, see [this](http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects).
## Notes:

I use `gw` instead of `./gradlew` or `../gradlew` (see [this](https://plus.google.com/+JakeWharton/posts/hPkaEwza6HG) post
by Jakewharton for more info) as well as [task name abbreviation](http://www.gradle.org/docs/current/userguide/userguide_single.html#N107F0) in
case you wonder what exactly I am doing in the benchmarks, `assDe` = `assembleDebug`.
