### PR TITLE
Flickr API key and basic functions added

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,7 @@ android {
         println "VersionName is " + versionName
         buildConfigField "String", "GIT_DESCRIBE", "\"${versionName}\""
         buildConfigField "String", "GIT_CURRENT_BRANCH", "\"${getCurrentGitBranch()}\""
+        buildConfigField "String", "FLICKR_API_KEY", FlickrApiKey
     }
 
     sourceSets {

--- a/catroid/src/org/catrobat/catroid/socialFeature/FlickrManager.java
+++ b/catroid/src/org/catrobat/catroid/socialFeature/FlickrManager.java
@@ -1,0 +1,170 @@
+package org.catrobat.catroid.socialFeature;
+
+/**
+ * Created by manthan on 29/3/16.
+ */
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Log;
+
+import org.catrobat.catroid.BuildConfig;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+
+/**
+ * Created by manthan on 29/3/16.
+ */
+
+public class FlickrManager {
+
+	private static final String FLICKR_BASE_URL = "https://api.flickr.com/services/rest/?method=";
+	private static final String FLICKR_PHOTOS_SEARCH_STRING = "flickr.photos.search";
+	private static final String FLICKR_GET_SIZES_STRING = "flickr.photos.getSizes";
+	private static final int FLICKR_PHOTOS_SEARCH_ID = 1;
+	private static final int FLICKR_GET_SIZES_ID = 2;
+	private static final int NUMBER_OF_PHOTOS = 20;
+
+	//API key can be modified here
+	private static final String APIKEY_SEARCH_STRING = "&api_key=" + BuildConfig.FLICKR_API_KEY;
+
+	private static final String TAGS_STRING = "&tags=";
+	private static final String PHOTO_ID_STRING = "&photo_id=";
+	private static final String FORMAT_STRING = "&format=json";
+	public static final int PHOTO_THUMB = 111;
+	public static final int PHOTO_LARGE = 222;
+
+	private static String createURL(int methodId, String parameter) {
+		String method_type = "";
+		String url = null;
+		switch (methodId) {
+			case FLICKR_PHOTOS_SEARCH_ID:
+				method_type = FLICKR_PHOTOS_SEARCH_STRING;
+				url = FLICKR_BASE_URL + method_type + APIKEY_SEARCH_STRING + TAGS_STRING + parameter + FORMAT_STRING + "&per_page=" + NUMBER_OF_PHOTOS + "&media=photos";
+				break;
+			case FLICKR_GET_SIZES_ID:
+				method_type = FLICKR_GET_SIZES_STRING;
+				url = FLICKR_BASE_URL + method_type + PHOTO_ID_STRING + parameter + APIKEY_SEARCH_STRING + FORMAT_STRING;
+				break;
+		}
+		return url;
+	}
+
+	public static void getImageURLS(ImageContener imgCon) {
+		String url = createURL(FLICKR_GET_SIZES_ID, imgCon.id);
+		ByteArrayOutputStream baos = URLConnector.readBytes(url);
+		String json = baos.toString();
+		try {
+			JSONObject root = new JSONObject(json.replace("jsonFlickrApi(", "").replace(")", ""));
+			JSONObject sizes = root.getJSONObject("sizes");
+			JSONArray size = sizes.getJSONArray("size");
+			for (int i = 0; i < size.length(); i++) {
+				JSONObject image = size.getJSONObject(i);
+				if (image.getString("label").equals("Square")) {
+					imgCon.setThumbURL(image.getString("source"));
+				} else if (image.getString("label").equals("Medium")) {
+					imgCon.setLargeURL(image.getString("source"));
+				}
+			}
+		} catch (JSONException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public static Bitmap getImage(ImageContener imgCon) {
+		Bitmap bm = null;
+		try {
+			URL aURL = new URL(imgCon.largeURL);
+			URLConnection conn = aURL.openConnection();
+			conn.connect();
+			InputStream is = conn.getInputStream();
+			BufferedInputStream bis = new BufferedInputStream(is);
+			bm = BitmapFactory.decodeStream(bis);
+			bis.close();
+			is.close();
+		} catch (Exception e) {
+			Log.e("FlickrManager", e.getMessage());
+		}
+		return bm;
+	}
+
+	public static void getThumbnails(ArrayList<ImageContener> imgCon) {
+		for (int i = 0; i < imgCon.size(); i++) {
+			new GetThumbnailsThread(imgCon.get(i)).start();
+		}
+	}
+
+	public static Bitmap getThumbnail(ImageContener imgCon) {
+		Bitmap bm = null;
+		try {
+			URL aURL = new URL(imgCon.thumbURL);
+			URLConnection conn = aURL.openConnection();
+			conn.connect();
+			InputStream is = conn.getInputStream();
+			BufferedInputStream bis = new BufferedInputStream(is);
+			bm = BitmapFactory.decodeStream(bis);
+			bis.close();
+			is.close();
+		} catch (Exception e) {
+			Log.e("FlickrManager", e.getMessage());
+		}
+		return bm;
+	}
+
+	public static class GetThumbnailsThread extends Thread {
+		ImageContener imgContener;
+
+		public GetThumbnailsThread(ImageContener imgCon) {
+			this.imgContener = imgCon;
+		}
+
+		@Override
+		public void run() {
+			// TODO Auto-generated method stub
+			imgContener.thumb = getThumbnail(imgContener);
+			if (imgContener.thumb != null) {
+
+			}
+		}
+	}
+
+	public static ArrayList<ImageContener> searchImagesByTag(Context ctx, String tag) {
+		String url = createURL(FLICKR_PHOTOS_SEARCH_ID, tag);
+		ArrayList<ImageContener> tmp = new ArrayList<ImageContener>();
+		String jsonString = null;
+		try {
+			if (URLConnector.isOnline(ctx)) {
+				ByteArrayOutputStream baos = URLConnector.readBytes(url);
+				jsonString = baos.toString();
+			}
+			try {
+				JSONObject root = new JSONObject(jsonString.replace("jsonFlickrApi(", "").replace(")", ""));
+				JSONObject photos = root.getJSONObject("photos");
+				JSONArray imageJSONArray = photos.getJSONArray("photo");
+				for (int i = 0; i < imageJSONArray.length(); i++) {
+					JSONObject item = imageJSONArray.getJSONObject(i);
+					ImageContener imgCon = new ImageContener(item.getString("id"), item.getString("owner"), item.getString("secret"), item.getString("server"),
+							item.getString("farm"));
+					imgCon.position = i;
+					tmp.add(imgCon);
+				}
+			} catch (JSONException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		} catch (NullPointerException nue) {
+			nue.printStackTrace();
+		}
+
+		return tmp;
+	}
+}

--- a/catroid/src/org/catrobat/catroid/socialFeature/IThumb.java
+++ b/catroid/src/org/catrobat/catroid/socialFeature/IThumb.java
@@ -1,0 +1,8 @@
+package org.catrobat.catroid.socialFeature;
+
+/**
+ * Created by manthan on 29/3/16.
+ */
+public interface IThumb {
+	void onSaveThumbURL(ImageContener ic);
+}

--- a/catroid/src/org/catrobat/catroid/socialFeature/ImageContener.java
+++ b/catroid/src/org/catrobat/catroid/socialFeature/ImageContener.java
@@ -1,0 +1,148 @@
+package org.catrobat.catroid.socialFeature;
+
+/**
+ * Created by manthan on 29/3/16.
+ */
+
+import android.graphics.Bitmap;
+
+public class ImageContener implements IThumb {
+	String id;
+	int position;
+	String thumbURL;
+	Bitmap thumb;
+	Bitmap photo;
+	String largeURL;
+	String owner;
+	String secret;
+	String server;
+	String farm;
+
+	public ImageContener(String id, String thumbURL, String largeURL, String owner, String secret, String server, String farm) {
+		super();
+		this.id = id;
+		this.owner = owner;
+		this.secret = secret;
+		this.server = server;
+		this.farm = farm;
+	}
+
+	public ImageContener(String id, String owner, String secret, String server, String farm) {
+		super();
+		this.id = id;
+		this.owner = owner;
+		this.secret = secret;
+		this.server = server;
+		this.farm = farm;
+		setThumbURL(createPhotoURL(FlickrManager.PHOTO_THUMB, this));
+		setLargeURL(createPhotoURL(FlickrManager.PHOTO_LARGE, this));
+	}
+
+	public String getThumbURL() {
+		return thumbURL;
+	}
+
+	public void setThumbURL(String thumbURL) {
+		this.thumbURL = thumbURL;
+		onSaveThumbURL(this);
+	}
+
+	public String getLargeURL() {
+		return largeURL;
+	}
+
+	public void setLargeURL(String largeURL) {
+		this.largeURL = largeURL;
+	}
+
+	@Override
+	public String toString() {
+		return "ImageContener [id=" + id + ", thumbURL=" + thumbURL + ", largeURL=" + largeURL + ", owner=" + owner + ", secret=" + secret + ", server=" + server + ", farm="
+				+ farm + "]";
+	}
+
+	private String createPhotoURL(int photoType, ImageContener imgCon) {
+		String tmp = null;
+		tmp = "https://farm" + imgCon.farm + ".staticflickr.com/" + imgCon.server + "/" + imgCon.id + "_" + imgCon.secret;// +".jpg";
+		switch (photoType) {
+			case FlickrManager.PHOTO_THUMB:
+				tmp += "_t";
+				break;
+			case FlickrManager.PHOTO_LARGE:
+				tmp += "_z";
+				break;
+		}
+		tmp += ".jpg";
+		return tmp;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public int getPosition() {
+		return position;
+	}
+
+	public void setPosition(int position) {
+		this.position = position;
+	}
+
+	public Bitmap getThumb() {
+		return thumb;
+	}
+
+	public void setThumb(Bitmap thumb) {
+		this.thumb = thumb;
+	}
+
+	public Bitmap getPhoto() {
+		return photo;
+	}
+
+	public void setPhoto(Bitmap photo) {
+		this.photo = photo;
+	}
+
+	public String getOwner() {
+		return owner;
+	}
+
+	public void setOwner(String owner) {
+		this.owner = owner;
+	}
+
+	public String getSecret() {
+		return secret;
+	}
+
+	public void setSecret(String secret) {
+		this.secret = secret;
+	}
+
+	public String getServer() {
+		return server;
+	}
+
+	public void setServer(String server) {
+		this.server = server;
+	}
+
+	public String getFarm() {
+		return farm;
+	}
+
+	public void setFarm(String farm) {
+		this.farm = farm;
+	}
+
+	@Override
+	public void onSaveThumbURL(ImageContener ic) {
+		// TODO Auto-generated method stub
+		new FlickrManager.GetThumbnailsThread(ic).start();
+	}
+}

--- a/catroid/src/org/catrobat/catroid/socialFeature/URLConnector.java
+++ b/catroid/src/org/catrobat/catroid/socialFeature/URLConnector.java
@@ -1,0 +1,86 @@
+package org.catrobat.catroid.socialFeature;
+
+/**
+ * Created by manthan on 29/3/16.
+ */
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.os.Build;
+import android.util.Log;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Created by manthan on 29/3/16.
+ */
+public class URLConnector {
+
+	private static int CONNECT_TIMEOUT_MS = 5000;
+	private static int READ_TIMEOUT_MS = 15000;
+
+	public static boolean isOnline(Context ctx) {
+		ConnectivityManager cm = (ConnectivityManager) ctx.getSystemService(Context.CONNECTIVITY_SERVICE);
+		NetworkInfo netInfo = cm.getActiveNetworkInfo();
+		if (netInfo != null && netInfo.isConnectedOrConnecting()) {
+			return true;
+		}
+		return false;
+	}
+
+	public static ByteArrayOutputStream readBytes(String urlS) {
+		ByteArrayOutputStream baos = null;
+		InputStream is = null;
+		HttpURLConnection httpURLConnection = null;
+		try {
+			// HTTP connection reuse which was buggy pre-froyo
+			if (Integer.parseInt(Build.VERSION.SDK) < Build.VERSION_CODES.FROYO) {
+				System.setProperty("http.keepAlive", "false");
+			}
+			URL url = new URL(urlS);
+			Log.i("URL", url.toString());
+			httpURLConnection = (HttpURLConnection) url.openConnection();
+			int response = httpURLConnection.getResponseCode();
+			if (response == HttpURLConnection.HTTP_OK) {
+				httpURLConnection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+				httpURLConnection.setReadTimeout(READ_TIMEOUT_MS);
+				is = new BufferedInputStream(httpURLConnection.getInputStream());
+
+				int size = 1024;
+				byte[] buffer = new byte[size];
+
+				baos = new ByteArrayOutputStream();
+				int read = 0;
+				while ((read = is.read(buffer)) != -1) {
+					if (read > 0) {
+						baos.write(buffer, 0, read);
+						buffer = new byte[size];
+					}
+				}
+			}
+		} catch (Exception exc) {
+			exc.printStackTrace();
+		} finally {
+			if (is != null) {
+				try {
+					is.close();
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+			if (httpURLConnection != null) {
+				try {
+					httpURLConnection.disconnect();
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		}
+		return baos;
+	}
+}


### PR DESCRIPTION
Rectifying the mistake of commiting idea files as well and having changes of drone also integrated (some git complicaitons), I have made a fresh PR that has the required code.
The things included in the PR are :-
1. modified .gitignore to stop tracking the .iml and .idea files
2. I added simple code for interacting with the Flickr API. Basic methods for getting images based on tags are written and the list of images is formed which can now be used further on after discussion.
3. Flickr API key is added as a parameter in default config. The team members need to add 
" FlickrApiKey="e539918aa64db4efc8ffe97698409115" " to their gradle.properties. (in the home folder)
This is done to not make the key public.