### PR TITLE
[CAT-971] Web View for Password Forgotten in Upload Dialog 

### DIFF
--- a/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -198,7 +198,7 @@ public class MainMenuActivity extends BaseActivity implements OnLoadProjectCompl
 
 	}
 
-	private void startWebViewActivity(String url) {
+	public void startWebViewActivity(String url) {
 		// TODO just a quick fix for not properly working webview on old devices
 		if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.GINGERBREAD_MR1) {
 			final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/LoginRegisterDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/LoginRegisterDialog.java
@@ -27,8 +27,6 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnShowListener;
-import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.text.Html;
@@ -45,11 +43,12 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.transfers.RegistrationTask;
 import org.catrobat.catroid.transfers.RegistrationTask.OnRegistrationCompleteListener;
+import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.web.ServerCalls;
 
 public class LoginRegisterDialog extends DialogFragment implements OnRegistrationCompleteListener {
 
-	private static final String PASSWORD_FORGOTTEN_PATH = "catroid/passwordrecovery?username=";
+	public static final String PASSWORD_FORGOTTEN_PATH = "catroid/passwordrecovery?username=";
 	public static final String DIALOG_FRAGMENT_TAG = "dialog_login_register";
 
 	private EditText usernameEditText;
@@ -126,8 +125,8 @@ public class LoginRegisterDialog extends DialogFragment implements OnRegistratio
 	private void handlePasswordForgottenButtonClick() {
 		String username = usernameEditText.getText().toString();
 		String baseUrl = ServerCalls.useTestUrl ? ServerCalls.BASE_URL_TEST_HTTP : Constants.BASE_URL_HTTPS;
+		String url = baseUrl + PASSWORD_FORGOTTEN_PATH + username;
 
-		Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(baseUrl + PASSWORD_FORGOTTEN_PATH + username));
-		getActivity().startActivity(browserIntent);
+		((MainMenuActivity) getActivity()).startWebViewActivity(url);
 	}
 }

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/WebViewActivityTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/WebViewActivityTest.java
@@ -31,7 +31,9 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.ui.WebViewActivity;
+import org.catrobat.catroid.ui.dialogs.LoginRegisterDialog;
 import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
+import org.catrobat.catroid.web.ServerCalls;
 
 public class WebViewActivityTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
 	private static final String COPYRIGHT_CHARACTER = "\u00A9";
@@ -116,6 +118,36 @@ public class WebViewActivityTest extends BaseActivityInstrumentationTestCase<Mai
 		}
 	}
 
+	public void testWebViewPasswordForgotten() {
+		String uploadButtonText = solo.getString(R.string.main_menu_upload);
+		solo.clickOnButton(uploadButtonText);
+
+		String passwordForgottenButtonText = solo.getString(R.string.password_forgotten);
+		solo.clickOnButton(passwordForgottenButtonText);
+
+		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.GINGERBREAD_MR1) {
+			solo.waitForView(solo.getView(R.id.webView));
+			solo.sleep(2000);
+
+			assertEquals("Current Activity is not WebViewActivity", WebViewActivity.class, solo.getCurrentActivity()
+					.getClass());
+
+			String baseUrl = ServerCalls.useTestUrl ? ServerCalls.BASE_URL_TEST_HTTP : Constants.BASE_URL_HTTPS;
+			final String url = baseUrl + LoginRegisterDialog.PASSWORD_FORGOTTEN_PATH;
+
+			final WebView webView = (WebView) solo.getCurrentActivity().findViewById(R.id.webView);
+			solo.getCurrentActivity().runOnUiThread(new Runnable() {
+				public void run() {
+					assertEquals("Catrobat password forgotten URL is not correct", url, webView.getUrl());
+				}
+			});
+
+			assertTrue("website hasn't been loaded properly", solo.searchText(COPYRIGHT_CHARACTER + " Catrobat"));
+
+		} else {
+			applyWebViewOnOldDevices(passwordForgottenButtonText);
+		}
+	}
 
 	private void applyWebViewOnOldDevices(String buttonText) {
 		String webButtonText = solo.getString(R.string.main_menu_web);


### PR DESCRIPTION
When you are not logged in and press the button “Upload” a Dialog appears where you can press “Password Forgotten” which will lead you to your installed Browser.

In this pull request, I changed the code to open a WebView instead, like when you press on “Help” or “Explore” in the Main menu.

This PR is same as https://github.com/Catrobat/Catroid/pull/966
