### PR TITLE
CAT-1353 fix UserBrickScriptActivityTest

### DIFF
--- a/catroid/src/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -107,7 +107,6 @@ public class FormulaEditorFragment extends SherlockFragment implements OnKeyList
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		setHasOptionsMenu(true);
 		setUpActionBar();
 		onFormulaChangedListener = (OnFormulaChangedListener) ((ScriptActivity) getActivity())
 				.getFragment(ScriptActivity.FRAGMENT_SCRIPTS);
@@ -116,6 +115,7 @@ public class FormulaEditorFragment extends SherlockFragment implements OnKeyList
 		currentBrickField = Brick.BrickField.valueOf(getArguments().getString(BRICKFIELD_BUNDLE_ARGUMENT));
 		cloneFormulaBrick(formulaBrick);
 		currentFormula = clonedFormulaBrick.getFormulaWithBrickField(currentBrickField);
+		setHasOptionsMenu(true);
 	}
 
 	private void setUpActionBar() {


### PR DESCRIPTION
the setHasOptionsMenu() was called at a point where it sometimes used variables which are not yet initialized

JIRA:
https://jira.catrob.at/browse/CAT-1353

Jenkins:
https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch-RELOADED/1876/?auto_refresh=false