### PR TITLE
CAT-1339 Bricks crashes on Galaxy S3 Mini

### DIFF
--- a/catroid/src/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -408,7 +408,7 @@ public class FormulaEditorFragment extends SherlockFragment implements OnKeyList
 		}
 
 		MenuItem undo = menu.findItem(R.id.menu_undo);
-		if (!formulaEditorEditText.getHistory().undoIsPossible()) {
+		if (formulaEditorEditText == null || !formulaEditorEditText.getHistory().undoIsPossible()) {
 			undo.setIcon(R.drawable.icon_undo_disabled);
 			undo.setEnabled(false);
 		} else {
@@ -417,7 +417,7 @@ public class FormulaEditorFragment extends SherlockFragment implements OnKeyList
 		}
 
 		MenuItem redo = menu.findItem(R.id.menu_redo);
-		if (!formulaEditorEditText.getHistory().redoIsPossible()) {
+		if (formulaEditorEditText == null || !formulaEditorEditText.getHistory().redoIsPossible()) {
 			redo.setIcon(R.drawable.icon_redo_disabled);
 			redo.setEnabled(false);
 		} else {


### PR DESCRIPTION
`onPrepareOptionsMenu` gets called before `onCreateView` and
causes a `Nullpointerexception`, because the EditText View of
the Formula Editor is not created yet.