### PR TITLE
Fixing CAT-1061 issue

### DIFF
--- a/catroid/src/org/catrobat/catroid/formulaeditor/InternFormula.java
+++ b/catroid/src/org/catrobat/catroid/formulaeditor/InternFormula.java
@@ -744,6 +744,17 @@ public class InternFormula {
 
 		Log.i("info", "replaceCursorPositionInternTokenByTokenList:enter");
 
+		if (cursorPositionInternToken.isNumber() && internTokensToReplaceWith.size() == 1
+				&& internTokensToReplaceWith.get(0).isOperator()){
+
+			int externNumberOffset = externInternRepresentationMapping.getExternTokenStartOffset(externCursorPosition,
+					cursorPositionInternTokenIndex);
+			List<InternToken> replaceList = InternFormulaUtils.insertOperatorToNumberToken(cursorPositionInternToken,externNumberOffset,internTokensToReplaceWith.get(0));
+			replaceInternTokens(replaceList,cursorPositionInternTokenIndex,cursorPositionInternTokenIndex);
+
+			return setCursorPositionAndSelectionAfterInput(cursorPositionInternTokenIndex);
+		}
+
 		if (cursorPositionInternToken.isNumber() && InternFormulaUtils.isNumberToken(internTokensToReplaceWith)) {
 
 			InternToken numberTokenToInsert = internTokensToReplaceWith.get(0);

--- a/catroid/src/org/catrobat/catroid/formulaeditor/InternFormulaUtils.java
+++ b/catroid/src/org/catrobat/catroid/formulaeditor/InternFormulaUtils.java
@@ -452,6 +452,24 @@ public final class InternFormulaUtils {
 
 		return internTokensToReplaceWith;
 	}
+	
+	public static List<InternToken> insertOperatorToNumberToken(InternToken numberTokenToBeModified,int externNumberOffset,InternToken operatorToInsert){
+		List<InternToken> replaceTokenList = new LinkedList<InternToken>();
+		String numberString = numberTokenToBeModified.getTokenStringValue();
+		String leftPart = numberString.substring(0, externNumberOffset);
+		String rightPart = numberString.substring(externNumberOffset);
+
+		InternToken leftNumber = new InternToken(InternTokenType.NUMBER,leftPart);
+		replaceTokenList.add(leftNumber);
+
+		replaceTokenList.add(operatorToInsert);
+
+		InternToken rightNumber = new InternToken(InternTokenType.NUMBER,rightPart);
+		replaceTokenList.add(rightNumber);
+
+		return replaceTokenList;
+
+	}
 
 	public static InternToken insertIntoNumberToken(InternToken numberTokenToBeModified, int externNumberOffset,
 			String numberToInsert) {

--- a/catroidTest/src/org/catrobat/catroid/test/formulaeditor/InternFormulaTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/formulaeditor/InternFormulaTest.java
@@ -134,6 +134,20 @@ public class InternFormulaTest extends InstrumentationTestCase {
 		assertTrue("Prepend decimal mark error", internTokens.get(0).getTokenStringValue().compareTo("0.") == 0);
 	}
 
+	public void testInsertOperatorInNumberToken(){
+		ArrayList<InternToken> internTokens = new ArrayList<InternToken>();
+		internTokens.add(new InternToken(InternTokenType.NUMBER, "1234"));
+		InternFormula internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(getInstrumentation().getTargetContext());
+		internFormula.setCursorAndSelection(2, false);
+		internFormula.handleKeyInput(R.id.formula_editor_keyboard_mult,
+				getInstrumentation().getTargetContext(), null);
+
+		assertTrue("Insert operator in number token error", internTokens.get(0).getTokenStringValue().compareTo("12") == 0);
+		assertTrue("Insert operator in number token error", internTokens.get(1).getTokenStringValue().compareTo("MULT") == 0);
+		assertTrue("Insert operator in number token error", internTokens.get(2).getTokenStringValue().compareTo("34") == 0);
+	}
+
 	public void testReplaceFunctionByToken() {
 
 		ArrayList<InternToken> internTokens = new ArrayList<InternToken>();


### PR DESCRIPTION
Fixing approach : When insert operator in number token divide the number token into another two number token instead of placing the number token by the operator. Example: if current formula is 2* 23, and I want this formula transform into 2 * 2+3 by insert an "+" in 23 the previous version will turn the formula into "2*+" which will  cause the issue cat-1061