### PR TITLE
fixed IfBrickTests

### DIFF
--- a/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -1459,8 +1459,14 @@ public final class UiTestUtils {
 	}
 
 	public static void acceptAndCloseActionMode(Solo solo) {
-		int doneButtonId = Resources.getSystem().getIdentifier("action_mode_close_button", "id", "android");
-		View doneButton = solo.getView(doneButtonId);
+		View doneButton;
+
+		if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+			doneButton = solo.getView(Resources.getSystem().getIdentifier("action_mode_close_button", "id", "android"));
+		} else {
+			doneButton = solo.getCurrentActivity().findViewById(R.id.abs__action_mode_close_button);
+		}
+
 		solo.clickOnView(doneButton);
 		solo.sleep(200);
 	}


### PR DESCRIPTION
Fixed testCopyIfLogicElseBrickActionMode, testCopyIfLogicEndBrickActionMode, testSelectionActionMode and testCopyIfLogicBeginBrickActionMode in class IfBrickTest by adding an if statement in UiTestUtils.acceptAndCloseActionMode which checks the android api level of the device used and changes how to get the button view accordingly.
https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch-RELOADED/376/
