### PR TITLE
refactor versionName

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ check.dependsOn 'checkstyle'
 check.dependsOn 'pmd'
 
 ext {
-    projectVersion = "0.9"
+    projectVersion = "0.9.8"
     featuresEnabled = [
             "lego_nxt"                          : true,
             "backpack"                          : false,
@@ -57,8 +57,13 @@ def generateVersionName(version, buildNumber) {
     def versionName
     if (buildNumber == -1) {
         versionName = getGitDescribe() + " " + getCurrentGitBranch()
+        // remove the 'v' from versionName: e.g. v0.9.8-96-g082c2c5 master
+        // otherwise upload to web (production and testserver) would not be possible
+        versionName = versionName.substring(1, versionName.length())
     } else {
-        versionName = version + "." + buildNumber
+        // local builds and jenkins builds are consistent now (0.9.8-...)
+        // could be refactored to major.minor.buildnumber in an upcoming release
+        versionName = version + "-" + buildNumber
     }
     return versionName
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:0.12.+'
-        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.10.+'
+        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
     }
 }
 


### PR DESCRIPTION
with a leading 'v' in the versionName, which is written to code.xml of our projects (tag: applicationVersion) an upload to either production server (pocketcode.org) or testservers is not successful with local builds (webteam uses a php function to compare versions, and this should be something like 0.9.8... instead of v0.9.8...)!
so the 'v' is removed, and upload and upload tests with local builds are working again.

however, the versionName schema differs in local builds and jenkins builds.
local -> 0.9.8-96-g082c2c5 master
jenkins -> 0.9.2001, where 2001 is the jenkins buildnumber

since we use the tag for local builds, which is 0.9.8, I adapted projectVersion, which leads to consistent versionNames on Jenkins like 0.9.8-2001.

if we agree to use a different format in the future (e.g. major.minor.buildnumber), this can be reverted, but we should use a different git tag as well (should be adapted from x.y.z to x.y then)

here is a testrun: https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch/1869/
have a look at the .apk filename (can be found in the build artifacts from Catroid-build-and-test-source # 2399) - catroid-debug-0.9.8-2399.apk; other branches have something like catroid-debug-0.9.2430.apk which is misleading, because our current version is 0.9.8