### PR TITLE
restored missing catroidSourceTest.iml

### DIFF
--- a/catroidSourceTest/catroidSourceTest.iml
+++ b/catroidSourceTest/catroidSourceTest.iml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="Catroid" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+</module>


### PR DESCRIPTION
The iml file was deleted during a rebase and merged unrecognized. For details see:
https://github.com/Catrobat/Catroid/commit/cff9c414b204ded06a7cb11967f816fec43a6c71
