### PR TITLE
CAT-1157 Physics Issue

### DIFF
--- a/catroid/src/org/catrobat/catroid/physics/PhysicsObject.java
+++ b/catroid/src/org/catrobat/catroid/physics/PhysicsObject.java
@@ -124,9 +124,9 @@ public class PhysicsObject {
 		}
 
 		Vector2 dimensions = getBoundaryBoxDimensions();
-		float a = dimensions.x / 2;
-		float b = dimensions.y / 2;
-		circumference = PhysicsWorldConverter.convertNormalToBox2dCoordinate((float) Math.sqrt(a * a + b * b));
+		float w = dimensions.x / 2;
+		float h = dimensions.y / 2;
+		circumference = PhysicsWorldConverter.convertNormalToBox2dCoordinate((float) Math.sqrt(w * w + h * h));
 	}
 
 	public Type getType() {
@@ -342,8 +342,8 @@ public class PhysicsObject {
 
 	public Vector2 getBoundaryBoxDimensions() {
 		calculateAABB();
-		float aabbWidth = PhysicsWorldConverter.convertBox2dToNormalCoordinate(Math.abs(bodyAABBUpperRight.x - bodyAABBLowerLeft.x)) + 1;
-		float aabbHeight = PhysicsWorldConverter.convertBox2dToNormalCoordinate(Math.abs(bodyAABBUpperRight.y - bodyAABBLowerLeft.y)) + 1;
+		float aabbWidth = PhysicsWorldConverter.convertBox2dToNormalCoordinate(Math.abs(bodyAABBUpperRight.x - bodyAABBLowerLeft.x)) + 1.0f;
+		float aabbHeight = PhysicsWorldConverter.convertBox2dToNormalCoordinate(Math.abs(bodyAABBUpperRight.y - bodyAABBLowerLeft.y)) + 1.0f;
 		return new Vector2(aabbWidth, aabbHeight);
 	}
 

--- a/catroid/src/org/catrobat/catroid/physics/PhysicsObject.java
+++ b/catroid/src/org/catrobat/catroid/physics/PhysicsObject.java
@@ -123,12 +123,10 @@ public class PhysicsObject {
 			return;
 		}
 
-		calculateAABB();
-		float max1 = Math.max(getMassCenter().dst(fixtureAABBUpperRight), getMassCenter().dst(fixtureAABBLowerLeft));
-		Vector2 aabbLowerRight = new Vector2(fixtureAABBUpperRight.x, fixtureAABBLowerLeft.y);
-		Vector2 aaabbUpperLeft = new Vector2(fixtureAABBLowerLeft.x, fixtureAABBUpperRight.y);
-		float max2 = Math.max(getMassCenter().dst(aabbLowerRight), getMassCenter().dst(aaabbUpperLeft));
-		circumference = Math.max(max1, max2);
+		Vector2 dimensions = getBoundaryBoxDimensions();
+		float a = dimensions.x / 2;
+		float b = dimensions.y / 2;
+		circumference = PhysicsWorldConverter.convertNormalToBox2dCoordinate((float) Math.sqrt(a * a + b * b));
 	}
 
 	public Type getType() {
@@ -183,7 +181,7 @@ public class PhysicsObject {
 	}
 
 	public float getCircumference() {
-		return circumference;
+		return PhysicsWorldConverter.convertBox2dToNormalCoordinate(circumference);
 	}
 
 	public Vector2 getPosition() {
@@ -341,6 +339,14 @@ public class PhysicsObject {
 		upperRight.x = PhysicsWorldConverter.convertBox2dToNormalVector(bodyAABBUpperRight).x;
 		upperRight.y = PhysicsWorldConverter.convertBox2dToNormalVector(bodyAABBUpperRight).y;
 	}
+
+	public Vector2 getBoundaryBoxDimensions() {
+		calculateAABB();
+		float aabbWidth = PhysicsWorldConverter.convertBox2dToNormalCoordinate(Math.abs(bodyAABBUpperRight.x - bodyAABBLowerLeft.x)) + 1;
+		float aabbHeight = PhysicsWorldConverter.convertBox2dToNormalCoordinate(Math.abs(bodyAABBUpperRight.y - bodyAABBLowerLeft.y)) + 1;
+		return new Vector2(aabbWidth, aabbHeight);
+	}
+
 
 	public void activateHangup() {
 		velocity = new Vector2(getVelocity());

--- a/catroid/src/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilder.java
+++ b/catroid/src/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilder.java
@@ -30,6 +30,7 @@ import com.badlogic.gdx.physics.box2d.PolygonShape;
 import com.badlogic.gdx.physics.box2d.Shape;
 
 import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.physics.PhysicsWorld;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,7 +38,9 @@ import java.util.List;
 import java.util.Map;
 
 public class PhysicsShapeBuilder {
+
 	private static final String TAG = PhysicsShapeBuilder.class.getSimpleName();
+	private static final float OFFSET_VALUE = 1 / (2 * PhysicsWorld.RATIO);
 	private final Map<String, Shape[]> shapeMap = new HashMap<String, Shape[]>();
 	private PhysicsShapeBuilderStrategy strategy = new PhysicsShapeBuilderStrategyFastHull();
 
@@ -45,7 +48,6 @@ public class PhysicsShapeBuilder {
 	}
 
 	public Shape[] getShape(LookData lookData, float scaleFactor) {
-
 
 		Shape[] shapes = null;
 		float scaleLevel = getScaleLevel(scaleFactor);
@@ -62,17 +64,17 @@ public class PhysicsShapeBuilder {
 			Pixmap thumb = new Pixmap((int) (pixmap.getWidth() * scaleLevel), (int) (pixmap.getHeight() * scaleLevel), pixmap.getFormat());
 			Pixmap.setFilter(Pixmap.Filter.NearestNeighbour);
 			thumb.drawPixmap(pixmap, 0, 0, pixmap.getWidth(), pixmap.getHeight(), 0, 0, thumb.getWidth(), thumb.getHeight());
-			shapes = strategy.build(thumb, scaleFactor);
+			shapes = strategy.build(pixmap, scaleFactor);
 			thumb.dispose();
-			shapes = normalize(shapes, scaleLevel);
+			//shapes = normalize(shapes, scaleLevel);
 			shapeMap.put(key, shapes);
 		}
 		return scaleShapes(shapes, scaleFactor);
 	}
 
-	private Shape[] normalize(Shape[] shapes, float scaleLevel) {
-		return scaleShapes(shapes, 1 / scaleLevel);
-	}
+	//private Shape[] normalize(Shape[] shapes, float scaleLevel) {
+	//	return scaleShapes(shapes, 1 / scaleLevel);
+	//}
 
 	private float getScaleLevel(float scaleFactor) {
 		if (scaleFactor >= 0.25f) {
@@ -95,7 +97,8 @@ public class PhysicsShapeBuilder {
 			for (int index = 0; index < polygon.getVertexCount(); index++) {
 				Vector2 vertex = new Vector2();
 				polygon.getVertex(index, vertex);
-				vertex = vertex.mul(scaleFactor);
+
+				vertex = scaleCoordinate(vertex, scaleFactor);
 				vertices.add(vertex);
 			}
 
@@ -105,5 +108,28 @@ public class PhysicsShapeBuilder {
 		}
 
 		return scaledShapes.toArray(new Shape[scaledShapes.size()]);
+	}
+
+	public static Vector2 scaleCoordinate(Vector2 vertex, float scaleFactor) {
+		if (Math.abs(scaleFactor) < 0.001f) {
+			vertex = vertex.mul(scaleFactor);
+		} else if (Math.abs(scaleFactor - 1.0f) > 0.001f) {
+			Vector2 offset = new Vector2();
+			offset.x = vertex.x < -0.001f ? -OFFSET_VALUE : vertex.x > 0.001f ? OFFSET_VALUE : 0.0f;
+			offset.y = vertex.y < -0.001f ? -OFFSET_VALUE : vertex.y > 0.001f ? OFFSET_VALUE : 0.0f;
+			vertex = vertex.add(offset).mul(scaleFactor).sub(offset);
+		}
+		return vertex;
+	}
+
+	public static float scaleCoordinate (float coord, float factor) {
+		if (Math.abs(factor) < 0.001f) {
+			coord = coord*factor;
+		} else if (Math.abs(factor - 1.0f) > 0.001f) {
+			float offset;
+			offset = coord < -0.001f ? -OFFSET_VALUE : coord > 0.001f ? OFFSET_VALUE : 0.0f;
+			coord = (((coord + offset) * factor) - offset);
+		}
+		return coord;
 	}
 }

--- a/catroid/src/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilder.java
+++ b/catroid/src/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilder.java
@@ -115,21 +115,24 @@ public class PhysicsShapeBuilder {
 			vertex = vertex.mul(scaleFactor);
 		} else if (Math.abs(scaleFactor - 1.0f) > 0.001f) {
 			Vector2 offset = new Vector2();
-			offset.x = vertex.x < -0.001f ? -OFFSET_VALUE : vertex.x > 0.001f ? OFFSET_VALUE : 0.0f;
-			offset.y = vertex.y < -0.001f ? -OFFSET_VALUE : vertex.y > 0.001f ? OFFSET_VALUE : 0.0f;
+			offset.x = getCoordinateScalingOffset(vertex.x);
+			offset.y = getCoordinateScalingOffset(vertex.y);
 			vertex = vertex.add(offset).mul(scaleFactor).sub(offset);
 		}
 		return vertex;
 	}
 
-	public static float scaleCoordinate (float coord, float factor) {
+	public static float scaleCoordinate(float coord, float factor) {
 		if (Math.abs(factor) < 0.001f) {
-			coord = coord*factor;
+			coord = coord * factor;
 		} else if (Math.abs(factor - 1.0f) > 0.001f) {
-			float offset;
-			offset = coord < -0.001f ? -OFFSET_VALUE : coord > 0.001f ? OFFSET_VALUE : 0.0f;
+			float offset = getCoordinateScalingOffset(coord);
 			coord = (((coord + offset) * factor) - offset);
 		}
 		return coord;
+	}
+
+	private static float getCoordinateScalingOffset(float coord) {
+		return coord < -0.001f ? -OFFSET_VALUE : coord > 0.001f ? OFFSET_VALUE : 0.0f;
 	}
 }

--- a/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsActiveStageAreaTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsActiveStageAreaTest.java
@@ -38,7 +38,7 @@ import java.io.File;
 
 public class PhysicsActiveStageAreaTest extends PhysicsBaseTest {
 
-	private static final int EXPECTED_CIRCUMFERENCE_125X125 = Math.round(new Float(Math.sqrt(2 * Math.pow(125 / 2, 2))));
+	private static final float EXPECTED_CIRCUMFERENCE_125X125 = (float) Math.sqrt(2 * Math.pow(125/2f, 2));
 	private PhysicsObject physicsObject;
 	private PhysicsLook physicsLook;
 
@@ -52,7 +52,7 @@ public class PhysicsActiveStageAreaTest extends PhysicsBaseTest {
 
 	public void testCircumferenceCalculation() {
 		assertTrue("calculated rectangle circumference not equal to expected value",
-				Math.abs(Math.round(physicsObject.getCircumference() * PhysicsWorld.RATIO) - EXPECTED_CIRCUMFERENCE_125X125) <= 1);
+				Math.abs(physicsObject.getCircumference() - EXPECTED_CIRCUMFERENCE_125X125) <= 1);
 	}
 
 	public void testCenteredObjectIsActive() {

--- a/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsLookTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsLookTest.java
@@ -209,8 +209,8 @@ public class PhysicsLookTest extends InstrumentationTestCase {
 					for (int idx = 0; idx < vertexCount; idx++) {
 						Vector2 vertex = new Vector2();
 						((PolygonShape) shape).getVertex(idx, vertex);
-						assertEquals("vertex x-value is not the expected", vertexXQueue.poll() * 2.0f, vertex.x);
-						assertEquals("vertex x-value is not the expected", vertexYQueue.poll() * 2.0f, vertex.y);
+						assertEquals("vertex x-value is not the expected", PhysicsShapeBuilder.scaleCoordinate(vertexXQueue.poll(), 2.0f), vertex.x);
+						assertEquals("vertex x-value is not the expected", PhysicsShapeBuilder.scaleCoordinate(vertexYQueue.poll(), 2.0f), vertex.y);
 						Log.d(TAG, "x=" + vertex.x + ";y=" + vertex.y);
 					}
 					break;

--- a/catroidTest/src/org/catrobat/catroid/test/physics/actions/SetSizeToActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/actions/SetSizeToActionTest.java
@@ -31,7 +31,6 @@ import org.catrobat.catroid.physics.PhysicsObject;
 import org.catrobat.catroid.test.physics.PhysicsBaseTest;
 import org.catrobat.catroid.test.utils.Reflection;
 import org.catrobat.catroid.test.utils.TestUtils;
-import org.catrobat.catroid.physics.shapebuilder.PhysicsShapeBuilder;
 
 
 public class SetSizeToActionTest extends PhysicsBaseTest {
@@ -50,12 +49,12 @@ public class SetSizeToActionTest extends PhysicsBaseTest {
 
 
 	public void testSizeLarger() {
-		Vector2 oldAABBDimensions = getAABBDimensions();
+		Vector2 oldAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float oldCircumference = physicsObject.getCircumference();
 		float scaleFactor = 500.0f;
 		performSetSizeToAction(scaleFactor);
 
-		Vector2 newAABBDimensions = getAABBDimensions();
+		Vector2 newAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float newCircumference = physicsObject.getCircumference();
 		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, TestUtils.DELTA);
 		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, TestUtils.DELTA);
@@ -63,12 +62,12 @@ public class SetSizeToActionTest extends PhysicsBaseTest {
 	}
 
 	public void testSizeSmaller() {
-		Vector2 oldAABBDimensions = getAABBDimensions();
+		Vector2 oldAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float oldCircumference = physicsObject.getCircumference();
 		float scaleFactor = 10.0f;
 		performSetSizeToAction(scaleFactor);
 
-		Vector2 newAABBDimensions = getAABBDimensions();
+		Vector2 newAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float newCircumference = physicsObject.getCircumference();
 		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, TestUtils.DELTA);
 		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, TestUtils.DELTA);
@@ -76,27 +75,27 @@ public class SetSizeToActionTest extends PhysicsBaseTest {
 	}
 
 	public void testSizeSame() {
-		Vector2 oldAABBDimensions = getAABBDimensions();
+		Vector2 oldAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float oldCircumference = physicsObject.getCircumference();
 		float scaleFactor = 100.0f;
 		performSetSizeToAction(scaleFactor);
 
-		Vector2 newAABBDimensions = getAABBDimensions();
+		Vector2 newAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float newCircumference = physicsObject.getCircumference();
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, TestUtils.DELTA);
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, TestUtils.DELTA);
-		assertEquals("Circumference is not being updated", oldCircumference * (scaleFactor / 100.0f), newCircumference, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x, newAABBDimensions.x, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y, newAABBDimensions.y, TestUtils.DELTA);
+		assertEquals("Circumference is not being updated", oldCircumference, newCircumference, TestUtils.DELTA);
 	}
 
 	public void testSizeSmallerAndOriginal() {
-		Vector2 oldAABBDimensions = getAABBDimensions();
+		Vector2 oldAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float oldCircumference = physicsObject.getCircumference();
 		float scaleFactor = 25.0f;
 		performSetSizeToAction(scaleFactor);
 		scaleFactor = 100.0f;
 		performSetSizeToAction(scaleFactor);
 
-		Vector2 newAABBDimensions = getAABBDimensions();
+		Vector2 newAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float newCircumference = physicsObject.getCircumference();
 		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x, newAABBDimensions.x, TestUtils.DELTA);
 		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y, newAABBDimensions.y, TestUtils.DELTA);
@@ -107,22 +106,13 @@ public class SetSizeToActionTest extends PhysicsBaseTest {
 		float scaleFactor = 0.0f;
 		performSetSizeToAction(scaleFactor);
 
-		Vector2 newAABBDimensions = getAABBDimensions();
+		Vector2 newAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float newCircumference = physicsObject.getCircumference();
 		assertEquals("Size is not being set to correct scale", 1, newAABBDimensions.x, TestUtils.DELTA);
 		assertEquals("Size is not being set to correct scale", 1, newAABBDimensions.y, TestUtils.DELTA);
-		assertEquals("Circumference is not being updated", (float) Math.sqrt(2.0f * Math.pow(0.5f , 2.0f)), newCircumference, TestUtils.DELTA);
+		assertEquals("Circumference is not being updated", Math.sqrt(2.0f * ((1.0f/2.0f) * (1.0f/2.0f))), newCircumference, TestUtils.DELTA);
 	}
 
-
-	private Vector2 getAABBDimensions() {
-		Vector2 lowerLeft = new Vector2();
-		Vector2 upperRight = new Vector2();
-		physicsObject.getBoundaryBox(lowerLeft, upperRight);
-		float aabbWidth = Math.abs(upperRight.x - lowerLeft.x) + 1.0f;
-		float aabbHeight = Math.abs(upperRight.y - lowerLeft.y) + 1.0f;
-		return new Vector2(aabbWidth, aabbHeight);
-	}
 
 	private void performSetSizeToAction(float scaleFactor) {
 		sprite.getActionFactory().createSetSizeToAction(sprite, new Formula(scaleFactor)).act(1.0f);

--- a/catroidTest/src/org/catrobat/catroid/test/physics/actions/SetSizeToActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/actions/SetSizeToActionTest.java
@@ -31,6 +31,7 @@ import org.catrobat.catroid.physics.PhysicsObject;
 import org.catrobat.catroid.test.physics.PhysicsBaseTest;
 import org.catrobat.catroid.test.utils.Reflection;
 import org.catrobat.catroid.test.utils.TestUtils;
+import org.catrobat.catroid.physics.shapebuilder.PhysicsShapeBuilder;
 
 
 public class SetSizeToActionTest extends PhysicsBaseTest {
@@ -64,7 +65,7 @@ public class SetSizeToActionTest extends PhysicsBaseTest {
 	public void testSizeSmaller() {
 		Vector2 oldAABBDimensions = getAABBDimensions();
 		float oldCircumference = physicsObject.getCircumference();
-		float scaleFactor = 25.0f;
+		float scaleFactor = 10.0f;
 		performSetSizeToAction(scaleFactor);
 
 		Vector2 newAABBDimensions = getAABBDimensions();
@@ -97,22 +98,20 @@ public class SetSizeToActionTest extends PhysicsBaseTest {
 
 		Vector2 newAABBDimensions = getAABBDimensions();
 		float newCircumference = physicsObject.getCircumference();
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, TestUtils.DELTA);
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, TestUtils.DELTA);
-		assertEquals("Circumference is not being updated", oldCircumference * (scaleFactor / 100.0f), newCircumference, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x, newAABBDimensions.x, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y, newAABBDimensions.y, TestUtils.DELTA);
+		assertEquals("Circumference is not being updated", oldCircumference, newCircumference, TestUtils.DELTA);
 	}
 
 	public void testSizeZero() {
-		Vector2 oldAABBDimensions = getAABBDimensions();
-		float oldCircumference = physicsObject.getCircumference();
 		float scaleFactor = 0.0f;
 		performSetSizeToAction(scaleFactor);
 
 		Vector2 newAABBDimensions = getAABBDimensions();
 		float newCircumference = physicsObject.getCircumference();
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, TestUtils.DELTA);
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, TestUtils.DELTA);
-		assertEquals("Circumference is not being updated", oldCircumference * (scaleFactor / 100.0f), newCircumference, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", 1, newAABBDimensions.x, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", 1, newAABBDimensions.y, TestUtils.DELTA);
+		assertEquals("Circumference is not being updated", (float) Math.sqrt(2.0f * Math.pow(0.5f , 2.0f)), newCircumference, TestUtils.DELTA);
 	}
 
 
@@ -120,8 +119,8 @@ public class SetSizeToActionTest extends PhysicsBaseTest {
 		Vector2 lowerLeft = new Vector2();
 		Vector2 upperRight = new Vector2();
 		physicsObject.getBoundaryBox(lowerLeft, upperRight);
-		float aabbWidth = Math.abs(Math.round(upperRight.x - lowerLeft.x));
-		float aabbHeight = Math.abs(Math.round(upperRight.y - lowerLeft.y));
+		float aabbWidth = Math.abs(upperRight.x - lowerLeft.x) + 1.0f;
+		float aabbHeight = Math.abs(upperRight.y - lowerLeft.y) + 1.0f;
 		return new Vector2(aabbWidth, aabbHeight);
 	}
 


### PR DESCRIPTION
calculation of shapes / their resulting dimensions should be more accurate now
scaling of shapes in PhysicsShapeBuilder should be more accurate now aswell
add getBoundaryBoxDimensions method to PhysicsObject
add public static scaleCoordinate method for Vector2 and float
physicsObject circumference stored as Box2DCoordinate, getter returns NormalCoordinate
Adjust tests for new scaling calculations