### PR TITLE
CAT-1797 Open backpack context menu right after click

### DIFF
--- a/catroid/src/org/catrobat/catroid/ui/adapter/BackPackSpriteAdapter.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/BackPackSpriteAdapter.java
@@ -81,7 +81,7 @@ public class BackPackSpriteAdapter extends SpriteBaseAdapter implements ActionMo
 		holder.background.setOnTouchListener(new View.OnTouchListener() {
 			@Override
 			public boolean onTouch(View v, MotionEvent event) {
-				if (event.getAction() == MotionEvent.ACTION_UP && backpackSpriteFragment != null) {
+				if (event.getAction() == MotionEvent.ACTION_DOWN && backpackSpriteFragment != null) {
 					backpackSpriteFragment.setSelectedSpritePosition(position);
 					backpackSpriteFragment.getListView().showContextMenuForChild(v);
 				}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackLookFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackLookFragment.java
@@ -393,7 +393,7 @@ public class BackPackLookFragment extends BackPackActivityFragment implements Di
 		holder.lookElement.setOnTouchListener(new View.OnTouchListener() {
 			@Override
 			public boolean onTouch(View view, MotionEvent event) {
-				if (event.getAction() == MotionEvent.ACTION_UP) {
+				if (event.getAction() == MotionEvent.ACTION_DOWN) {
 					selectedLookPosition = position;
 					listView.showContextMenuForChild(view);
 				}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackScriptFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackScriptFragment.java
@@ -402,7 +402,7 @@ public class BackPackScriptFragment extends BackPackActivityFragment implements 
 		holder.scriptGroupElement.setOnTouchListener(new View.OnTouchListener() {
 			@Override
 			public boolean onTouch(View v, MotionEvent event) {
-				if (event.getAction() == MotionEvent.ACTION_UP) {
+				if (event.getAction() == MotionEvent.ACTION_DOWN) {
 					selectedScriptGroupPosition = position;
 					listView.showContextMenuForChild(v);
 				}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSoundFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSoundFragment.java
@@ -333,7 +333,7 @@ public class BackPackSoundFragment extends BackPackActivityFragment implements S
 		holder.soundFragmentButtonLayout.setOnTouchListener(new View.OnTouchListener() {
 			@Override
 			public boolean onTouch(View v, MotionEvent event) {
-				if (event.getAction() == MotionEvent.ACTION_UP) {
+				if (event.getAction() == MotionEvent.ACTION_DOWN) {
 					selectedSoundPosition = position;
 					listView.showContextMenuForChild(v);
 				}


### PR DESCRIPTION
Context menu in backpack now opens right after it has been clicked (not when it has been released).