### PR TITLE
Fix incorrect broadcast behaviour

### DIFF
--- a/catroid/src/org/catrobat/catroid/content/BroadcastHandler.java
+++ b/catroid/src/org/catrobat/catroid/content/BroadcastHandler.java
@@ -42,7 +42,7 @@ import java.util.HashMap;
 public final class BroadcastHandler {
 
 	private static Multimap<String, String> actionsToRestartMap = ArrayListMultimap.create();
-	private static HashMap<Action, Sprite> actionSpriteMap = new HashMap<Action, Sprite>();
+	private static HashMap<Action, Script> actionScriptMap = new HashMap<Action, Script>();
 	private static HashMap<String, Action> stringActionMap = new HashMap<String, Action>();
 
 	private static final String TAG = "BroadcastHandler";
@@ -57,9 +57,9 @@ public final class BroadcastHandler {
 		}
 
 		for (SequenceAction action : BroadcastSequenceMap.get(broadcastMessage)) {
-			Sprite spriteOfAction = actionSpriteMap.get(action);
+			Script scriptOfAction = actionScriptMap.get(action);
 
-			if (!handleAction(action, spriteOfAction)) {
+			if (!handleAction(action, scriptOfAction)) {
 				addOrRestartAction(look, action);
 			}
 		}
@@ -114,9 +114,10 @@ public final class BroadcastHandler {
 		for (SequenceAction action : BroadcastSequenceMap.get(broadcastMessage)) {
 			SequenceAction broadcastWaitAction = ExtendedActions.sequence(action,
 					ExtendedActions.broadcastNotify(event));
-			Sprite receiverSprite = actionSpriteMap.get(action);
-			actionSpriteMap.put(broadcastWaitAction, receiverSprite);
-			String actionName = broadcastWaitAction.toString() + Constants.ACTION_SPRITE_SEPARATOR + receiverSprite.getName();
+			Script receiverScript = actionScriptMap.get(action);
+			actionScriptMap.put(broadcastWaitAction, receiverScript);
+			Sprite receiverSprite = receiverScript.getObject();
+			String actionName = broadcastWaitAction.toString() + Constants.ACTION_SPRITE_SEPARATOR + receiverSprite.getName() + receiverSprite.getScriptIndex(receiverScript);
 			stringActionMap.put(actionName, broadcastWaitAction);
 			if (!handleActionFromBroadcastWait(look, broadcastWaitAction)) {
 				event.raiseNumberOfReceivers();
@@ -129,8 +130,9 @@ public final class BroadcastHandler {
 		}
 	}
 
-	private static boolean handleAction(Action action, Sprite spriteOfAction) {
-		String actionToHandle = action.toString() + Constants.ACTION_SPRITE_SEPARATOR + spriteOfAction.getName();
+	private static boolean handleAction(Action action, Script scriptOfAction) {
+		Sprite spriteOfAction = scriptOfAction.getObject();
+		String actionToHandle = action.toString() + Constants.ACTION_SPRITE_SEPARATOR + spriteOfAction.getName() + spriteOfAction.getScriptIndex(scriptOfAction);
 
 		if (!actionsToRestartMap.containsKey(actionToHandle)) {
 			return false;
@@ -182,7 +184,7 @@ public final class BroadcastHandler {
 
 	public static void clearActionMaps() {
 		actionsToRestartMap.clear();
-		actionSpriteMap.clear();
+		actionScriptMap.clear();
 		stringActionMap.clear();
 	}
 
@@ -190,8 +192,8 @@ public final class BroadcastHandler {
 		return actionsToRestartMap;
 	}
 
-	public static HashMap<Action, Sprite> getActionSpriteMap() {
-		return actionSpriteMap;
+	public static HashMap<Action, Script> getActionScriptMap() {
+		return actionScriptMap;
 	}
 
 	public static HashMap<String, Action> getStringActionMap() {

--- a/catroid/src/org/catrobat/catroid/content/Script.java
+++ b/catroid/src/org/catrobat/catroid/content/Script.java
@@ -165,6 +165,10 @@ public abstract class Script implements Serializable {
 		return brickList.get(index);
 	}
 
+	public Sprite getObject() {
+		return object;
+	}
+
 	protected void setIfBrickReferences(IfLogicEndBrick copiedIfEndBrick, IfLogicEndBrick originalIfEndBrick) {
 		List<NestingBrick> ifBrickList = originalIfEndBrick.getAllNestingBrickParts(true);
 		IfLogicBeginBrick copiedIfBeginBrick = ((IfLogicBeginBrick) ifBrickList.get(0)).getCopy();

--- a/catroid/src/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/org/catrobat/catroid/content/Sprite.java
@@ -108,12 +108,13 @@ public class Sprite implements Serializable, Cloneable {
 	}
 
 	public void createStartScriptActionSequenceAndPutToMap(Map<String, List<String>> scriptActions) {
-		for (Script script : scriptList) {
+		for (int scriptCounter = 0; scriptCounter < scriptList.size(); scriptCounter++) {
+			Script script = scriptList.get(scriptCounter);
 			if (script instanceof StartScript) {
 				Action sequenceAction = createActionSequence(script);
 				look.addAction(sequenceAction);
-				BroadcastHandler.getActionSpriteMap().put(sequenceAction, script.getScriptBrick().getSprite());
-				String actionName = sequenceAction.toString() + Constants.ACTION_SPRITE_SEPARATOR + name;
+				BroadcastHandler.getActionScriptMap().put(sequenceAction, script);
+				String actionName = sequenceAction.toString() + Constants.ACTION_SPRITE_SEPARATOR + name + scriptCounter;
 				if (scriptActions.containsKey(Constants.START_SCRIPT)) {
 					scriptActions.get(Constants.START_SCRIPT).add(actionName);
 					BroadcastHandler.getStringActionMap().put(actionName, sequenceAction);
@@ -127,9 +128,9 @@ public class Sprite implements Serializable, Cloneable {
 			if (script instanceof BroadcastScript) {
 				BroadcastScript broadcastScript = (BroadcastScript) script;
 				SequenceAction action = createActionSequence(broadcastScript);
-				BroadcastHandler.getActionSpriteMap().put(action, script.getScriptBrick().getSprite());
+				BroadcastHandler.getActionScriptMap().put(action, script);
 				putBroadcastSequenceAction(broadcastScript.getBroadcastMessage(), action);
-				String actionName = action.toString() + Constants.ACTION_SPRITE_SEPARATOR + name;
+				String actionName = action.toString() + Constants.ACTION_SPRITE_SEPARATOR + name + scriptCounter;
 
 				if (scriptActions.containsKey(Constants.BROADCAST_SCRIPT)) {
 					scriptActions.get(Constants.BROADCAST_SCRIPT).add(actionName);

--- a/catroid/src/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/org/catrobat/catroid/stage/StageListener.java
@@ -415,7 +415,7 @@ public class StageListener implements ApplicationListener {
 		}
 		for (String action : actions) {
 			for (String actionOfLook : actions) {
-				if (action.equals(actionOfLook) || bothSequenceActionsAndEqual(actionOfLook, action)
+				if (action.equals(actionOfLook)
 						|| isFirstSequenceActionAndEqualsSecond(action, actionOfLook)
 						|| isFirstSequenceActionAndEqualsSecond(actionOfLook, action)) {
 					if (!actionsToRestartMap.containsKey(action)) {
@@ -449,34 +449,6 @@ public class StageListener implements ApplicationListener {
 			return true;
 		}
 		return false;
-	}
-
-	private static boolean bothSequenceActionsAndEqual(String action1, String action2) {
-		String spriteOfAction1 = action1.substring(action1.indexOf(Constants.ACTION_SPRITE_SEPARATOR));
-		String spriteOfAction2 = action2.substring(action2.indexOf(Constants.ACTION_SPRITE_SEPARATOR));
-
-		if (!spriteOfAction1.equals(spriteOfAction2)) {
-			return false;
-		}
-
-		if (!(action1.startsWith(SEQUENCE) && action2.startsWith(SEQUENCE))) {
-			return false;
-		}
-
-		int startIndex1 = action1.indexOf(Constants.OPENING_BRACE);
-		int endIndex1 = action1.lastIndexOf(Constants.CLOSING_BRACE) + 1;
-
-		int startIndex2 = action2.indexOf(Constants.OPENING_BRACE);
-		int endIndex2 = action2.lastIndexOf(Constants.CLOSING_BRACE) + 1;
-
-		String sequenceOfAction1 = action1.substring(startIndex1, endIndex1);
-		String sequenceOfAction2 = action2.substring(startIndex2, endIndex2);
-
-		if (sequenceOfAction1.equals(sequenceOfAction2)) {
-			return true;
-		} else {
-			return false;
-		}
 	}
 
 	private void drawAxes() {

--- a/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -264,6 +264,56 @@ public final class UiTestUtils {
 		return initialRotation;
 	}
 
+	public static SetVariableBrick createSameActionsBroadcastProject(String message) {
+		Project project = new Project(null, DEFAULT_TEST_PROJECT_NAME);
+		Sprite firstSprite = new Sprite("sprite1");
+		Script firstScript = new StartScript(firstSprite);
+
+		firstSprite.addScript(firstScript);
+		project.addSprite(firstSprite);
+
+		Script startScript = firstSprite.getScript(0);
+		SetVariableBrick setVariableBrick = new SetVariableBrick(firstSprite, 0.0f);
+		startScript.addBrick(setVariableBrick);
+		LoopBeginBrick beginBrick = new RepeatBrick(firstSprite, 10);
+		LoopEndBrick endBrick = new LoopEndBrick(firstSprite, beginBrick);
+		beginBrick.setLoopEndBrick(endBrick);
+		startScript.addBrick(beginBrick);
+		startScript.addBrick(new BroadcastWaitBrick(firstSprite, message));
+		startScript.addBrick(endBrick);
+
+		Sprite secondSprite = new Sprite("sprite2");
+		Script secondScript = new BroadcastScript(secondSprite, message);
+		secondSprite.addScript(secondScript);
+		IfLogicBeginBrick ifBeginBrickSecondScript = new IfLogicBeginBrick(secondSprite, 1);
+		IfLogicElseBrick ifElseBrickSecondScript = new IfLogicElseBrick(secondSprite, ifBeginBrickSecondScript);
+		IfLogicEndBrick ifEndBrickSecondScript = new IfLogicEndBrick(secondSprite, ifElseBrickSecondScript, ifBeginBrickSecondScript);
+		secondScript.addBrick(ifBeginBrickSecondScript);
+		secondScript.addBrick(new ChangeVariableBrick(secondSprite, 1.0f));
+		secondScript.addBrick(ifElseBrickSecondScript);
+		secondScript.addBrick(ifEndBrickSecondScript);
+		project.addSprite(secondSprite);
+
+		Sprite thirdSprite = new Sprite("sprite3");
+		Script thirdScript = new BroadcastScript(thirdSprite, message);
+		thirdSprite.addScript(thirdScript);
+		IfLogicBeginBrick ifBeginBrickThirdScript = new IfLogicBeginBrick(thirdSprite, 1);
+		IfLogicElseBrick ifElseBrickThirdScript = new IfLogicElseBrick(thirdSprite, ifBeginBrickThirdScript);
+		IfLogicEndBrick ifEndBrickThirdScript = new IfLogicEndBrick(thirdSprite, ifElseBrickThirdScript, ifBeginBrickThirdScript);
+		thirdScript.addBrick(ifBeginBrickThirdScript);
+		thirdScript.addBrick(new ChangeVariableBrick(thirdSprite, 1.0f));
+		thirdScript.addBrick(ifElseBrickThirdScript);
+		thirdScript.addBrick(ifEndBrickThirdScript);
+		project.addSprite(thirdSprite);
+
+		projectManager.setFileChecksumContainer(new FileChecksumContainer());
+		projectManager.setProject(project);
+		projectManager.setCurrentSprite(firstSprite);
+		projectManager.setCurrentScript(thirdScript);
+
+		return setVariableBrick;
+	}
+
 	public static enum FileTypes {
 		IMAGE, SOUND, ROOT
 	};


### PR DESCRIPTION
There was a special in which broadcast were not restarted correctly:
- One sprite contains identical string representations of scripts. In the case of TicTacToe these were nested IfLogic-Actions --> e.g "Sequence(IfLogic)#upper left", which was 5 times in there and led to confusion on which actions to restart
  The simple solution is to add a script counter and change the string representation to e.g. "Sequence(IfLogic)#upper left0", "Sequence(IfLogic)#upper left1" etc. and also to lookup scripts instead of sprites.

Furthermore, I've added another regression test for that as well as a file logging method, which was extremely useful to identify the incorrectly restarted actions (too much output for the console or logcat).

Jenkins testrun:
https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch/2031/
Checkystyle error is fixed.
