### PR TITLE
[CAT-1074] nexus7 workaround for checking flash

### DIFF
--- a/catroid/src/org/catrobat/catroid/stage/PreStageActivity.java
+++ b/catroid/src/org/catrobat/catroid/stage/PreStageActivity.java
@@ -29,6 +29,7 @@ import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.hardware.Camera;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -57,6 +58,7 @@ import org.catrobat.catroid.utils.VibratorUtil;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 
 @SuppressWarnings("deprecation")
@@ -124,10 +126,8 @@ public class PreStageActivity extends BaseActivity {
 		}
 
 		if ((requiredResources & Brick.CAMERA_LED ) > 0) {
-			boolean hasCamera = getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA);
-			boolean hasLed = getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH);
 
-			if ( hasCamera && hasLed ) {
+			if ( hasFlash() ) {
 				requiredResourceCounter--;
 				LedUtil.activateLedThread();
 			} else {
@@ -158,6 +158,44 @@ public class PreStageActivity extends BaseActivity {
 			droneInitializer = new DroneInitializer(this, returnToActivityIntent);
 		}
 		return droneInitializer;
+	}
+
+	protected boolean hasFlash() {
+		boolean hasCamera = getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA);
+		boolean hasLed = getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH);
+
+		if (!hasCamera || !hasLed) {
+			return false;
+		}
+
+		Camera camera = LedUtil.getCamera();
+
+		try {
+			if (camera == null) {
+				LedUtil.openCamera();
+				camera = LedUtil.getCamera();
+			}
+		} catch (Exception exception) {
+			Log.e(getString(R.string.app_name), "failed to open Camera", exception);
+		}
+
+		if (camera == null) {
+			return false;
+		}
+
+		Camera.Parameters parameters = camera.getParameters();
+
+		if (parameters.getFlashMode() == null) {
+			return false;
+		}
+
+		List<String> supportedFlashModes = parameters.getSupportedFlashModes();
+		if (supportedFlashModes == null || supportedFlashModes.isEmpty() ||
+				supportedFlashModes.size() == 1 && supportedFlashModes.get(0).equals(Camera.Parameters.FLASH_MODE_OFF)) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Override

