### PR TITLE
CAT-1575 Landscape programs: incorrect calculations

### DIFF
--- a/catroid/src/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/org/catrobat/catroid/stage/StageListener.java
@@ -329,6 +329,7 @@ public class StageListener implements ApplicationListener {
 		batch.setProjectionMatrix(camera.combined);
 
 		if (firstStart) {
+			ProjectManager.getInstance().getCurrentProject().getDataContainer().resetAllDataObjects();
 			int spriteSize = sprites.size();
 			if (spriteSize > 0) {
 				sprites.get(0).look.setLookData(createWhiteBackgroundLookData());


### PR DESCRIPTION
If you click in a landscape program on the play button, the activity started twice (first in portrait, then he changed to landscape mode) and so we have incorrect calculations. For this reason we have to reset all data objects at first start and the bug is fixed.