### PR TITLE
Broadcast performance fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ ext {
 dependencies {
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
     compile 'com.android.support:support-v4:19.1.0'
+    compile 'com.google.guava:guava:11.0.2'
     compile fileTree(include: '*.jar', dir: 'catroid/libs')
     compile fileTree(include: '*.jar', dir: 'catroid/libs-natives')
     androidTestCompile fileTree(include: '*.jar', dir: 'catroidTest/libs')

--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -56,6 +56,14 @@ public final class Constants {
 
 	public static final int NO_POSITION = -1;
 
+	//Broadcast system:
+	public static final String ACTION_SPRITE_SEPARATOR = "#";
+	public static final String BROADCAST_NOTIFY_ACTION = "broadcast_notify";
+	public static final String START_SCRIPT = "start_script";
+	public static final String BROADCAST_SCRIPT = "broadcast_script";
+	public static final String OPENING_BRACE = "(";
+	public static final String CLOSING_BRACE = ")";
+
 	//Web:
 	public static final String BASE_URL_HTTPS = "https://www.pocketcode.org/";
 	public static final String CATROBAT_TERMS_OF_USE_URL = BASE_URL_HTTPS + "termsOfUse";

--- a/catroid/src/org/catrobat/catroid/content/BroadcastEvent.java
+++ b/catroid/src/org/catrobat/catroid/content/BroadcastEvent.java
@@ -87,14 +87,14 @@ public class BroadcastEvent extends Event {
 		this.numberOfFinishedReceivers++;
 	}
 
-	public boolean checkIfAllReceiversHaveFinished() {
+	public boolean allReceiversHaveFinished() {
 		return numberOfReceivers <= numberOfFinishedReceivers;
 	}
 
 	public void resetEventAndResumeScript() {
 		resetNumberOfReceivers();
 		resetNumberOfFinishedReceivers();
-		BroadcastWaitSequenceMap.remove(getBroadcastMessage());
+		BroadcastWaitSequenceMap.remove(broadcastMessage);
 		BroadcastWaitSequenceMap.clearCurrentBroadcastEvent();
 		setRun(true);
 	}

--- a/catroid/src/org/catrobat/catroid/content/BroadcastHandler.java
+++ b/catroid/src/org/catrobat/catroid/content/BroadcastHandler.java
@@ -22,18 +22,30 @@
  */
 package org.catrobat.catroid.content;
 
+import android.util.Log;
+
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.BroadcastSequenceMap;
 import org.catrobat.catroid.common.BroadcastWaitSequenceMap;
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.content.actions.BroadcastNotifyAction;
 import org.catrobat.catroid.content.actions.ExtendedActions;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 public final class BroadcastHandler {
+
+	private static Multimap<String, String> actionsToRestartMap = ArrayListMultimap.create();
+	private static HashMap<Action, Sprite> actionSpriteMap = new HashMap<Action, Sprite>();
+	private static HashMap<String, Action> stringActionMap = new HashMap<String, Action>();
+
+	private static final String TAG = "BroadcastHandler";
 
 	private BroadcastHandler() {
 		throw new AssertionError();
@@ -45,7 +57,9 @@ public final class BroadcastHandler {
 		}
 
 		for (SequenceAction action : BroadcastSequenceMap.get(broadcastMessage)) {
-			if (!handleAction(action)) {
+			Sprite spriteOfAction = actionSpriteMap.get(action);
+
+			if (!handleAction(action, spriteOfAction)) {
 				addOrRestartAction(look, action);
 			}
 		}
@@ -100,6 +114,10 @@ public final class BroadcastHandler {
 		for (SequenceAction action : BroadcastSequenceMap.get(broadcastMessage)) {
 			SequenceAction broadcastWaitAction = ExtendedActions.sequence(action,
 					ExtendedActions.broadcastNotify(event));
+			Sprite receiverSprite  = actionSpriteMap.get(action);
+			actionSpriteMap.put(broadcastWaitAction, receiverSprite);
+			String actionName = broadcastWaitAction.toString() + Constants.ACTION_SPRITE_SEPARATOR + receiverSprite.getName();
+			stringActionMap.put(actionName, broadcastWaitAction);
 			if (!handleActionFromBroadcastWait(look, broadcastWaitAction)) {
 				event.raiseNumberOfReceivers();
 				actionList.add(broadcastWaitAction);
@@ -111,18 +129,24 @@ public final class BroadcastHandler {
 		}
 	}
 
-	private static boolean handleAction(Action action) {
-		for (Sprite sprites : ProjectManager.getInstance().getCurrentProject().getSpriteList()) {
-			for (Action actionOfLook : sprites.look.getActions()) {
-				if (action == actionOfLook || bothSequenceActionsAndEqual(actionOfLook, action)
-						|| isFirstSequenceActionAndEqualsSecond(action, actionOfLook)
-						|| isFirstSequenceActionAndEqualsSecond(actionOfLook, action)) {
-					Look.actionsToRestartAdd(actionOfLook);
-					return true;
-				}
-			}
+	private static boolean handleAction(Action action, Sprite spriteOfAction) {
+		String actionToHandle = action.toString() + Constants.ACTION_SPRITE_SEPARATOR + spriteOfAction.getName();
+
+		if(!actionsToRestartMap.containsKey(actionToHandle)) {
+			return false;
 		}
-		return false;
+		for(String actionString : actionsToRestartMap.get(actionToHandle)) {
+			Action actionOfLook = stringActionMap.get(actionString);
+			if(actionOfLook == null) {
+				Log.d(TAG, "Action of look is skipped with action: " + actionString + ". It is probably a BroadcastNotify-Action that must not be restarted yet");
+				continue;
+			}
+			if(actionOfLook.getActor() == null) {
+				return false;
+			}
+			Look.actionsToRestartAdd(actionOfLook);
+		}
+		return true;
 	}
 
 	private static boolean handleActionFromBroadcastWait(Look look,
@@ -131,42 +155,46 @@ public final class BroadcastHandler {
 
 		for (Sprite sprites : ProjectManager.getInstance().getCurrentProject().getSpriteList()) {
 			for (Action actionOfLook : sprites.look.getActions()) {
-
 				Action actualActionOfLook = null;
-
 				if (actionOfLook instanceof SequenceAction && ((SequenceAction) actionOfLook).getActions().size > 0) {
 					actualActionOfLook = ((SequenceAction) actionOfLook).getActions().get(0);
 				}
-
 				if (sequenceActionWithBroadcastNotifyAction == actionOfLook) {
 					((BroadcastNotifyAction) ((SequenceAction) actionOfLook).getActions().get(1)).getEvent()
 							.resetNumberOfFinishedReceivers();
 					Look.actionsToRestartAdd(actionOfLook);
 					return true;
+				} else {
+					if (actualActionOfLook != null && actualActionOfLook == actualAction) {
+						((BroadcastNotifyAction) ((SequenceAction) actionOfLook).getActions().get(1)).getEvent()
+								.resetEventAndResumeScript();
+						Look.actionsToRestartAdd(actionOfLook);
+						return false;
+					} else {
+						addOrRestartAction(look, sequenceActionWithBroadcastNotifyAction);
+						return false;
+					}
 				}
-
-				if (actualActionOfLook != null && actualActionOfLook == actualAction) {
-					((BroadcastNotifyAction) ((SequenceAction) actionOfLook).getActions().get(1)).getEvent()
-							.resetEventAndResumeScript();
-					Look.actionsToRestartAdd(actionOfLook);
-					return false;
-				}
-
-				addOrRestartAction(look, sequenceActionWithBroadcastNotifyAction);
-				return false;
 			}
 		}
 		return false;
 	}
 
-	private static boolean isFirstSequenceActionAndEqualsSecond(Action action1, Action action2) {
-		return action1 instanceof SequenceAction && ((SequenceAction) action1).getActions().size > 0
-				&& ((SequenceAction) action1).getActions().get(0) == action2;
+	public static void clearActionMaps(){
+		actionsToRestartMap.clear();
+		actionSpriteMap.clear();
+		stringActionMap.clear();
 	}
 
-	private static boolean bothSequenceActionsAndEqual(Action action1, Action action2) {
-		return action1 instanceof SequenceAction && ((SequenceAction) action1).getActions().size > 0
-				&& action2 instanceof SequenceAction && ((SequenceAction) action2).getActions().size > 0
-				&& ((SequenceAction) action1).getActions().get(0) == ((SequenceAction) action2).getActions().get(0);
+	public static Multimap<String, String> getActionsToRestartMap() {
+		return actionsToRestartMap;
+	}
+
+	public static HashMap<Action, Sprite> getActionSpriteMap() {
+		return actionSpriteMap;
+	}
+
+	public static HashMap<String, Action> getStringActionMap() {
+		return stringActionMap;
 	}
 }

--- a/catroid/src/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/org/catrobat/catroid/content/Look.java
@@ -53,7 +53,7 @@ public class Look extends Image {
 	protected float brightness = 1f;
 	protected Pixmap pixmap;
 	private ParallelAction whenParallelAction;
-	private boolean allActionAreFinished = false;
+	private boolean allActionsAreFinished = false;
 	private BrightnessContrastShader shader;
 
 	public Look(Sprite sprite) {
@@ -107,7 +107,7 @@ public class Look extends Image {
 		cloneLook.brightness = this.brightness;
 		cloneLook.visible = this.visible;
 		cloneLook.whenParallelAction = null;
-		cloneLook.allActionAreFinished = this.allActionAreFinished;
+		cloneLook.allActionsAreFinished = this.allActionsAreFinished;
 
 		return cloneLook;
 	}
@@ -158,7 +158,7 @@ public class Look extends Image {
 	@Override
 	public void act(float delta) {
 		Array<Action> actions = getActions();
-		allActionAreFinished = false;
+		allActionsAreFinished = false;
 		int finishedCount = 0;
 
 		for (Iterator<Action> iterator = Look.actionsToRestart.iterator(); iterator.hasNext(); ) {
@@ -174,14 +174,14 @@ public class Look extends Image {
 			}
 		}
 		if (finishedCount == actions.size) {
-			allActionAreFinished = true;
+			allActionsAreFinished = true;
 		}
 	}
 
 	@Override
 	public void addAction(Action action) {
 		super.addAction(action);
-		allActionAreFinished = false;
+		allActionsAreFinished = false;
 	}
 
 	protected void checkImageChanged() {
@@ -228,7 +228,7 @@ public class Look extends Image {
 	}
 
 	public boolean getAllActionsAreFinished() {
-		return allActionAreFinished;
+		return allActionsAreFinished;
 	}
 
 	public String getImagePath() {

--- a/catroid/src/org/catrobat/catroid/content/actions/BroadcastNotifyAction.java
+++ b/catroid/src/org/catrobat/catroid/content/actions/BroadcastNotifyAction.java
@@ -33,7 +33,7 @@ public class BroadcastNotifyAction extends Action {
 	@Override
 	public boolean act(float delta) {
 		event.raiseNumberOfFinishedReceivers();
-		if (event.checkIfAllReceiversHaveFinished()) {
+		if (event.allReceiversHaveFinished()) {
 			event.resetEventAndResumeScript();
 		}
 		return true;

--- a/catroid/src/org/catrobat/catroid/content/bricks/BroadcastBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/BroadcastBrick.java
@@ -2,21 +2,21 @@
  *  Catroid: An on-device visual programming system for Android devices
  *  Copyright (C) 2010-2013 The Catrobat Team
  *  (<http://developer.catrobat.org/credits>)
- *  
+ *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
  *  published by the Free Software Foundation, either version 3 of the
  *  License, or (at your option) any later version.
- *  
+ *
  *  An additional term exception under section 7 of the GNU Affero
  *  General Public License, version 3, is available at
  *  http://developer.catrobat.org/license_additional_term
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU Affero General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -52,10 +52,10 @@ import java.util.List;
 public class BroadcastBrick extends BrickBaseType implements BroadcastMessage {
 	private static final long serialVersionUID = 1L;
 
-	private String broadcastMessage;
-	private transient AdapterView<?> adapterView;
+	protected String broadcastMessage;
+	protected transient AdapterView<?> adapterView;
 
-	private Object readResolve() {
+	protected Object readResolve() {
 		MessageContainer.addMessage(broadcastMessage);
 		return this;
 	}
@@ -180,13 +180,13 @@ public class BroadcastBrick extends BrickBaseType implements BroadcastMessage {
 		return view;
 	}
 
-	private void setSpinnerSelection(Spinner spinner) {
+	protected void setSpinnerSelection(Spinner spinner) {
 		int position = MessageContainer.getPositionOfMessageInAdapter(spinner.getContext(), broadcastMessage);
 		spinner.setSelection(position, true);
 	}
 
-	// TODO: BroadcastBrick, BroadcastReceiverBrick and BroadcastWaitBrick contain this identical method.
-	private void showNewMessageDialog(final Spinner spinner) {
+	// TODO: BroadcastBrick and BroadcastReceiverBrick contain this identical method.
+	protected void showNewMessageDialog(final Spinner spinner) {
 		final Context context = spinner.getContext();
 		BrickTextDialog editDialog = new BrickTextDialog() {
 

--- a/catroid/src/org/catrobat/catroid/content/bricks/BroadcastReceiverBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/BroadcastReceiverBrick.java
@@ -189,7 +189,7 @@ public class BroadcastReceiverBrick extends ScriptBrick implements BroadcastMess
 		spinner.setSelection(position, true);
 	}
 
-	// TODO: BroadcastBrick, BroadcastReceiverBrick and BroadcastWaitBrick contain this identical method.
+    // TODO: BroadcastBrick and BroadcastReceiverBrick contain this identical method.
 	private void showNewMessageDialog(final Spinner spinner) {
 		final Context context = spinner.getContext();
 		BrickTextDialog editDialog = new BrickTextDialog() {

--- a/catroid/src/org/catrobat/catroid/content/bricks/BroadcastWaitBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/BroadcastWaitBrick.java
@@ -2,31 +2,29 @@
  *  Catroid: An on-device visual programming system for Android devices
  *  Copyright (C) 2010-2013 The Catrobat Team
  *  (<http://developer.catrobat.org/credits>)
- *  
+ *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
  *  published by the Free Software Foundation, either version 3 of the
  *  License, or (at your option) any later version.
- *  
+ *
  *  An additional term exception under section 7 of the GNU Affero
  *  General Public License, version 3, is available at
  *  http://developer.catrobat.org/license_additional_term
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU Affero General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
-import android.support.v4.app.FragmentActivity;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
@@ -45,25 +43,14 @@ import org.catrobat.catroid.content.BroadcastMessage;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ExtendedActions;
-import org.catrobat.catroid.ui.dialogs.BrickTextDialog;
 
 import java.util.List;
 
-public class BroadcastWaitBrick extends BrickBaseType implements BroadcastMessage {
+public class BroadcastWaitBrick extends BroadcastBrick implements BroadcastMessage {
 	private static final long serialVersionUID = 1L;
 
-	private String broadcastMessage;
-	private transient AdapterView<?> adapterView;
-
-	private Object readResolve() {
-		MessageContainer.addMessage(broadcastMessage);
-		return this;
-	}
-
 	public BroadcastWaitBrick(Sprite sprite, String broadcastMessage) {
-		this.sprite = sprite;
-		this.broadcastMessage = broadcastMessage;
-		MessageContainer.addMessage(broadcastMessage);
+		super(sprite, broadcastMessage);
 	}
 
 	@Override
@@ -76,16 +63,6 @@ public class BroadcastWaitBrick extends BrickBaseType implements BroadcastMessag
 	@Override
 	public Brick clone() {
 		return new BroadcastWaitBrick(sprite, broadcastMessage);
-	}
-
-	@Override
-	public int getRequiredResources() {
-		return NO_RESOURCES;
-	}
-
-	@Override
-	public String getBroadcastMessage() {
-		return broadcastMessage;
 	}
 
 	@Override
@@ -178,50 +155,6 @@ public class BroadcastWaitBrick extends BrickBaseType implements BroadcastMessag
 		}
 
 		return view;
-	}
-
-	private void setSpinnerSelection(Spinner spinner) {
-		int position = MessageContainer.getPositionOfMessageInAdapter(spinner.getContext(), broadcastMessage);
-		spinner.setSelection(position, true);
-	}
-
-	// TODO: BroadcastBrick, BroadcastReceiverBrick and BroadcastWaitBrick contain this identical method.
-	private void showNewMessageDialog(final Spinner spinner) {
-		final Context context = spinner.getContext();
-		BrickTextDialog editDialog = new BrickTextDialog() {
-
-			@Override
-			protected void initialize() {
-				inputTitle.setText(R.string.dialog_new_broadcast_message_name);
-			}
-
-			@Override
-			protected boolean handleOkButton() {
-				String newMessage = (input.getText().toString()).trim();
-				if (newMessage.isEmpty() || newMessage.equals(context.getString(R.string.new_broadcast_message))) {
-					dismiss();
-					return false;
-				}
-
-				broadcastMessage = newMessage;
-				MessageContainer.addMessage(broadcastMessage);
-				setSpinnerSelection(spinner);
-				return true;
-			}
-
-			@Override
-			public void onDismiss(DialogInterface dialog) {
-				setSpinnerSelection(spinner);
-				super.onDismiss(dialog);
-			}
-
-			@Override
-			protected String getTitle() {
-				return getString(R.string.dialog_new_broadcast_message_title);
-			}
-		};
-
-		editDialog.show(((FragmentActivity) context).getSupportFragmentManager(), "dialog_broadcast_brick");
 	}
 
 	@Override

--- a/catroid/src/org/catrobat/catroid/ui/ScriptActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/ScriptActivity.java
@@ -40,6 +40,7 @@ import com.actionbarsherlock.view.MenuItem;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.BroadcastHandler;
 import org.catrobat.catroid.drone.DroneInitializer;
 import org.catrobat.catroid.stage.PreStageActivity;
 import org.catrobat.catroid.stage.StageActivity;
@@ -356,7 +357,7 @@ public class ScriptActivity extends BaseActivity {
 			fragmentTransaction.remove(formulaEditorFragment);
 			fragmentTransaction.commit();
 		}
-
+		BroadcastHandler.clearActionMaps();
 		if (isHoveringActive()) {
 			scriptFragment.getListView().animateHoveringBrick();
 		} else {

--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/BroadcastActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/BroadcastActionTest.java
@@ -37,6 +37,9 @@ import org.catrobat.catroid.content.bricks.SetXBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
 import org.catrobat.catroid.uitest.util.UiTestUtils;
 
+import java.util.HashMap;
+import java.util.List;
+
 public class BroadcastActionTest extends AndroidTestCase {
 
 	public void testBroadcast() {
@@ -57,7 +60,7 @@ public class BroadcastActionTest extends AndroidTestCase {
 		project.addSprite(sprite);
 		ProjectManager.getInstance().setProject(project);
 
-		sprite.createStartScriptActionSequence();
+		sprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		while (!allActionsOfAllSpritesAreFinished()) {
 			for (Sprite spriteOfList : ProjectManager.getInstance().getCurrentProject().getSpriteList()) {
@@ -91,7 +94,7 @@ public class BroadcastActionTest extends AndroidTestCase {
 		project.addSprite(sprite);
 		ProjectManager.getInstance().setProject(project);
 
-		sprite.createStartScriptActionSequence();
+		sprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		while (!allActionsOfAllSpritesAreFinished()) {
 			for (Sprite spriteOfList : ProjectManager.getInstance().getCurrentProject().getSpriteList()) {
@@ -126,7 +129,7 @@ public class BroadcastActionTest extends AndroidTestCase {
 		project.addSprite(sprite);
 		ProjectManager.getInstance().setProject(project);
 
-		sprite.createStartScriptActionSequence();
+		sprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		int loopCounter = 0;
 		while (!allActionsOfAllSpritesAreFinished() && loopCounter++ < 20) {
@@ -168,7 +171,7 @@ public class BroadcastActionTest extends AndroidTestCase {
 		project.addSprite(sprite);
 		ProjectManager.getInstance().setProject(project);
 
-		sprite.createStartScriptActionSequence();
+		sprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		int loopCounter = 0;
 		while (!allActionsOfAllSpritesAreFinished() && loopCounter++ < 20) {

--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/ChangeVariableActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/ChangeVariableActionTest.java
@@ -38,6 +38,9 @@ import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
 import org.catrobat.catroid.formulaeditor.Operators;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 
+import java.util.HashMap;
+import java.util.List;
+
 public class ChangeVariableActionTest extends AndroidTestCase {
 
 	private static final String TEST_USERVARIABLE = "testUservariable";
@@ -92,7 +95,7 @@ public class ChangeVariableActionTest extends AndroidTestCase {
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
 
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		testSprite.look.act(1f);
 
@@ -132,7 +135,7 @@ public class ChangeVariableActionTest extends AndroidTestCase {
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
 
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		testSprite.look.act(100f);
 

--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/ForeverActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/ForeverActionTest.java
@@ -31,6 +31,9 @@ import org.catrobat.catroid.content.bricks.ForeverBrick;
 import org.catrobat.catroid.content.bricks.LoopBeginBrick;
 import org.catrobat.catroid.content.bricks.LoopEndBrick;
 
+import java.util.HashMap;
+import java.util.List;
+
 public class ForeverActionTest extends InstrumentationTestCase {
 
 	private static final int REPEAT_TIMES = 4;
@@ -52,7 +55,7 @@ public class ForeverActionTest extends InstrumentationTestCase {
 		testScript.addBrick(loopEndBrick);
 
 		testSprite.addScript(testScript);
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		/*
 		 * This is only to document that a delay of 20ms is by contract. See Issue 28 in Google Code

--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/IfLogicActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/IfLogicActionTest.java
@@ -40,6 +40,9 @@ import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
 import org.catrobat.catroid.formulaeditor.Operators;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 
+import java.util.HashMap;
+import java.util.List;
+
 public class IfLogicActionTest extends AndroidTestCase {
 
 	private static final int IF_TRUE_VALUE = 42;
@@ -108,7 +111,7 @@ public class IfLogicActionTest extends AndroidTestCase {
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
 
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1f);
 		}
@@ -157,7 +160,7 @@ public class IfLogicActionTest extends AndroidTestCase {
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
 
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 		testSprite.look.act(100f);
 
 		userVariable = ProjectManager.getInstance().getCurrentProject().getUserVariables()
@@ -203,7 +206,7 @@ public class IfLogicActionTest extends AndroidTestCase {
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
 
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		testSprite.look.act(100f);
 

--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/RepeatActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/RepeatActionTest.java
@@ -40,6 +40,9 @@ import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
 import org.catrobat.catroid.formulaeditor.Sensors;
 import org.catrobat.catroid.test.utils.Reflection;
 
+import java.util.HashMap;
+import java.util.List;
+
 public class RepeatActionTest extends InstrumentationTestCase {
 	private static final int REPEAT_TIMES = 4;
 
@@ -64,7 +67,7 @@ public class RepeatActionTest extends InstrumentationTestCase {
 		testScript.addBrick(new ChangeYByNBrick(testSprite, 150));
 
 		testSprite.addScript(testScript);
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		// http://code.google.com/p/catroid/issues/detail?id=28
 		for (int index = 0; index < REPEAT_TIMES; index++) {
@@ -92,7 +95,7 @@ public class RepeatActionTest extends InstrumentationTestCase {
 		testScript.addBrick(loopEndBrick);
 
 		testSprite.addScript(testScript);
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1.0f);
@@ -119,7 +122,7 @@ public class RepeatActionTest extends InstrumentationTestCase {
 		testScript.addBrick(loopEndBrick);
 
 		testSprite.addScript(testScript);
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1.0f);
@@ -150,7 +153,7 @@ public class RepeatActionTest extends InstrumentationTestCase {
 		testScript.addBrick(loopEndBrick);
 
 		testSprite.addScript(testScript);
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		float timePerActCycle = 0.5f;
 

--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/SetVariableActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/SetVariableActionTest.java
@@ -39,6 +39,9 @@ import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
 import org.catrobat.catroid.formulaeditor.Operators;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 
+import java.util.HashMap;
+import java.util.List;
+
 public class SetVariableActionTest extends AndroidTestCase {
 
 	private static final String TEST_USERVARIABLE = "testUservariable";
@@ -92,7 +95,7 @@ public class SetVariableActionTest extends AndroidTestCase {
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
 
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		testSprite.look.act(100f);
 
@@ -132,7 +135,7 @@ public class SetVariableActionTest extends AndroidTestCase {
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
 
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		testSprite.look.act(100f);
 

--- a/catroidTest/src/org/catrobat/catroid/test/content/sprite/SpriteTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/sprite/SpriteTest.java
@@ -39,6 +39,7 @@ import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.test.utils.TestUtils;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -165,7 +166,7 @@ public class SpriteTest extends AndroidTestCase {
 
 		testSprite.addScript(testScript);
 
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		testSprite.look.act(1.0f);
 

--- a/catroidTest/src/org/catrobat/catroid/test/content/sprite/StartResumeSpriteTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/sprite/StartResumeSpriteTest.java
@@ -32,6 +32,9 @@ import org.catrobat.catroid.content.bricks.SetSizeToBrick;
 import org.catrobat.catroid.content.bricks.ShowBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
 
+import java.util.HashMap;
+import java.util.List;
+
 public class StartResumeSpriteTest extends AndroidTestCase {
 
 	public void testStartThreads() throws InterruptedException {
@@ -45,7 +48,7 @@ public class StartResumeSpriteTest extends AndroidTestCase {
 		testScript.addBrick(setSizeToBrick);
 		testSprite.addScript(testScript);
 
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1.0f);
@@ -68,7 +71,7 @@ public class StartResumeSpriteTest extends AndroidTestCase {
 		testScript.addBrick(showBrick);
 		testSprite.addScript(testScript);
 
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		testSprite.look.act(1.0f);
 		testSprite.look.act(1.0f);
@@ -83,7 +86,7 @@ public class StartResumeSpriteTest extends AndroidTestCase {
 
 		testScript.getBrickList().clear();
 		testScript.addBrick(hideBrick);
-		testSprite.createStartScriptActionSequence();
+		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
 
 		assertTrue("Sprite is hidden - this script shall not be execute", testSprite.look.visible);
 	}

--- a/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -193,6 +193,76 @@ public final class UiTestUtils {
 		FRAGMENT_INDEX_LIST.add(R.id.fragment_sound);
 	}
 
+	public static SetVariableBrick createSendBroadcastAfterBroadcastAndWaitProject(String message) {
+		Project project = new Project(null, DEFAULT_TEST_PROJECT_NAME);
+		Sprite firstSprite = new Sprite("sprite1");
+		Script scriptOfSprite1 = new StartScript(firstSprite);
+
+		firstSprite.addScript(scriptOfSprite1);
+		project.addSprite(firstSprite);
+
+		Script startScript = firstSprite.getScript(0);
+		SetVariableBrick setVariableBrick = new SetVariableBrick(firstSprite, 1.0f);
+		startScript.addBrick(setVariableBrick);
+		startScript.addBrick(new BroadcastWaitBrick(firstSprite, message));
+		startScript.addBrick(new ChangeVariableBrick(firstSprite, 10.0f));
+
+		Sprite secondSprite = new Sprite("sprite2");
+		Script scriptOfSprite2 = new StartScript(secondSprite);
+		secondSprite.addScript(scriptOfSprite2);
+		scriptOfSprite2.addBrick(new WaitBrick(secondSprite, 300));
+		scriptOfSprite2.addBrick(new ChangeVariableBrick(secondSprite, 100.0f));
+		scriptOfSprite2.addBrick(new BroadcastBrick(secondSprite, message));
+		project.addSprite(secondSprite);
+
+		Sprite thirdSprite = new Sprite("sprite3");
+		Script whenIReceive = new BroadcastScript(thirdSprite, message);
+		thirdSprite.addScript(whenIReceive);
+		whenIReceive.addBrick(new ChangeVariableBrick(thirdSprite, 1000.0f));
+		project.addSprite(thirdSprite);
+
+		projectManager.setFileChecksumContainer(new FileChecksumContainer());
+		projectManager.setProject(project);
+		projectManager.setCurrentSprite(firstSprite);
+		projectManager.setCurrentScript(scriptOfSprite2);
+
+		return setVariableBrick;
+	}
+
+	public static int createSendBroadcastInBroadcastAndWaitProject(String message1, String message2, double degreesToTurn, Sprite secondSprite, Sprite thirdSprite) {
+		Project project = new Project(null, DEFAULT_TEST_PROJECT_NAME);
+		Sprite firstSprite = new Sprite("sprite1");
+		Script testScript = new StartScript(firstSprite);
+
+		firstSprite.addScript(testScript);
+		project.addSprite(firstSprite);
+
+		projectManager.setFileChecksumContainer(new FileChecksumContainer());
+		projectManager.setProject(project);
+		projectManager.setCurrentSprite(firstSprite);
+		projectManager.setCurrentScript(testScript);
+
+		int initialRotation = (int) firstSprite.look.getRotation();
+		Script startScript = firstSprite.getScript(0);
+		startScript.addBrick(new BroadcastBrick(firstSprite, message1));
+
+		Script whenIReceiveSecondSprite = new BroadcastScript(secondSprite, message1);
+		secondSprite.addScript(whenIReceiveSecondSprite);
+		whenIReceiveSecondSprite.addBrick(new TurnRightBrick(secondSprite, degreesToTurn));
+		whenIReceiveSecondSprite.addBrick(new WaitBrick(secondSprite, 1000));
+		whenIReceiveSecondSprite.addBrick(new BroadcastWaitBrick(secondSprite, message2));
+		project.addSprite(secondSprite);
+
+		Script whenIReceiveThirdSprite = new BroadcastScript(thirdSprite, message1);
+		thirdSprite.addScript(whenIReceiveThirdSprite);
+		whenIReceiveThirdSprite.addBrick(new TurnLeftBrick(thirdSprite, degreesToTurn));
+		whenIReceiveThirdSprite.addBrick(new WaitBrick(thirdSprite, 1000));
+		whenIReceiveThirdSprite.addBrick(new BroadcastBrick(thirdSprite, message1));
+		project.addSprite(thirdSprite);
+
+		return initialRotation;
+	}
+
 	public static enum FileTypes {
 		IMAGE, SOUND, ROOT
 	};


### PR DESCRIPTION
fixes CAT-893:
The performance of broadcasts is improved now, Air Fight runs very smoothly again. Also the correct restarting of actions is guaranteed (I've added 2 regression tests for that).

Actions to restart are now precomputed per sprite and looked up during execution on the stage.

Jenkins testrun:
https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch/1829/
It seems that there's a problem with the internet connection of the device. However, there's nothing changed in the web package in this PR.