--- a/catroid/src/org/catrobat/catroid/utils/LedUtil.java
+++ b/catroid/src/org/catrobat/catroid/utils/LedUtil.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Semaphore;
 public final class LedUtil {
 
 	private static final String TAG = LedUtil.class.getSimpleName();
-	private static Camera cam = Camera.open();
+	private static Camera cam = null;
 	private static Camera.Parameters paramsOn = null;
 	private static Camera.Parameters paramsOff = null;
 
@@ -68,6 +68,20 @@ public final class LedUtil {
 
 	public static boolean isActive() {
 		return keepAlive;
+	}
+
+	public static Camera getCamera() {
+		return cam;
+	}
+
+	public static void openCamera() {
+		if (cam == null) {
+			try {
+				cam = Camera.open();
+			} catch (Exception exception) {
+				Log.e(TAG, "failed to open Camera", exception);
+			}
+		}
 	}
 
 	public static void setNextLedValue(boolean val) {
@@ -137,9 +151,7 @@ public final class LedUtil {
 			});
 		}
 
-		if (cam == null) {
-			cam = Camera.open();
-		}
+		openCamera();
 
 		if (cam != null) {
 
@@ -152,7 +164,7 @@ public final class LedUtil {
 				paramsOff.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
 			}
 
-			initializeCamera();
+			initializeSurfaceTexture();
 
 			if (!lightThread.isAlive()) {
 				try {
@@ -164,8 +176,6 @@ public final class LedUtil {
 				lightThread.setName("lightThread");
 				lightThread.start();
 			}
-		} else {
-			Log.e(TAG, "cam.open() failed!");
 		}
 	}
 
@@ -180,6 +190,10 @@ public final class LedUtil {
 
 		lightThread = null;
 
+		closeCamera();
+	}
+
+	public static void closeCamera() {
 		if (cam != null) {
 			cam.stopPreview();
 			cam.release();
@@ -192,7 +206,7 @@ public final class LedUtil {
 	}
 
 	@TargetApi(Build.VERSION_CODES.HONEYCOMB)
-	private static void initializeCamera() {
+	private static void initializeSurfaceTexture() {
 		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.GINGERBREAD_MR1) {
 			try {
 				surfaceTexture = new SurfaceTexture(1);

--- a/catroidTest/src/org/catrobat/catroid/uitest/content/brick/VibrationBrickTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/content/brick/VibrationBrickTest.java
@@ -61,27 +61,18 @@ public class VibrationBrickTest extends BaseActivityInstrumentationTestCase<Scri
 
 	@Override
 	protected void setUp() throws Exception {
-
 		createProject();
-		super.setUp();
-
-		// create server connection
 		SensorTestServerConnection.connectToArduinoServer();
-
-		// disable touch screen while testing
 		setActivityInitialTouchMode(false);
-
-		Log.d(TAG, "setUp() - no flash led available");
-
+		SensorTestServerConnection.closeConnection();
+		super.setUp();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
-		super.tearDown();
-
 		SensorTestServerConnection.closeConnection();
-
 		setActivityInitialTouchMode(true);
+		super.tearDown();
 	}
 
 	@Device
@@ -109,16 +100,14 @@ public class VibrationBrickTest extends BaseActivityInstrumentationTestCase<Scri
 		UiTestUtils.clickOnBottomBar(solo, R.id.button_play);
 		solo.waitForActivity(StageActivity.class.getSimpleName());
 
-		solo.sleep(3000);
+		solo.sleep(WLAN_DELAY_MS);
 		SensorTestServerConnection.checkVibrationSensorValue(SensorTestServerConnection.SET_VIBRATION_ON_VALUE);
 		solo.sleep(WLAN_DELAY_MS);
 
-		Log.d(TAG, "sleep two seconds. the phone should have stopped vibrating");
+		Log.d(TAG, "sleep four seconds. the phone should have stopped vibrating");
 
-		solo.sleep(2000);
+		solo.sleep(4000);
 		Log.d(TAG, "checking vibration sensor value");
-		SensorTestServerConnection.checkVibrationSensorValue(SensorTestServerConnection.SET_VIBRATION_OFF_VALUE);
-		solo.sleep(WLAN_DELAY_MS);
 		SensorTestServerConnection.checkVibrationSensorValue(SensorTestServerConnection.SET_VIBRATION_OFF_VALUE);
 		solo.sleep(WLAN_DELAY_MS);
 
@@ -167,5 +156,4 @@ public class VibrationBrickTest extends BaseActivityInstrumentationTestCase<Scri
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 		ProjectManager.getInstance().setCurrentScript(startScript);
 	}
-
 }

--- a/catroidTest/src/org/catrobat/catroid/uitest/util/SensorTestServerConnection.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/util/SensorTestServerConnection.java
@@ -97,15 +97,15 @@ public final class SensorTestServerConnection {
 			assertString = "Error: LED is turned on!";
 		}
 		try {
-			clientSocket.close();
-			Thread.sleep(NETWORK_DELAY_MS);
 			connectToArduinoServer();
+			Thread.sleep(NETWORK_DELAY_MS);
 			Log.d(TAG, "requesting sensor value: ");
 			sendToServer.writeByte(Integer.toHexString(GET_LIGHT_VALUE_ID).charAt(0));
 			sendToServer.flush();
 			Thread.sleep(NETWORK_DELAY_MS);
 			response = receiveFromServer.readLine();
 			Log.d(TAG, "response received! " + response);
+			clientSocket.close();
 
 			assertFalse("Wrong Command!", response.contains("ERROR"));
 			assertTrue("Wrong data received!", response.contains("LIGHT_END"));
@@ -131,15 +131,15 @@ public final class SensorTestServerConnection {
 			assertString = "Error: Vibrator is turned on!";
 		}
 		try {
-			clientSocket.close();
-			Thread.sleep(NETWORK_DELAY_MS);
 			connectToArduinoServer();
+			Thread.sleep(NETWORK_DELAY_MS);
 			Log.d(TAG, "requesting sensor value: ");
 			sendToServer.writeByte(Integer.toHexString(GET_VIBRATION_VALUE_ID).charAt(0));
 			sendToServer.flush();
 			Thread.sleep(NETWORK_DELAY_MS);
 			response = receiveFromServer.readLine();
 			Log.d(TAG, "response received! " + response);
+			clientSocket.close();
 
 			assertFalse("Wrong Command!", response.contains("ERROR"));
 			assertTrue("Wrong data received!", response.contains("VIBRATION_END"));
@@ -155,15 +155,15 @@ public final class SensorTestServerConnection {
 	public static void calibrateVibrationSensor() {
 		String response;
 		try {
-			clientSocket.close();
-			Thread.sleep(NETWORK_DELAY_MS);
 			connectToArduinoServer();
+			Thread.sleep(NETWORK_DELAY_MS);
 			Log.d(TAG, "requesting sensor value: ");
 			sendToServer.writeByte(Integer.toHexString(CALIBRATE_VIBRATION_SENSOR_ID).charAt(0));
 			sendToServer.flush();
 			Thread.sleep(NETWORK_DELAY_MS);
 			response = receiveFromServer.readLine();
 			Log.d(TAG, "response received! " + response);
+			clientSocket.close();
 
 		} catch (IOException ioException) {
 			throw new AssertionFailedError("Data exchange failed! Check server connection!");


### PR DESCRIPTION
nexus7 bug fixed. prevents stage start and displays toast message

nexus 7 flashlight bug fixed

LedBrickTest for other devices extended

stacktrace prints

forgot to release camera in test class

fixed number of bricks in category brick test

wrong number of motion bricks fixed

vibration measurement debugging

nexus7 bug fixed. prevents stage start and displays toast message

nexus 7 flashlight bug fixed

LedBrickTest for other devices extended

forgot to release camera in test class

fixed number of bricks in category brick test

wrong number of motion bricks fixed

testcase refactored

wrong ip address
