### PR TITLE
fixed error in notification statusbar

### DIFF
--- a/catroid/src/org/catrobat/catroid/utils/DownloadUtil.java
+++ b/catroid/src/org/catrobat/catroid/utils/DownloadUtil.java
@@ -37,6 +37,7 @@ import org.catrobat.catroid.web.ProgressResponseBody;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
@@ -98,6 +99,7 @@ public final class DownloadUtil {
 		return programDownloadQueue.contains(programName.toLowerCase(Locale.getDefault()));
 	}
 
+	ArrayList<Integer> notificationIdArray = new ArrayList<Integer>();
 	private class DownloadReceiver extends ResultReceiver {
 		public DownloadReceiver(Handler handler) {
 			super(handler);
@@ -105,17 +107,21 @@ public final class DownloadUtil {
 
 		@Override
 		protected void onReceiveResult(int resultCode, Bundle resultData) {
-			super.onReceiveResult(resultCode, resultData);
-			if (resultCode == Constants.UPDATE_DOWNLOAD_PROGRESS) {
-				long progress = resultData.getLong(ProgressResponseBody.TAG_PROGRESS);
-				boolean endOfFileReached = resultData.getBoolean(ProgressResponseBody.TAG_ENDOFFILE);
-				Integer notificationId = resultData.getInt(ProgressResponseBody.TAG_NOTIFICATION_ID);
-				if (endOfFileReached) {
-					progress = 100;
+			Integer notificationId = resultData.getInt(ProgressResponseBody.TAG_NOTIFICATION_ID);
+			if (!notificationIdArray.contains(notificationId)) {
+				notificationIdArray.add(notificationId);
+			}
+			if (notificationIdArray.size() - 1 == notificationId) {
+				super.onReceiveResult(resultCode, resultData);
+				if (resultCode == Constants.UPDATE_DOWNLOAD_PROGRESS) {
+					long progress = resultData.getLong(ProgressResponseBody.TAG_PROGRESS);
+					boolean endOfFileReached = resultData.getBoolean(ProgressResponseBody.TAG_ENDOFFILE);
+					if (endOfFileReached) {
+						progress = 100;
+					}
+					StatusBarNotificationManager.getInstance().showOrUpdateNotification(notificationId,
+							Long.valueOf(progress).intValue());
 				}
-
-				StatusBarNotificationManager.getInstance().showOrUpdateNotification(notificationId,
-						Long.valueOf(progress).intValue());
 			}
 		}
 	}


### PR DESCRIPTION
"fixed" error: everytime when the user downloads a project all previous projects are also loading again in the notification status bar (only loading/not downloading). These lines fix only the display of the additional loading bars, but it needs further debugging why the method onReceiveResult() is called nevertheless for every previous project