### PR TITLE
fixingMaster_fixIlegalArgumentInLoadProjectIfNeeded

### DIFF
--- a/catroid/src/org/catrobat/catroid/common/StandardProjectHandler.java
+++ b/catroid/src/org/catrobat/catroid/common/StandardProjectHandler.java
@@ -72,7 +72,15 @@ public final class StandardProjectHandler {
 
 	public static Project createAndSaveStandardProject(Context context) throws IOException {
 		String projectName = context.getString(R.string.default_project_name);
-		return createAndSaveStandardProject(projectName, context);
+		Project standardProject = null;
+
+		try {
+			standardProject = createAndSaveStandardProject(projectName, context);
+		} catch (IllegalArgumentException ilArgument) {
+			Log.e(TAG, "Could not create standard project!", ilArgument);
+		}
+
+		return standardProject;
 	}
 
 	public static Project createAndSaveStandardDroneProject(Context context) throws IOException {

--- a/catroid/src/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/org/catrobat/catroid/utils/Utils.java
@@ -282,7 +282,7 @@ public final class Utils {
 			SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
 			String projectName = sharedPreferences.getString(Constants.PREF_PROJECTNAME_KEY, null);
 
-			if (projectName == null) {
+			if (projectName == null || !StorageHandler.getInstance().projectExists(projectName)) {
 				projectName = context.getString(R.string.default_project_name);
 			}
 
@@ -300,7 +300,7 @@ public final class Utils {
 		if (ProjectManager.getInstance().getCurrentProject() == null) {
 			SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
 			String currentProjectName = sharedPreferences.getString(Constants.PREF_PROJECTNAME_KEY, null);
-			if (currentProjectName == null) {
+			if (currentProjectName == null || !StorageHandler.getInstance().projectExists(currentProjectName)) {
 				currentProjectName = UtilFile.getProjectNames(new File(Constants.DEFAULT_ROOT)).get(0);
 			}
 			return currentProjectName;


### PR DESCRIPTION
This is only a tmp solution but it works.
The reason was a ProjectException exception was triggered at loadProjectIfNeeded(), probably because we tried to load a project (whose name we recieved from the sharedPreferences) which was already deleted.

An extended approach (which refactores the deleteProject process) is in refactor_deleteBranch.
