### PR TITLE
CAT-1775 resolved device freeze on download

### DIFF
--- a/catroid/src/org/catrobat/catroid/web/ProgressResponseBody.java
+++ b/catroid/src/org/catrobat/catroid/web/ProgressResponseBody.java
@@ -77,12 +77,18 @@ public class ProgressResponseBody extends ResponseBody {
 	private Source source(Source source) {
 		return new ForwardingSource(source) {
 			long totalBytesRead = 0L;
+			long lastProgess = -1L;
 
 			@Override
 			public long read(Buffer sink, long byteCount) throws IOException {
 				long bytesRead = super.read(sink, byteCount);
 				totalBytesRead += bytesRead != -1 ? bytesRead : 0;
-				sendUpdateIntent((100 * totalBytesRead) / contentLength(), bytesRead == -1);
+				long progress = (100 * totalBytesRead) / contentLength();
+				boolean endOfFile = bytesRead == -1;
+				if (progress > lastProgess || endOfFile) {
+					sendUpdateIntent(progress, endOfFile);
+					lastProgess = progress;
+				}
 				return bytesRead;
 			}
 		};


### PR DESCRIPTION
The problem was that the progress was reported after each read, even if it was the same percentage, that resulted in roughly 200 notification updates per second.
The check introduces a mechanism where progress is only reported if it is at least 1% further than the last update. It has to be in this deep level in the code, cause even checking in the `onReceiveResult()` in `DownloadUtil.java` causes a massive amount of function calls within the android system until it gets there which - in the end - has no effect at all