### PR TITLE
MUS-177 Add Placeholder for musicdroid elements.

### DIFF
--- a/catroid/res/layout/activity_pocketmusic.xml
+++ b/catroid/res/layout/activity_pocketmusic.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Catroid: An on-device visual programming system for Android devices
   ~ Copyright (C) 2010-2015 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
@@ -21,7 +20,38 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:orientation="vertical" android:layout_width="match_parent" android:layout_height="match_parent">
-
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical">
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_weight=".8"
+        android:orientation="horizontal"> 
+        <View
+            android:id="@+id/musicdroid_piano"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight=".8"
+            android:background="@color/color_chooser_rgb_red"/> 
+        <View
+            android:id="@+id/musicdroid_note_grid"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight=".2"
+            android:background="@color/color_chooser_rgb_blue"/>
+    </LinearLayout>
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight=".1">
+    <ImageButton
+        android:id="@+id/musicdroid_button_play"
+        android:layout_width="fill_parent"
+        android:layout_height="@dimen/actionbar_height"
+        android:layout_gravity="center"
+        android:background="@drawable/bottom_bar_background_selector"
+        android:src="@drawable/ic_play" />
+    </LinearLayout>
 </LinearLayout>

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/PocketMusicTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/PocketMusicTest.java
@@ -65,9 +65,33 @@ public class PocketMusicTest extends BaseActivityInstrumentationTestCase<MainMen
 		solo.sleep(200);
 
 		assertEquals(SoundRecorderActivity.class.getSimpleName()
-						+ " not set to be in portrait mode in AndroidManifest.xml!", ActivityInfo.SCREEN_ORIENTATION_PORTRAIT,
+						+ " not set to be in portrait mode in AndroidManifest.xml!",
+				ActivityInfo.SCREEN_ORIENTATION_PORTRAIT,
 				activityInfo.screenOrientation
 		);
+	}
+
+	public void testPianoElement() {
+		prepareTest();
+		solo.waitForActivity(PocketMusicActivity.class.getSimpleName());
+
+		assertNotNull("Piano Element was not found.", solo.getCurrentActivity().findViewById(R.id.musicdroid_piano));
+	}
+
+	public void testNoteGridElement() {
+		prepareTest();
+		solo.waitForActivity(PocketMusicActivity.class.getSimpleName());
+
+		assertNotNull("NoteGrid Element was not found.", solo.getCurrentActivity().findViewById(R.id
+				.musicdroid_note_grid));
+	}
+
+	public void testPlayButtonElement() {
+		prepareTest();
+		solo.waitForActivity(PocketMusicActivity.class.getSimpleName());
+
+		assertNotNull("Play Button Element was not found.",
+				solo.getCurrentActivity().findViewById(R.id.musicdroid_button_play));
 	}
 
 	private void prepareTest() {


### PR DESCRIPTION
added GUI element placeholder for the new musicdroid GUI according to the mockups given from UX-Team.
The GUI exists of a piano, a button grid and a play button on the bottom.
These placeholder elemnts need to be replaced by the original elements in another task.