### PR TITLE
CAT-1770 Fix flash for restarting programs

### DIFF
--- a/catroid/src/org/catrobat/catroid/utils/FlashUtil.java
+++ b/catroid/src/org/catrobat/catroid/utils/FlashUtil.java
@@ -79,6 +79,7 @@ public final class FlashUtil {
 		currentFlashValue = false;
 		paused = false;
 		available = false;
+		startAgain = false;
 
 		if (CameraManager.getInstance().isReady()) {
 			paramsOff = null;


### PR DESCRIPTION
Flash incorrectly started on restart if previous program had it
turned on.