### PR TITLE
Hide backpack in default menu

### DIFF
--- a/catroid/res/menu/context_menu_default.xml
+++ b/catroid/res/menu/context_menu_default.xml
@@ -25,9 +25,11 @@
 
     <item
         android:id="@+id/context_menu_backpack"
+        android:visible="false"
         android:title="@string/backpack" />
 	<item
         android:id="@+id/context_menu_unpacking"
+        android:visible="false"
         android:title="@string/unpack" />
     <item
         android:id="@+id/context_menu_delete"


### PR DESCRIPTION
Hides backpack in SoundFragment when an item is longpressed (and in default menu).