### PR TITLE
Add custom Checkstyle checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
     pmd 'net.sourceforge.pmd:pmd:5.1.1'
-	checkstyle 'com.puppycrawl.tools:checkstyle:6.7'
+    checkstyle project(':catroidSourceTest')
 }
 
 task copyAndroidNatives() {

--- a/catroid/src/org/catrobat/catroid/ui/fragment/SoundFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/SoundFragment.java
@@ -550,7 +550,7 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 			case R.id.context_menu_delete:
 				showConfirmDeleteDialog();
 				break;
-			case  R.id.context_menu_move_down:
+			case R.id.context_menu_move_down:
 				moveSoundDown();
 				break;
 			case R.id.context_menu_move_to_bottom:

--- a/catroidSourceTest/build.gradle
+++ b/catroidSourceTest/build.gradle
@@ -7,10 +7,16 @@ apply plugin: 'java'
 dependencies {
     testCompile files( project(":").buildDir.getPath() + '/intermediates/classes/debug' )
     testCompile 'junit:junit:4.12'
+
+    compile fileTree(include: ['*.jar'], dir: 'libs')
+    compile 'com.puppycrawl.tools:checkstyle:6.7'
 }
 
 sourceSets {
     main {
+        checkstyle {
+            java.srcDir 'checkstyle/src'
+        }
         test {
             java.srcDir 'src'
         }

--- a/catroidSourceTest/checkstyle/src/org/catrobat/catroid/checks/GroupImportsCheck.java
+++ b/catroidSourceTest/checkstyle/src/org/catrobat/catroid/checks/GroupImportsCheck.java
@@ -1,0 +1,120 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.checks;
+
+import com.puppycrawl.tools.checkstyle.Utils;
+import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+public class GroupImportsCheck extends Check {
+	public static final String MESSAGE = "Group imports by the first package identifier.";
+	public static final String NO_COMMENTS_ALLOWED_MESSAGE = "Comments in the import section will be removed or rearranged by the Android Studio formatter. Remove or move them.";
+
+	private static final int[] IMPORT_TYPES = new int[] { TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT };
+
+	private String[] lines;
+
+	@Override
+	public int[] getDefaultTokens() {
+		return new int[] { TokenTypes.IMPORT };
+	}
+
+	@Override
+	public boolean isCommentNodesRequired() {
+		return true;
+	}
+
+	@Override
+	public void beginTree(DetailAST rootAST) {
+		super.beginTree(rootAST);
+		this.lines = getLines();
+		logCommentsInImportSection(rootAST);
+	}
+
+	private void logCommentsInImportSection(DetailAST rootAST) {
+		DetailAST packageDefintion = null;
+		DetailAST lastImport = null;
+
+		DetailAST currentAst = rootAST;
+		while (currentAst != null) {
+			if (currentAst.getType() == TokenTypes.PACKAGE_DEF) {
+				packageDefintion = currentAst;
+			} else if (isImport(currentAst)) {
+				lastImport = currentAst;
+			}
+			currentAst = currentAst.getNextSibling();
+		}
+
+		if (lastImport == null) {
+			return;
+		}
+
+		currentAst = packageDefintion;
+		while (currentAst != null && currentAst != lastImport) {
+			if (Utils.isCommentType(currentAst.getType())) {
+				log(currentAst.getLineNo(), NO_COMMENTS_ALLOWED_MESSAGE);
+			}
+			currentAst = currentAst.getNextSibling();
+		}
+	}
+
+	@Override
+	public void visitToken(DetailAST ast) {
+		DetailAST nextSibling = ast.getNextSibling();
+		while (nextSibling != null && ast.getLineNo() == nextSibling.getLineNo()) {
+			nextSibling = nextSibling.getNextSibling();
+		}
+
+		if (nextSibling != null
+				&& isImport(nextSibling)
+				&& nextSibling.getLineNo() - ast.getLineNo() > 1
+				&& haveSameRootPackageIdentifier(ast, nextSibling)) {
+			log(ast.getLineNo() + 1, MESSAGE);
+		}
+	}
+
+	private boolean isImport(DetailAST ast) {
+		for (int importType : IMPORT_TYPES) {
+			if (ast.getType() == importType) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean haveSameRootPackageIdentifier(DetailAST firstImportAst, DetailAST secondImportAst) {
+		String firstRootPackageIdentifier = getRootPackageIdentifier(getLine(firstImportAst));
+		String secondRootPackageIdentifier = getRootPackageIdentifier(getLine(secondImportAst));
+		return firstRootPackageIdentifier.equals(secondRootPackageIdentifier);
+	}
+
+	private String getLine(DetailAST ast) {
+		return lines[ast.getLineNo() - 1];
+	}
+
+	private String getRootPackageIdentifier(String line) {
+		return line.substring(line.indexOf(' ') + 1, line.indexOf('.'));
+	}
+}

--- a/catroidSourceTest/checkstyle/src/org/catrobat/catroid/checks/GroupTokensCheck.java
+++ b/catroidSourceTest/checkstyle/src/org/catrobat/catroid/checks/GroupTokensCheck.java
@@ -1,0 +1,45 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.checks;
+
+import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+public class GroupTokensCheck extends Check {
+	public static final String MESSAGE = "Keep else-if tokens on the same line";
+
+	@Override
+	public int[] getDefaultTokens() {
+		return new int[] { TokenTypes.LITERAL_ELSE };
+	}
+
+	@Override
+	public void visitToken(DetailAST ast) {
+		DetailAST child = ast.getFirstChild();
+		if (child != null && child.getType() == TokenTypes.LITERAL_IF && ast.getLineNo() != child.getLineNo()) {
+			log(ast.getLineNo(), MESSAGE);
+		}
+	}
+}

--- a/catroidSourceTest/checkstyle/src/org/catrobat/catroid/checks/SingleSpaceSeparatorCheck.java
+++ b/catroidSourceTest/checkstyle/src/org/catrobat/catroid/checks/SingleSpaceSeparatorCheck.java
@@ -1,0 +1,73 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.checks;
+
+import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+public class SingleSpaceSeparatorCheck extends Check {
+	private static final String MESSAGE = "Only use a single space to separate tokens";
+
+	@Override
+	public int[] getDefaultTokens() {
+		return new int[] { TokenTypes.EOF };
+	}
+
+	@Override
+	public void beginTree(DetailAST rootAST) {
+		visitEachToken(rootAST);
+	}
+
+	private void visitEachToken(DetailAST ast) {
+		DetailAST sibling = ast;
+		while (sibling != null) {
+			checkJavaToken(sibling);
+			if (sibling.getChildCount() > 0) {
+				visitEachToken(sibling.getFirstChild());
+			}
+			sibling = sibling.getNextSibling();
+		}
+	}
+
+	private void checkJavaToken(DetailAST ast) {
+		if (ast.getColumnNo() < 2) {
+			return;
+		}
+
+		String line = getLine(ast.getLineNo() - 1);
+		char precedingChar = line.charAt(ast.getColumnNo() - 1);
+		char prePrecedingChar = line.charAt(ast.getColumnNo() - 2);
+		if (Character.isWhitespace(precedingChar) && !isFirstTokenInLine(ast)
+				&& (precedingChar != ' ' || Character.isWhitespace(prePrecedingChar))) {
+			log(ast.getLineNo(), ast.getColumnNo() - 1, MESSAGE);
+		}
+	}
+
+	private boolean isFirstTokenInLine(DetailAST ast) {
+		String line = getLine(ast.getLineNo() - 1);
+		return line.substring(0, ast.getColumnNo()).trim().length() == 0;
+	}
+}
+

--- a/catroidTest/src/org/catrobat/catroid/uitest/web/UserConceptTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/web/UserConceptTest.java
@@ -38,7 +38,6 @@ import org.catrobat.catroid.test.utils.Reflection;
 import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.uitest.annotation.Device;
 import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
-
 import org.catrobat.catroid.uitest.util.UiTestUtils;
 import org.catrobat.catroid.web.ServerCalls;
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -33,6 +33,11 @@
     <!-- To enable SuppressWithNearbyCommentFilter -->
     <module name="FileContentsHolder" />
 
+    <!-- Custom Catroid checks -->
+    <module name="org.catrobat.catroid.checks.GroupImportsCheck" />
+    <module name="org.catrobat.catroid.checks.GroupTokensCheck" />
+    <module name="org.catrobat.catroid.checks.SingleSpaceSeparatorCheck" />
+
     <!-- Annotations -->
     <module name="AnnotationLocation">
       <property name="allowSamelineMultipleAnnotations" value="false" />


### PR DESCRIPTION
The new checks GroupImportsCheck, GroupTokensCheck, and
SingleSpaceSeparatorCheck deal with unformatted code according to the
Android Studio Formatter which Checkstyle misses.

- GroupImportsCheck: Imports are grouped by the first package
  identifier (e.g. org, com or java). The core Checkstyle tool only
  checks if those groups are separated correctly but doesn't check if
  the group itself isn't separated.

- GroupTokensCheck: else-if tokens have to be on the same line. Closes
  CAT-1542

- SingleSpaceSeparatorCheck: Java tokens are separated by a single
  space. Multiple or other whitespace characters aren't allowed. Closes
  CAT-1479 and CAT-1484.

https://jira.catrob.at/browse/CAT-1479
https://jira.catrob.at/browse/CAT-1484
https://jira.catrob.at/browse/CAT-1542

--- END OF COMMIT MESSAGE ---

I can has custom checkstyle checkz plz?

The checks are tested well. However, there is no way to get these tests from the Checkstyle testing framework to Catroid. I can provide a clone of the Checkstyle project including the tests if really necessary.

Anybody who knows gradle should also take a look at the changes. It works on jenkins and my machine.