### PR TITLE
Nullpointerexception in Stagelistener.menuPause()

### DIFF
--- a/catroid/src/org/catrobat/catroid/camera/CameraManager.java
+++ b/catroid/src/org/catrobat/catroid/camera/CameraManager.java
@@ -45,6 +45,7 @@ import java.util.List;
 public final class CameraManager implements Camera.PreviewCallback {
 
 	public static final int TEXTURE_NAME = 1;
+	private static final String TAG = CameraManager.class.getSimpleName();
 	private static CameraManager instance;
 	private Camera camera;
 	private SurfaceTexture texture;
@@ -110,8 +111,8 @@ public final class CameraManager implements Camera.PreviewCallback {
 		}
 		try {
 			camera = Camera.open(cameraID);
-		} catch (RuntimeException exception) {
-			Log.e("Camera", exception.getMessage());
+		} catch (RuntimeException runtimeException) {
+			Log.e(TAG, "Creating camera failed!", runtimeException);
 			return false;
 		}
 		camera.setPreviewCallbackWithBuffer(this);
@@ -119,8 +120,8 @@ public final class CameraManager implements Camera.PreviewCallback {
 		if (useTexture && texture != null) {
             try {
                 setTexture();
-            } catch (IOException e) {
-                Log.e("CameraManager", Log.getStackTraceString(e));
+            } catch (IOException iOException) {
+                Log.e(TAG, "Setting preview texture failed!", iOException);
                 return false;
             }
 		}

--- a/catroid/src/org/catrobat/catroid/facedetection/FaceDetectionHandler.java
+++ b/catroid/src/org/catrobat/catroid/facedetection/FaceDetectionHandler.java
@@ -37,7 +37,7 @@ import org.catrobat.catroid.formulaeditor.SensorHandler;
 
 public final class FaceDetectionHandler {
 
-
+	private static final String TAG = FaceDetectionHandler.class.getSimpleName();
 	private static FaceDetector faceDetector;
 	private static boolean running = false;
 	private static boolean paused = false;
@@ -157,7 +157,7 @@ public final class FaceDetectionHandler {
 			Camera camera = CameraManager.getInstance().getCamera();
 			possibleFaces = getNumberOfCameras(camera);
 		} catch (Exception exception) {
-            Log.e("Camera", "Camera unaccessable!", exception);
+            Log.e(TAG, "Camera unaccessable!", exception);
 		}
 		return possibleFaces > 0;
 	}

--- a/catroid/src/org/catrobat/catroid/stage/PreStageActivity.java
+++ b/catroid/src/org/catrobat/catroid/stage/PreStageActivity.java
@@ -190,7 +190,7 @@ public class PreStageActivity extends BaseActivity {
 				camera = CameraManager.getInstance().getCamera();
 			}
 		} catch (Exception exception) {
-			Log.e(getString(R.string.app_name), "failed to open Camera", exception);
+			Log.e(TAG, "failed to open Camera", exception);
 		}
 
 		if (camera == null) {

--- a/catroid/src/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/org/catrobat/catroid/stage/StageListener.java
@@ -76,6 +76,7 @@ import java.util.Map;
 
 public class StageListener implements ApplicationListener {
 
+	private static final String TAG = StageListener.class.getSimpleName();
 	private static final int AXIS_WIDTH = 4;
 	private static final float DELTA_ACTIONS_DIVIDER_MAXIMUM = 50f;
 	private static final int ACTIONS_COMPUTATION_TIME_MAXIMUM = 8;
@@ -236,8 +237,8 @@ public class StageListener implements ApplicationListener {
 			for (Sprite sprite : sprites) {
 				sprite.pause();
 			}
-		} catch (Exception e) {
-			Log.e("StageListener", e.getMessage());
+		} catch (Exception exception) {
+			Log.e(TAG, "Pausing menu failed!", exception);
 		}
 	}
 


### PR DESCRIPTION
* [Nullpointerexception caused in Stagelistener.menuPause()
  triggered by FaceDetectionSettingTest fixed.](https://jenkins.catrob.at/job/Catroid-PartialEmulatorUITest/8850/console)
* Refactoring of some Log.e() calls.

The [message](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8-b132/java/lang/Throwable.java#311) of the exception can be null.

[Test ![Green](https://jenkins.catrob.at/static/a6652cc0/images/24x24/blue.png)] (https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch-RELOADED/1349/) 