### PR TITLE
CAT-1157 Physics Issue

### DIFF
--- a/catroid/src/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/org/catrobat/catroid/content/Look.java
@@ -44,7 +44,6 @@ import java.util.Iterator;
 public class Look extends Image {
 	private static final float DEGREE_UI_OFFSET = 90.0f;
 	private static ArrayList<Action> actionsToRestart = new ArrayList<Action>();
-	public boolean visible = true;
 	protected boolean imageChanged = false;
 	protected boolean brightnessChanged = false;
 	protected LookData lookData;
@@ -105,7 +104,7 @@ public class Look extends Image {
 
 		cloneLook.alpha = this.alpha;
 		cloneLook.brightness = this.brightness;
-		cloneLook.visible = this.visible;
+		cloneLook.setVisible(isVisible());
 		cloneLook.whenParallelAction = null;
 		cloneLook.allActionsAreFinished = this.allActionsAreFinished;
 
@@ -116,7 +115,7 @@ public class Look extends Image {
 		if (sprite.isPaused) {
 			return true;
 		}
-		if (!visible) {
+		if (!isVisible()) {
 			return false;
 		}
 
@@ -150,7 +149,7 @@ public class Look extends Image {
 		} else {
 			super.setVisible(true);
 		}
-		if (visible && this.getDrawable() != null) {
+		if (isVisible() && this.getDrawable() != null) {
 			super.draw(batch, this.alpha);
 		}
 	}
@@ -334,15 +333,20 @@ public class Look extends Image {
 	}
 
 	public void setTransparencyInUserInterfaceDimensionUnit(float percent) {
+		updateTransparency(percent, true);
+	}
+
+	protected void updateTransparency(float percent, boolean updateVisibility) {
 		if (percent < 0f) {
 			percent = 0f;
+			if (updateVisibility) {
+				setVisible(true);
+			}
 		} else if (percent >= 100f) {
 			percent = 100f;
-			super.setVisible(false);
-		}
-
-		if (percent < 100.0f) {
-			super.setVisible(true);
+			if (updateVisibility) {
+				setVisible(false);
+			}
 		}
 
 		alpha = (100f - percent) / 100f;
@@ -370,10 +374,6 @@ public class Look extends Image {
 
 	public void changeBrightnessInUserInterfaceDimensionUnit(float changePercent) {
 		setBrightnessInUserInterfaceDimensionUnit(getBrightnessInUserInterfaceDimensionUnit() + changePercent);
-	}
-
-	public void setVisible(boolean visible) {
-		this.visible = visible;
 	}
 
 	private boolean isAngleInCatroidIntervall(float catroidAngle) {

--- a/catroid/src/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilderStrategyFastHull.java
+++ b/catroid/src/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilderStrategyFastHull.java
@@ -35,26 +35,25 @@ import java.util.Stack;
 
 public final class PhysicsShapeBuilderStrategyFastHull implements PhysicsShapeBuilderStrategy {
 
-	private final Stack<Vector2> convexHull = new Stack<Vector2>();
+	private static final int MINIMUM_PIXEL_ALPHA_VALUE = 1;
 
 	@Override
 	public Shape[] build(Pixmap pixmap, float scale) {
-
 		if (pixmap == null) {
 			return null;
 		}
 
 		int width = pixmap.getWidth();
 		int height = pixmap.getHeight();
-		convexHull.clear();
+		float coordinateAdjustmentValue = 1.0f;
+		Stack<Vector2> convexHull = new Stack<Vector2>();
 
 		Vector2 point = new Vector2(width, height);
 		for (int y = 0; y < height; y++) {
 			for (int x = 0; x < point.x; x++) {
-				if ((pixmap.getPixel(x, y) & 0xff) > 0) {
+				if ((pixmap.getPixel(x, y) & 0xff) >= MINIMUM_PIXEL_ALPHA_VALUE) {
 					point = new Vector2(x, y);
 					addPoint(convexHull, point);
-					//Log.d("PhysicsShapeBuilderStrategyFastHull", "X:" + point.x + " Y:" + point.y);
 					break;
 				}
 			}
@@ -66,9 +65,9 @@ public final class PhysicsShapeBuilderStrategyFastHull implements PhysicsShapeBu
 
 		for (int x = (int) point.x; x < width; x++) {
 			for (int y = height - 1; y > point.y; y--) {
-				if ((pixmap.getPixel(x, y) & 0xff) > 0) {
+				if ((pixmap.getPixel(x, y) & 0xff) >= MINIMUM_PIXEL_ALPHA_VALUE) {
 					point = new Vector2(x, y);
-					addPoint(convexHull, point);
+					addPoint(convexHull, new Vector2(x, y + coordinateAdjustmentValue));
 					break;
 				}
 			}
@@ -77,9 +76,9 @@ public final class PhysicsShapeBuilderStrategyFastHull implements PhysicsShapeBu
 		Vector2 firstPoint = convexHull.firstElement();
 		for (int y = (int) point.y; y >= firstPoint.y; y--) {
 			for (int x = width - 1; x > point.x; x--) {
-				if ((pixmap.getPixel(x, y) & 0xff) > 0) {
+				if ((pixmap.getPixel(x, y) & 0xff) >= MINIMUM_PIXEL_ALPHA_VALUE) {
 					point = new Vector2(x, y);
-					addPoint(convexHull, point);
+					addPoint(convexHull, new Vector2(x + coordinateAdjustmentValue, y + coordinateAdjustmentValue));
 					break;
 				}
 			}
@@ -87,9 +86,9 @@ public final class PhysicsShapeBuilderStrategyFastHull implements PhysicsShapeBu
 
 		for (int x = (int) point.x; x > firstPoint.x; x--) {
 			for (int y = (int) firstPoint.y; y < point.y; y++) {
-				if ((pixmap.getPixel(x, y) & 0xff) > 0) {
+				if ((pixmap.getPixel(x, y) & 0xff) >= MINIMUM_PIXEL_ALPHA_VALUE) {
 					point = new Vector2(x, y);
-					addPoint(convexHull, point);
+					addPoint(convexHull, new Vector2(x + coordinateAdjustmentValue, y));
 					break;
 				}
 			}

--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/HideActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/HideActionTest.java
@@ -37,7 +37,7 @@ public class HideActionTest extends AndroidTestCase {
 		ActionFactory factory = sprite.getActionFactory();
 		Action action = factory.createHideAction(sprite);
 		action.act(1.0f);
-		assertFalse("Sprite is still visible after HideBrick executed", sprite.look.visible);
+		assertFalse("Sprite is still visible after HideBrick executed", sprite.look.isVisible());
 	}
 
 	public void testNullSprite() {

--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/ShowActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/ShowActionTest.java
@@ -34,12 +34,12 @@ public class ShowActionTest extends AndroidTestCase {
 	public void testShow() {
 		Sprite sprite = new Sprite("new sprite");
 		sprite.look.setVisible(false);
-		assertFalse("Sprite is still visible after calling hide", sprite.look.visible);
+		assertFalse("Sprite is still visible after calling hide", sprite.look.isVisible());
 
 		ActionFactory factory = sprite.getActionFactory();
 		Action action = factory.createShowAction(sprite);
 		action.act(1.0f);
-		assertTrue("Sprite is not visible after ShowBrick executed", sprite.look.visible);
+		assertTrue("Sprite is not visible after ShowBrick executed", sprite.look.isVisible());
 	}
 
 	public void testNullSprite() {

--- a/catroidTest/src/org/catrobat/catroid/test/content/sprite/StartResumeSpriteTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/sprite/StartResumeSpriteTest.java
@@ -54,7 +54,7 @@ public class StartResumeSpriteTest extends AndroidTestCase {
 			testSprite.look.act(1.0f);
 		}
 
-		assertFalse("Sprite is not hidden", testSprite.look.visible);
+		assertFalse("Sprite is not hidden", testSprite.look.isVisible());
 		assertEquals("the size is not as expected", (float) size / 100, testSprite.look.getScaleX());
 		assertEquals("the size is not as expected", (float) size / 100, testSprite.look.getScaleY());
 	}
@@ -77,13 +77,13 @@ public class StartResumeSpriteTest extends AndroidTestCase {
 		testSprite.look.act(1.0f);
 
 		testSprite.pause();
-		assertFalse("Sprite is not hidden", testSprite.look.visible);
+		assertFalse("Sprite is not hidden", testSprite.look.isVisible());
 		testSprite.resume();
 
 		testSprite.look.act(1.0f);
 		testSprite.look.act(1.0f);
 
-		assertTrue("Sprite is hidden", testSprite.look.visible);
+		assertTrue("Sprite is hidden", testSprite.look.isVisible());
 
 		testScript.getBrickList().clear();
 		testScript.addBrick(hideBrick);

--- a/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsActiveStageAreaTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsActiveStageAreaTest.java
@@ -28,7 +28,6 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.physics.PhysicsLook;
 import org.catrobat.catroid.physics.PhysicsObject;
 import org.catrobat.catroid.physics.PhysicsWorld;
-import org.catrobat.catroid.physics.PhysicsWorldConverter;
 import org.catrobat.catroid.physics.content.ActionPhysicsFactory;
 import org.catrobat.catroid.test.R;
 import org.catrobat.catroid.test.utils.PhysicsTestUtils;
@@ -38,7 +37,8 @@ import java.io.File;
 
 public class PhysicsActiveStageAreaTest extends PhysicsBaseTest {
 
-	private static final int EXPECTED_CIRCUMFERENCE_125X125 = Math.round(new Float(Math.sqrt(2 * Math.pow(125 / 2, 2))));
+	private static final float EXPECTED_CIRCUMFERENCE_125X125 = (float) Math.sqrt(2 * Math.pow(125/2f, 2));
+	private static final float CIRCUMFERENCE_COMPARISON_DELTA = 1.0f;
 	private PhysicsObject physicsObject;
 	private PhysicsLook physicsLook;
 
@@ -51,8 +51,8 @@ public class PhysicsActiveStageAreaTest extends PhysicsBaseTest {
 	}
 
 	public void testCircumferenceCalculation() {
-		assertTrue("calculated rectangle circumference not equal to expected value",
-				Math.abs(Math.round(physicsObject.getCircumference() * PhysicsWorld.RATIO) - EXPECTED_CIRCUMFERENCE_125X125) <= 1);
+		assertEquals("calculated rectangle circumference not equal to expected value",
+				EXPECTED_CIRCUMFERENCE_125X125, physicsObject.getCircumference(), CIRCUMFERENCE_COMPARISON_DELTA);
 	}
 
 	public void testCenteredObjectIsActive() {
@@ -63,13 +63,13 @@ public class PhysicsActiveStageAreaTest extends PhysicsBaseTest {
 
 	public void testXOutOfBounds() {
 		physicsObject.setX(PhysicsWorld.activeArea.x / 2.0f
-				+ PhysicsWorldConverter.convertBox2dToNormalCoordinate(physicsObject.getCircumference()) - 1);
+				+ physicsObject.getCircumference() - 1);
 		physicsWorld.step(0.05f);
 		physicsLook.updatePhysicsObjectState(true);
 		assertTrue("physicsObject inside active area is hung up", !physicsLook.isHangedUp());
 
 		physicsObject.setX(PhysicsWorld.activeArea.x / 2.0f
-				+ PhysicsWorldConverter.convertBox2dToNormalCoordinate(physicsObject.getCircumference()) + 1);
+				+ physicsObject.getCircumference() + 1);
 		physicsWorld.step(0.05f);
 		physicsLook.updatePhysicsObjectState(true);
 		assertTrue("physicsObject outside active area is not hung up", physicsLook.isHangedUp());
@@ -77,13 +77,13 @@ public class PhysicsActiveStageAreaTest extends PhysicsBaseTest {
 
 	public void testYOutOfBounds() {
 		physicsObject.setY(PhysicsWorld.activeArea.y / 2.0f
-				+ PhysicsWorldConverter.convertBox2dToNormalCoordinate(physicsObject.getCircumference()) - 1);
+				+ physicsObject.getCircumference() - 1);
 		physicsWorld.step(0.05f);
 		physicsLook.updatePhysicsObjectState(true);
 		assertTrue("physicsObject inside active area is hung up", !physicsLook.isHangedUp());
 
 		physicsObject.setY(PhysicsWorld.activeArea.y / 2.0f
-				+ PhysicsWorldConverter.convertBox2dToNormalCoordinate(physicsObject.getCircumference()) + 1);
+				+ physicsObject.getCircumference() + 1);
 		physicsWorld.step(0.05f);
 		physicsLook.updatePhysicsObjectState(true);
 		assertTrue("physicsObject outside active area is not hung up", physicsLook.isHangedUp());
@@ -91,9 +91,9 @@ public class PhysicsActiveStageAreaTest extends PhysicsBaseTest {
 
 	public void testNegativeXYOutOfBounds() {
 		physicsObject.setX(-PhysicsWorld.activeArea.x / 2.0f
-				- PhysicsWorldConverter.convertBox2dToNormalCoordinate(physicsObject.getCircumference()) - 1);
+				- physicsObject.getCircumference() - 1);
 		physicsObject.setY(-PhysicsWorld.activeArea.y / 2.0f
-				- PhysicsWorldConverter.convertBox2dToNormalCoordinate(physicsObject.getCircumference()) - 1);
+				- physicsObject.getCircumference() - 1);
 		physicsWorld.step(0.05f);
 		physicsLook.updatePhysicsObjectState(true);
 		assertTrue("physicsObject outside active area is not hung up", physicsLook.isHangedUp());
@@ -101,9 +101,9 @@ public class PhysicsActiveStageAreaTest extends PhysicsBaseTest {
 
 	public void testResumeAfterXYHangup() {
 		physicsObject.setX(PhysicsWorld.activeArea.x / 2.0f
-				+ PhysicsWorldConverter.convertBox2dToNormalCoordinate(physicsObject.getCircumference()) + 1);
+				+ physicsObject.getCircumference() + 1);
 		physicsObject.setY(PhysicsWorld.activeArea.y / 2.0f
-				+ PhysicsWorldConverter.convertBox2dToNormalCoordinate(physicsObject.getCircumference()) + 1);
+				+ physicsObject.getCircumference() + 1);
 		physicsWorld.step(0.05f);
 		physicsLook.updatePhysicsObjectState(true);
 		assertTrue("physicsObject outside active area is not hung up", physicsLook.isHangedUp());
@@ -135,9 +135,9 @@ public class PhysicsActiveStageAreaTest extends PhysicsBaseTest {
 		assertTrue("huge physicsObject is hung up at start", !physicsLook.isHangedUp());
 
 		physicsObject.setX(PhysicsWorld.activeArea.x / 2.0f
-				+ PhysicsWorldConverter.convertBox2dToNormalCoordinate(physicsObject.getCircumference()) + 1);
+				+ physicsObject.getCircumference() + 1);
 		physicsObject.setY(PhysicsWorld.activeArea.y / 2.0f
-				+ PhysicsWorldConverter.convertBox2dToNormalCoordinate(physicsObject.getCircumference()) + 1);
+				+ physicsObject.getCircumference() + 1);
 		physicsWorld.step(0.05f);
 		physicsLook.updatePhysicsObjectState(true);
 		assertTrue("physicsObject outside active area is not hung up", physicsLook.isHangedUp());

--- a/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsLookTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsLookTest.java
@@ -149,8 +149,7 @@ public class PhysicsLookTest extends InstrumentationTestCase {
 		lookData.setLookFilename(testImage.getName());
 		lookData.setLookName(testImageFilename);
 		sprite.getLookDataList().add(lookData);
-		Pixmap pixmap = null;
-		pixmap = Utils.getPixmapFromFile(testImage);
+		Pixmap pixmap = Utils.getPixmapFromFile(testImage);
 		lookData.setPixmap(pixmap);
 
 		PhysicsObject physicsObject = physicsWorld.getPhysicsObject(sprite);
@@ -192,7 +191,18 @@ public class PhysicsLookTest extends InstrumentationTestCase {
 			}
 		}
 
-		physicsLook.setScale(2.0f, 2.0f);
+		float testScaleFactor = 1.1f;
+		if (PhysicsShapeBuilder.ACCURACY_LEVELS.length > 1) {
+			for (int i = 0; i < PhysicsShapeBuilder.ACCURACY_LEVELS.length - 1; i++) {
+				if (Math.abs(PhysicsShapeBuilder.ACCURACY_LEVELS[i] - 1.0f) < 0.05) {
+					testScaleFactor = (PhysicsShapeBuilder.ACCURACY_LEVELS[i] + PhysicsShapeBuilder.ACCURACY_LEVELS[i + 1]);
+					testScaleFactor /= 2.0f;
+					testScaleFactor -= 0.025f;
+				}
+			}
+		}
+
+		physicsLook.setScale(testScaleFactor, testScaleFactor);
 		shapes = (Shape[]) Reflection.getPrivateField(physicsObject, "shapes");
 		assertNotNull("shapes is null", shapes);
 		assertTrue("shapes length not > 0", shapes.length > 0);
@@ -214,8 +224,8 @@ public class PhysicsLookTest extends InstrumentationTestCase {
 					for (int idx = 0; idx < vertexCount; idx++) {
 						Vector2 vertex = new Vector2();
 						((PolygonShape) shape).getVertex(idx, vertex);
-						assertEquals("vertex x-value is not the expected", vertexXQueue.poll() * 2.0f, vertex.x);
-						assertEquals("vertex x-value is not the expected", vertexYQueue.poll() * 2.0f, vertex.y);
+						assertEquals("vertex x-value is not the expected", PhysicsShapeBuilder.scaleCoordinate(vertexXQueue.poll(), testScaleFactor), vertex.x);
+						assertEquals("vertex x-value is not the expected", PhysicsShapeBuilder.scaleCoordinate(vertexYQueue.poll(), testScaleFactor), vertex.y);
 						Log.d(TAG, "x=" + vertex.x + ";y=" + vertex.y);
 					}
 					break;

--- a/catroidTest/src/org/catrobat/catroid/test/physics/actions/SetSizeToActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/actions/SetSizeToActionTest.java
@@ -38,6 +38,7 @@ public class SetSizeToActionTest extends PhysicsBaseTest {
 
 	private PhysicsLook physicsLook;
 	private PhysicsObject physicsObject;
+	public static final float SIZE_COMPARISON_DELTA = 1.0f;
 
 
 	@Override
@@ -49,81 +50,70 @@ public class SetSizeToActionTest extends PhysicsBaseTest {
 
 
 	public void testSizeLarger() {
-		Vector2 oldAABBDimensions = getAABBDimensions();
+		Vector2 oldAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float oldCircumference = physicsObject.getCircumference();
 		float scaleFactor = 500.0f;
 		performSetSizeToAction(scaleFactor);
 
-		Vector2 newAABBDimensions = getAABBDimensions();
+		Vector2 newAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float newCircumference = physicsObject.getCircumference();
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, TestUtils.DELTA);
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, TestUtils.DELTA);
-		assertEquals("Circumference is not being updated", oldCircumference * (scaleFactor / 100.0f), newCircumference, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, SIZE_COMPARISON_DELTA * scaleFactor/100f);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, SIZE_COMPARISON_DELTA * scaleFactor/100f);
+		assertEquals("Circumference is not being updated", oldCircumference * (scaleFactor / 100.0f), newCircumference, SIZE_COMPARISON_DELTA * scaleFactor/100f);
 	}
 
 	public void testSizeSmaller() {
-		Vector2 oldAABBDimensions = getAABBDimensions();
+		float smallerSizeComparisonDelta = 1.5f;
+		Vector2 oldAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float oldCircumference = physicsObject.getCircumference();
-		float scaleFactor = 25.0f;
+		float scaleFactor = 10.0f;
 		performSetSizeToAction(scaleFactor);
-
-		Vector2 newAABBDimensions = getAABBDimensions();
+		Vector2 newAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float newCircumference = physicsObject.getCircumference();
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, TestUtils.DELTA);
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, TestUtils.DELTA);
-		assertEquals("Circumference is not being updated", oldCircumference * (scaleFactor / 100.0f), newCircumference, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, smallerSizeComparisonDelta);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, smallerSizeComparisonDelta);
+		assertEquals("Circumference is not being updated", oldCircumference * (scaleFactor / 100.0f), newCircumference, smallerSizeComparisonDelta);
 	}
 
 	public void testSizeSame() {
-		Vector2 oldAABBDimensions = getAABBDimensions();
+		Vector2 oldAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float oldCircumference = physicsObject.getCircumference();
 		float scaleFactor = 100.0f;
 		performSetSizeToAction(scaleFactor);
 
-		Vector2 newAABBDimensions = getAABBDimensions();
+		Vector2 newAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float newCircumference = physicsObject.getCircumference();
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, TestUtils.DELTA);
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, TestUtils.DELTA);
-		assertEquals("Circumference is not being updated", oldCircumference * (scaleFactor / 100.0f), newCircumference, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x, newAABBDimensions.x, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y, newAABBDimensions.y, TestUtils.DELTA);
+		assertEquals("Circumference is not being updated", oldCircumference, newCircumference, TestUtils.DELTA);
 	}
 
 	public void testSizeSmallerAndOriginal() {
-		Vector2 oldAABBDimensions = getAABBDimensions();
+		Vector2 oldAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float oldCircumference = physicsObject.getCircumference();
 		float scaleFactor = 25.0f;
 		performSetSizeToAction(scaleFactor);
 		scaleFactor = 100.0f;
 		performSetSizeToAction(scaleFactor);
 
-		Vector2 newAABBDimensions = getAABBDimensions();
+		Vector2 newAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float newCircumference = physicsObject.getCircumference();
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, TestUtils.DELTA);
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, TestUtils.DELTA);
-		assertEquals("Circumference is not being updated", oldCircumference * (scaleFactor / 100.0f), newCircumference, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x, newAABBDimensions.x, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y, newAABBDimensions.y, TestUtils.DELTA);
+		assertEquals("Circumference is not being updated", oldCircumference, newCircumference, TestUtils.DELTA);
 	}
 
 	public void testSizeZero() {
-		Vector2 oldAABBDimensions = getAABBDimensions();
-		float oldCircumference = physicsObject.getCircumference();
 		float scaleFactor = 0.0f;
 		performSetSizeToAction(scaleFactor);
 
-		Vector2 newAABBDimensions = getAABBDimensions();
+		Vector2 newAABBDimensions = physicsObject.getBoundaryBoxDimensions();
 		float newCircumference = physicsObject.getCircumference();
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.x * (scaleFactor / 100.0f), newAABBDimensions.x, TestUtils.DELTA);
-		assertEquals("Size is not being set to correct scale", oldAABBDimensions.y * (scaleFactor / 100.0f), newAABBDimensions.y, TestUtils.DELTA);
-		assertEquals("Circumference is not being updated", oldCircumference * (scaleFactor / 100.0f), newCircumference, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", 1, newAABBDimensions.x, TestUtils.DELTA);
+		assertEquals("Size is not being set to correct scale", 1, newAABBDimensions.y, TestUtils.DELTA);
+		assertEquals("Circumference is not being updated", 0.0f, newCircumference, TestUtils.DELTA);
 	}
 
-
-	private Vector2 getAABBDimensions() {
-		Vector2 lowerLeft = new Vector2();
-		Vector2 upperRight = new Vector2();
-		physicsObject.getBoundaryBox(lowerLeft, upperRight);
-		float aabbWidth = Math.abs(Math.round(upperRight.x - lowerLeft.x));
-		float aabbHeight = Math.abs(Math.round(upperRight.y - lowerLeft.y));
-		return new Vector2(aabbWidth, aabbHeight);
-	}
 
 	private void performSetSizeToAction(float scaleFactor) {
 		sprite.getActionFactory().createSetSizeToAction(sprite, new Formula(scaleFactor)).act(1.0f);

--- a/catroidTest/src/org/catrobat/catroid/test/physics/actions/conditional/HideActionAndCollisionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/actions/conditional/HideActionAndCollisionTest.java
@@ -53,7 +53,7 @@ public class HideActionAndCollisionTest extends PhysicsCollisionBaseTest {
 	public void testHide() {
 		Action action = sprite.getActionFactory().createHideAction(sprite);
 		action.act(1.0f);
-		assertFalse("Sprite is still visible after HideBrick executed", sprite.look.visible);
+		assertFalse("Sprite is still visible after HideBrick executed", sprite.look.isVisible());
 	}
 
 	public void testNullSprite() {


### PR DESCRIPTION
add getBoundaryBoxDimensions method to PhysicsObject
add public static scaleCoordinate method for Vector2 and float
physicsObject circumference stored as Box2DCoordinate, getter returns NormalCoordinate
calculate physicsObject base shapes according to accuracyLevels
calculate base shapes in separate thread, adjust PhysicsShapeBuilderStrategyFastHull for simultaneous calls
remove public boolean visible in class which extends another with private boolean with same name
add invisible conditions to physicsObjects
handling physicsObjectStates for very small objects
update PhysicsObjectStates after every call to PhysicsObject.setType
downscale large Pixmaps when creating physicsObject Shapes to increase performance
adjust physics tests
correct calculation of PhysicsObjectStateHandler's positionCondition
fix not all fixtures of PhysicsObject being destroyed