### PR TITLE
CAT 1759 - Drone video in add look dialog

### DIFF
--- a/catroid/res/layout/dialog_new_look.xml
+++ b/catroid/res/layout/dialog_new_look.xml
@@ -95,6 +95,7 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/dialog_new_look_drone"
             style="@style/DefaultDialog.Item"
             android:baselineAligned="false"
             android:orientation="horizontal"

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/NewLookDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/NewLookDialog.java
@@ -64,10 +64,7 @@ public class NewLookDialog extends DialogFragment {
 		setupGalleryButton(dialogView);
 		setupCameraButton(dialogView);
 		setupMediaLibraryButton(dialogView);
-
-		if (SettingsActivity.isDroneSharedPreferenceEnabled(getActivity())) {
-			setupDroneVideoButton(dialogView);
-		}
+		setupDroneVideoButton(dialogView);
 
 		AlertDialog dialog;
 		AlertDialog.Builder dialogBuilder = new CustomAlertDialogBuilder(getActivity()).setView(dialogView).setTitle(
@@ -152,9 +149,15 @@ public class NewLookDialog extends DialogFragment {
 
 	private void setupDroneVideoButton(View parentView) {
 		View droneVideoButton = parentView.findViewById(R.id.dialog_new_look_drone_video);
+		View droneDialogItem = parentView.findViewById(R.id.dialog_new_look_drone);
+		if (!SettingsActivity.isDroneSharedPreferenceEnabled(getActivity())) {
+			droneVideoButton.setVisibility(View.GONE);
+			droneDialogItem.setVisibility(View.GONE);
+			return;
+		}
 
+		droneDialogItem.setVisibility(View.VISIBLE);
 		droneVideoButton.setOnClickListener(new View.OnClickListener() {
-
 			@Override
 			public void onClick(View view) {
 				fragment.addLookDroneVideo();

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/NewSpriteDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/NewSpriteDialog.java
@@ -33,7 +33,6 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.provider.MediaStore;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -341,8 +340,7 @@ public class NewSpriteDialog extends DialogFragment {
 	private void setupDroneVideoButton(View parentView) {
 		View droneVideoButton = parentView.findViewById(R.id.dialog_new_object_drone_video);
 		View linearLayout2ndRow = parentView.findViewById(R.id.dialog_new_object_drone);
-		if (!PreferenceManager.getDefaultSharedPreferences(getActivity()).getBoolean("setting_parrot_airdrone_bricks",
-				true)) {
+		if (!SettingsActivity.isDroneSharedPreferenceEnabled(getActivity())) {
 			linearLayout2ndRow.setVisibility(View.GONE);
 			return;
 		}


### PR DESCRIPTION
Drone video is displayed in add look dialog if it is not enabled in
settings, and also if it is deactivated in build file.