### PR TITLE
CAT Fix - Set allowBackup flag to false

### DIFF
--- a/catroid/AndroidManifest.xml
+++ b/catroid/AndroidManifest.xml
@@ -62,7 +62,7 @@
         android:required="true" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:name=".CatroidApplication"


### PR DESCRIPTION
Set allowbackup flag to false, only affects api23+, fixes lint warning.