### PR TITLE
[CAT-1275] Introduce pmd java-logging ruleset

### DIFF
--- a/catroidBluetoothTestServer/src/org/catrobat/catroid/bluetoothtestserver/BTServer.java
+++ b/catroidBluetoothTestServer/src/org/catrobat/catroid/bluetoothtestserver/BTServer.java
@@ -31,6 +31,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.bluetooth.BluetoothStateException;
 import javax.bluetooth.LocalDevice;
@@ -40,6 +42,7 @@ import javax.microedition.io.StreamConnectionNotifier;
 
 public final class BTServer {
 	private static final String TAG = BTServer.class.getSimpleName();
+	private static final Logger LOGGER = Logger.getLogger(TAG);
 
 	static BTServer btServer;
 	private static boolean gui = false;
@@ -63,7 +66,8 @@ public final class BTServer {
 				out.write(arg);
 				out.flush();
 			} catch (Exception localException) {
-				System.out.println("BTTestServer: Unable to log messages. Do you have permission to log file?");
+				LOGGER.log(Level.SEVERE, "BTTestServer: Unable to log messages. Do you have permission to log file?",
+						localException);
 			}
 		} else {
 			GUI.writeMessage(arg);
@@ -76,8 +80,6 @@ public final class BTServer {
 
 	public static void logMessage(String tag, String message) {
 		writeMessage(getTime() + " L/" + tag + ": " + message);
-
-		//Log.d(tag, message);
 	}
 
 	public static void logMessage(String tag, String message, Exception e) {

--- a/catroidSourceTest/src/org/catrobat/catroid/test/code/CheckForVerifiesOrAssertionsTest.java
+++ b/catroidSourceTest/src/org/catrobat/catroid/test/code/CheckForVerifiesOrAssertionsTest.java
@@ -43,7 +43,8 @@ public class CheckForVerifiesOrAssertionsTest extends TestCase {
 			"Util.java", "BeforeAfterSteps.java", "Cucumber.java", "CallbackAction.java", "ObjectSteps.java",
 			"CucumberAnnotation.java", "CatroidExampleSteps.java", "PrintBrick.java", "TestFaceDetector.java", "DroneTestUtils.java", "SystemAnimations.java",
 			"ObservedInputStream.java", "ObservedOutputStream.java", "LocalConnectionProxy.java", "BluetoothConnectionProxy.java", "DeviceModel.java",
-			"Logger.java", "ModelRunner.java", "ConnectionDataLogger.java", "MindstormsNXTTestModel.java", "FirmataMessage.java" };
+			"BluetoothLogger.java", "ModelRunner.java", "ConnectionDataLogger.java", "MindstormsNXTTestModel.java",
+			"FirmataMessage.java" };
 
 	private boolean fileHasVerifiesOrAssertions(File file) throws IOException {
 		BufferedReader reader = new BufferedReader(new FileReader(file));

--- a/catroidSourceTest/src/org/catrobat/catroid/test/code/SystemOutTest.java
+++ b/catroidSourceTest/src/org/catrobat/catroid/test/code/SystemOutTest.java
@@ -38,11 +38,8 @@ public class SystemOutTest extends TestCase {
 	private String errorMessages;
 	private boolean errorFound;
 
-	private static final String[] SYSTEM_OUT_DIRECTORIES = Utils.SOURCE_FILE_DIRECTORIES;
-	private static final String[] STACK_TRACE_DIRECTORIES = Utils.PRINT_STACK_TRACE_TEST_DIRECTORIES;
+	private static final String[] TOAST_STACK_TRACE_DIRECTORIES = Utils.TOAST_STACK_TRACE_TEST_DIRECTORIES;
 	private static final String[] IGNORED_FILES = { "SystemOutTest.java", "ToastUtil.java", "BTServer.java" };
-	private static final String SYSTEM_OUT = "System.out";
-	private static final String PRINT_STACK_TRACE = ".printStackTrace()";
 	private static final String TOAST_STRING = "Toast.makeText";
 	private static final String SUPERTOAST_STRING = "SuperToast";
 
@@ -98,24 +95,14 @@ public class SystemOutTest extends TestCase {
 		errorFound = false;
 	}
 
-	public void testForSystemOut() throws IOException {
-		checkForStringInFiles(SYSTEM_OUT, SYSTEM_OUT_DIRECTORIES);
-		assertFalse("Files with 'System.out' found! \nPlease use 'Log.d(TAG, message)' instead \n\n" + errorMessages, errorFound);
-	}
-
-	public void testForPrintStackTrace() throws IOException {
-		checkForStringInFiles(PRINT_STACK_TRACE, STACK_TRACE_DIRECTORIES);
-		assertFalse("Files with '.printStackTrace()' found! \nPlease use 'Log.e(TAG, \"Reason for Exception\", exception)' or 'Log.e(TAG, Log.getStackTraceString(exception))' instead\n\n" + errorMessages, errorFound);
-	}
-
 	public void testForToast() throws IOException {
-		checkForStringInFiles(TOAST_STRING, STACK_TRACE_DIRECTORIES);
+		checkForStringInFiles(TOAST_STRING, TOAST_STACK_TRACE_DIRECTORIES);
 		assertFalse("Files with 'Toast.makeText(context, text, duration)' found! \nPlease use 'ToastUtil.showError(context, message), or "
 				+ "ToastUtil.showSuccess(context, message)' instead\n\n" + errorMessages, errorFound);
 	}
 
 	public void testForSuperToast() throws IOException {
-		checkForStringInFiles(SUPERTOAST_STRING, STACK_TRACE_DIRECTORIES);
+		checkForStringInFiles(SUPERTOAST_STRING, TOAST_STACK_TRACE_DIRECTORIES);
 		assertFalse("Files with 'SuperToast' found! \nPlease use 'ToastUtil.showError(context, message), or "
 				+ "ToastUtil.showSuccess(context, message)' instead\n\n" + errorMessages, errorFound);
 	}

--- a/catroidSourceTest/src/org/catrobat/catroid/test/utils/Utils.java
+++ b/catroidSourceTest/src/org/catrobat/catroid/test/utils/Utils.java
@@ -40,7 +40,7 @@ public final class Utils {
 	public static final String[] SOURCE_AND_RESOURCE_DIRECTORIES = { "src", "res", "../catroid/src", "../catroid/res",
 			"../catroidTest/src", "../catroidTest/res", "../catroidCucumberTest/src", "../catroidBluetoothTestServer/src" };
 	public static final String[] TEST_FILE_DIRECTORIES = { "src", "../catroidTest/src", "../catroidCucumberTest/src" };
-	public static final String[] PRINT_STACK_TRACE_TEST_DIRECTORIES = { "src", "../catroid/src",
+	public static final String[] TOAST_STACK_TRACE_TEST_DIRECTORIES = { "src", "../catroid/src",
 			"../catroidCucumberTest/src", "../catroidBluetoothTestServer/src" };
 	public static final String[] VERSION_NAME_AND_CODE_TEST_DIRECTORIES = { "../catroid", "../catroidTest",
 			"../catroidCucumberTest" };

--- a/catroidTest/src/org/catrobat/catroid/common/bluetooth/BluetoothConnectionProxy.java
+++ b/catroidTest/src/org/catrobat/catroid/common/bluetooth/BluetoothConnectionProxy.java
@@ -34,14 +34,14 @@ import java.util.UUID;
 
 class BluetoothConnectionProxy implements BluetoothConnection {
 
-	Logger logger;
+	private final BluetoothLogger logger;
 
 	BluetoothConnection btConnection;
 
 	ObservedInputStream observedInputStream;
 	ObservedOutputStream observedOutputStream;
 
-	BluetoothConnectionProxy(String macAddress, UUID uuid, Logger logger) {
+	BluetoothConnectionProxy(String macAddress, UUID uuid, final BluetoothLogger logger) {
 
 		btConnection = new BluetoothConnectionImpl(macAddress, uuid);
 		this.logger = logger;

--- a/catroidTest/src/org/catrobat/catroid/common/bluetooth/BluetoothLogger.java
+++ b/catroidTest/src/org/catrobat/catroid/common/bluetooth/BluetoothLogger.java
@@ -24,7 +24,7 @@ package org.catrobat.catroid.common.bluetooth;
 
 import org.catrobat.catroid.bluetooth.base.BluetoothConnection;
 
-interface Logger {
+interface BluetoothLogger {
 	void logSentData(byte[] b);
 	void logReceivedData(byte[] b);
 	void loggerAttached(BluetoothConnection proxy);

--- a/catroidTest/src/org/catrobat/catroid/common/bluetooth/BluetoothTestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/common/bluetooth/BluetoothTestUtils.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.common.bluetooth;
 import android.app.Instrumentation;
 import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
+import android.util.Log;
 
 import junit.framework.Assert;
 
@@ -39,6 +40,7 @@ import java.util.Arrays;
 import java.util.UUID;
 
 public final class BluetoothTestUtils {
+	private static final String TAG = BluetoothTestUtils.class.getSimpleName();
 
 	private BluetoothTestUtils() {
 	}
@@ -76,7 +78,7 @@ public final class BluetoothTestUtils {
 		});
 	}
 
-	static void hookInConnectionFactoryWithBluetoothConnectionProxy(final Logger logger) {
+	static void hookInConnectionFactoryWithBluetoothConnectionProxy(final BluetoothLogger logger) {
 		ConnectBluetoothDeviceActivity.setConnectionFactory(new BluetoothConnectionFactory() {
 			@Override
 			public <T extends BluetoothDevice> BluetoothConnection createBTConnectionForDevice(Class<T> device, String address, UUID deviceUUID, Context applicationContext) {
@@ -108,7 +110,7 @@ public final class BluetoothTestUtils {
 			try {
 				Thread.sleep(4000);
 			} catch (InterruptedException e) {
-				e.printStackTrace();
+				Log.w(TAG, "Sleep was interrupted", e);
 			}
 		}
 	}
@@ -123,7 +125,7 @@ public final class BluetoothTestUtils {
 			try {
 				Thread.sleep(4000);
 			} catch (InterruptedException e) {
-				e.printStackTrace();
+				Log.w(TAG, "Sleep was interrupted", e);
 			}
 		}
 	}

--- a/catroidTest/src/org/catrobat/catroid/common/bluetooth/ConnectionDataLogger.java
+++ b/catroidTest/src/org/catrobat/catroid/common/bluetooth/ConnectionDataLogger.java
@@ -147,7 +147,7 @@ public final class ConnectionDataLogger {
 
 	private BluetoothConnection connectionProxy;
 
-	private Logger logger = new Logger() {
+	private BluetoothLogger logger = new BluetoothLogger() {
 
 		@Override
 		public void logSentData(byte[] b) {
@@ -218,7 +218,7 @@ public final class ConnectionDataLogger {
 		return connectionProxy;
 	}
 
-	Logger getLogger() {
+	BluetoothLogger getLogger() {
 		return logger;
 	}
 }

--- a/catroidTest/src/org/catrobat/catroid/common/bluetooth/LocalConnectionProxy.java
+++ b/catroidTest/src/org/catrobat/catroid/common/bluetooth/LocalConnectionProxy.java
@@ -46,7 +46,7 @@ class LocalConnectionProxy implements BluetoothConnection {
 	private State connectionState = State.NOT_CONNECTED;
 	private ModelRunner modelRunner;
 
-	LocalConnectionProxy(Logger logger) {
+	LocalConnectionProxy(BluetoothLogger logger) {
 
 		observedInputStream = new ObservedInputStream(new InputStream() {
 			@Override
@@ -64,7 +64,7 @@ class LocalConnectionProxy implements BluetoothConnection {
 		logger.loggerAttached(this);
 	}
 
-	LocalConnectionProxy(Logger logger, DeviceModel deviceModel) {
+	LocalConnectionProxy(BluetoothLogger logger, DeviceModel deviceModel) {
 
 		PipedInputStream serverInputStreamFromClientsOutputStream = new PipedInputStream();
 		PipedOutputStream serverOutputStreamToClientsInputStream = new PipedOutputStream();

--- a/catroidTest/src/org/catrobat/catroid/common/bluetooth/ObservedInputStream.java
+++ b/catroidTest/src/org/catrobat/catroid/common/bluetooth/ObservedInputStream.java
@@ -26,10 +26,10 @@ import java.io.IOException;
 import java.io.InputStream;
 
 class ObservedInputStream extends InputStream {
-	private final Logger logger;
+	private final BluetoothLogger logger;
 	private final InputStream inputStream;
 
-	ObservedInputStream(InputStream inputStream, Logger logger) {
+	ObservedInputStream(InputStream inputStream, BluetoothLogger logger) {
 		this.inputStream = inputStream;
 		this.logger = logger;
 	}

--- a/catroidTest/src/org/catrobat/catroid/common/bluetooth/ObservedOutputStream.java
+++ b/catroidTest/src/org/catrobat/catroid/common/bluetooth/ObservedOutputStream.java
@@ -28,9 +28,9 @@ import java.io.OutputStream;
 class ObservedOutputStream extends OutputStream {
 
 	private final OutputStream outputStream;
-	private final Logger logger;
+	private final BluetoothLogger logger;
 
-	ObservedOutputStream(OutputStream outputStream, Logger logger) {
+	ObservedOutputStream(OutputStream outputStream, BluetoothLogger logger) {
 		this.outputStream = outputStream;
 		this.logger = logger;
 	}

--- a/catroidTest/src/org/catrobat/catroid/test/content/bricks/UserBrickTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/bricks/UserBrickTest.java
@@ -23,6 +23,7 @@
 package org.catrobat.catroid.test.content.bricks;
 
 import android.test.AndroidTestCase;
+import android.util.Log;
 
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
@@ -48,6 +49,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class UserBrickTest extends AndroidTestCase {
+	private static final String TAG = UserBrickTest.class.getSimpleName();
+
 	private Sprite sprite;
 	private Project project;
 
@@ -165,7 +168,7 @@ public class UserBrickTest extends AndroidTestCase {
 			try {
 				assertEquals("outerBrick.formula.interpretDouble: ", (float) moveValue, formula.interpretFloat(sprite));
 			} catch (InterpretationException e) {
-				e.printStackTrace();
+				Log.e(TAG, "Interpretation Error", e);
 			}
 		}
 

--- a/catroidTest/src/org/catrobat/catroid/test/utils/SimulatedSensorManager.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utils/SimulatedSensorManager.java
@@ -26,6 +26,7 @@ package org.catrobat.catroid.test.utils;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
+import android.util.Log;
 
 import org.catrobat.catroid.formulaeditor.SensorCustomEvent;
 import org.catrobat.catroid.formulaeditor.SensorCustomEventListener;
@@ -39,6 +40,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class SimulatedSensorManager implements SensorManagerInterface {
+	private static final String TAG = SimulatedSensorManager.class.getSimpleName();
 
 	public class Pair<L, R> {
 		private L firstEntry;
@@ -172,16 +174,9 @@ public class SimulatedSensorManager implements SensorManagerInterface {
 				Constructor<SensorEvent> constructor = SensorEvent.class.getDeclaredConstructor(int.class);
 				constructor.setAccessible(true);
 				sensorEvent = constructor.newInstance(3);
-			} catch (NoSuchMethodException noSuchMethodException) {
-				noSuchMethodException.printStackTrace();
-			} catch (IllegalArgumentException illegalArgumentException) {
-				illegalArgumentException.printStackTrace();
-			} catch (InstantiationException instantiationException) {
-				instantiationException.printStackTrace();
-			} catch (IllegalAccessException illegalAccessException) {
-				illegalAccessException.printStackTrace();
-			} catch (InvocationTargetException invocationTargetException) {
-				invocationTargetException.printStackTrace();
+			} catch (NoSuchMethodException | IllegalArgumentException | InstantiationException
+					| IllegalAccessException | InvocationTargetException ex) {
+				Log.e(TAG, "Sleep was interrupted.", ex);
 			}
 
 			if (sensorEvent == null) {

--- a/catroidTest/src/org/catrobat/catroid/test/utils/StatusBarNotificationManagerTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utils/StatusBarNotificationManagerTest.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.test.utils;
 
 import android.os.Bundle;
 import android.test.AndroidTestCase;
+import android.util.Log;
 import android.util.SparseArray;
 
 import org.catrobat.catroid.R;
@@ -32,6 +33,7 @@ import org.catrobat.catroid.utils.NotificationData;
 import org.catrobat.catroid.utils.StatusBarNotificationManager;
 
 public class StatusBarNotificationManagerTest extends AndroidTestCase {
+	private static final String TAG = StatusBarNotificationManagerTest.class.getSimpleName();
 
 	private final StatusBarNotificationManager notificationManager = StatusBarNotificationManager.getInstance();
 
@@ -78,7 +80,7 @@ public class StatusBarNotificationManagerTest extends AndroidTestCase {
 		try {
 			notificationManager.showOrUpdateNotification(-1, 0);
 		} catch (Exception ex) {
-			ex.printStackTrace();
+			Log.e(TAG, "showOrUpdateNotification() failed", ex);
 			fail("there shouldn't be any exception thrown");
 		}
 	}

--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/ImageEditingTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/ImageEditingTest.java
@@ -26,6 +26,7 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.BitmapFactory;
+import android.util.Log;
 
 import junit.framework.TestCase;
 
@@ -41,6 +42,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 
 public class ImageEditingTest extends TestCase {
+	private static final String TAG = ImageEditingTest.class.getSimpleName();
 
 	public void testScaleImage() {
 		Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.RGB_565);
@@ -64,8 +66,8 @@ public class ImageEditingTest extends TestCase {
 			bos.flush();
 			bos.close();
 		} catch (Exception e) {
-			assertFalse("Test file could not be created", true);
-			e.printStackTrace();
+			Log.e(TAG, "Test file could not be created", e);
+			fail("Test file could not be created");
 		}
 
 		int[] dimensions = new int[2];
@@ -95,8 +97,8 @@ public class ImageEditingTest extends TestCase {
 			bos.flush();
 			bos.close();
 		} catch (Exception e) {
-			assertFalse("Test file could not be created", true);
-			e.printStackTrace();
+			Log.e(TAG, "Test file could not be created", e);
+			fail("Test file could not be created");
 		}
 
 		Bitmap loadedBitmap = ImageEditing.getScaledBitmapFromPath(testImageFile.getAbsolutePath(), maxBitmapWidth,
@@ -126,8 +128,8 @@ public class ImageEditingTest extends TestCase {
 			bos.flush();
 			bos.close();
 		} catch (Exception e) {
-			assertFalse("Test file could not be created", true);
-			e.printStackTrace();
+			Log.e(TAG, "Test file could not be created", e);
+			fail("Test file could not be created");
 		}
 
 		loadedBitmap = ImageEditing.getScaledBitmapFromPath(testImageFile.getAbsolutePath(), maxBitmapWidth,
@@ -158,8 +160,8 @@ public class ImageEditingTest extends TestCase {
 			bos.flush();
 			bos.close();
 		} catch (Exception e) {
-			assertFalse("Test file could not be created", true);
-			e.printStackTrace();
+			Log.e(TAG, "Test file could not be created", e);
+			fail("Test file could not be created");
 		}
 
 		Bitmap loadedBitmap = ImageEditing.getScaledBitmapFromPath(testImageFile.getAbsolutePath(), targetBitmapWidth,
@@ -189,8 +191,8 @@ public class ImageEditingTest extends TestCase {
 		try {
 			ImageEditing.scaleImageFile(testImageFile, 1 / sampleSizeReturnValue);
 		} catch (FileNotFoundException e) {
-			assertFalse("Testfile not found", true);
-			e.printStackTrace();
+			Log.e(TAG, "Test not found", e);
+			fail("Test not found");
 		}
 		imageFileDimensions = ImageEditing.getImageDimensions(testImageFile.getAbsolutePath());
 		assertEquals("Width should be initial value again", bitmapWidth, imageFileDimensions[0]);
@@ -224,8 +226,8 @@ public class ImageEditingTest extends TestCase {
 		try {
 			StorageHandler.saveBitmapToImageFile(file, scaledBitmap);
 		} catch (FileNotFoundException e) {
-			e.printStackTrace();
-			fail("file saving error");
+			Log.e(TAG, "Error while saving file", e);
+			fail("Error while saving file");
 		}
 
 		double sampleSizeWidth = ((double) originalBackgroundImageDimensions[0]) / ((double) newWidth);

--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilFileTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilFileTest.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.test.utiltests;
 
 import android.os.Environment;
 import android.test.InstrumentationTestCase;
+import android.util.Log;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Project;
@@ -40,6 +41,7 @@ import java.text.DecimalFormat;
 import java.util.List;
 
 public class UtilFileTest extends InstrumentationTestCase {
+	private static final String TAG = UtilFileTest.class.getSimpleName();
 	private static final String CATROID_DIRECTORY = Environment.getExternalStorageDirectory().getAbsolutePath()
 			+ "/Pocket Code";
 
@@ -112,7 +114,7 @@ public class UtilFileTest extends InstrumentationTestCase {
 			printWriter = new PrintWriter(testFile);
 			printWriter.print("catroid");
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "File handling error", e);
 		} finally {
 			if (printWriter != null) {
 				printWriter.close();

--- a/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilsTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utiltests/UtilsTest.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.test.utiltests;
 
 import android.os.SystemClock;
 import android.test.AndroidTestCase;
+import android.util.Log;
 
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.LookData;
@@ -52,6 +53,8 @@ import java.util.List;
 import java.util.Locale;
 
 public class UtilsTest extends AndroidTestCase {
+	private static final String TAG = UtilsTest.class.getSimpleName();
+
 	private final String testFileContent = "Hello, this is a Test-String";
 	private static final String MD5_EMPTY = "D41D8CD98F00B204E9800998ECF8427E";
 	private static final String MD5_CATROID = "4F982D927F4784F69AD6D6AF38FD96AD";
@@ -74,7 +77,7 @@ public class UtilsTest extends AndroidTestCase {
 				outputStream.flush();
 			}
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "File handling error", e);
 		} finally {
 			if (outputStream != null) {
 				outputStream.close();
@@ -118,7 +121,7 @@ public class UtilsTest extends AndroidTestCase {
 			printWriter = new PrintWriter(md5TestFile);
 			printWriter.print("catroid");
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "File handling error", e);
 		} finally {
 			if (printWriter != null) {
 				printWriter.close();
@@ -181,11 +184,8 @@ public class UtilsTest extends AndroidTestCase {
 
 		try {
 			standardProject = StandardProjectHandler.createAndSaveStandardProject(NEW_PROGRAM_NAME, getContext());
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-			fail("error creating standard project");
-		} catch (IOException e) {
-			e.printStackTrace();
+		} catch (IOException | IllegalArgumentException e) {
+			Log.e(TAG, "error creating standard project", e);
 			fail("error creating standard project");
 		}
 		assertTrue("Failed to recognize the standard project", Utils.isStandardProject(standardProject, getContext()));

--- a/catroidTest/src/org/catrobat/catroid/test/web/ServerCallsTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/web/ServerCallsTest.java
@@ -36,7 +36,7 @@ import org.catrobat.catroid.web.WebconnectionException;
  * This tests need an internet connection
  */
 public class ServerCallsTest extends AndroidTestCase {
-	private static final String LOG_TAG = ServerCalls.class.getSimpleName();
+	private static final String TAG = ServerCalls.class.getSimpleName();
 	public static final int STATUS_CODE_USER_PASSWORD_TOO_SHORT = 753;
 	public static final int STATUS_CODE_USER_ADD_EMAIL_EXISTS = 757;
 	public static final int STATUS_CODE_USER_EMAIL_INVALID = 765;
@@ -76,12 +76,12 @@ public class ServerCallsTest extends AndroidTestCase {
 			token = sharedPreferences.getString(Constants.TOKEN, Constants.NO_TOKEN);
 			boolean tokenOk = ServerCalls.getInstance().checkToken(token, testUser);
 
-			Log.i(LOG_TAG, "tokenOk: " + tokenOk);
+			Log.i(TAG, "tokenOk: " + tokenOk);
 			assertTrue("token should be ok", tokenOk);
 		} catch (WebconnectionException e) {
-			e.printStackTrace();
-			assertFalse("WebconnectionException: the token should be valid \nstatus code:" + e.getStatusCode()
-					+ "\nmessage: " + e.getMessage(), true);
+			Log.e(TAG, "Webconnection error", e);
+			fail("WebconnectionException: the token should be valid \nstatus code:" + e.getStatusCode()
+					+ "\nmessage: " + e.getMessage());
 		}
 	}
 
@@ -95,7 +95,7 @@ public class ServerCallsTest extends AndroidTestCase {
 			boolean userRegistered = ServerCalls.getInstance().registerOrCheckToken(testUser, testPassword, testEmail,
 					"de", "at", token, getContext());
 
-			Log.i(LOG_TAG, "user registered: " + userRegistered);
+			Log.i(TAG, "user registered: " + userRegistered);
 			assertTrue("Should be a new user, but server response indicates that this user already exists",
 					userRegistered);
 
@@ -104,14 +104,13 @@ public class ServerCallsTest extends AndroidTestCase {
 			userRegistered = ServerCalls.getInstance().registerOrCheckToken(testUser, testPassword, testEmail, "de",
 					"at", token, getContext());
 
-			Log.i(LOG_TAG, "user registered: " + userRegistered);
+			Log.i(TAG, "user registered: " + userRegistered);
 			assertFalse("Should be an existing user, but server responce indicates that this user is new",
 					userRegistered);
 		} catch (WebconnectionException e) {
-			e.printStackTrace();
-			assertFalse(
-					"an exception should not be thrown! \nstatus code:" + e.getStatusCode() + "\nmessage: "
-							+ e.getMessage(), true);
+			Log.e(TAG, "Webconnection error", e);
+			fail("an exception should not be thrown! \nstatus code:" + e.getStatusCode() + "\nmessage: "
+					+ e.getMessage());
 		}
 	}
 
@@ -125,7 +124,7 @@ public class ServerCallsTest extends AndroidTestCase {
 			boolean userRegistered = ServerCalls.getInstance().registerOrCheckToken(testUser, testPassword, testEmail,
 					"de", "at", token, getContext());
 
-			Log.i(LOG_TAG, "user registered: " + userRegistered);
+			Log.i(TAG, "user registered: " + userRegistered);
 			assertTrue("Should be a new user, but server response indicates that this user already exists",
 					userRegistered);
 
@@ -137,7 +136,7 @@ public class ServerCallsTest extends AndroidTestCase {
 
 			assertFalse("should never be reached because the password is wrong", true);
 		} catch (WebconnectionException e) {
-			e.printStackTrace();
+			Log.i(TAG, "Webconnection error (this is expected behaviour)", e);
 			assertTrue("an exception should be thrown because the password is wrong", true);
 			assertEquals("wrong status code from server", STATUS_CODE_AUTHENTICATION_FAILED, e.getStatusCode());
 			assertNotNull("no error message available", e.getMessage());
@@ -155,7 +154,7 @@ public class ServerCallsTest extends AndroidTestCase {
 			boolean userRegistered = ServerCalls.getInstance().registerOrCheckToken(testUser, testPassword, testEmail,
 					"de", "at", token, getContext());
 
-			Log.i(LOG_TAG, "user registered: " + userRegistered);
+			Log.i(TAG, "user registered: " + userRegistered);
 			assertTrue("Should be a new user, but server responce indicates that this user already exists",
 					userRegistered);
 
@@ -168,7 +167,7 @@ public class ServerCallsTest extends AndroidTestCase {
 					"should never be reached because two registrations with the same email address are not allowed",
 					true);
 		} catch (WebconnectionException e) {
-			e.printStackTrace();
+			Log.i(TAG, "Webconnection error (this is expected behaviour)", e);
 			assertTrue("an exception should be thrown because the email already exists on the server", true);
 			assertEquals("wrong status code from server", STATUS_CODE_USER_ADD_EMAIL_EXISTS,
 					e.getStatusCode());
@@ -189,7 +188,7 @@ public class ServerCallsTest extends AndroidTestCase {
 
 			assertFalse("should never be reached because the password is too short", true);
 		} catch (WebconnectionException e) {
-			e.printStackTrace();
+			Log.i(TAG, "Webconnection error (this is expected behaviour)", e);
 			assertTrue("an exception should be thrown because the password is too short", true);
 			assertEquals("wrong status code from server", STATUS_CODE_USER_PASSWORD_TOO_SHORT,
 					e.getStatusCode());
@@ -210,7 +209,7 @@ public class ServerCallsTest extends AndroidTestCase {
 
 			assertFalse("should never be reached because the email is not valid", true);
 		} catch (WebconnectionException e) {
-			e.printStackTrace();
+			Log.i(TAG, "Webconnection error (this is expected behaviour)", e);
 			assertTrue("an exception should be thrown because the email is not valid", true);
 			assertEquals("wrong status code from server", STATUS_CODE_USER_EMAIL_INVALID,
 					e.getStatusCode());
@@ -225,9 +224,10 @@ public class ServerCallsTest extends AndroidTestCase {
 			String username = "badUser";
 			boolean tokenOk = ServerCalls.getInstance().checkToken(wrongToken, username);
 
-			Log.i(LOG_TAG, "tokenOk: " + tokenOk);
+			Log.i(TAG, "tokenOk: " + tokenOk);
 			assertFalse("should not be reached, exception is thrown", tokenOk);
 		} catch (WebconnectionException e) {
+			Log.i(TAG, "Webconnection error (this is expected behaviour)", e);
 			assertTrue("exception is thrown if we pass a wrong token", true);
 			assertEquals("wrong status code from server", STATUS_CODE_AUTHENTICATION_FAILED, e.getStatusCode());
 			assertNotNull("no error message available", e.getMessage());
@@ -245,7 +245,7 @@ public class ServerCallsTest extends AndroidTestCase {
 			boolean userRegistered = ServerCalls.getInstance().registerOrCheckToken(testUser, testPassword, testEmail,
 					"de", "at", token, getContext());
 
-			Log.i(LOG_TAG, "user registered: " + userRegistered);
+			Log.i(TAG, "user registered: " + userRegistered);
 			assertTrue("Should be a new user, but server responce indicates that this user already exists",
 					userRegistered);
 
@@ -253,12 +253,11 @@ public class ServerCallsTest extends AndroidTestCase {
 			token = sharedPreferences.getString(Constants.TOKEN, Constants.NO_TOKEN);
 			boolean tokenOk = ServerCalls.getInstance().checkToken(token, testUser);
 
-			Log.i(LOG_TAG, "tokenOk: " + tokenOk);
+			Log.i(TAG, "tokenOk: " + tokenOk);
 			assertTrue("token should be ok", tokenOk);
 		} catch (WebconnectionException e) {
-			assertFalse("WebconnectionException \nstatus code:" + e.getStatusCode() + "\nmessage: " + e.getMessage(),
-					true);
-			e.printStackTrace();
+			Log.e(TAG, "Webconnection error", e);
+			fail("WebconnectionException \nstatus code:" + e.getStatusCode() + "\nmessage: " + e.getMessage());
 		}
 	}
 }

--- a/catroidTest/src/org/catrobat/catroid/uitest/stage/SwitchToLookCrashTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/stage/SwitchToLookCrashTest.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.uitest.stage;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
@@ -51,6 +52,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class SwitchToLookCrashTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
+	private static final String TAG = SwitchToLookCrashTest.class.getSimpleName();
 
 	public SwitchToLookCrashTest() {
 		super(MainMenuActivity.class);
@@ -77,7 +79,7 @@ public class SwitchToLookCrashTest extends BaseActivityInstrumentationTestCase<M
 					Constants.IMAGE_DIRECTORY, nyanCatPng);
 			writeBufferToFile(inputStream, nyanCatPath);
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Image not loaded from Assets", e);
 			fail("Image not loaded from Assets");
 		}
 
@@ -129,7 +131,7 @@ public class SwitchToLookCrashTest extends BaseActivityInstrumentationTestCase<M
 					Constants.IMAGE_DIRECTORY, manImageJpg);
 			writeBufferToFile(inputStream, manImagePath);
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Image not loaded from Assets", e);
 			fail("Image not loaded from Assets");
 		}
 

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/MainMenuActivityTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/MainMenuActivityTest.java
@@ -29,6 +29,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Configuration;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ListView;
@@ -64,6 +65,7 @@ import java.io.File;
 import java.io.IOException;
 
 public class MainMenuActivityTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
+	private static final String TAG = MainMenuActivityTest.class.getSimpleName();
 
 	private String testProject = UiTestUtils.PROJECTNAME1;
 	private String testProject2 = UiTestUtils.PROJECTNAME2;
@@ -418,8 +420,8 @@ public class MainMenuActivityTest extends BaseActivityInstrumentationTestCase<Ma
 			standardProject = StandardProjectHandler.createAndSaveStandardProject(standardProjectName,
 					getInstrumentation().getTargetContext());
 		} catch (IOException e) {
+			Log.e(TAG, "Could not create standard project", e);
 			fail("Could not create standard project");
-			e.printStackTrace();
 		}
 
 		if (standardProject == null) {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
@@ -76,6 +76,7 @@ import java.util.List;
 import java.util.Locale;
 
 public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
+
 	private static final String INVALID_PROJECT_MODIFIER = "invalidProject";
 	private static final int IMAGE_RESOURCE_1 = org.catrobat.catroid.test.R.drawable.catroid_sunglasses;
 	private static final int IMAGE_RESOURCE_2 = org.catrobat.catroid.test.R.drawable.background_white;
@@ -182,7 +183,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		try {
 			StandardProjectHandler.createAndSaveStandardProject(getActivity());
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Standard Project not created", e);
 			fail("Standard Project not created");
 		}
 
@@ -231,7 +232,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		try {
 			StandardProjectHandler.createAndSaveStandardProject(getActivity());
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Standard Project not created", e);
 			fail("Standard Project not created");
 		}
 		UiTestUtils.createTestProject();
@@ -271,7 +272,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		try {
 			StandardProjectHandler.createAndSaveStandardProject(getActivity());
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Standard Project not created", e);
 			fail("Standard Project not created");
 		}
 		UiTestUtils.createTestProject();
@@ -885,7 +886,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		try {
 			StandardProjectHandler.createAndSaveStandardProject(getActivity());
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Standard Project not created", e);
 			fail("Standard Project not created");
 		}
 		String delete = solo.getString(R.string.delete);
@@ -1903,7 +1904,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 			StandardProjectHandler.createAndSaveStandardProject(getActivity());
 			StandardProjectHandler.createAndSaveStandardProject("test", getActivity());
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Standard Project not created", e);
 			fail("Standard Project not created");
 		}
 
@@ -2162,7 +2163,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 			try {
 				StandardProjectHandler.createAndSaveStandardProject(getActivity());
 			} catch (IOException e) {
-				e.printStackTrace();
+				Log.e(TAG, "Standard Project not created", e);
 				fail("Standard Project could not be not created");
 			}
 		}

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/ProjectActivityTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/ProjectActivityTest.java
@@ -84,6 +84,8 @@ import java.util.List;
 import java.util.Locale;
 
 public class ProjectActivityTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
+	private static final String TAG = ProjectActivityTest.class.getSimpleName();
+
 	private static final String TEST_SPRITE_NAME = "cat";
 	private static final String FIRST_TEST_SPRITE_NAME = "test1";
 	private static final String SECOND_TEST_SPRITE_NAME = "test2";
@@ -272,7 +274,7 @@ public class ProjectActivityTest extends BaseActivityInstrumentationTestCase<Mai
 		try {
 			StandardProjectHandler.createAndSaveStandardProject(getActivity());
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Standard Project not created", e);
 			fail("Standard Project not created");
 		}
 		Sprite sprite = new Sprite(defaultSpriteName + solo.getString(R.string.copy_sprite_name_suffix));

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
@@ -58,6 +58,8 @@ import java.util.ArrayList;
 import java.util.Locale;
 
 public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
+	private static final String TAG = LookFragmentTest.class.getSimpleName();
+
 	private static final int RESOURCE_IMAGE = org.catrobat.catroid.test.R.drawable.catroid_sunglasses;
 	private static final int RESOURCE_IMAGE2 = org.catrobat.catroid.test.R.drawable.catroid_banzai;
 	private static final int RESOURCE_IMAGE3 = org.catrobat.catroid.test.R.drawable.catroid_sunglasses_jpg;
@@ -662,7 +664,7 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 			imageFile = UiTestUtils.createTestMediaFile(Utils.buildPath(Constants.DEFAULT_ROOT, fileName + ".png"),
 					RESOURCE_IMAGE2, getActivity());
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Image was not created", e);
 			fail("Image was not created");
 		}
 		String md5ChecksumImageFile = Utils.md5Checksum(imageFile);
@@ -689,7 +691,7 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 			imageFile = UiTestUtils.createTestMediaFile(Utils.buildPath(Constants.DEFAULT_ROOT, fileName + ".png"),
 					RESOURCE_IMAGE, getActivity());
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Image was not created", e);
 			fail("Image was not created");
 		}
 		md5ChecksumImageFile = Utils.md5Checksum(imageFile);
@@ -1239,8 +1241,8 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		try {
 			UiTestUtils.cropImage(pathToImageFile, sampleSize);
 		} catch (FileNotFoundException e) {
+			Log.e(TAG, "Image was not found", e);
 			fail("Test failed because file was not found");
-			e.printStackTrace();
 		}
 
 		UiTestUtils.clickOnHomeActionBarButton(solo);

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/ScriptFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/ScriptFragmentTest.java
@@ -58,8 +58,7 @@ import java.util.List;
 import java.util.Locale;
 
 public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
-
-	private static final String SCRIPT_FRAGMENT_TEST_TAG = ScriptFragmentTest.class.getSimpleName();
+	private static final String TAG = ScriptFragmentTest.class.getSimpleName();
 
 	public ScriptFragmentTest() {
 		super(MainMenuActivity.class);
@@ -692,8 +691,8 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 			standardProject = StandardProjectHandler.createAndSaveStandardProject(
 					UiTestUtils.DEFAULT_TEST_PROJECT_NAME, getInstrumentation().getTargetContext());
 		} catch (IOException e) {
+			Log.e(TAG, "Could not create standard project", e);
 			fail("Could not create standard project");
-			e.printStackTrace();
 		}
 
 		if (standardProject == null) {
@@ -766,7 +765,7 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 	@SuppressWarnings("deprecation")
 	public void testReturnFromStageAfterInvokingFormulaEditor() {
 		if (Settings.System.getInt(getActivity().getContentResolver(), Settings.System.ALWAYS_FINISH_ACTIVITIES, 0) == 0) {
-			Log.i(SCRIPT_FRAGMENT_TEST_TAG, "Developer option \'Don't keep activities\' is not set.");
+			Log.i(TAG, "Developer option 'Don't keep activities' is not set.");
 			return;
 		}
 

--- a/catroidTest/src/org/catrobat/catroid/uitest/util/SensorTestServerConnection.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/util/SensorTestServerConnection.java
@@ -37,6 +37,7 @@ import static junit.framework.Assert.assertTrue;
 
 @SuppressWarnings("AvoidUsingHardCodedIP")
 public final class SensorTestServerConnection {
+
 	private static final String TAG = SensorTestServerConnection.class.getSimpleName();
 
 	// fields to provide ethernet connection to the arduino server
@@ -113,7 +114,7 @@ public final class SensorTestServerConnection {
 		} catch (IOException ioException) {
 			throw new AssertionFailedError("Data exchange failed! Check server connection!");
 		} catch (InterruptedException e) {
-			e.printStackTrace();
+			Log.w(TAG, "InterruptedException", e);
 		}
 	}
 
@@ -146,7 +147,7 @@ public final class SensorTestServerConnection {
 		} catch (IOException ioException) {
 			throw new AssertionFailedError("Data exchange failed! Check server connection!");
 		} catch (InterruptedException e) {
-			e.printStackTrace();
+			Log.w(TAG, "InterruptedException", e);
 		}
 	}
 
@@ -165,7 +166,7 @@ public final class SensorTestServerConnection {
 		} catch (IOException ioException) {
 			throw new AssertionFailedError("Data exchange failed! Check server connection!");
 		} catch (InterruptedException e) {
-			e.printStackTrace();
+			Log.w(TAG, "InterruptedException", e);
 		}
 	}
 }

--- a/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -175,7 +175,7 @@ public final class UiTestUtils {
 	public static final String PROJECTNAME1 = "testingproject1";
 	public static final String PROJECTNAME2 = "testingproject2";
 	public static final String PROJECTNAME3 = "testingproject3";
-	public static final String PROJECTNAMEOFFENSIVELANGUAGE = "fuck i have to use fuck";
+	public static final String PROJECTNAMEOFFENSIVELANGUAGE = "fuck i have to use fuck penis";
 	public static final String PROJECTDESCRIPTION1 = "testdescription1";
 	public static final String PROJECTDESCRIPTION2 = "testdescription2";
 	public static final String DEFAULT_TEST_PROJECT_NAME_MIXED_CASE = "TeStPROjeCt";
@@ -1243,7 +1243,7 @@ public final class UiTestUtils {
 
 			return tempFile;
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, "File handling error", e);
 			return null;
 		}
 	}
@@ -1576,7 +1576,7 @@ public final class UiTestUtils {
 
 			assert (userRegistered);
 		} catch (WebconnectionException e) {
-			e.printStackTrace();
+			Log.e(TAG, "Error creating test user.", e);
 			fail("Error creating test user.");
 		}
 	}
@@ -1690,7 +1690,7 @@ public final class UiTestUtils {
 						MotionEvent.ACTION_UP, xTo, yTo, 0);
 				activity.dispatchTouchEvent(upEvent);
 				upEvent.recycle();
-				Log.d("Robotium - waitForLogMessage", "longClickAndDrag finished: " + (int) yTo);
+				Log.d(TAG, "longClickAndDrag finished: " + (int) yTo);
 			}
 		});
 
@@ -2032,8 +2032,8 @@ public final class UiTestUtils {
 					SpinnerAdapterWrapper.class);
 			constructor.setAccessible(true);
 			dialog = constructor.newInstance(DialogWizardStep.STEP_2, uri, spriteName, actionToPerform, spinner);
-		} catch (Exception exception) {
-			exception.printStackTrace();
+		} catch (Exception e) {
+			Log.e(TAG, "Reflection failure.", e);
 			fail("Reflection failure");
 			return;
 		}

--- a/catroidTest/src/org/catrobat/catroid/uitest/web/ProjectUpAndDownloadTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/web/ProjectUpAndDownloadTest.java
@@ -58,6 +58,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
+	private static final String TAG = ProjectUpAndDownloadTest.class.getSimpleName();
+
 	private static final String TEST_FILE_DOWNLOAD_URL = ServerCalls.BASE_URL_TEST_HTTP + "catroid/download/";
 	private static final int LONG_TEST_SOUND = org.catrobat.catroid.test.R.raw.longsound;
 	private final String testProject = UiTestUtils.PROJECTNAME1;
@@ -477,7 +479,7 @@ public class ProjectUpAndDownloadTest extends BaseActivityInstrumentationTestCas
 			ProjectManager.getInstance().setProject(standardProject);
 		} catch (ProjectException projectException) {
 
-			projectException.printStackTrace();
+			Log.e(TAG, "Cannot load old standard project", projectException);
 			fail("Cannot load old standard project");
 		} catch (IOException exception) {
 			fail("Standard project not created");

--- a/config/pmd_logging.xml
+++ b/config/pmd_logging.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2015 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 name="Catroid PMD logging ruleset"
+		 xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+		 xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd" >
+	<description >PMD Java Logging Ruleset for Catroid/PocketCode</description >
+	<rule ref="rulesets/java/logging-java.xml" >
+		<exclude name="GuardLogStatementJavaUtil" />
+	</rule>
+</ruleset >

--- a/gradle/code_quality_tasks.gradle
+++ b/gradle/code_quality_tasks.gradle
@@ -28,8 +28,10 @@ task checkstyle(type: Checkstyle) {
 task pmd(type: Pmd) {
     // complete rulesets can be used with the abbrevation
     // rulesets with specific excludes are moved to a config file containing just a single ruleset with exclude(s)
-	ruleSets = ['java-android', 'java-braces', 'java-sunsecure', 'java-unusedcode', 'config/pmd_basic.xml',
-				'config/pmd_empty.xml', 'config/pmd_strings.xml', 'config/pmd_unnecessary.xml']
+    ruleSets = ['java-android', 'java-braces', 'java-sunsecure', 'java-unusedcode', 'config/pmd_basic.xml',
+                'config/pmd_empty.xml', 'config/pmd_strings.xml', 'config/pmd_unnecessary.xml',
+                'config/pmd_logging.xml']
+
     source '.'
     include '**/*.java'
     exclude '**/gen/**', '**/build/**', '**/res/**', 'libraryProjects/**', '**/catroidCucumberTest/**'


### PR DESCRIPTION
JIRA issue: 
https://jira.catrob.at/browse/CAT-1275

Jenkins run:
https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch-RELOADED/1595/

introduced pmd java-logging ruleset

removed system out test

renamed interface org.catrobat.catroid.common.bluetooth.Logger to org.catrobat.catroid.common.bluetooth.BluetoothLogger to make it distinguishable from java.util.logging.Logger for pmd checks