### PR TITLE
Fix non unique ids for undo/redo

### DIFF
--- a/catroid/src/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/org/catrobat/catroid/ProjectManager.java
@@ -64,6 +64,7 @@ import org.catrobat.catroid.transfers.CheckTokenTask.OnCheckTokenCompleteListene
 import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.ui.dialogs.LoginRegisterDialog;
 import org.catrobat.catroid.ui.dialogs.UploadProjectDialog;
+import org.catrobat.catroid.utils.IdPool;
 import org.catrobat.catroid.utils.Utils;
 import org.catrobat.catroid.web.ServerCalls;
 
@@ -75,6 +76,8 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 	private static final ProjectManager INSTANCE = new ProjectManager();
 	private static final String TAG = ProjectManager.class.getSimpleName();
 
+	private final IdPool idPool = new IdPool();
+
 	private Project project;
 	private Script currentScript;
 	private Sprite currentSprite;
@@ -83,7 +86,6 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 	private boolean comingFromScriptFragmentToSoundFragment;
 	private boolean comingFromScriptFragmentToLooksFragment;
 	private boolean handleCorrectAddButton;
-	private ArrayList<Integer> idList = new ArrayList<>();
 	private FileChecksumContainer fileChecksumContainer = new FileChecksumContainer();
 
 	private ProjectManager() {
@@ -121,12 +123,7 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 	}
 
 	public int getNewId() {
-		int id = 0;
-		while (idList.contains(id)) {
-			id++;
-		}
-		idList.add(id);
-		return id;
+		return idPool.getNewId();
 	}
 
 	public void uploadProject(String projectName, FragmentActivity fragmentActivity) {
@@ -221,6 +218,26 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 		}
 
 		if (project != null) {
+			idPool.clear();
+			for (Sprite sprite : project.getSpriteList()) {
+				idPool.voidId(sprite.getId());
+				for (LookData lookData : sprite.getLookDataList()) {
+					idPool.voidId(lookData.getId());
+				}
+				for (SoundInfo soundInfo : sprite.getSoundList()) {
+					idPool.voidId(soundInfo.getId());
+				}
+				for (PlaySoundBrick playSoundBrick : sprite.getPlaySoundBricks()) {
+					idPool.voidId(playSoundBrick.getId());
+				}
+				for (PointToBrick pointToBrick : sprite.getPointToBricks()) {
+					idPool.voidId(pointToBrick.getId());
+				}
+				for (SetLookBrick setLookBrick : sprite.getSetLookBricks()) {
+					idPool.voidId(setLookBrick.getId());
+				}
+			}
+
 			for (Sprite sprite : project.getSpriteList()) {
 				setCurrentSprite(sprite);
 				LookDataHistory.getInstance(sprite.getId()).update();

--- a/catroid/src/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/org/catrobat/catroid/ProjectManager.java
@@ -219,24 +219,7 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 
 		if (project != null) {
 			idPool.clear();
-			for (Sprite sprite : project.getSpriteList()) {
-				idPool.voidId(sprite.getId());
-				for (LookData lookData : sprite.getLookDataList()) {
-					idPool.voidId(lookData.getId());
-				}
-				for (SoundInfo soundInfo : sprite.getSoundList()) {
-					idPool.voidId(soundInfo.getId());
-				}
-				for (PlaySoundBrick playSoundBrick : sprite.getPlaySoundBricks()) {
-					idPool.voidId(playSoundBrick.getId());
-				}
-				for (PointToBrick pointToBrick : sprite.getPointToBricks()) {
-					idPool.voidId(pointToBrick.getId());
-				}
-				for (SetLookBrick setLookBrick : sprite.getSetLookBricks()) {
-					idPool.voidId(setLookBrick.getId());
-				}
-			}
+			voidIdsAfterLoading(project);
 
 			for (Sprite sprite : project.getSpriteList()) {
 				setCurrentSprite(sprite);
@@ -256,6 +239,27 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 
 			if ((resources & Brick.FACE_DETECTION) > 0) {
 				SettingsActivity.setFaceDetectionSharedPreferenceEnabled(context, true);
+			}
+		}
+	}
+
+	private void voidIdsAfterLoading(Project project) {
+		for (Sprite sprite : project.getSpriteList()) {
+			idPool.voidId(sprite.getLoadedId());
+			for (LookData lookData : sprite.getLookDataList()) {
+				idPool.voidId(lookData.getLoadedId());
+			}
+			for (SoundInfo soundInfo : sprite.getSoundList()) {
+				idPool.voidId(soundInfo.getLoadedId());
+			}
+			for (PlaySoundBrick playSoundBrick : sprite.getPlaySoundBricks()) {
+				idPool.voidId(playSoundBrick.getLoadedId());
+			}
+			for (PointToBrick pointToBrick : sprite.getPointToBricks()) {
+				idPool.voidId(pointToBrick.getLoadedId());
+			}
+			for (SetLookBrick setLookBrick : sprite.getSetLookBricks()) {
+				idPool.voidId(setLookBrick.getLoadedId());
 			}
 		}
 	}

--- a/catroid/src/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/org/catrobat/catroid/common/LookData.java
@@ -63,7 +63,6 @@ public class LookData implements Serializable, Cloneable {
 
 		cloneLookData.name = this.name;
 		cloneLookData.fileName = this.fileName;
-		cloneLookData.id = this.id;
 		String filePath = getPathToImageDirectory() + "/" + fileName;
 		try {
 			ProjectManager.getInstance().getFileChecksumContainer().incrementUsage(filePath);
@@ -82,10 +81,6 @@ public class LookData implements Serializable, Cloneable {
 
 	public int getId() {
 		return this.id;
-	}
-
-	public void setId(int id) {
-		this.id = id;
 	}
 
 	public TextureRegion getTextureRegion() {

--- a/catroid/src/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/org/catrobat/catroid/common/LookData.java
@@ -55,7 +55,7 @@ public class LookData implements Serializable, Cloneable {
 	private transient Pixmap pixmap = null;
 	private transient Pixmap originalPixmap = null;
 	private transient TextureRegion region = null;
-	private int id = ProjectManager.getInstance().getNewId();
+	private int id;
 
 	@Override
 	public LookData clone() {
@@ -80,7 +80,10 @@ public class LookData implements Serializable, Cloneable {
 	}
 
 	public int getId() {
-		return this.id;
+		if (id == 0) {
+			id = ProjectManager.getInstance().getNewId();
+		}
+		return id;
 	}
 
 	public TextureRegion getTextureRegion() {

--- a/catroid/src/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/org/catrobat/catroid/common/LookData.java
@@ -86,6 +86,10 @@ public class LookData implements Serializable, Cloneable {
 		return id;
 	}
 
+	public int getLoadedId() {
+		return id;
+	}
+
 	public TextureRegion getTextureRegion() {
 		if (region == null) {
 			region = new TextureRegion(new Texture(getPixmap()));

--- a/catroid/src/org/catrobat/catroid/common/SoundInfo.java
+++ b/catroid/src/org/catrobat/catroid/common/SoundInfo.java
@@ -40,7 +40,7 @@ public class SoundInfo implements Serializable, Comparable<SoundInfo>, Cloneable
 	private String name;
 	private String fileName;
 	public transient boolean isPlaying;
-	private int id = ProjectManager.getInstance().getNewId();
+	private int id;
 
 	public SoundInfo() {
 	}
@@ -75,7 +75,10 @@ public class SoundInfo implements Serializable, Comparable<SoundInfo>, Cloneable
 	}
 
 	public int getId() {
-		return this.id;
+		if (id == 0) {
+			id = ProjectManager.getInstance().getNewId();
+		}
+		return id;
 	}
 
 	public String getAbsolutePath() {

--- a/catroid/src/org/catrobat/catroid/common/SoundInfo.java
+++ b/catroid/src/org/catrobat/catroid/common/SoundInfo.java
@@ -81,6 +81,10 @@ public class SoundInfo implements Serializable, Comparable<SoundInfo>, Cloneable
 		return id;
 	}
 
+	public int getLoadedId() {
+		return id;
+	}
+
 	public String getAbsolutePath() {
 		if (fileName != null) {
 			return Utils.buildPath(getPathToSoundDirectory(), fileName);

--- a/catroid/src/org/catrobat/catroid/common/SoundInfo.java
+++ b/catroid/src/org/catrobat/catroid/common/SoundInfo.java
@@ -51,7 +51,6 @@ public class SoundInfo implements Serializable, Comparable<SoundInfo>, Cloneable
 
 		cloneSoundInfo.name = this.name;
 		cloneSoundInfo.fileName = this.fileName;
-		cloneSoundInfo.id = this.id;
 
 		return cloneSoundInfo;
 	}
@@ -77,10 +76,6 @@ public class SoundInfo implements Serializable, Comparable<SoundInfo>, Cloneable
 
 	public int getId() {
 		return this.id;
-	}
-
-	public void setId(int id) {
-		this.id = id;
 	}
 
 	public String getAbsolutePath() {

--- a/catroid/src/org/catrobat/catroid/common/StandardProjectHandler.java
+++ b/catroid/src/org/catrobat/catroid/common/StandardProjectHandler.java
@@ -502,7 +502,6 @@ public final class StandardProjectHandler {
 			ProjectManager.getInstance().getFileChecksumContainer().addChecksum(soundFile2.getName(), soundFile2.getAbsolutePath());
 
 			mole2Sprite.setName(mole2Name);
-			mole2Sprite.setId(ProjectManager.getInstance().getNewId());
 			defaultProject.addSprite(mole2Sprite);
 
 			Script tempScript = mole2Sprite.getScript(0);
@@ -521,7 +520,6 @@ public final class StandardProjectHandler {
 			ProjectManager.getInstance().getFileChecksumContainer().addChecksum(soundFile3.getName(), soundFile3.getAbsolutePath());
 
 			mole3Sprite.setName(mole3Name);
-			mole3Sprite.setId(ProjectManager.getInstance().getNewId());
 			defaultProject.addSprite(mole3Sprite);
 
 			tempScript = mole3Sprite.getScript(0);
@@ -540,7 +538,6 @@ public final class StandardProjectHandler {
 			ProjectManager.getInstance().getFileChecksumContainer().addChecksum(soundFile4.getName(), soundFile4.getAbsolutePath());
 
 			mole4Sprite.setName(mole4Name);
-			mole4Sprite.setId(ProjectManager.getInstance().getNewId());
 			defaultProject.addSprite(mole4Sprite);
 
 			tempScript = mole4Sprite.getScript(0);

--- a/catroid/src/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/org/catrobat/catroid/content/Sprite.java
@@ -64,7 +64,7 @@ public class Sprite implements Serializable, Cloneable {
 	private ArrayList<UserBrick> userBricks;
 	private transient int newUserBrickNext = 1;
 
-	private Integer id;
+	private int id = ProjectManager.getInstance().getNewId();
 
 	public Sprite(String name) {
 		this.name = name;
@@ -112,9 +112,6 @@ public class Sprite implements Serializable, Cloneable {
 		}
 		if (userBricks == null) {
 			userBricks = new ArrayList<UserBrick>();
-		}
-		if (this.id == null) {
-			this.id = ProjectManager.getInstance().getNewId();
 		}
 	}
 

--- a/catroid/src/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/org/catrobat/catroid/content/Sprite.java
@@ -64,7 +64,7 @@ public class Sprite implements Serializable, Cloneable {
 	private ArrayList<UserBrick> userBricks;
 	private transient int newUserBrickNext = 1;
 
-	private int id = ProjectManager.getInstance().getNewId();
+	private int id;
 
 	public Sprite(String name) {
 		this.name = name;
@@ -96,7 +96,10 @@ public class Sprite implements Serializable, Cloneable {
 	}
 
 	public int getId() {
-		return this.id;
+		if (id == 0) {
+			id = ProjectManager.getInstance().getNewId();
+		}
+		return id;
 	}
 	private void init() {
 		look = new Look(this);

--- a/catroid/src/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/org/catrobat/catroid/content/Sprite.java
@@ -38,6 +38,7 @@ import org.catrobat.catroid.common.SoundInfo;
 import org.catrobat.catroid.content.actions.ExtendedActions;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.PlaySoundBrick;
+import org.catrobat.catroid.content.bricks.PointToBrick;
 import org.catrobat.catroid.content.bricks.SetLookBrick;
 import org.catrobat.catroid.content.bricks.UserBrick;
 import org.catrobat.catroid.content.bricks.UserScriptDefinitionBrick;
@@ -63,7 +64,6 @@ public class Sprite implements Serializable, Cloneable {
 	private ArrayList<SoundInfo> soundList;
 	private ArrayList<UserBrick> userBricks;
 	private transient int newUserBrickNext = 1;
-
 	private int id;
 
 	public Sprite(String name) {
@@ -147,6 +147,16 @@ public class Sprite implements Serializable, Cloneable {
 		for (Brick brick : getAllBricks()) {
 			if (brick instanceof PlaySoundBrick) {
 				result.add((PlaySoundBrick) brick);
+			}
+		}
+		return result;
+	}
+
+	public List<PointToBrick> getPointToBricks() {
+		List<PointToBrick> result = new ArrayList<>();
+		for (Brick brick : getAllBricks()) {
+			if (brick instanceof PointToBrick) {
+				result.add((PointToBrick) brick);
 			}
 		}
 		return result;

--- a/catroid/src/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/org/catrobat/catroid/content/Sprite.java
@@ -101,6 +101,11 @@ public class Sprite implements Serializable, Cloneable {
 		}
 		return id;
 	}
+
+	public int getLoadedId() {
+		return id;
+	}
+
 	private void init() {
 		look = new Look(this);
 		isPaused = false;

--- a/catroid/src/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/org/catrobat/catroid/content/Sprite.java
@@ -95,10 +95,6 @@ public class Sprite implements Serializable, Cloneable {
 		return this;
 	}
 
-	public void setId(int id) {
-		this.id = id;
-	}
-
 	public int getId() {
 		return this.id;
 	}
@@ -244,7 +240,6 @@ public class Sprite implements Serializable, Cloneable {
 	public Sprite clone() {
 		final Sprite cloneSprite = new Sprite();
 		cloneSprite.setName(this.getName());
-		cloneSprite.setId(this.id);
 
 		Project currentProject = ProjectManager.getInstance().getCurrentProject();
 		if (currentProject == null || !currentProject.getSpriteList().contains(this)) {

--- a/catroid/src/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
@@ -58,7 +58,7 @@ public class PlaySoundBrick extends BrickBaseType implements OnItemSelectedListe
 	private static final long serialVersionUID = 1L;
 
 	private SoundInfo sound;
-	private int id = ProjectManager.getInstance().getNewId();
+	private int id;
 	private transient SoundInfo oldSelectedSound;
 	private transient AdapterView<?> adapterView;
 
@@ -66,6 +66,9 @@ public class PlaySoundBrick extends BrickBaseType implements OnItemSelectedListe
 	}
 
 	public int getId() {
+		if (id == 0) {
+			id = ProjectManager.getInstance().getNewId();
+		}
 		return id;
 	}
 

--- a/catroid/src/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
@@ -72,6 +72,10 @@ public class PlaySoundBrick extends BrickBaseType implements OnItemSelectedListe
 		return id;
 	}
 
+	public int getLoadedId() {
+		return id;
+	}
+
 	@Override
 	public int getRequiredResources() {
 		return NO_RESOURCES;

--- a/catroid/src/org/catrobat/catroid/content/bricks/PointToBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PointToBrick.java
@@ -64,7 +64,7 @@ public class PointToBrick extends BrickBaseType {
 
 	private static final long serialVersionUID = 1L;
 	private Sprite pointedObject;
-	private int id = ProjectManager.getInstance().getNewId();
+	private int id;
 	private transient String oldSelectedObject;
 	private transient AdapterView<?> adapterView;
 	private transient SpinnerAdapterWrapper spinnerAdapterWrapper;
@@ -78,6 +78,9 @@ public class PointToBrick extends BrickBaseType {
 	}
 
 	public int getId() {
+		if (id == 0) {
+			id = ProjectManager.getInstance().getNewId();
+		}
 		return id;
 	}
 

--- a/catroid/src/org/catrobat/catroid/content/bricks/PointToBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PointToBrick.java
@@ -84,6 +84,10 @@ public class PointToBrick extends BrickBaseType {
 		return id;
 	}
 
+	public int getLoadedId() {
+		return id;
+	}
+
 	@Override
 	public int getRequiredResources() {
 		return NO_RESOURCES;

--- a/catroid/src/org/catrobat/catroid/content/bricks/SetLookBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/SetLookBrick.java
@@ -56,7 +56,7 @@ import java.util.List;
 public class SetLookBrick extends BrickBaseType implements OnLookDataListChangedAfterNewListener {
 	private static final long serialVersionUID = 1L;
 	private LookData look;
-	private int id = ProjectManager.getInstance().getNewId();
+	private int id;
 	private transient View prototypeView;
 	private transient LookData oldSelectedLook;
 	private transient AdapterView<?> adapterView;
@@ -65,6 +65,9 @@ public class SetLookBrick extends BrickBaseType implements OnLookDataListChanged
 	}
 
 	public int getId() {
+		if (id == 0) {
+			id = ProjectManager.getInstance().getNewId();
+		}
 		return id;
 	}
 

--- a/catroid/src/org/catrobat/catroid/content/bricks/SetLookBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/SetLookBrick.java
@@ -71,6 +71,10 @@ public class SetLookBrick extends BrickBaseType implements OnLookDataListChanged
 		return id;
 	}
 
+	public int getLoadedId() {
+		return id;
+	}
+
 	public void setLook(LookData lookData) {
 		this.look = lookData;
 	}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
@@ -483,7 +483,6 @@ public class SpritesListFragment extends SherlockListFragment implements OnSprit
 		Sprite copiedSprite = spriteToEdit.clone();
 		copiedSprite.setName(getSpriteName(spriteToEdit.getName().concat(getString(R.string.copy_sprite_name_suffix)),
 				0));
-		copiedSprite.setId(ProjectManager.getInstance().getNewId());
 
 		ProjectManager projectManager = ProjectManager.getInstance();
 

--- a/catroid/src/org/catrobat/catroid/utils/IdPool.java
+++ b/catroid/src/org/catrobat/catroid/utils/IdPool.java
@@ -1,0 +1,48 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.utils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class IdPool {
+	private final Set<Integer> ids = new HashSet<>();
+
+	public int getNewId() {
+		int id = 1;
+		while (ids.contains(id)) {
+			id++;
+		}
+		voidId(id);
+		return id;
+	}
+
+	public void clear() {
+		ids.clear();
+	}
+
+	public void voidId(int id) {
+		ids.add(id);
+	}
+}

--- a/catroidTest/src/org/catrobat/catroid/test/history/UniqueIdTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/history/UniqueIdTest.java
@@ -1,0 +1,81 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.history;
+
+import android.test.AndroidTestCase;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.exceptions.CompatibilityProjectException;
+import org.catrobat.catroid.exceptions.LoadingProjectException;
+import org.catrobat.catroid.exceptions.OutdatedVersionProjectException;
+import org.catrobat.catroid.test.utils.Reflection;
+import org.catrobat.catroid.test.utils.TestUtils;
+import org.catrobat.catroid.utils.IdPool;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class UniqueIdTest extends AndroidTestCase {
+
+	private final ProjectManager pm = ProjectManager.getInstance();
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		Reflection.setPrivateField(pm, "asynchronTask", false);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		Reflection.setPrivateField(pm, "asynchronTask", true);
+		super.tearDown();
+	}
+
+	public void testUniqueId() throws CompatibilityProjectException, OutdatedVersionProjectException, LoadingProjectException {
+		Project project = TestUtils.createEmptyProject();
+		Sprite firstSprite = new Sprite("A");
+		project.addSprite(firstSprite);
+		project.addSprite(new Sprite("B"));
+		project.removeSprite(firstSprite);
+
+		pm.setProject(project);
+		pm.saveProject(getContext());
+		Reflection.setPrivateField(pm, "idPool", new IdPool());
+//		Reflection.setPrivateField(pm, "idList", new ArrayList<Integer>());
+		pm.loadProject(project.getName(), getContext());
+		project = pm.getCurrentProject();
+
+		project.addSprite(new Sprite("C"));
+		project.addSprite(new Sprite("D"));
+
+		Set<Integer> ids = new HashSet<>();
+		for (Sprite sprite : project.getSpriteList()) {
+			int id = sprite.getId();
+			assertFalse("Id is not unique", ids.contains(id));
+			ids.add(id);
+		}
+	}
+}

--- a/catroidTest/src/org/catrobat/catroid/test/utils/IdPoolTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/utils/IdPoolTest.java
@@ -1,0 +1,62 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.utils;
+
+import android.test.AndroidTestCase;
+
+import com.google.common.primitives.Ints;
+
+import org.catrobat.catroid.utils.IdPool;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class IdPoolTest extends AndroidTestCase {
+
+	public void testUniqueIds() {
+		IdPool idPool = new IdPool();
+		Set<Integer> usedIds = new HashSet<>();
+
+		for (int i = 0; i < 128; i++) {
+			int newId = idPool.getNewId();
+			assertFalse("IdPool doesn't return unique ids", usedIds.contains(newId));
+			usedIds.add(newId);
+		}
+	}
+
+	public void testVoidIds() {
+		IdPool idPool = new IdPool();
+		List<Integer> voidedIds = Ints.asList(1, 3, 5, 7, 9, 15, 20);
+
+		for (int id : voidedIds) {
+			idPool.voidId(id);
+		}
+
+		for (int i = 0; i < 24; i++) {
+			int newId = idPool.getNewId();
+			assertFalse("IdPool returned voided id", voidedIds.contains(newId));
+		}
+	}
+}


### PR DESCRIPTION
After a project has been loaded, all used object ids (Sprite, LookData,
SoundInfo and some Bricks) have to be voided. So the ProjectManager
will only hand out unique ids.