### PR TITLE
fixed Problem with project in Settings

### DIFF
--- a/catroid/res/values-de/strings.xml
+++ b/catroid/res/values-de/strings.xml
@@ -493,6 +493,8 @@
     <string name="error_no_writiable_external_storage_available">Um Pocket Code zu starten wird beschreibbarer externer Speicher wie z.B. eine SD Karte benötigt.\nSie können diesen Fehler beheben indem sie den externen Speicher beschreibbar machen oder eine SD Karte einlegen und es erneut versuchen.</string>
     <string name="error_no_name_entered">Bitte einen Namen eingeben.</string>
     <string name="error_project_exists">Es gibt bereits ein Programm mit dem eingegebenen Namen.\nBitte einen anderen Namen eingeben.</string>
+    <string name="error_delete_project">Ein Fehler beim Löschen des Programms ist aufgetreten.</string>
+    <string name="error_unknown_project">Ein Programm mit diesem Namen existiert nicht!</string>
     <string name="error_project_upload">Beim Upload des Programms ist ein Fehler aufgetreten.</string>
     <string name="error_project_download">Beim Download des Programms ist ein Fehler aufgetreten.</string>
     <string name="error_new_project">Beim Erstellen des neuen Programms ist ein Fehler aufgetreten.</string>

--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -490,6 +490,8 @@
     <string name="error_no_writiable_external_storage_available">Pocket Code requires writable external storage like an SD card in order to run, but none was found.\nYou can fix this by making the external storage writable or inserting an SD card, then try again.</string>
     <string name="error_no_name_entered">Please enter a name.</string>
     <string name="error_project_exists">A program with the same name already exists.\nPlease choose a different name.</string>
+    <string name="error_delete_project">An error while deleting the program occurred</string>
+    <string name="error_unknown_project">A program with that name does not exist.</string>
     <string name="error_project_upload">An error occurred while uploading the program.</string>
     <string name="error_project_download">An error occurred while downloading the program.</string>
     <string name="error_new_project">An error occurred while creating a new program.</string>

--- a/catroid/src/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/org/catrobat/catroid/ProjectManager.java
@@ -248,9 +248,31 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 		this.project = project;
 	}
 
-	public void deleteCurrentProject() {
-		StorageHandler.getInstance().deleteProject(project);
-		project = null;
+	@Deprecated
+	public void deleteCurrentProject(Context context) throws IllegalArgumentException, IOException {
+		deleteProject(project.getName(), context);
+	}
+
+
+	public void deleteProject(String projectName, Context context) throws IllegalArgumentException, IOException {
+		Log.d(TAG, "deleteProject " + projectName);
+		if (StorageHandler.getInstance().projectExists(projectName)) {
+			StorageHandler.getInstance().deleteProject(projectName);
+		}
+
+		if (project != null && project.getName().equals(projectName)) {
+			Log.d(TAG, "deleteProject(): project instance set to null");
+
+			project = null;
+
+			if (context != null) {
+				SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+				String currentProjectName = sharedPreferences.getString(Constants.PREF_PROJECTNAME_KEY, "notFound");
+				if (!currentProjectName.equals("notFound")) {
+					Utils.removeFromPreferences(context, Constants.PREF_PROJECTNAME_KEY);
+				}
+			}
+		}
 	}
 
 	public boolean renameProject(String newProjectName, Context context) {
@@ -367,15 +389,6 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 		this.fileChecksumContainer = fileChecksumContainer;
 	}
 
-	private class SaveProjectAsynchronousTask extends AsyncTask<Void, Void, Void> {
-
-		@Override
-		protected Void doInBackground(Void... params) {
-			StorageHandler.getInstance().saveProject(project);
-			return null;
-		}
-	}
-
 	@Override
 	public void onTokenNotValid(FragmentActivity fragmentActivity) {
 		showLoginRegisterDialog(fragmentActivity);
@@ -480,6 +493,15 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 				((IfLogicEndBrick) currentBrick).setIfElseBrick(elseBrick);
 				ifBeginList.remove(ifBeginBrick);
 			}
+		}
+	}
+
+	private class SaveProjectAsynchronousTask extends AsyncTask<Void, Void, Void> {
+
+		@Override
+		protected Void doInBackground(Void... params) {
+			StorageHandler.getInstance().saveProject(project);
+			return null;
 		}
 	}
 }

