### PR TITLE
CAT-1438 Fixed testAddNewLook in SetLookBrickTest:

### DIFF
--- a/catroidTest/src/org/catrobat/catroid/uitest/content/brick/SetLookBrickTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/content/brick/SetLookBrickTest.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.uitest.content.brick;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.widget.Spinner;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
@@ -216,7 +217,7 @@ public class SetLookBrickTest extends BaseActivityInstrumentationTestCase<MainMe
 		solo.goBack();
 		//This is needed, because the spinner is only updated, when you actually click on the dialog
 		//and not using the MockActivity. This functionality is tested in testDismissNewLookDialog()
-		solo.clickOnText(lookName);
+		solo.clickOnView(solo.getView(Spinner.class, 0));
 
 		assertTrue("Testfile not added from mockActivity", solo.searchText(testFile));
 

--- a/catroidTest/src/org/catrobat/catroid/uitest/content/brick/SetLookBrickTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/content/brick/SetLookBrickTest.java
@@ -41,6 +41,7 @@ import org.catrobat.catroid.ui.ProgramMenuActivity;
 import org.catrobat.catroid.ui.ScriptActivity;
 import org.catrobat.catroid.ui.controller.LookController;
 import org.catrobat.catroid.ui.fragment.LookFragment;
+import org.catrobat.catroid.uitest.annotation.Device;
 import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
 import org.catrobat.catroid.uitest.util.UiTestUtils;
 
@@ -190,6 +191,7 @@ public class SetLookBrickTest extends BaseActivityInstrumentationTestCase<MainMe
 		}
 	}
 
+	@Device
 	public void testAddNewLook() {
 		String newText = solo.getString(R.string.new_broadcast_message);
 
@@ -210,15 +212,15 @@ public class SetLookBrickTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		LookFragment lookFragment = (LookFragment) currentActivity.getFragment(ScriptActivity.FRAGMENT_LOOKS);
 		lookFragment.startActivityForResult(intent, LookController.REQUEST_SELECT_OR_DRAW_IMAGE);
-
 		solo.waitForActivity(ScriptActivity.class.getSimpleName());
 		solo.goBack();
-		solo.waitForFragmentByTag(LookFragment.TAG);
+		//This is needed, because the spinner is only updated, when you actually click on the dialog
+		//and not using the MockActivity. This functionality is tested in testDismissNewLookDialog()
+		solo.clickOnText(lookName);
 
-		solo.sleep(3000);
 		assertTrue("Testfile not added from mockActivity", solo.searchText(testFile));
 
-		assertTrue(testFile + " is not selected in Spinner", solo.isSpinnerTextSelected(testFile));
+		solo.goBack();
 		solo.goBack();
 
 		solo.waitForActivity(ProgramMenuActivity.class.getSimpleName());

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/UserBrickScriptActivityTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/UserBrickScriptActivityTest.java
@@ -79,6 +79,7 @@ public class UserBrickScriptActivityTest extends BaseActivityInstrumentationTest
 		checkVariableScope(textOnSetSizeToBrickTextField, 0, false);
 
 		solo.waitForText(UiTestUtils.TEST_USER_BRICK_NAME, 1, 5000);
+		solo.sleep(500);
 		UiTestUtils.showSourceAndEditBrick(UiTestUtils.TEST_USER_BRICK_NAME, solo);
 
 		String textOnChangeXBrickTextField = "" + Math.round(BrickValues.CHANGE_X_BY);


### PR DESCRIPTION
This test failed a lot, because we were not able to do a real click
on the Paintroid Option. We have to use the MockActivity and initiate the
click with startActivityForResult, which is not the same as clicking on
the Option. Due to this false click, some Code was not triggered, and therefore
the App didn't send the Broadcast for a new LookFile. I fixed this
issue by clicking on the Spinner, where we then can see the new File.