### PR TITLE
Issue#935

### DIFF
--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -2,21 +2,21 @@
  *  Catroid: An on-device visual programming system for Android devices
  *  Copyright (C) 2010-2013 The Catrobat Team
  *  (<http://developer.catrobat.org/credits>)
- *  
+ *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
  *  published by the Free Software Foundation, either version 3 of the
  *  License, or (at your option) any later version.
- *  
+ *
  *  An additional term exception under section 7 of the GNU Affero
  *  General Public License, version 3, is available at
  *  http://developer.catrobat.org/license_additional_term
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU Affero General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -34,6 +34,7 @@ public final class Constants {
 	public static final int APPLICATION_BUILD_NUMBER = 0; // updated from jenkins nightly/release build
 	public static final String APPLICATION_BUILD_NAME = ""; // updated from jenkins nightly/release build
 	public static final String PROJECTCODE_NAME = "code.xml";
+	public static final String PROJECTCODE_NAME_TMP = "tmp_" + PROJECTCODE_NAME;
 
 	public static final String CATROBAT_EXTENSION = ".catrobat";
 	public static final String IMAGE_STANDARD_EXTENTION = ".png";
@@ -84,11 +85,10 @@ public final class Constants {
 	public static final String EXTRA_X_VALUE_POCKET_PAINT = "org.catrobat.extra.PAINTROID_X";
 	public static final String EXTRA_Y_VALUE_POCKET_PAINT = "org.catrobat.extra.PAINTROID_Y";
 	public static final String POCKET_PAINT_PACKAGE_NAME = "org.catrobat.paintroid";
+	public static final String POCKET_PAINT_DOWNLOAD_LINK = "market://details?id=" + POCKET_PAINT_PACKAGE_NAME;
 	public static final String POCKET_PAINT_INTENT_ACTIVITY_NAME = "org.catrobat.paintroid.MainActivity";
-
 	//Various:
 	public static final int BUFFER_8K = 8 * 1024;
-	public static final String POCKET_PAINT_DOWNLOAD_LINK = "market://details?id=" + POCKET_PAINT_PACKAGE_NAME;
 	public static final String PREF_PROJECTNAME_KEY = "projectName";
 	public static final String PROJECTNAME_TO_LOAD = "projectNameToLoad";
 

--- a/catroid/src/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/org/catrobat/catroid/io/StorageHandler.java
@@ -26,6 +26,8 @@ import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.util.Log;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.reflection.FieldDictionary;
 import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
@@ -130,6 +132,7 @@ import static org.catrobat.catroid.common.Constants.DEFAULT_ROOT;
 import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY;
 import static org.catrobat.catroid.common.Constants.NO_MEDIA_FILE;
 import static org.catrobat.catroid.common.Constants.PROJECTCODE_NAME;
+import static org.catrobat.catroid.common.Constants.PROJECTCODE_NAME_TMP;
 import static org.catrobat.catroid.common.Constants.SOUND_DIRECTORY;
 import static org.catrobat.catroid.utils.Utils.buildPath;
 import static org.catrobat.catroid.utils.Utils.buildProjectPath;
@@ -279,6 +282,10 @@ public final class StorageHandler {
 	}
 
 	public Project loadProject(String projectName) {
+		codeFileSanityCheck(projectName);
+
+		Log.d(TAG, "loadProject " + projectName);
+
 		loadSaveLock.lock();
 		try {
 			File projectCodeFile = new File(buildProjectPath(projectName), PROJECTCODE_NAME);
@@ -311,22 +318,51 @@ public final class StorageHandler {
 		return false;
 	}
 
+
 	public boolean saveProject(Project project) {
 		BufferedWriter writer = null;
 
+		if (project == null) {
+			return false;
+		}
+
+		Log.d(TAG, "saveProject " + project.getName());
+
+		codeFileSanityCheck(project.getName());
+
 		loadSaveLock.lock();
+
+		String projectXml;
+		File tmpCodeFile = null;
+		File currentCodeFile = null;
+
 		try {
 
-			if (project == null) {
-				return false;
+			projectXml = XML_HEADER.concat(xstream.toXML(project));
+			tmpCodeFile = new File(buildProjectPath(project.getName()), PROJECTCODE_NAME_TMP);
+			currentCodeFile = new File(buildProjectPath(project.getName()), PROJECTCODE_NAME);
+
+			if (currentCodeFile.exists()) {
+				try {
+					String oldProjectXml = Files.toString(currentCodeFile, Charsets.UTF_8);
+
+					if (oldProjectXml.equals(projectXml)) {
+						Log.d(TAG, "Project version is the same. Do not update " + currentCodeFile.getName());
+						return false;
+					}
+					Log.d(TAG, "Project version differ <" + oldProjectXml.length() + "> <"
+							+ projectXml.length() + ">. update " + currentCodeFile.getName());
+
+				} catch (Exception exception) {
+					Log.e(TAG, "Opening old project " + currentCodeFile.getName() + " failed.", exception);
+					return false;
+				}
 			}
 
 			File projectDirectory = new File(buildProjectPath(project.getName()));
 			createProjectDataStructure(projectDirectory);
 
-			writer = new BufferedWriter(new FileWriter(new File(projectDirectory, PROJECTCODE_NAME)),
-					Constants.BUFFER_8K);
-			String projectXml = XML_HEADER.concat(xstream.toXML(project));
+			writer = new BufferedWriter(new FileWriter(tmpCodeFile), Constants.BUFFER_8K);
 			writer.write(projectXml);
 			writer.flush();
 			return true;
@@ -337,10 +373,53 @@ public final class StorageHandler {
 			if (writer != null) {
 				try {
 					writer.close();
+
+					if (currentCodeFile.exists() && !currentCodeFile.delete()) {
+						Log.e(TAG, "Could not delete " + currentCodeFile.getName());
+					}
+
+					if (!tmpCodeFile.renameTo(currentCodeFile)) {
+						Log.e(TAG, "Could not rename " + currentCodeFile.getName());
+					}
+
 				} catch (IOException ioException) {
 					Log.e(TAG, "Failed closing the buffered writer", ioException);
 				}
 			}
+
+			loadSaveLock.unlock();
+		}
+	}
+
+	public void codeFileSanityCheck(String projectName) {
+		loadSaveLock.lock();
+
+		try {
+			File tmpCodeFile = new File(buildProjectPath(projectName), PROJECTCODE_NAME_TMP);
+
+			if (tmpCodeFile.exists()) {
+				File currentCodeFile = new File(buildProjectPath(projectName), PROJECTCODE_NAME);
+				if (currentCodeFile.exists()) {
+					Log.w(TAG, "TMP File probably corrupted. Both files exist. Discard " + tmpCodeFile.getName());
+
+					if (!tmpCodeFile.delete()) {
+						Log.e(TAG, "Could not delete " + tmpCodeFile.getName());
+					}
+
+					return;
+				}
+
+				Log.w(TAG, "Process interrupted before renaming. Rename " + PROJECTCODE_NAME_TMP +
+						" to " + PROJECTCODE_NAME);
+
+				if (!tmpCodeFile.renameTo(currentCodeFile)) {
+					Log.e(TAG, "Could not rename " + tmpCodeFile.getName());
+				}
+
+			}
+		} catch (Exception exception) {
+			Log.e(TAG, "Exception " + exception);
+		} finally {
 			loadSaveLock.unlock();
 		}
 	}
@@ -432,14 +511,12 @@ public final class StorageHandler {
 		File outputFile = new File(buildPath(soundDirectory.getAbsolutePath(),
 				inputFileChecksum + "_" + inputFile.getName()));
 
-		return copyFileAddCheckSum(outputFile, inputFile, soundDirectory);
+		return copyFileAddCheckSum(outputFile, inputFile);
 	}
 
 	public File copySoundFileBackPack(SoundInfo selectedSoundInfo) throws IOException, IllegalArgumentException {
 
 		String path = selectedSoundInfo.getAbsolutePath();
-
-		File backPackDirectory = new File(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, BACKPACK_SOUND_DIRECTORY));
 
 		File inputFile = new File(path);
 		if (!inputFile.exists() || !inputFile.canRead()) {
@@ -452,7 +529,7 @@ public final class StorageHandler {
 		File outputFile = new File(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, BACKPACK_SOUND_DIRECTORY, currentProject
 				+ "_" + selectedSoundInfo.getTitle() + "_" + inputFileChecksum));
 
-		return copyFileAddCheckSum(outputFile, inputFile, backPackDirectory);
+		return copyFileAddCheckSum(outputFile, inputFile);
 	}
 
 	public File copyImage(String currentProjectName, String inputFilePath, String newName) throws IOException {
@@ -493,7 +570,7 @@ public final class StorageHandler {
 			}
 
 			File outputFile = new File(newFilePath);
-			return copyFileAddCheckSum(outputFile, inputFile, imageDirectory);
+			return copyFileAddCheckSum(outputFile, inputFile);
 		}
 	}
 
@@ -512,7 +589,7 @@ public final class StorageHandler {
 
 		File outputFile = new File(Constants.TMP_IMAGE_PATH);
 
-		File copiedFile = UtilFile.copyFile(outputFile, inputFile, tempDirectory);
+		File copiedFile = UtilFile.copyFile(outputFile, inputFile);
 
 		return copiedFile;
 	}
@@ -586,11 +663,18 @@ public final class StorageHandler {
 	}
 
 	public String getXMLStringOfAProject(Project project) {
-		return xstream.toXML(project);
+		loadSaveLock.lock();
+		String xmlProject = "";
+		try {
+			xmlProject = xstream.toXML(project);
+		} finally {
+			loadSaveLock.unlock();
+		}
+		return xmlProject;
 	}
 
-	private File copyFileAddCheckSum(File destinationFile, File sourceFile, File directory) throws IOException {
-		File copiedFile = UtilFile.copyFile(destinationFile, sourceFile, directory);
+	private File copyFileAddCheckSum(File destinationFile, File sourceFile) throws IOException {
+		File copiedFile = UtilFile.copyFile(destinationFile, sourceFile);
 		addChecksum(destinationFile, sourceFile);
 
 		return copiedFile;

--- a/catroid/src/org/catrobat/catroid/utils/CopyProjectTask.java
+++ b/catroid/src/org/catrobat/catroid/utils/CopyProjectTask.java
@@ -103,7 +103,7 @@ public class CopyProjectTask extends AsyncTask<String, Long, Boolean> {
 				copyDirectory(new File(destinationFile, subDirectoryName), new File(sourceFile, subDirectoryName));
 			}
 		} else {
-			UtilFile.copyFile(destinationFile, sourceFile, null);
+			UtilFile.copyFile(destinationFile, sourceFile);
 		}
 	}
 }

--- a/catroid/src/org/catrobat/catroid/utils/UtilFile.java
+++ b/catroid/src/org/catrobat/catroid/utils/UtilFile.java
@@ -2,21 +2,21 @@
  *  Catroid: An on-device visual programming system for Android devices
  *  Copyright (C) 2010-2013 The Catrobat Team
  *  (<http://developer.catrobat.org/credits>)
- *  
+ *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
  *  published by the Free Software Foundation, either version 3 of the
  *  License, or (at your option) any later version.
- *  
+ *
  *  An additional term exception under section 7 of the GNU Affero
  *  General Public License, version 3, is available at
  *  http://developer.catrobat.org/license_additional_term
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU Affero General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -46,10 +46,6 @@ import java.util.List;
 import java.util.Locale;
 
 public final class UtilFile {
-	public enum FileType {
-		TYPE_IMAGE_FILE, TYPE_SOUND_FILE
-	}
-
 	private static final String TAG = UtilFile.class.getSimpleName();
 
 	// Suppress default constructor for noninstantiability
@@ -209,7 +205,7 @@ public final class UtilFile {
 		return projectList;
 	}
 
-	public static File copyFile(File destinationFile, File sourceFile, File directory) throws IOException {
+	public static File copyFile(File destinationFile, File sourceFile) throws IOException {
 		FileInputStream inputStream = null;
 		FileChannel inputChannel = null;
 		FileOutputStream outputStream = null;
@@ -342,4 +338,7 @@ public final class UtilFile {
 		return projectName;
 	}
 
+	public enum FileType {
+		TYPE_IMAGE_FILE, TYPE_SOUND_FILE
+	}
 }

--- a/catroidTest/src/org/catrobat/catroid/test/utils/TestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utils/TestUtils.java
@@ -2,21 +2,21 @@
  *  Catroid: An on-device visual programming system for Android devices
  *  Copyright (C) 2010-2013 The Catrobat Team
  *  (<http://developer.catrobat.org/credits>)
- *  
+ *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as
  *  published by the Free Software Foundation, either version 3 of the
  *  License, or (at your option) any later version.
- *  
+ *
  *  An additional term exception under section 7 of the GNU Affero
  *  General Public License, version 3, is available at
  *  http://developer.catrobat.org/license_additional_term
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU Affero General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -73,16 +73,12 @@ public final class TestUtils {
 	/**
 	 * saves a file into the project folder
 	 * if project == null or "" file will be saved into Catroid folder
-	 * 
-	 * @param project
-	 *            Folder where the file will be saved, this folder should exist
-	 * @param name
-	 *            Name of the file
-	 * @param fileID
-	 *            the id of the file --> needs the right context
+	 *
+	 * @param project Folder where the file will be saved, this folder should exist
+	 * @param name    Name of the file
+	 * @param fileID  the id of the file --> needs the right context
 	 * @param context
-	 * @param type
-	 *            type of the file: 0 = imagefile, 1 = soundfile
+	 * @param type    type of the file: 0 = imagefile, 1 = soundfile
 	 * @return the file
 	 * @throws IOException
 	 */

--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilsTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilsTest.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.test.utiltests;
 
+import android.os.SystemClock;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.common.Constants;
@@ -64,6 +65,7 @@ public class UtilsTest extends AndroidTestCase {
 	@Override
 	protected void setUp() throws Exception {
 		OutputStream outputStream = null;
+		TestUtils.deleteTestProjects(NEW_PROGRAM_NAME);
 		try {
 			testFile = File.createTempFile("testCopyFiles", ".txt");
 			if (testFile.canWrite()) {
@@ -90,6 +92,7 @@ public class UtilsTest extends AndroidTestCase {
 		if (copiedFile != null && copiedFile.exists()) {
 			copiedFile.delete();
 		}
+
 		TestUtils.deleteTestProjects(NEW_PROGRAM_NAME);
 		super.tearDown();
 	}
@@ -195,6 +198,7 @@ public class UtilsTest extends AndroidTestCase {
 		removeScriptAndCompareToStandardProject();
 		removeSpriteAndCompareToStandardProject();
 
+		SystemClock.sleep(1000);
 	}
 
 	private void addSpriteAndCompareToStandardProject() {

--- a/catroidTest/src/org/catrobat/catroid/uitest/content/brick/SpeakBrickTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/content/brick/SpeakBrickTest.java
@@ -88,6 +88,7 @@ public class SpeakBrickTest extends BaseActivityInstrumentationTestCase<MainMenu
 
 		String brickText = (String) Reflection.getPrivateField(speakBrick, "text");
 		assertEquals("Wrong text in field.", testString, brickText);
+		solo.waitForText(testString);
 		assertEquals("Value in Brick is not updated.", testString,
 				((TextView) solo.getView(R.id.brick_speak_edit_text)).getText().toString());
 
@@ -98,6 +99,7 @@ public class SpeakBrickTest extends BaseActivityInstrumentationTestCase<MainMenu
 
 		brickText = (String) Reflection.getPrivateField(speakBrick, "text");
 		assertEquals("Wrong text in field.", leading, brickText);
+		solo.waitForText(leading);
 		assertEquals("Value in Brick is not updated.", leading, ((TextView) solo.getView(R.id.brick_speak_edit_text))
 				.getText().toString());
 
@@ -108,6 +110,7 @@ public class SpeakBrickTest extends BaseActivityInstrumentationTestCase<MainMenu
 
 		brickText = (String) Reflection.getPrivateField(speakBrick, "text");
 		assertEquals("Wrong text in field.", trailing, brickText);
+		solo.waitForText(trailing);
 		assertEquals("Value in Brick is not updated.", trailing, ((TextView) solo.getView(R.id.brick_speak_edit_text))
 				.getText().toString());
 	}

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
@@ -260,6 +260,7 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		assertEquals("New count is not correct - one look should be deleted", 1, newCount);
 		assertEquals("Count of the lookDataList is not correct", newCount, lookDataList.size());
 
+		Log.d("LookFragmentTest", "path: " + lookToDelete.getAbsolutePath());
 		File deletedFile = new File(lookToDelete.getAbsolutePath());
 		assertFalse("File should be deleted", deletedFile.exists());
 	}


### PR DESCRIPTION
Incoming Jenkins testrun:
https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch/1937/

Process How Files are getting saved (in order to avoid data loss):
You have 3 steps. During/Before/After the first 2 steps (The renaming should be atomic on Linux/Android) an error can occur, this will be checked within the SanityCheckFunction().

-- Filestate: code.xml
1. Write to tmp_code.xml  
-- Filestate: code.xml tmp_code.xml  
2. Delete code.xml
-- Filestate: tmp_code.xml  
3. (usually atomic) rename tmp_code.xml    --> code.xml
-- Filestate: code.xml

To make things clearer:
SanityCheckFunction only needs to verify 2 states.

Either tmp_code.xml AND code.xml exist:
-Then it has to delete tmp_code.xml as this state only occurs during/after step 1 and before step 2.
Or only tmp_code.xml exists
-then it has to rename tmp_code.xml to code.xml. This state can only occur after step 2 but before step 3.

@aried3r 
