### PR TITLE
adding .iml files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *.metadata
 
 #IntelliJ IDEA
+Catroid.iml
+catroidSourceTest/catroidSourceTest.iml
 .idea
 *.ipr
 *.iws


### PR DESCRIPTION
since the Android Studio iml files are not versioned in the catroid master branch I guess we can add them to the .gitignore to avoid merge conflicts.