--- a/catroid/src/org/catrobat/catroid/common/StandardProjectHandler.java
+++ b/catroid/src/org/catrobat/catroid/common/StandardProjectHandler.java
@@ -337,6 +337,10 @@ public final class StandardProjectHandler {
 			UtilFile.copyFromResourceIntoProject(projectName, ".", StageListener.SCREENSHOT_AUTOMATIC_FILE_NAME,
 					R.drawable.default_project_screenshot, context, false);
 
+			Log.i(TAG, String.format("createAndSaveStandardProject(%s) %s created%n %s created%n %s created%n %s created%n %s created%n %s created%n %s created%n %s created%n",
+					projectName, backgroundFile.getName(), movingMoleFile.getName(), diggedOutMoleFile.getName(), whackedMoleFile.getName(),
+						soundFile1.getName(), soundFile2.getName(), soundFile3.getName(), soundFile4.getName()));
+
 			LookData movingMoleLookData = new LookData();
 			movingMoleLookData.setLookName(movingMoleLookName);
 			movingMoleLookData.setLookFilename(movingMoleFile.getName());

--- a/catroid/src/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/org/catrobat/catroid/io/StorageHandler.java
@@ -35,7 +35,6 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.FileChecksumContainer;
 import org.catrobat.catroid.common.LookData;
-import org.catrobat.catroid.common.ProjectData;
 import org.catrobat.catroid.common.SoundInfo;
 import org.catrobat.catroid.content.BroadcastScript;
 import org.catrobat.catroid.content.Project;
@@ -199,9 +198,14 @@ public final class StorageHandler {
 				bitmap.compress(CompressFormat.PNG, 0, outputStream);
 			}
 			outputStream.flush();
-			outputStream.close();
 		} catch (IOException ioException) {
 			Log.e(TAG, Log.getStackTraceString(ioException));
+		} finally {
+			try {
+				outputStream.close();
+			} catch (IOException e) {
+				Log.e(TAG, "Could not close outputstream.", e);
+			}
 		}
 	}
 
