### PR TITLE
CAT-1655 Fix upload for restricted profile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.1'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
     }
 }
@@ -26,22 +26,44 @@ apply from: 'gradle/intellij_config_tasks.gradle'
 check.dependsOn 'checkstyle'
 check.dependsOn 'pmd'
 
+android {
+    buildTypes {
+        debug {
+            buildConfigField "boolean", "FEATURE_LEGO_NXT_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_PHIRO_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_LED_BRICK_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_VIBRATION_BRICK_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_BACKPACK_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_PARROT_AR_DRONE_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_APK_GENERATOR_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_COMPUTER_VISION_ENHANCEMENT_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_FORMULA_EDITOR_LISTS_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_PHYSICS_ENGINE_COLLISSION_FILTERING_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_TIME_CAPSULE_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_USERBRICKS_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_ARDUINO_ENABLED", "true"
+        }
+        release {
+            buildConfigField "boolean", "FEATURE_LEGO_NXT_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_PHIRO_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_LED_BRICK_ENABLED", "false"
+            buildConfigField "boolean", "FEATURE_VIBRATION_BRICK_ENABLED", "false"
+            buildConfigField "boolean", "FEATURE_BACKPACK_ENABLED", "false"
+            buildConfigField "boolean", "FEATURE_PARROT_AR_DRONE_ENABLED", "false"
+            buildConfigField "boolean", "FEATURE_APK_GENERATOR_ENABLED", "false"
+            buildConfigField "boolean", "FEATURE_COMPUTER_VISION_ENHANCEMENT_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_FORMULA_EDITOR_LISTS_ENABLED", "true"
+            buildConfigField "boolean", "FEATURE_PHYSICS_ENGINE_COLLISSION_FILTERING_ENABLED", "false"
+            buildConfigField "boolean", "FEATURE_TIME_CAPSULE_ENABLED", "false"
+            buildConfigField "boolean", "FEATURE_USERBRICKS_ENABLED", "false"
+            buildConfigField "boolean", "FEATURE_ARDUINO_ENABLED", "false"
+        }
+    }
+}
+
+
 ext {
     projectVersion = "0.9"
-    featuresEnabled = [
-            "lego_nxt"                          : true,
-            "phiro"                             : true,
-            "led_brick"                         : false,
-            "vibration_brick"                   : false,
-            "backpack"                          : false,
-            "parrot_ar_drone"                   : false,
-            "apk_generator"                     : false,
-            "computer_vision_enhancement"       : true,
-            "formula_editor_lists"              : true,
-            "physics_engine_collision_filtering": false,
-            "time_capsule"                      : false,
-            "userbricks"                        : false
-    ]
 }
 
 configurations {
@@ -153,6 +175,7 @@ android {
         }
 
         androidTest {
+            manifest.srcFile 'catroidTest/AndroidManifest.xml'
             java.srcDirs = ['catroidTest/src']
             resources.srcDirs = ['catroidTest/src']
             aidl.srcDirs = ['catroidTest/src']
@@ -179,7 +202,7 @@ android {
         ignore 'ContentDescription', 'InvalidPackage', 'ValidFragment', 'GradleDependency',
                 'ClickableViewAccessibility', 'UnusedAttribute', 'CommitPrefEdits', 'OldTargetApi',
                 'RtlSymmetry', 'GradleDynamicVersion', 'RtlHardcoded', 'HandlerLeak', 'IconMissingDensityFolder',
-                'WrongRegion', 'RelativeOverlap', 'IconColors', 'MissingTranslation'
+                'WrongRegion', 'RelativeOverlap', 'IconColors', 'MissingTranslation', 'ExtraTranslation'
 
         textReport true
         xmlReport true
@@ -212,49 +235,4 @@ if (project.hasProperty('jenkins')) {
 
         }
     }
-}
-
-task featuresToBuildconfig << {
-    println "Activated Features:"
-    for (feature in featuresEnabled) {
-        def name = feature.key
-        def value = feature.value
-        if (project.hasProperty("allFeatures_enabled"))
-            value = project["allFeatures_enabled"]
-        if (project.hasProperty("${name}_enabled"))
-            value = project["${name}_enabled"]
-
-        if (!(value.toString().equals("true") || value.toString().equals("false")))
-            throw new IllegalArgumentException("Wrong Argument! Usage:\ne.g. -PallFeatures_enabled=true -Pparrot_ar_drone_enabled=false")
-
-        if (value.toString().equals("true")) {
-            println "- " + name
-        }
-        android.defaultConfig.buildConfigField "boolean", "FEATURE_${name.toUpperCase()}_ENABLED", "${value}"
-    }
-    println ""
-}
-
-task testManifestHack << {
-    def origManifest = file('catroidTest/AndroidManifest.xml')
-    def generatedManifest = file("build/intermediates/manifests/test/debug/AndroidManifest.xml")
-    def origContent = origManifest.getText()
-    def generatedContent = generatedManifest.getText()
-    def pattern = Pattern.compile("<application.*?>.*?</application>", Pattern.DOTALL)
-    def matcher = pattern.matcher(origContent)
-    matcher.find()
-    origContent = matcher.group()
-    generatedContent = pattern.matcher(generatedContent).replaceAll(origContent)
-    generatedManifest.write(generatedContent)
-}
-
-gradle.projectsEvaluated {
-    generateDebugTestBuildConfig.dependsOn testManifestHack
-}
-
-preBuild.dependsOn featuresToBuildconfig
-
-def signing_config_file = file(System.getProperty("user.home") + "/.catrobat/catroid_signing_config.gradle")
-if (signing_config_file.exists()) {
-    apply from: signing_config_file.absolutePath
 }

--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -99,6 +99,7 @@ public final class Constants {
 	public static final String NO_TOKEN = "no_token";
 	public static final String USERNAME = "username";
 	public static final String NO_USERNAME = "no_username";
+	public static final String RESTRICTED_USER = "restricted_user";
 
 	public static final String FLAVOR_DEFAULT = "PocketCode";
 	public static final String PLATFORM_DEFAULT = "Android";

--- a/catroid/src/org/catrobat/catroid/transfers/ProjectUploadService.java
+++ b/catroid/src/org/catrobat/catroid/transfers/ProjectUploadService.java
@@ -25,8 +25,10 @@ package org.catrobat.catroid.transfers;
 import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.ResultReceiver;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.catrobat.catroid.ProjectManager;
@@ -155,6 +157,14 @@ public class ProjectUploadService extends IntentService {
 			StatusBarNotificationManager.getInstance().showUploadRejectedNotification(notificationId, statusCode, serverAnswer, uploadBackupBundle);
 		} else {
 			ToastUtil.showSuccess(this, R.string.notification_upload_finished);
+		}
+
+		Context context = getApplicationContext();
+
+		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+		if (sharedPreferences.getBoolean(Constants.RESTRICTED_USER, false)) {
+			sharedPreferences.edit().putString(Constants.TOKEN, Constants.NO_TOKEN).commit();
+			sharedPreferences.edit().putString(Constants.USERNAME, Constants.NO_USERNAME).commit();
 		}
 		super.onDestroy();
 	}

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
@@ -120,7 +120,7 @@ public class UploadProjectDialog extends DialogFragment {
 					}
 				}).create();
 
