### PR TITLE
CAT-1347 fix BroadcastActionTest.testWhenScriptRestartingItself

### DIFF
--- a/catroidTest/src/org/catrobat/catroid/test/content/actions/BroadcastActionTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/actions/BroadcastActionTest.java
@@ -123,6 +123,9 @@ public class BroadcastActionTest extends AndroidTestCase {
 		BroadcastBrick broadcastBrickLoop = new BroadcastBrick(message);
 		broadcastScript.addBrick(broadcastBrickLoop);
 
+		WaitBrick wb = new WaitBrick(5);
+		broadcastScript.addBrick(wb);
+
 		sprite.addScript(broadcastScript);
 
 		Project project = new Project(getContext(), UiTestUtils.DEFAULT_TEST_PROJECT_NAME);


### PR DESCRIPTION
added WaitBrick(5) to the broadcast script, this seems to fix a timing issue on some devices with this test

JIRA:
https://jira.catrob.at/browse/CAT-1347

Jenkins:
https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch-RELOADED/1840/?auto_refresh=false#showFailuresLink