@@ -347,6 +351,7 @@ public final class StorageHandler {
 		BufferedWriter writer = null;
 
 		if (project == null) {
+			Log.d(TAG, "project is null!");
 			return false;
 		}
 
@@ -361,7 +366,6 @@ public final class StorageHandler {
 		File currentCodeFile = null;
 
 		try {
-
 			projectXml = XML_HEADER.concat(xstream.toXML(project));
 			tmpCodeFile = new File(buildProjectPath(project.getName()), PROJECTCODE_NAME_TMP);
 			currentCodeFile = new File(buildProjectPath(project.getName()), PROJECTCODE_NAME);
@@ -449,6 +453,7 @@ public final class StorageHandler {
 	}
 
 	private void createProjectDataStructure(File projectDirectory) throws IOException {
+		Log.d(TAG, "create Project Data structure");
 		createCatroidRoot();
 		projectDirectory.mkdir();
 
@@ -493,18 +498,15 @@ public final class StorageHandler {
 		}
 	}
 
-	public boolean deleteProject(Project project) {
-		if (project != null) {
-			return UtilFile.deleteDirectory(new File(buildProjectPath(project.getName())));
+	public void deleteProject(String projectName) throws IllegalArgumentException, IOException {
+		boolean success;
+		if (projectName == null || !projectExists(projectName)) {
+			throw new IllegalArgumentException("Project with name " + projectName + " does not exist");
 		}
-		return false;
-	}
-
-	public boolean deleteProject(ProjectData projectData) {
-		if (projectData != null) {
-			return UtilFile.deleteDirectory(new File(buildProjectPath(projectData.projectName)));
+		success = UtilFile.deleteDirectory(new File(buildProjectPath(projectName)));
+		if (!success) {
+			throw new IOException("Error at deleting project " + projectName);
 		}
-		return false;
 	}
 
 	public boolean projectExists(String projectName) {

--- a/catroid/src/org/catrobat/catroid/ui/fragment/ProjectsListFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/ProjectsListFragment.java
@@ -44,6 +44,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.ListView;
+import android.widget.Toast;
 
 import com.actionbarsherlock.app.SherlockListFragment;
 import com.actionbarsherlock.view.ActionMode;
@@ -57,7 +58,6 @@ import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.exceptions.CompatibilityProjectException;
 import org.catrobat.catroid.exceptions.LoadingProjectException;
 import org.catrobat.catroid.exceptions.OutdatedVersionProjectException;
-import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.ui.BottomBar;
 import org.catrobat.catroid.ui.MyProjectsActivity;
 import org.catrobat.catroid.ui.ProjectActivity;
@@ -74,6 +74,7 @@ import org.catrobat.catroid.utils.UtilFile;
 import org.catrobat.catroid.utils.Utils;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -84,9 +85,9 @@ import java.util.Set;
 public class ProjectsListFragment extends SherlockListFragment implements OnProjectRenameListener,
 		OnUpdateProjectDescriptionListener, OnCopyProjectListener, OnProjectEditListener {
 
-	private static final String TAG = ProjectsListFragment.class.getSimpleName();
 	private static final String BUNDLE_ARGUMENTS_PROJECT_DATA = "project_data";
 	private static final String SHARED_PREFERENCE_NAME = "showDetailsMyProjects";
+	private static final String TAG = ProjectsListFragment.class.getSimpleName();
 
 	private static String deleteActionModeTitle;
 	private static String singleItemAppendixDeleteActionMode;
@@ -103,6 +104,110 @@ public class ProjectsListFragment extends SherlockListFragment implements OnProj
 	private View selectAllActionModeButton;
 
 	private boolean actionModeActive = false;
+	private ActionMode.Callback deleteModeCallBack = new ActionMode.Callback() {
+		@Override
+		public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+			return false;
+		}
+
+		@Override
+		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+			setSelectMode(ListView.CHOICE_MODE_MULTIPLE);
+
+			actionModeActive = true;
+
+			deleteActionModeTitle = getString(R.string.delete);
+			singleItemAppendixDeleteActionMode = getString(R.string.program);
+			multipleItemAppendixDeleteActionMode = getString(R.string.programs);
+
+			mode.setTitle(deleteActionModeTitle);
+			addSelectAllActionModeButton(mode, menu);
+
+			return true;
+		}
+
+		@Override
+		public boolean onActionItemClicked(ActionMode mode, com.actionbarsherlock.view.MenuItem item) {
+			return false;
+		}
+
+		@Override
+		public void onDestroyActionMode(ActionMode mode) {
+			if (adapter.getAmountOfCheckedProjects() == 0) {
+				clearCheckedProjectsAndEnableButtons();
+			} else {
+				showConfirmDeleteDialog();
+			}
+		}
+	};
+	private ActionMode.Callback renameModeCallBack = new ActionMode.Callback() {
+
+		@Override
+		public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+			return false;
+		}
+
+		@Override
+		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+			setSelectMode(ListView.CHOICE_MODE_SINGLE);
+			mode.setTitle(R.string.rename);
+
+			actionModeActive = true;
+
+			return true;
+		}
+
+		@Override
+		public boolean onActionItemClicked(ActionMode mode, com.actionbarsherlock.view.MenuItem item) {
+			return false;
+		}
+
+		@Override
+		public void onDestroyActionMode(ActionMode mode) {
+			Set<Integer> checkedSprites = adapter.getCheckedProjects();
+			Iterator<Integer> iterator = checkedSprites.iterator();
+			if (iterator.hasNext()) {
+				int position = iterator.next();
+				projectToEdit = (ProjectData) getListView().getItemAtPosition(position);
+				showRenameDialog();
+			}
+			clearCheckedProjectsAndEnableButtons();
+		}
+	};
+	private ActionMode.Callback copyModeCallBack = new ActionMode.Callback() {
+
+		@Override
+		public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+			return false;
+		}
+
+		@Override
+		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+			setSelectMode(ListView.CHOICE_MODE_SINGLE);
+			mode.setTitle(R.string.copy);
+
+			actionModeActive = true;
+
+			return true;
+		}
+
+		@Override
+		public boolean onActionItemClicked(ActionMode mode, com.actionbarsherlock.view.MenuItem item) {
+			return false;
+		}
+
+		@Override
+		public void onDestroyActionMode(ActionMode mode) {
+			Set<Integer> checkedSprites = adapter.getCheckedProjects();
+			Iterator<Integer> iterator = checkedSprites.iterator();
+			if (iterator.hasNext()) {
+				int position = iterator.next();
+				projectToEdit = (ProjectData) getListView().getItemAtPosition(position);
+				showCopyProjectDialog();
+			}
+			clearCheckedProjectsAndEnableButtons();
+		}
+	};
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -188,22 +293,22 @@ public class ProjectsListFragment extends SherlockListFragment implements OnProj
 		initAdapter();
 	}
 
+	public boolean getShowDetails() {
+		return adapter.getShowDetails();
+	}
+
 	public void setShowDetails(boolean showDetails) {
 		adapter.setShowDetails(showDetails);
 		adapter.notifyDataSetChanged();
 	}
 
-	public boolean getShowDetails() {
-		return adapter.getShowDetails();
+	public int getSelectMode() {
+		return adapter.getSelectMode();
 	}
 
 	public void setSelectMode(int selectMode) {
 		adapter.setSelectMode(selectMode);
 		adapter.notifyDataSetChanged();
-	}
-
-	public int getSelectMode() {
-		return adapter.getSelectMode();
 	}
 
 	public boolean getActionModeActive() {
@@ -417,23 +522,25 @@ public class ProjectsListFragment extends SherlockListFragment implements OnProj
 		alertDialog.show();
 	}
 
-	private void deleteProject() {
+	private void deleteProject(ProjectData project) {
 		ProjectManager projectManager = ProjectManager.getInstance();
-		Project currentProject = projectManager.getCurrentProject();
-
-		if (currentProject != null && currentProject.getName().equalsIgnoreCase(projectToEdit.projectName)) {
-			projectManager.deleteCurrentProject();
-		} else {
-			StorageHandler.getInstance().deleteProject(projectToEdit);
+		try {
+			projectManager.deleteProject(project.projectName, getActivity().getApplicationContext());
+			projectList.remove(project);
+		} catch (IOException exception) {
+			Log.e(TAG, "Project could not be deleted", exception);
+			Toast.makeText(getActivity(), R.string.error_delete_project, Toast.LENGTH_SHORT).show();
+		} catch (IllegalArgumentException exception) {
+			Log.e(TAG, "Project does not exist!", exception);
+			Toast.makeText(getActivity(), R.string.error_unknown_project, Toast.LENGTH_SHORT).show();
 		}
-		projectList.remove(projectToEdit);
 	}
 
 	private void deleteCheckedProjects() {
 		int numDeleted = 0;
 		for (int position : adapter.getCheckedProjects()) {
 			projectToEdit = (ProjectData) getListView().getItemAtPosition(position - numDeleted);
-			deleteProject();
+			deleteProject(projectToEdit);
 			numDeleted++;
 		}
 
@@ -473,113 +580,6 @@ public class ProjectsListFragment extends SherlockListFragment implements OnProj
 
 		});
 	}
-
-	private ActionMode.Callback deleteModeCallBack = new ActionMode.Callback() {
-		@Override
-		public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
-			return false;
-		}
-
-		@Override
-		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
-			setSelectMode(ListView.CHOICE_MODE_MULTIPLE);
-
-			actionModeActive = true;
-
-			deleteActionModeTitle = getString(R.string.delete);
-			singleItemAppendixDeleteActionMode = getString(R.string.program);
-			multipleItemAppendixDeleteActionMode = getString(R.string.programs);
-
-			mode.setTitle(deleteActionModeTitle);
-			addSelectAllActionModeButton(mode, menu);
-
-			return true;
-		}
-
-		@Override
-		public boolean onActionItemClicked(ActionMode mode, com.actionbarsherlock.view.MenuItem item) {
-			return false;
-		}
-
-		@Override
-		public void onDestroyActionMode(ActionMode mode) {
-			if (adapter.getAmountOfCheckedProjects() == 0) {
-				clearCheckedProjectsAndEnableButtons();
-			} else {
-				showConfirmDeleteDialog();
-			}
-		}
-	};
-
-	private ActionMode.Callback renameModeCallBack = new ActionMode.Callback() {
-
-		@Override
-		public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
-			return false;
-		}
-
-		@Override
-		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
-			setSelectMode(ListView.CHOICE_MODE_SINGLE);
-			mode.setTitle(R.string.rename);
-
-			actionModeActive = true;
-
-			return true;
-		}
-
-		@Override
-		public boolean onActionItemClicked(ActionMode mode, com.actionbarsherlock.view.MenuItem item) {
-			return false;
-		}
-
-		@Override
-		public void onDestroyActionMode(ActionMode mode) {
-			Set<Integer> checkedSprites = adapter.getCheckedProjects();
-			Iterator<Integer> iterator = checkedSprites.iterator();
-			if (iterator.hasNext()) {
-				int position = iterator.next();
-				projectToEdit = (ProjectData) getListView().getItemAtPosition(position);
-				showRenameDialog();
-			}
-			clearCheckedProjectsAndEnableButtons();
-		}
-	};
-
-	private ActionMode.Callback copyModeCallBack = new ActionMode.Callback() {
-
-		@Override
-		public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
-			return false;
-		}
-
-		@Override
-		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
-			setSelectMode(ListView.CHOICE_MODE_SINGLE);
-			mode.setTitle(R.string.copy);
-
-			actionModeActive = true;
-
-			return true;
-		}
-
-		@Override
-		public boolean onActionItemClicked(ActionMode mode, com.actionbarsherlock.view.MenuItem item) {
-			return false;
-		}
-
-		@Override
-		public void onDestroyActionMode(ActionMode mode) {
-			Set<Integer> checkedSprites = adapter.getCheckedProjects();
-			Iterator<Integer> iterator = checkedSprites.iterator();
-			if (iterator.hasNext()) {
-				int position = iterator.next();
-				projectToEdit = (ProjectData) getListView().getItemAtPosition(position);
-				showCopyProjectDialog();
-			}
-			clearCheckedProjectsAndEnableButtons();
-		}
-	};
 
 	private class ProjectListInitReceiver extends BroadcastReceiver {
 		@Override

--- a/catroid/src/org/catrobat/catroid/utils/UtilFile.java
+++ b/catroid/src/org/catrobat/catroid/utils/UtilFile.java
@@ -96,26 +96,40 @@ public final class UtilFile {
 		return String.format(Locale.getDefault(), "%.1f %sB", bytes / Math.pow(unit, exponent), prefix);
 	}
 
-	public static boolean clearDirectory(File path) {
-		if (path.exists()) {
-			File[] filesInDirectory = path.listFiles();
-			if (filesInDirectory == null) {
+	public static boolean deleteDirectory(File fileOrDirectory) {
+		return deleteDirectory(fileOrDirectory, 0);
+	}
+
+	private static boolean deleteDirectory(File fileOrDirectory, int space) {
+		if (fileOrDirectory == null) {
+			return false;
+		}
+
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < space; i++) {
+			sb.append('-');
+		}
+
+		boolean success = true;
+		if (fileOrDirectory.exists() && fileOrDirectory.isDirectory()) {
+			// Please note: especially with MyProjectsActivityTest.testAddNewProjectMixedCase(), it happens that listFiles
+			// returns null (although fileOrDirectory exists and is a directory). This should definitely not happen
+			// and there is probably an I/O Error from the system. So we just check this manually and abort if so.
+			File[] files = fileOrDirectory.listFiles();
+			if (files == null) {
 				return false;
 			}
-			for (File file : filesInDirectory) {
-				if (file.isDirectory()) {
-					deleteDirectory(file);
-				} else {
-					file.delete();
+
+			for (File child : files) {
+				success = deleteDirectory(child, space + 1);
+				if (!success) {
+					return false;
 				}
 			}
 		}
-		return true;
-	}
 
-	public static boolean deleteDirectory(File path) {
-		clearDirectory(path);
-		return (path.delete());
+		Log.v(TAG, sb.toString() + "delete: " + fileOrDirectory.getName());
+		return fileOrDirectory.delete();
 	}
 
 	public static File saveFileToProject(String project, String name, int fileID, Context context, FileType type) {

--- a/catroidCucumberTest/src/org/catrobat/catroid/test/cucumber/BeforeAfterSteps.java
+++ b/catroidCucumberTest/src/org/catrobat/catroid/test/cucumber/BeforeAfterSteps.java
@@ -64,6 +64,6 @@ public class BeforeAfterSteps extends ActivityInstrumentationTestCase2<MainMenuA
 	public void after() {
 		Log.d(CucumberInstrumentation.TAG, "after step");
 		solo.finishOpenedActivities();
-		ProjectManager.getInstance().deleteCurrentProject();
+		ProjectManager.getInstance().deleteCurrentProject(null);
 	}
 }

--- a/catroidTest/src/org/catrobat/catroid/test/utils/TestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utils/TestUtils.java
@@ -24,6 +24,8 @@ package org.catrobat.catroid.test.utils;
 
 import android.app.NotificationManager;
 import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.util.Log;
 import android.util.SparseArray;
 
@@ -259,6 +261,7 @@ public final class TestUtils {
 	}
 
 	public static void deleteTestProjects(String... additionalProjectNames) {
+		Log.d(TAG, "deleteTestProjects");
 		ProjectManager.getInstance().setFileChecksumContainer(new FileChecksumContainer());
 
 		File directory = new File(Constants.DEFAULT_ROOT + "/" + DEFAULT_TEST_PROJECT_NAME);
@@ -296,5 +299,12 @@ public final class TestUtils {
 		 "definitionBrick");
 		 sprite.addUserBrick(userBrick);
 		 return definitionBrick.getScriptSafe();
-		 }	
+		 }
+
+	public static void removeFromPreferences(Context context, String key) {
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+		SharedPreferences.Editor edit = preferences.edit();
+		edit.remove(key);
+		edit.commit();
+	}
 }

--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilFileTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilFileTest.java
@@ -74,14 +74,6 @@ public class UtilFileTest extends InstrumentationTestCase {
 		super.tearDown();
 	}
 
-	public void testClearDirectory() {
-		UtilFile.clearDirectory(testDirectory);
-		assertFalse("File in subdirectory still exists after call to clearDirectory", file2.exists());
-		assertFalse("Subdirectory in test directory still exists after call to clearDirectory", subDirectory.exists());
-		assertFalse("File in test directory still exists after call to clearDirectory", file1.exists());
-		assertTrue("Directory itself was deleted as well after call to clearDirectory", testDirectory.exists());
-	}
-
 	public void testDeleteDirectory() {
 		UtilFile.deleteDirectory(testDirectory);
 		assertFalse("File in subdirectory still exists after call to deleteDirectory", file2.exists());

--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilsTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilsTest.java
@@ -201,6 +201,16 @@ public class UtilsTest extends AndroidTestCase {
 		SystemClock.sleep(1000);
 	}
 
+	public void testLoadProjectIfNeeded() {
+		Utils.saveToPreferences(getContext(), Constants.PREF_PROJECTNAME_KEY, "projectNameWhichDoesNotExist");
+		try {
+			Utils.loadProjectIfNeeded(getContext());
+		} catch (Exception e) {
+			fail("Tried to load project which should not be loadable.");
+		}
+		TestUtils.removeFromPreferences(getContext(), Constants.PREF_PROJECTNAME_KEY);
+	}
+
 	private void addSpriteAndCompareToStandardProject() {
 		Sprite sprite = new Sprite("TestSprite");
 		standardProject.addSprite(sprite);

--- a/catroidTest/src/org/catrobat/catroid/uitest/content/brick/LoopBrickTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/content/brick/LoopBrickTest.java
@@ -64,14 +64,6 @@ public class LoopBrickTest extends BaseActivityInstrumentationTestCase<MainMenuA
 		UiTestUtils.getIntoScriptActivityFromMainMenu(solo);
 	}
 
-	@Override
-	public void tearDown() throws Exception {
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
-		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
-	}
-
 	public void testRepeatBrick() {
 		ArrayList<Integer> yPosition;
 		ArrayList<Brick> projectBrickList = project.getSpriteList().get(0).getScript(0).getBrickList();

--- a/catroidTest/src/org/catrobat/catroid/uitest/content/brick/WhenStartedBrickTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/content/brick/WhenStartedBrickTest.java
@@ -52,14 +52,6 @@ public class WhenStartedBrickTest extends BaseActivityInstrumentationTestCase<Ma
 		UiTestUtils.getIntoScriptActivityFromMainMenu(solo);
 	}
 
-	@Override
-	public void tearDown() throws Exception {
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
-		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
-	}
-
 	public void testWhenStartedBrick() {
 		if (!solo.waitForView(DragAndDropListView.class, 0, 5000, false)) {
 			fail("DragAndDropListView not shown in 5 secs!");

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/MainMenuActivityTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/MainMenuActivityTest.java
@@ -89,10 +89,7 @@ public class MainMenuActivityTest extends BaseActivityInstrumentationTestCase<Ma
 		UtilFile.deleteDirectory(new File(Utils.buildProjectPath(projectNameJustSpecialChars2)));
 		UtilFile.deleteDirectory(new File(Utils.buildProjectPath(projectNameJustOneDot)));
 		UtilFile.deleteDirectory(new File(Utils.buildProjectPath(projectNameJustTwoDots)));
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
 		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
 	}
 
 	public void testCreateNewProject() {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/ProgramMenuActivityTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/ProgramMenuActivityTest.java
@@ -74,11 +74,7 @@ public class ProgramMenuActivityTest extends BaseActivityInstrumentationTestCase
 	@Override
 	public void tearDown() throws Exception {
 		lookFile.delete();
-
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
 		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
 	}
 
 	public void testOrientation() throws NameNotFoundException {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/DeleteDialogTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/DeleteDialogTest.java
@@ -69,14 +69,6 @@ public class DeleteDialogTest extends BaseActivityInstrumentationTestCase<MainMe
 		lookDataList = ProjectManager.getInstance().getCurrentSprite().getLookDataList();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
-		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
-	}
-
 	public void testDeleteLooks() throws Exception {
 		addLooksToProject();
 		String buttonOkText = solo.getString(R.string.yes);

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/FormulaEditorComputDialogTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/FormulaEditorComputDialogTest.java
@@ -55,14 +55,6 @@ public class FormulaEditorComputDialogTest extends BaseActivityInstrumentationTe
 		solo.clickOnView(solo.getView(R.id.formula_editor_keyboard_compute));
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
-		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
-	}
-
 	public void testDialogCreation(){
 		assertTrue("Dialog not loaded!",
 				solo.searchText(testInteger + solo.getString(R.string.formula_editor_decimal_mark) + "0" , true));

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/NewProjectDialogTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/NewProjectDialogTest.java
@@ -71,10 +71,7 @@ public class NewProjectDialogTest extends BaseActivityInstrumentationTestCase<Ma
 		UtilFile.deleteDirectory(new File(Utils.buildProjectPath(testingProjectWithNormalAndSpecialChars)));
 		UtilFile.deleteDirectory(new File(Utils.buildProjectPath(testingProjectJustOneDot)));
 		UtilFile.deleteDirectory(new File(Utils.buildProjectPath(testingProjectJustTwoDots)));
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
 		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
 	}
 
 	public void testNewProjectDialog() {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/NewSpriteDialogTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/NewSpriteDialogTest.java
@@ -62,11 +62,7 @@ public class NewSpriteDialogTest extends BaseActivityInstrumentationTestCase<Mai
 	@Override
 	protected void tearDown() throws Exception {
 		lookFile.delete();
-
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
 		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
 	}
 
 	public void testNewSpriteDialogStep1() throws Exception {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/NewStringDialogTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/NewStringDialogTest.java
@@ -57,14 +57,6 @@ public class NewStringDialogTest extends BaseActivityInstrumentationTestCase<Mai
 		solo.clickOnView(solo.getView(R.id.formula_editor_keyboard_string));
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
-		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
-	}
-
 	public void testDialogCreation(){
 		assertTrue(NewStringDialog.class.getSimpleName() + " did not load under 5 seconds!",
 				solo.waitForFragmentByTag(NewStringDialog.DIALOG_FRAGMENT_TAG, 5000));

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/RenameSpriteDialogTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/RenameSpriteDialogTest.java
@@ -27,7 +27,6 @@ import android.widget.ListView;
 
 import com.robotium.solo.Solo;
 
-import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Sprite;
@@ -47,14 +46,6 @@ public class RenameSpriteDialogTest extends BaseActivityInstrumentationTestCase<
 
 	public RenameSpriteDialogTest() {
 		super(MainMenuActivity.class);
-	}
-
-	@Override
-	public void tearDown() throws Exception {
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
-		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
 	}
 
 	public void testRenameSpriteDialog() throws NameNotFoundException, IOException {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/SetDescriptionDialogTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/SetDescriptionDialogTest.java
@@ -26,7 +26,6 @@ import android.annotation.TargetApi;
 import android.os.Build;
 import android.widget.EditText;
 
-import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.io.StorageHandler;
@@ -41,14 +40,6 @@ public class SetDescriptionDialogTest extends BaseActivityInstrumentationTestCas
 
 	public SetDescriptionDialogTest() {
 		super(MainMenuActivity.class);
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
-		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
 	}
 
 	// Not testable with Android 2.3, because solo is not able to enter new lines

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/StageDialogTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/StageDialogTest.java
@@ -66,14 +66,6 @@ public class StageDialogTest extends BaseActivityInstrumentationTestCase<MainMen
 		UiTestUtils.prepareStageForTest();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
-		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
-	}
-
 	public void testBackButtonPressedTwice() {
 		Project project = createTestProject(testProject);
 		ProjectManager.getInstance().setProject(project);

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/UploadDialogTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/dialog/UploadDialogTest.java
@@ -77,11 +77,8 @@ public class UploadDialogTest extends BaseActivityInstrumentationTestCase<MainMe
 	public void tearDown() throws Exception {
 		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
 		prefs.edit().putString(Constants.TOKEN, saveToken).commit();
-		// normally super.teardown should be called last
-		// but tests crashed with Nullpointer
-		super.tearDown();
-		ProjectManager.getInstance().deleteCurrentProject();
 		uploadProject = null;
+		super.tearDown();
 	}
 
 	private void setServerURLToTestURL() throws Throwable {

--- a/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -167,6 +167,7 @@ public final class UiTestUtils {
 	private static ProjectManager projectManager = ProjectManager.getInstance();
 	private static SparseIntArray brickCategoryMap;
 	private static List<InternToken> internTokenList = new ArrayList<InternToken>();
+	private static final String TAG = UiTestUtils.class.getName();
 
 	public static final String DEFAULT_TEST_PROJECT_NAME = "testProject";
 	public static final String PROJECTNAME1 = "testingproject1";
@@ -1351,6 +1352,7 @@ public final class UiTestUtils {
 	}
 
 	public static void clearAllUtilTestProjects() {
+		Log.v(TAG, "clearAllUtilTestProjects");
 		projectManager.setFileChecksumContainer(new FileChecksumContainer());
 		File directory = new File(Constants.DEFAULT_ROOT + "/" + PROJECTNAME1);
 		if (directory.exists()) {
@@ -1805,7 +1807,7 @@ public final class UiTestUtils {
 	}
 
 	public static boolean longClickOnTextInList(Solo solo, String text) {
-		solo.sleep(300);
+		solo.waitForView(solo.getView(android.R.id.list));
 		ArrayList<TextView> textViews = solo.getCurrentViews(TextView.class);
 		for (int position = 0; position < textViews.size(); position++) {
 			TextView view = textViews.get(position);

--- a/catroidTest/src/org/catrobat/catroid/uitest/web/ProjectUpAndDownloadTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/web/ProjectUpAndDownloadTest.java
@@ -484,7 +484,7 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 		try {
 			if (StorageHandler.getInstance().projectExists(standardProjectName)) {
 				ProjectManager.getInstance().loadProject(standardProjectName, getActivity());
-				ProjectManager.getInstance().deleteCurrentProject();
+				ProjectManager.getInstance().deleteCurrentProject(null);
 			}
 			standardProject = StandardProjectHandler.createAndSaveStandardProject(standardProjectName,
 					getInstrumentation().getTargetContext());


### PR DESCRIPTION
(continued from @stypen and @avihric)
- project now gets also deleted from settings
- added tests
- refactored testDeleteSprite and testDeleteViaActionBar
- no NULL pointer expcetion in teardown anymore (when you change the order of the super call)
- some minor changes

_Jira_
https://jira.catrob.at/browse/CAT-1174

_master testrun (8 fails)_
https://jenkins.catrob.at/view/All-Categories/view/Catroid/job/Catroid-Multi-Job-Custom-Branch/2505/#showFailuresLink

_refactor_deleteProject testrun (8 fails)_
https://jenkins.catrob.at/view/All-Categories/view/Catroid/job/Catroid-Multi-Job-Custom-Branch/2506/

As you may have noticed there are now 2 tests fixed but 2 tests also failed.
Here you can see that the same tests (which are not device tests) fail also on the master branch:

_org.catrobat.catroid.uitest.content.interaction.UserBrickTest.testSetParameterOfUserbricksInScript_
https://jenkins.catrob.at/view/All-Categories/view/Catroid/job/Catroid-CustomEmulator-Single-ClassAndPackage-Test/108/
https://jenkins.catrob.at/view/All-Categories/view/Catroid/job/Catroid-CustomEmulator-Single-ClassAndPackage-Test/107/

_org.catrobat.catroid.uitest.ui.activity.MyProjectsActivityTest.testDeletingProjectAndVerifySettings_
https://jenkins.catrob.at/view/All-Categories/view/Catroid/job/Catroid-CustomEmulator-Single-ClassAndPackage-Test/106/
https://jenkins.catrob.at/view/All-Categories/view/Catroid/job/Catroid-CustomEmulator-Single-ClassAndPackage-Test/105/
