### PR TITLE
fixes double entries in MainMenuActivity's setting menu

### DIFF
--- a/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -137,12 +137,6 @@ public class MainMenuActivity extends BaseActivity implements OnLoadProjectCompl
 		}
 	}
 
-	@Override
-	public boolean onCreateOptionsMenu(Menu menu) {
-		getSupportMenuInflater().inflate(R.menu.menu_main_menu, menu);
-		return super.onCreateOptionsMenu(menu);
-	}
-
 	// needed because of android:onClick in activity_main_menu.xml
 	public void handleContinueButton(View view) {
 		handleContinueButton();


### PR DESCRIPTION
This was caused by merging CAT-1055.

Jenkins:
https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch/2349
