### PR TITLE
CAT-907 Removed colon as proposed

### DIFF
--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -273,7 +273,7 @@
     <string name="new_project_dialog_title">New program</string>
     <string name="new_project_dialog_hint">My Program</string>
     <string name="new_project_description_dialog_hint">My Description</string>
-    <string name="new_project_name">Program name:</string>
+    <string name="new_project_name">Program name</string>
     <string name="new_project_empty">Create empty program</string>
     <!--  -->
 


### PR DESCRIPTION
@thmq Please fix translation files in crowdin (all have the ":" added at the end of new_"project_name-String")