### PR TITLE
Disable preDex step for jenkins builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,8 @@ task pmd(type: Pmd) {
     }
 }
 
-task jenkins() << {
+if(project.hasProperty('jenkins')) {
+    project.android.dexOptions.preDexLibraries = false
 //    android.buildTypes.each { type ->
 //        if (type.name == "debug") {
 //            type.packageNameSuffix = ".jenkinsdebug"


### PR DESCRIPTION
- Disable preDex step for jenkins builds
- Also switch from jenkins task to jenkins property
