### PR TITLE
Adapt formatter to separate static import groups

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -41,6 +41,24 @@
             <emptyLine />
             <package name="" withSubpackages="true" static="false" />
             <emptyLine />
+            <package name="android" withSubpackages="true" static="true" />
+            <emptyLine />
+            <package name="com" withSubpackages="true" static="true" />
+            <emptyLine />
+            <package name="cucumber" withSubpackages="true" static="true" />
+            <emptyLine />
+            <package name="edu" withSubpackages="true" static="true" />
+            <emptyLine />
+            <package name="junit" withSubpackages="true" static="true" />
+            <emptyLine />
+            <package name="net" withSubpackages="true" static="true" />
+            <emptyLine />
+            <package name="org" withSubpackages="true" static="true" />
+            <emptyLine />
+            <package name="java" withSubpackages="true" static="true" />
+            <emptyLine />
+            <package name="javax" withSubpackages="true" static="true" />
+            <emptyLine />
             <package name="" withSubpackages="true" static="true" />
           </value>
         </option>


### PR DESCRIPTION
The Android Studio formatter separates static import groups (android,
com, java, ...) by an empty newline now. Like it already does with
normal imports. Checkstyle also requires separated static import groups.