### PR TITLE
CAT-1697 Fix translation in CategoryBrickFactory

### DIFF
--- a/catroid/src/org/catrobat/catroid/common/BrickValues.java
+++ b/catroid/src/org/catrobat/catroid/common/BrickValues.java
@@ -47,7 +47,6 @@ public final class BrickValues {
 	//constants Sounds
 	public static final Float SET_VOLUME_TO = 60f;
 	public static final Float CHANGE_VOLUME_BY = -10f;
-	public static final String SPEAK = "Hello!";
 
 	//Constants Control
 	public static final int WAIT = 1000;

--- a/catroid/src/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
@@ -284,7 +284,7 @@ public class CategoryBricksFactory {
 		);
 		soundBrickList.add(new ChangeVolumeByNBrick(new Formula(defaultValueChangeVolumeBy)));
 
-		soundBrickList.add(new SpeakBrick(BrickValues.SPEAK));
+		soundBrickList.add(new SpeakBrick(context.getString(R.string.brick_speak_default_value)));
 
 		if (SettingsActivity.isPhiroSharedPreferenceEnabled(context)) {
 			soundBrickList.add(new PhiroPlayToneBrick(PhiroPlayToneBrick.Tone.DO,


### PR DESCRIPTION
Fixed the Bug which appears when you don't use PocketCode in english, now we
check before we create all the Bricks in the Category Sound if there is a difference between the constant value for the Brick  and our translated Value. If there is a difference we use the value from the translation file.