### PR TITLE
CAT-1679 Tapping on menu right after opening a project crashes app

### DIFF
--- a/catroid/src/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/ProjectActivity.java
@@ -94,7 +94,7 @@ public class ProjectActivity extends BaseActivity {
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
-		if (spritesListFragment != null && !spritesListFragment.isLoading) {
+		if (spritesListFragment != null) {
 			getMenuInflater().inflate(R.menu.menu_current_project, menu);
 		}
 		return super.onCreateOptionsMenu(menu);


### PR DESCRIPTION
Timing related problem, happened because onPrepareOptionsMenu of
projectActivity could be called before its onCreateOptionsMenu when
tapping on menu button right after loading the project.