### PR TITLE
CAT-1651 Fixed en_US locale gradle build issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ android {
             buildConfigField "boolean", "FEATURE_LEGO_NXT_ENABLED", "true"
             buildConfigField "boolean", "FEATURE_PHIRO_ENABLED", "true"
             buildConfigField "boolean", "FEATURE_LED_BRICK_ENABLED", "false"
-            buildConfigField "boolean", "FEATURE_VIBRATION_BRICK_ENABLED", “true”
+            buildConfigField "boolean", "FEATURE_VIBRATION_BRICK_ENABLED", "true"
             buildConfigField "boolean", "FEATURE_BACKPACK_ENABLED", "false"
             buildConfigField "boolean", "FEATURE_PARROT_AR_DRONE_ENABLED", "false"
             buildConfigField "boolean", "FEATURE_APK_GENERATOR_ENABLED", "false"
@@ -56,7 +56,7 @@ android {
             buildConfigField "boolean", "FEATURE_PHYSICS_ENGINE_COLLISSION_FILTERING_ENABLED", "false"
             buildConfigField "boolean", "FEATURE_TIME_CAPSULE_ENABLED", "false"
             buildConfigField "boolean", "FEATURE_USERBRICKS_ENABLED", "false"
-            buildConfigField "boolean", "FEATURE_ARDUINO_ENABLED", “true”
+            buildConfigField "boolean", "FEATURE_ARDUINO_ENABLED", "true"
         }
     }
 }


### PR DESCRIPTION
Fixes an issue that prevents gradle.build form running on en_US locale systems because of using the wrong/german quotation marks “” surrounding some statements