### PR TITLE
fix IndexOutOfBoundsException

### DIFF
--- a/catroid/src/org/catrobat/catroid/utils/UtilFile.java
+++ b/catroid/src/org/catrobat/catroid/utils/UtilFile.java
@@ -164,7 +164,7 @@ public final class UtilFile {
 
 	public static void createStandardProjectIfRootDirectoryIsEmpty(Context context) {
 		File rootDirectory = new File(Constants.DEFAULT_ROOT);
-		if (rootDirectory == null || rootDirectory.listFiles() == null || rootDirectory.listFiles().length == 0) {
+		if (rootDirectory == null || rootDirectory.listFiles() == null || getProjectNames(rootDirectory).size() == 0) {
 			ProjectManager.getInstance().initializeDefaultProject(context);
 		}
 	}


### PR DESCRIPTION
happend if PocketCode folder wasn't empty but didn't contain
a valid structured project
