### PR TITLE
Quick fix for LookFragmentTest timing issue

### DIFF
--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
@@ -463,6 +463,7 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		solo.sleep(200);
 		solo.waitForActivity(ScriptActivity.class.getSimpleName());
+		solo.sleep(200);
 		assertNotNull("there must be an Intent", getLookFragment().lastRecivedIntent);
 		Bundle bundle = getLookFragment().lastRecivedIntent.getExtras();
 		String pathOfPocketPaintImage = bundle.getString(Constants.EXTRA_PICTURE_PATH_POCKET_PAINT);


### PR DESCRIPTION
Just a quick timing workaround so that this test does not fail with the new emulators (should still be refactored later)

New Emulator Testrun: https://jenkins.catrob.at/view/All-Categories/view/Experimental/job/Catroid-Multi-Job-Custom-Branch-RELOADED/152/
Old Emulator Testrun: https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch/1929/
