### PR TITLE
SDK version update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,11 +96,11 @@ def getCurrentGitBranch() {
 
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion '19.1.0'
+    compileSdkVersion 22
+    buildToolsVersion '22.0.1'
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 19
+        minSdkVersion 16
+        targetSdkVersion 22
         applicationId 'org.catrobat.catroid'
         testApplicationId "org.catrobat.catroid.test"
         testInstrumentationRunner 'pl.polidea.instrumentation.PolideaInstrumentationTestRunner'
@@ -149,7 +149,7 @@ android {
         ignore 'ContentDescription', 'InvalidPackage', 'ValidFragment', 'GradleDependency',
                 'ClickableViewAccessibility', 'UnusedAttribute', 'CommitPrefEdits', 'OldTargetApi',
                 'RtlSymmetry', 'GradleDynamicVersion', 'RtlHardcoded', 'HandlerLeak', 'IconMissingDensityFolder',
-                'WrongRegion', 'RelativeOverlap'
+                'WrongRegion', 'RelativeOverlap', 'IconColors', 'MissingTranslation'
 
         textReport true
         xmlReport true


### PR DESCRIPTION
* Min skd version `16`
* Target sdk version `22`
* Tool version `22.0.1`
* Add of `'IconColors'` and `'MissingTranslation'` lint ignore flags in build.gradle

We need the `'MissingTranslation'` flag otherwise we always get in trouble with the not up to date translated (or not translated -> missing ) crowdin `res/value-xx/strings.xml` . 

The `'IconColors'` flag is temporary. I will create a separate issue after the merge.

[Test ![Green](https://jenkins.catrob.at/static/a6652cc0/images/24x24/blue.png)] (https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch-RELOADED/1305/) 