### PR TITLE
Enable comment markers to disable code formatting per region

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -64,6 +64,7 @@
         </option>
         <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
         <option name="JD_P_AT_EMPTY_LINES" value="false" />
+        <option name="FORMATTER_TAGS_ENABLED" value="true" />
         <AndroidXmlCodeStyleSettings>
           <option name="USE_CUSTOM_SETTINGS" value="true" />
         </AndroidXmlCodeStyleSettings>

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -261,4 +261,9 @@
     <property name="influenceFormat" value="$2" />
   </module>
 
+  <module name="SuppressionCommentFilter">
+    <property name="offCommentFormat" value="@formatter\:off" />
+    <property name="onCommentFormat" value="@formatter\:on" />
+  </module>
+
 </module>


### PR DESCRIPTION
By using special comments, the Android Studio code formatter can be
disabled for code blocks. Checkstyle will also be disabled in these
blocks.

// @formatter:off
...
// @formatter:on

https://youtrack.jetbrains.com/issue/IDEA-56995