### PR TITLE
facedetection fix and resource fixes, mainly needed for standalone apk

### DIFF
--- a/catroid/src/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/org/catrobat/catroid/ProjectManager.java
@@ -53,6 +53,7 @@ import org.catrobat.catroid.io.LoadProjectTask.OnLoadProjectCompleteListener;
 import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.transfers.CheckTokenTask;
 import org.catrobat.catroid.transfers.CheckTokenTask.OnCheckTokenCompleteListener;
+import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.ui.dialogs.LoginRegisterDialog;
 import org.catrobat.catroid.ui.dialogs.UploadProjectDialog;
 import org.catrobat.catroid.utils.Utils;
@@ -201,6 +202,16 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 
 		if (project != null) {
 			project.loadLegoNXTSettingsFromProject(context);
+
+			int resources = project.getRequiredResources();
+
+			if ((resources & Brick.BLUETOOTH_PHIRO) > 0) {
+				SettingsActivity.setPhiroSharedPreferenceEnabled(context, true);
+			}
+
+			if ((resources & Brick.FACE_DETECTION) > 0) {
+				SettingsActivity.setFaceDetectionSharedPreferenceEnabled(context, true);
+			}
 		}
 	}
 

--- a/catroid/src/org/catrobat/catroid/content/bricks/LegoNxtMotorMoveBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/LegoNxtMotorMoveBrick.java
@@ -90,7 +90,7 @@ public class LegoNxtMotorMoveBrick extends FormulaBrick {
 
 	@Override
 	public int getRequiredResources() {
-		return BLUETOOTH_LEGO_NXT;
+		return BLUETOOTH_LEGO_NXT | getFormulaWithBrickField(BrickField.LEGO_NXT_SPEED).getRequiredResources();
 	}
 
 	@Override

--- a/catroid/src/org/catrobat/catroid/content/bricks/PhiroMotorMoveBackwardBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PhiroMotorMoveBackwardBrick.java
@@ -95,7 +95,7 @@ public class PhiroMotorMoveBackwardBrick extends FormulaBrick {
 
 	@Override
 	public int getRequiredResources() {
-		return BLUETOOTH_PHIRO;
+		return BLUETOOTH_PHIRO | getFormulaWithBrickField(BrickField.PHIRO_SPEED).getRequiredResources();
 	}
 
 	@Override

--- a/catroid/src/org/catrobat/catroid/content/bricks/PhiroMotorMoveForwardBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PhiroMotorMoveForwardBrick.java
@@ -97,7 +97,7 @@ public class PhiroMotorMoveForwardBrick extends FormulaBrick {
 
 	@Override
 	public int getRequiredResources() {
-		return BLUETOOTH_PHIRO;
+		return BLUETOOTH_PHIRO | getFormulaWithBrickField(BrickField.PHIRO_SPEED).getRequiredResources();
 	}
 
 	@Override

--- a/catroid/src/org/catrobat/catroid/content/bricks/PhiroPlayToneBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PhiroPlayToneBrick.java
@@ -90,7 +90,7 @@ public class PhiroPlayToneBrick extends FormulaBrick {
 
 	@Override
 	public int getRequiredResources() {
-		return BLUETOOTH_PHIRO;
+		return BLUETOOTH_PHIRO | getFormulaWithBrickField(BrickField.PHIRO_DURATION_IN_SECONDS).getRequiredResources();
 	}
 
 	@Override

--- a/catroid/src/org/catrobat/catroid/content/bricks/PhiroRGBLightBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PhiroRGBLightBrick.java
@@ -105,7 +105,10 @@ public class PhiroRGBLightBrick extends FormulaBrick {
 
 	@Override
 	public int getRequiredResources() {
-		return BLUETOOTH_PHIRO;
+		return BLUETOOTH_PHIRO
+				| getFormulaWithBrickField(BrickField.PHIRO_LIGHT_RED).getRequiredResources()
+				| getFormulaWithBrickField(BrickField.PHIRO_LIGHT_GREEN).getRequiredResources()
+				| getFormulaWithBrickField(BrickField.PHIRO_LIGHT_BLUE).getRequiredResources();
 	}
 
 	@Override

--- a/catroid/src/org/catrobat/catroid/facedetection/FaceDetectionHandler.java
+++ b/catroid/src/org/catrobat/catroid/facedetection/FaceDetectionHandler.java
@@ -30,8 +30,6 @@ import android.util.Log;
 
 import org.catrobat.catroid.camera.CameraManager;
 import org.catrobat.catroid.formulaeditor.SensorCustomEventListener;
-import org.catrobat.catroid.formulaeditor.SensorHandler;
-import org.catrobat.catroid.ui.SettingsActivity;
 
 public final class FaceDetectionHandler {
 
@@ -58,10 +56,6 @@ public final class FaceDetectionHandler {
 	}
 
 	public static boolean startFaceDetection(Context context) {
-		if (context != null && !useFaceDetection(context)) {
-			SensorHandler.clearFaceDetectionValues();
-			return true;
-		}
 		if (running) {
 			return true;
 		}
@@ -158,10 +152,6 @@ public final class FaceDetectionHandler {
 			Log.e(TAG, "Camera unaccessable!", exception);
 		}
 		return possibleFaces > 0;
-	}
-
-	public static boolean useFaceDetection(Context context) {
-		return SettingsActivity.isFaceDetectionPreferenceEnabled(context);
 	}
 
 	@TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)

--- a/catroid/src/org/catrobat/catroid/ui/SettingsActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/SettingsActivity.java
@@ -139,6 +139,12 @@ public class SettingsActivity extends SherlockPreferenceActivity {
 				context.getString(R.string.preference_key_use_face_detection), context);
 	}
 
+	public static void setFaceDetectionSharedPreferenceEnabled(Context context, boolean value) {
+		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
+		editor.putBoolean(context.getString(R.string.preference_key_use_face_detection), value);
+		editor.commit();
+	}
+
 	public static boolean isMindstormsNXTSharedPreferenceEnabled(Context context) {
 		return getBooleanSharedPreference(false, SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, context);
 	}
@@ -152,9 +158,9 @@ public class SettingsActivity extends SherlockPreferenceActivity {
 		return getBooleanSharedPreference(false, SETTINGS_SHOW_PHIRO_BRICKS, context);
 	}
 
-	public static void setFaceDetectionSharedPreferenceEnabled(Context context, boolean value) {
+	public static void setPhiroSharedPreferenceEnabled(Context context, boolean value) {
 		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-		editor.putBoolean(context.getString(R.string.preference_key_use_face_detection), value);
+		editor.putBoolean(SETTINGS_SHOW_PHIRO_BRICKS, value);
 		editor.commit();
 	}
 
@@ -232,5 +238,9 @@ public class SettingsActivity extends SherlockPreferenceActivity {
 	public static boolean getShowLegoMindstormsSensorInfoDialog(Context context) {
 		SharedPreferences preferences = getSharedPreferences(context);
 		return preferences.getBoolean(SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED, false);
+	}
+
+	public static void resetSharedPreferences(Context context) {
+		getSharedPreferences(context).edit().clear().commit();
 	}
 }

--- a/catroidTest/src/org/catrobat/catroid/test/devices/phiro/PhiroSettingsTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/devices/phiro/PhiroSettingsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.devices.phiro;
+
+import android.content.Context;
+import android.test.InstrumentationTestCase;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.SetSizeToBrick;
+import org.catrobat.catroid.exceptions.CompatibilityProjectException;
+import org.catrobat.catroid.exceptions.LoadingProjectException;
+import org.catrobat.catroid.exceptions.OutdatedVersionProjectException;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.catrobat.catroid.formulaeditor.Sensors;
+import org.catrobat.catroid.test.utils.Reflection;
+import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+
+import java.io.IOException;
+
+public class PhiroSettingsTest extends InstrumentationTestCase {
+
+	Context context = null;
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+
+		context = this.getInstrumentation().getTargetContext();
+		SettingsActivity.setPhiroSharedPreferenceEnabled(context, false);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		SettingsActivity.setPhiroSharedPreferenceEnabled(context, false);
+		super.tearDown();
+	}
+
+	public void testIfPhiroBricksAreEnabledIfItItUsedInAProgram() throws IOException, CompatibilityProjectException, OutdatedVersionProjectException, LoadingProjectException {
+
+		createProjectPhiro();
+
+		assertFalse("By default phiro should be disabled",
+				SettingsActivity.isPhiroSharedPreferenceEnabled(context));
+
+		ProjectManager.getInstance().loadProject(UiTestUtils.DEFAULT_TEST_PROJECT_NAME, context);
+
+		assertTrue("After loading a project which needs phiro it should be enabled",
+				SettingsActivity.isPhiroSharedPreferenceEnabled(context));
+
+		ProjectManager.getInstance().deleteProject(UiTestUtils.DEFAULT_TEST_PROJECT_NAME, context);
+	}
+
+	private void createProjectPhiro() {
+		Project projectPhiro = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
+		Sprite sprite = new Sprite("Phiro");
+		StartScript startScript = new StartScript();
+		SetSizeToBrick setSizeToBrick = new SetSizeToBrick(new Formula(new FormulaElement(FormulaElement.ElementType.SENSOR,
+				Sensors.PHIRO_BOTTOM_LEFT.name(), null)));
+		startScript.addBrick(setSizeToBrick);
+		sprite.addScript(startScript);
+		projectPhiro.addSprite(sprite);
+
+		Reflection.setPrivateField(ProjectManager.getInstance(), "asynchronTask", false);
+		ProjectManager.getInstance().setProject(projectPhiro);
+		ProjectManager.getInstance().saveProject(context);
+		ProjectManager.getInstance().setProject(null);
+	}
+}

--- a/catroidTest/src/org/catrobat/catroid/test/facedetection/FaceDetectionSettingsTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/facedetection/FaceDetectionSettingsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.facedetection;
+
+import android.content.Context;
+import android.test.InstrumentationTestCase;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.SetSizeToBrick;
+import org.catrobat.catroid.exceptions.CompatibilityProjectException;
+import org.catrobat.catroid.exceptions.LoadingProjectException;
+import org.catrobat.catroid.exceptions.OutdatedVersionProjectException;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.catrobat.catroid.formulaeditor.Sensors;
+import org.catrobat.catroid.test.utils.Reflection;
+import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+
+import java.io.IOException;
+
+public class FaceDetectionSettingsTest extends InstrumentationTestCase {
+
+	Context context = null;
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+
+		context = this.getInstrumentation().getTargetContext();
+		SettingsActivity.setFaceDetectionSharedPreferenceEnabled(context, false);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		SettingsActivity.setFaceDetectionSharedPreferenceEnabled(context, false);
+		super.tearDown();
+	}
+
+	public void testIfFaceDetectionIsEnabledIfItIsUsedInAProgram() throws IOException, CompatibilityProjectException, OutdatedVersionProjectException, LoadingProjectException {
+
+		createProjectFaceDetection();
+
+		assertFalse("By default facedetection should be disabled",
+				SettingsActivity.isFaceDetectionPreferenceEnabled(context));
+
+		ProjectManager.getInstance().loadProject(UiTestUtils.DEFAULT_TEST_PROJECT_NAME, context);
+
+		assertTrue("After loading a project which needs facedetection it should be enabled",
+				SettingsActivity.isFaceDetectionPreferenceEnabled(context));
+
+		ProjectManager.getInstance().deleteProject(UiTestUtils.DEFAULT_TEST_PROJECT_NAME, context);
+	}
+
+	private void createProjectFaceDetection() {
+		Project projectFaceDetection = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
+		Sprite sprite = new Sprite("Facedetection!");
+		StartScript startScript = new StartScript();
+		SetSizeToBrick setSizeToBrick = new SetSizeToBrick(new Formula(new FormulaElement(FormulaElement.ElementType.SENSOR,
+				Sensors.FACE_SIZE.name(), null)));
+		startScript.addBrick(setSizeToBrick);
+		sprite.addScript(startScript);
+		projectFaceDetection.addSprite(sprite);
+
+		Reflection.setPrivateField(ProjectManager.getInstance(), "asynchronTask", false);
+		ProjectManager.getInstance().setProject(projectFaceDetection);
+		ProjectManager.getInstance().saveProject(context);
+		ProjectManager.getInstance().setProject(null);
+	}
+}

--- a/catroidTest/src/org/catrobat/catroid/test/ui/CategoryBricksFactoryTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/ui/CategoryBricksFactoryTest.java
@@ -30,6 +30,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.ui.fragment.CategoryBricksFactory;
 
 import java.util.List;
@@ -45,6 +46,8 @@ public class CategoryBricksFactoryTest extends AndroidTestCase {
 	protected void setUp() throws Exception {
 		super.setUp();
 		context = getContext();
+
+		SettingsActivity.resetSharedPreferences(context);
 
 		Project project = new Project(context, "Project");
 		background = project.getSpriteList().get(0);

--- a/catroidTest/src/org/catrobat/catroid/uitest/devices/mindstorms/nxt/LegoNXTPreferencesTests.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/devices/mindstorms/nxt/LegoNXTPreferencesTests.java
@@ -75,8 +75,13 @@ public class LegoNXTPreferencesTests extends BaseActivityInstrumentationTestCase
 		solo.waitForText(solo.getString(R.string.main_menu_new));
 		solo.clickOnText(solo.getString(R.string.main_menu_new));
 		solo.enterText(0, "testNXTAllBricksAvailable");
+
 		solo.waitForText(solo.getString(R.string.ok));
 		solo.clickOnText(solo.getString(R.string.ok));
+
+		solo.waitForText(solo.getString(R.string.ok));
+		solo.clickOnText(solo.getString(R.string.ok));
+
 		solo.waitForText(solo.getString(R.string.background));
 		solo.clickOnText(solo.getString(R.string.background));
 		solo.waitForText(solo.getString(R.string.scripts));
@@ -253,8 +258,13 @@ public class LegoNXTPreferencesTests extends BaseActivityInstrumentationTestCase
 		solo.waitForText(solo.getString(R.string.main_menu_new));
 		solo.clickOnText(solo.getString(R.string.main_menu_new));
 		solo.enterText(0, "testNXTSensorsAvailable");
+
 		solo.waitForText(solo.getString(R.string.ok));
 		solo.clickOnText(solo.getString(R.string.ok));
+
+		solo.waitForText(solo.getString(R.string.ok));
+		solo.clickOnText(solo.getString(R.string.ok));
+
 		solo.waitForText(solo.getString(R.string.background));
 		solo.clickOnText(solo.getString(R.string.background));
 		solo.waitForText(solo.getString(R.string.scripts));

--- a/catroidTest/src/org/catrobat/catroid/uitest/facedetection/FaceDetectionSettingTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/facedetection/FaceDetectionSettingTest.java
@@ -77,19 +77,6 @@ public class FaceDetectionSettingTest extends BaseActivityInstrumentationTestCas
 		super.tearDown();
 	}
 
-	public void testFaceDetectionDefaultPreference() {
-		UiTestUtils.clickOnBottomBar(solo, R.id.button_play);
-		solo.waitForActivity(StageActivity.class.getSimpleName());
-
-		assertFalse("Default preference for using face detection should be <false>",
-				FaceDetectionHandler.isFaceDetectionRunning());
-
-		solo.sleep(500);
-
-		solo.goBackToActivity(MainMenuActivity.class.getSimpleName());
-		solo.waitForActivity(MainMenuActivity.class.getSimpleName());
-	}
-
 	public void testReadFaceDetectionPreference() {
 		setFaceDetectionPreference(false);
 
@@ -98,7 +85,7 @@ public class FaceDetectionSettingTest extends BaseActivityInstrumentationTestCas
 		solo.waitForActivity(StageActivity.class.getSimpleName());
 		solo.sleep(1000);
 
-		assertFalse("Face Detection was started although disabled in settings",
+		assertTrue("Face Detection should be started if needed, although it is disabled in settings",
 				FaceDetectionHandler.isFaceDetectionRunning());
 
 		solo.goBackToActivity(MainMenuActivity.class.getSimpleName());


### PR DESCRIPTION
facedetection works now even if it is disabled in the settings. The facedetection setting affects now only the sensor list, i.e. if the facedetection sensors are visible or not

Additionally:
 - fix phiro resource issue
 - phiro and facedetection gets enabled in the settings if a program with a resource of them are opened
 - added tests for new behavior of facedetection and phiro
 - fixed 2 nxt tests issues due to new orientation dialog

[Jenkins Test Run](https://jenkins.catrob.at/view/All-Categories/view/Catroid-multi-job/job/Catroid-Multi-Job-Custom-Branch-RELOADED/2349/)