### PR TITLE
CAT-1655 Fix upload for restricted profile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.1'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
     }
 }

--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -99,6 +99,7 @@ public final class Constants {
 	public static final String NO_TOKEN = "no_token";
 	public static final String USERNAME = "username";
 	public static final String NO_USERNAME = "no_username";
+	public static final String RESTRICTED_USER = "restricted_user";
 
 	public static final String FLAVOR_DEFAULT = "PocketCode";
 	public static final String PLATFORM_DEFAULT = "Android";

--- a/catroid/src/org/catrobat/catroid/transfers/ProjectUploadService.java
+++ b/catroid/src/org/catrobat/catroid/transfers/ProjectUploadService.java
@@ -25,8 +25,10 @@ package org.catrobat.catroid.transfers;
 import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.ResultReceiver;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.catrobat.catroid.ProjectManager;
@@ -155,6 +157,14 @@ public class ProjectUploadService extends IntentService {
 			StatusBarNotificationManager.getInstance().showUploadRejectedNotification(notificationId, statusCode, serverAnswer, uploadBackupBundle);
 		} else {
 			ToastUtil.showSuccess(this, R.string.notification_upload_finished);
+		}
+
+		Context context = getApplicationContext();
+
+		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+		if (sharedPreferences.getBoolean(Constants.RESTRICTED_USER, false)) {
+			sharedPreferences.edit().putString(Constants.TOKEN, Constants.NO_TOKEN).commit();
+			sharedPreferences.edit().putString(Constants.USERNAME, Constants.NO_USERNAME).commit();
 		}
 		super.onDestroy();
 	}

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
@@ -120,7 +120,7 @@ public class UploadProjectDialog extends DialogFragment {
 					}
 				}).create();
 
-		dialog.setCanceledOnTouchOutside(true);
+		dialog.setCanceledOnTouchOutside(false);
 		dialog.getWindow().setLayout(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
 		dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
 
@@ -265,6 +265,12 @@ public class UploadProjectDialog extends DialogFragment {
 	}
 
 	private void handleCancelButtonClick() {
+		Context context = getActivity().getApplicationContext();
+		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+		if (sharedPreferences.getBoolean(Constants.RESTRICTED_USER, false)) {
+			sharedPreferences.edit().putString(Constants.TOKEN, Constants.NO_TOKEN).commit();
+			sharedPreferences.edit().putString(Constants.USERNAME, Constants.NO_USERNAME).commit();
+		}
 		dismiss();
 	}
 }

--- a/catroid/src/org/catrobat/catroid/web/ServerCalls.java
+++ b/catroid/src/org/catrobat/catroid/web/ServerCalls.java
@@ -344,6 +344,12 @@ public final class ServerCalls {
 			userEmail = emailForUiTests;
 		}
 
+		if (userEmail == null) { //restricted users
+			userEmail = "restricted";
+			SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+			sharedPreferences.edit().putBoolean(Constants.RESTRICTED_USER, true).commit();
+		}
+
 		try {
 			HashMap<String, String> postValues = new HashMap<String, String>();
 			postValues.put(REGISTRATION_USERNAME_KEY, username);


### PR DESCRIPTION
Trying to log in for upload with restricted profile crashed app.
Restricted profiles are used in school classes on shared tablets.

Quickfix:
- If email returned by AccountManager is null, replace with empty
string, to prevent the null exception.

Further changes to handle arising problems:
- Automaticall invalidate TOKEN to "log out" users again right after
upload, failed upload, and canceled upload. (since without this there
is no possibility to log out to prepare tablets for next class)

Limitations:
- Not possible to register new users using a restricted profile.
- Maybe not automatically logged out if upload process is disrupted.
- Log in error messages for restricted users propably misleading,
  eg. not existing username triggers "invalid email adress" error.