### PR TITLE
Adapt checkstyle rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,26 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import java.util.regex.Pattern
 
 buildscript {
@@ -91,7 +114,7 @@ dependencies {
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
     pmd 'net.sourceforge.pmd:pmd:5.1.1'
-	checkstyle 'com.puppycrawl.tools:checkstyle:6.7'
+    checkstyle 'com.puppycrawl.tools:checkstyle:6.7'
 }
 
 task copyAndroidNatives() {
@@ -230,7 +253,6 @@ if (project.hasProperty('jenkins')) {
                 }
                 manifestOutputFile.write(generatedContent)
             }
-
         }
     }
 }

--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -91,7 +91,6 @@
     <!--  -->
 
 
-
     <!-- New Object Dialog -->
     <string name="dialog_new_object_pocketpaint">Draw Image</string>
     <string name="dialog_new_object_gallery">Select Image</string>

--- a/catroidSourceTest/build.gradle
+++ b/catroidSourceTest/build.gradle
@@ -1,3 +1,26 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 repositories{
     mavenCentral()
 }

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -239,6 +239,12 @@
     <property name="message" value="Maximum of blank lines is 1" />
   </module>
 
+  <module name="RegexpMultiline">
+    <property name="fileExtensions" value="xml" />
+    <property name="format" value=".\n{4,}" />
+    <property name="message" value="Maximum of blank lines is 2" />
+  </module>
+
   <module name="RegexpSingleline">
     <property name="fileExtensions" value="java" />
     <property name="format" value="^\s+$" />

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -206,14 +206,13 @@
   </module>
 
   <module name="NewlineAtEndOfFile">
-    <property name="fileExtensions" value="java" />
+    <property name="fileExtensions" value="java,gradle" />
     <property name="lineSeparator" value="lf_cr_crlf" />
   </module>
   <module name="UniqueProperties" />
 
   <module name="RegexpHeader">
     <property name="headerFile" value="catroidSourceTest/res/agpl_license_text.txt" />
-    <property name="fileExtensions" value="java,xml" />
     <property name="multiLines" value="1,2" />
   </module>
 
@@ -227,14 +226,19 @@
     <property name="message" value="Remove author from the comment." />
   </module>
 
+  <module name="RegexpSingleline">
+    <property name="fileExtensions" value="gradle" />
+    <property name="format" value="^ *\t" />
+    <property name="message" value="Tabs aren't allowed for indentation. Spaces only" />
+  </module>
+
   <module name="RegexpMultiline">
-    <property name="fileExtensions" value="java" />
     <property name="format" value=".\n{2,}\s*\}" />
     <property name="message" value="Next line is an unnecessary newline" />
   </module>
 
   <module name="RegexpMultiline">
-    <property name="fileExtensions" value="java" />
+    <property name="fileExtensions" value="java,gradle" />
     <property name="format" value=".\n{3,}" />
     <property name="message" value="Maximum of blank lines is 1" />
   </module>
@@ -246,7 +250,7 @@
   </module>
 
   <module name="RegexpSingleline">
-    <property name="fileExtensions" value="java" />
+    <property name="fileExtensions" value="java,gradle" />
     <property name="format" value="^\s+$" />
     <property name="message" value="Empty line contains whitespaces." />
   </module>

--- a/gradle/adb_tasks.gradle
+++ b/gradle/adb_tasks.gradle
@@ -1,3 +1,26 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 def getAdb() {
     def adbPath = "adb"
     if (System.properties['adbPath']) {

--- a/gradle/code_quality_tasks.gradle
+++ b/gradle/code_quality_tasks.gradle
@@ -1,3 +1,26 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 // Doesn't work atm. Maybe if the pmd plugin gets updated.
 //task findbugs(type: FindBugs) {
 //    classes = fileTree('build/classes/debug/')
@@ -11,8 +34,8 @@
 task checkstyle(type: Checkstyle) {
     configFile file('config/checkstyle.xml')
     source '.'
-	include '**/*.java', '**/*.xml'
-	exclude '**/gen/**', '**/build/**', 'libraryProjects/**', 'catroidCucumberTest/**', '.idea/**'
+    include '**/*.java', '**/*.xml', '**/*.gradle'
+    exclude '**/gen/**', '**/build/**', 'libraryProjects/**', 'catroidCucumberTest/**', '.idea/**'
 
     classpath = files()
 

--- a/gradle/intellij_config_tasks.gradle
+++ b/gradle/intellij_config_tasks.gradle
@@ -1,3 +1,26 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 task gitSkipWorktreeForIntellijConfigFiles << {
     try {
         'git update-index --skip-worktree .idea/misc.xml'.execute().text.trim()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,24 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2015 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 include 'catroidSourceTest'


### PR DESCRIPTION
- Add gradle file extension to Checkstyle.
- Add tabs for indentation check for gradle files.
- Add unnecessary multiple newline check for XML files. Maximum is 2 to conform with (almost all) current XML files.

@jonny911: Since there is a change in the strings.xml file, is there any problem with crowdin?