### PR TITLE
Remove Windows line ending checks

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -207,13 +207,9 @@
 
   <module name="NewlineAtEndOfFile">
     <property name="fileExtensions" value="java" />
-    <property name="lineSeparator" value="lf" />
+    <property name="lineSeparator" value="lf_cr_crlf" />
   </module>
   <module name="UniqueProperties" />
-  <module name="RegexpMultiline">
-    <property name="format" value="\r" />
-    <property name="message" value="Do not use Windows line endings." />
-  </module>
 
   <module name="RegexpHeader">
     <property name="headerFile" value="catroidSourceTest/res/agpl_license_text.txt" />


### PR DESCRIPTION
According to our .gitattributes configuration, checking out files will
convert line endings to native ones and committing will convert line
endings back to LF. Therefore, checking out files on Windows will
convert line endings to CRLF locally. Checkstyle doesn't permit CRLF
line endings and will show lots of errors when ran locally. Since git
normalize line endings on commits automatically, there is no need to
check for unified line endings.

- Remove Windows line ending regexp check
- Adapt NewlineAtEndOfFile check to allow any newline style.