### PR TITLE
CAT-1353 fix UserBrickScriptActivityTest

### DIFF
--- a/catroid/src/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -40,6 +40,7 @@ import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnKeyListener;
+import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.widget.ImageButton;
@@ -107,7 +108,6 @@ public class FormulaEditorFragment extends SherlockFragment implements OnKeyList
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		setHasOptionsMenu(true);
 		setUpActionBar();
 		onFormulaChangedListener = (OnFormulaChangedListener) ((ScriptActivity) getActivity())
 				.getFragment(ScriptActivity.FRAGMENT_SCRIPTS);
@@ -116,6 +116,7 @@ public class FormulaEditorFragment extends SherlockFragment implements OnKeyList
 		currentBrickField = Brick.BrickField.valueOf(getArguments().getString(BRICKFIELD_BUNDLE_ARGUMENT));
 		cloneFormulaBrick(formulaBrick);
 		currentFormula = clonedFormulaBrick.getFormulaWithBrickField(currentBrickField);
+		setHasOptionsMenu(!ViewConfiguration.get(getActivity()).hasPermanentMenuKey());
 	}
 
 	private void setUpActionBar() {
@@ -235,7 +236,7 @@ public class FormulaEditorFragment extends SherlockFragment implements OnKeyList
 
 		setInputFormula(currentBrickField, SET_FORMULA_ON_CREATE_VIEW);
 
-		setHasOptionsMenu(true);
+		setHasOptionsMenu(!ViewConfiguration.get(getActivity()).hasPermanentMenuKey());
 		setUpActionBar();
 
 		return fragmentView;


### PR DESCRIPTION
setHasOptionsMenu() triggers a callback (onPrepareOptionsMenu()) which uses the variable formulaEditorEditText. This variable was unassigned when calling setHasOptionsMenu() at the beginning of onCreate().

Now the Test passes:
https://jenkins.catrob.at/job/Catroid-Multi-Job-Custom-Branch-RELOADED/1688/#showFailuresLink

JIRA issue:
https://jira.catrob.at/browse/CAT-1353