-		dialog.setCanceledOnTouchOutside(true);
+		dialog.setCanceledOnTouchOutside(false);
 		dialog.getWindow().setLayout(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
 		dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
 
@@ -265,6 +265,12 @@ public class UploadProjectDialog extends DialogFragment {
 	}
 
 	private void handleCancelButtonClick() {
+		Context context = getActivity().getApplicationContext();
+		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+		if (sharedPreferences.getBoolean(Constants.RESTRICTED_USER, false)) {
+			sharedPreferences.edit().putString(Constants.TOKEN, Constants.NO_TOKEN).commit();
+			sharedPreferences.edit().putString(Constants.USERNAME, Constants.NO_USERNAME).commit();
+		}
 		dismiss();
 	}
 }

--- a/catroid/src/org/catrobat/catroid/web/ServerCalls.java
+++ b/catroid/src/org/catrobat/catroid/web/ServerCalls.java
@@ -344,6 +344,12 @@ public final class ServerCalls {
 			userEmail = emailForUiTests;
 		}
 
+		if (userEmail == null) { //restricted users
+			userEmail = "restricted";
+			SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+			sharedPreferences.edit().putBoolean(Constants.RESTRICTED_USER, true).commit();
+		}
+
 		try {
 			HashMap<String, String> postValues = new HashMap<String, String>();
 			postValues.put(REGISTRATION_USERNAME_KEY, username);


### PR DESCRIPTION
Trying to log in for upload with restricted profile crashed app.
Restricted profiles are used in school classes on shared tablets.

Quickfix:
- If email returned by AccountManager is null, replace with empty
string, to prevent the null exception.

Further changes to handle arising problems:
- Automaticall invalidate TOKEN to "log out" users again right after
upload, failed upload, and canceled upload. (since without this there
is no possibility to log out to prepare tablets for next class)

Limitations:
- Not possible to register new users using a restricted profile.
- Maybe not automatically logged out if upload process is disrupted.
- Log in error messages for restricted users propably misleading,
  eg. not existing username triggers "invalid email adress" error.