### PR TITLE
CAT-1355 Fix wrong coordinate setting behaviour

### DIFF
--- a/catroid/src/org/catrobat/catroid/physics/PhysicsLook.java
+++ b/catroid/src/org/catrobat/catroid/physics/PhysicsLook.java
@@ -67,14 +67,17 @@ public class PhysicsLook extends Look {
 	}
 
 	@Override
-	public void setPosition (float x, float y) {
-		setX(x);
-		setY(y);
+	public void setPosition(float x, float y) {
 		super.setPosition(x, y);
+		if (null != physicsObject) {
+			physicsObject.setX(x + getWidth() / 2.0f);
+			physicsObject.setY(y + getHeight() / 2.0f);
+		}
 	}
 
 	@Override
 	public void setX(float x) {
+		super.setX(x);
 		if (null != physicsObject) {
 			physicsObject.setX(x + getWidth() / 2.0f);
 		}
@@ -82,6 +85,7 @@ public class PhysicsLook extends Look {
 
 	@Override
 	public void setY(float y) {
+		super.setY(y);
 		if (null != physicsObject) {
 			physicsObject.setY(y + getHeight() / 2.0f);
 		}
@@ -104,12 +108,16 @@ public class PhysicsLook extends Look {
 
 	@Override
 	public float getX() {
-		return physicsObject.getX() - getWidth() / 2.0f;
+		float x = physicsObject.getX() - getWidth() / 2.0f;
+		super.setX(x);
+		return x;
 	}
 
 	@Override
 	public float getY() {
-		return physicsObject.getY() - getHeight() / 2.0f;
+		float y = physicsObject.getY() - getHeight() / 2.0f;
+		super.setY(y);
+		return y;
 	}
 
 	@Override

--- a/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsLookTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/physics/PhysicsLookTest.java
@@ -119,16 +119,20 @@ public class PhysicsLookTest extends InstrumentationTestCase {
 
 		float x = 1.2f;
 		physicsLook.setX(x);
-		assertEquals("Wrong x position", x, physicsObject.getX());
+		assertEquals("Wrong x position in PhysicsObject", x, physicsObject.getX());
+		assertEquals("Wrong x position in PhysicsLook", x, physicsLook.getX());
 
 		float y = -3.4f;
 		physicsLook.setY(y);
-		assertEquals("Wrong y position", y, physicsObject.getY());
+		assertEquals("Wrong y position in PhysicsObject", y, physicsObject.getY());
+		assertEquals("Wrong y position in PhysicsLook", y, physicsLook.getY());
 
 		x = 5.6f;
 		y = 7.8f;
 		physicsLook.setPosition(x, y);
 		assertEquals("Wrong position", new Vector2(x, y), physicsObject.getPosition());
+		assertEquals("Wrong x position in PhysicsLook (due to set/getPosition)", x, physicsLook.getX());
+		assertEquals("Wrong y position in PhysicsLook (due to set/getPosition)", y, physicsLook.getY());
 
 		float rotation = 9.0f;
 		physicsLook.setRotation(rotation);
@@ -230,6 +234,5 @@ public class PhysicsLookTest extends InstrumentationTestCase {
 			Log.e(TAG, "unexpected exception", exception);
 			fail("unexpected exception");
 		}
-
 	}
 }


### PR DESCRIPTION
There occured a bug after merging the new libgdx with the setX setY and setPosition.