### PR TITLE
CAT-1673 Program crashes on resume if no or only one camera available

### DIFF
--- a/catroid/res/values-de/strings.xml
+++ b/catroid/res/values-de/strings.xml
@@ -699,4 +699,5 @@
   <string name="warning">Warnung</string>
   <string name="abort">Abbruch</string>
   <string name="variable">Variable</string>
+  <string name="no_camera_available">Gesichtserkennung nicht verfügbar</string>
 </resources>

--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -253,6 +253,7 @@
     <string name="text_to_speech_engine_not_installed">Text-to-Speech engine not installed!\nDo you want to install it?</string>
     <string name="no_flash_led_available">No flash LED available</string>
     <string name="no_vibrator_available">Vibrator not available</string>
+    <string name="no_camera_available">Facedetection not supported</string>
     <string name="led_and_front_camera_warning">Led AND Front Camera are not supported</string>
     <!--  -->
 

--- a/catroid/src/org/catrobat/catroid/facedetection/FaceDetectionHandler.java
+++ b/catroid/src/org/catrobat/catroid/facedetection/FaceDetectionHandler.java
@@ -59,6 +59,9 @@ public final class FaceDetectionHandler {
 		}
 		if (context != null) {
 			CameraManager.getInstance().updateCameraID(context);
+			if (CameraManager.getInstance().getCameraID() == CameraManager.NO_CAMERA) {
+				return false;
+			}
 		}
 		if (faceDetector == null) {
 			createFaceDetector();

--- a/catroid/src/org/catrobat/catroid/stage/PreStageActivity.java
+++ b/catroid/src/org/catrobat/catroid/stage/PreStageActivity.java
@@ -117,7 +117,16 @@ public class PreStageActivity extends BaseActivity {
 			if (success) {
 				resourceInitialized();
 			} else {
-				resourceFailed();
+				AlertDialog.Builder builder = new AlertDialog.Builder(this);
+				builder.setMessage(getString(R.string.no_camera_available)).setCancelable(false)
+						.setPositiveButton(getString(R.string.ok), new DialogInterface.OnClickListener() {
+							@Override
+							public void onClick(DialogInterface dialog, int id) {
+								resourceFailed();
+							}
+						});
+				AlertDialog alert = builder.create();
+				alert.show();
 			}
 		}
 


### PR DESCRIPTION
Fix program crash that happens when no or only one camera is available
on device in following cases:
- restart any program
- resume any program
- start program that utilizes facedetection
Also added message shown on program start if facedetection is to be used
but no camera is available on device.