### PR TITLE
CAT-1531 Renamed "Math"-String to "Functions" in FE

### DIFF
--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -770,7 +770,7 @@
     <string name="formula_editor_object_layer">layer</string>
     <string name="formula_editor_compute">Compute</string>
     <string name="formula_editor_object">Object</string>
-    <string name="formula_editor_math">Math</string>
+    <string name="formula_editor_math">Functions</string>
     <string name="formula_editor_logic">Logic</string>
     <string name="formula_editor_sensors">Sensors</string>
     <string name="formula_editor_variables">Variables</string>


### PR DESCRIPTION
@thmq Please fix translations at crowdin (Also in german it should be named "Funktionen")