### PR TITLE
Cat 1879 - Permanent Backpack

### DIFF
--- a/catroid/src/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/org/catrobat/catroid/ProjectManager.java
@@ -204,13 +204,6 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 			if (project.getCatrobatLanguageVersion() == 0.97f) {
 				project.setCatrobatLanguageVersion(Constants.CURRENT_CATROBAT_LANGUAGE_VERSION);
 			}
-			if (project.getCatrobatLanguageVersion() == 0.98f) {
-				//Inserted object background flag for backpack deserialization
-				project.setCatrobatLanguageVersion(Constants.CURRENT_CATROBAT_LANGUAGE_VERSION);
-				if (project.getSpriteList().size() > 0) {
-					project.getSpriteList().get(0).isBackgroundObject = true;
-				}
-			}
 //			insert further conversions here
 
 			checkNestingBrickReferences(true, false);
@@ -581,7 +574,6 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 	}
 
 	private void checkCurrentScript(Script script, boolean assumeWrong) {
-
 		boolean scriptCorrect = true;
 		if (assumeWrong) {
 			scriptCorrect = false;

--- a/catroid/src/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/org/catrobat/catroid/ProjectManager.java
@@ -60,6 +60,7 @@ import org.catrobat.catroid.transfers.CheckTokenTask;
 import org.catrobat.catroid.transfers.CheckTokenTask.OnCheckTokenCompleteListener;
 import org.catrobat.catroid.transfers.FacebookExchangeTokenTask;
 import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.ui.controller.BackPackListManager;
 import org.catrobat.catroid.ui.dialogs.SignInDialog;
 import org.catrobat.catroid.ui.dialogs.UploadProjectDialog;
 import org.catrobat.catroid.utils.Utils;
@@ -67,6 +68,8 @@ import org.catrobat.catroid.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 public final class ProjectManager implements OnLoadProjectCompleteListener, OnCheckTokenCompleteListener, CheckFacebookServerTokenValidityTask.OnCheckFacebookServerTokenValidityCompleteListener, FacebookExchangeTokenTask.OnFacebookExchangeTokenCompleteListener {
 	private static final ProjectManager INSTANCE = new ProjectManager();
@@ -181,7 +184,7 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 			if (project.getCatrobatLanguageVersion() == 0.91f) {
 				project.setCatrobatLanguageVersion(0.92f);
 				project.setScreenMode(ScreenModes.STRETCH);
-				checkNestingBrickReferences(false);
+				checkNestingBrickReferences(false, false);
 			}
 
 			if (project.getCatrobatLanguageVersion() == 0.92f || project.getCatrobatLanguageVersion() == 0.93f) {
@@ -201,9 +204,16 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 			if (project.getCatrobatLanguageVersion() == 0.97f) {
 				project.setCatrobatLanguageVersion(Constants.CURRENT_CATROBAT_LANGUAGE_VERSION);
 			}
+			if (project.getCatrobatLanguageVersion() == 0.98f) {
+				//Inserted object background flag for backpack deserialization
+				project.setCatrobatLanguageVersion(Constants.CURRENT_CATROBAT_LANGUAGE_VERSION);
+				if (project.getSpriteList().size() > 0) {
+					project.getSpriteList().get(0).isBackgroundObject = true;
+				}
+			}
 //			insert further conversions here
 
-			checkNestingBrickReferences(true);
+			checkNestingBrickReferences(true, false);
 			if (project.getCatrobatLanguageVersion() == Constants.CURRENT_CATROBAT_LANGUAGE_VERSION) {
 				//project seems to be converted now and can be loaded
 				localizeBackgroundSprite(context);
@@ -313,10 +323,7 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 		int virtualScreenWidth = getCurrentProject().getXmlHeader().virtualScreenWidth;
 		int virtualScreenHeight = getCurrentProject().getXmlHeader().virtualScreenHeight;
 
-		if (virtualScreenWidth > virtualScreenHeight) {
-			return true;
-		}
-		return false;
+		return virtualScreenWidth > virtualScreenHeight;
 	}
 
 	public void setProject(Project project) {
@@ -364,7 +371,7 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 		String newProjectPath = Utils.buildProjectPath(newProjectName);
 		File newProjectDirectory = new File(newProjectPath);
 
-		boolean directoryRenamed = false;
+		boolean directoryRenamed;
 
 		if (oldProjectPath.equalsIgnoreCase(newProjectPath)) {
 			String tmpProjectPath = Utils.buildProjectPath(createTemporaryDirectoryName(newProjectName));
@@ -540,28 +547,53 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 	public void onLoadProjectFailure() {
 	}
 
-	public void checkNestingBrickReferences(boolean assumeWrong) {
-		Project currentProject = ProjectManager.getInstance().getCurrentProject();
-		if (currentProject != null) {
-			for (Sprite currentSprite : currentProject.getSpriteList()) {
-				int numberOfScripts = currentSprite.getNumberOfScripts();
-				for (int pos = 0; pos < numberOfScripts; pos++) {
-					Script script = currentSprite.getScript(pos);
-					boolean scriptCorrect = true;
-					if (assumeWrong) {
-						scriptCorrect = false;
-					}
-					for (Brick currentBrick : script.getBrickList()) {
-						if (!scriptCorrect) {
-							continue;
-						}
-						scriptCorrect = checkReferencesOfCurrentBrick(currentBrick);
-					}
-					if (!scriptCorrect) {
-						correctAllNestedReferences(script);
-					}
+	public void checkNestingBrickReferences(boolean assumeWrong, boolean inBackPack) {
+		List<Sprite> spritesToCheck;
+		if (inBackPack) {
+			spritesToCheck = BackPackListManager.getInstance().getAllBackPackedSprites();
+
+			HashMap<String, List<Script>> backPackedScripts = BackPackListManager.getInstance().getAllBackPackedScripts();
+			for (String scriptGroup : backPackedScripts.keySet()) {
+				List<Script> scriptListToCheck = backPackedScripts.get(scriptGroup);
+				for (Script scriptToCheck : scriptListToCheck) {
+					checkCurrentScript(scriptToCheck, assumeWrong);
 				}
 			}
+		} else {
+			Project currentProject = ProjectManager.getInstance().getCurrentProject();
+			if (currentProject == null) {
+				return;
+			}
+			spritesToCheck = currentProject.getSpriteList();
+		}
+
+		for (Sprite currentSprite : spritesToCheck) {
+			checkCurrentSprite(currentSprite, assumeWrong);
+		}
+	}
+
+	private void checkCurrentSprite(Sprite currentSprite, boolean assumeWrong) {
+		int numberOfScripts = currentSprite.getNumberOfScripts();
+		for (int pos = 0; pos < numberOfScripts; pos++) {
+			Script script = currentSprite.getScript(pos);
+			checkCurrentScript(script, assumeWrong);
+		}
+	}
+
+	private void checkCurrentScript(Script script, boolean assumeWrong) {
+
+		boolean scriptCorrect = true;
+		if (assumeWrong) {
+			scriptCorrect = false;
+		}
+		for (Brick currentBrick : script.getBrickList()) {
+			if (!scriptCorrect) {
+				break;
+			}
+			scriptCorrect = checkReferencesOfCurrentBrick(currentBrick);
+		}
+		if (!scriptCorrect) {
+			correctAllNestedReferences(script);
 		}
 	}
 
@@ -593,9 +625,9 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 	}
 
 	private void correctAllNestedReferences(Script script) {
-		ArrayList<IfLogicBeginBrick> ifBeginList = new ArrayList<IfLogicBeginBrick>();
-		ArrayList<PhiroIfLogicBeginBrick> ifSensorBeginList = new ArrayList<PhiroIfLogicBeginBrick>();
-		ArrayList<LoopBeginBrick> loopBeginList = new ArrayList<LoopBeginBrick>();
+		ArrayList<IfLogicBeginBrick> ifBeginList = new ArrayList<>();
+		ArrayList<PhiroIfLogicBeginBrick> ifSensorBeginList = new ArrayList<>();
+		ArrayList<LoopBeginBrick> loopBeginList = new ArrayList<>();
 		for (Brick currentBrick : script.getBrickList()) {
 			if (currentBrick instanceof IfLogicBeginBrick) {
 				ifBeginList.add((IfLogicBeginBrick) currentBrick);

--- a/catroid/src/org/catrobat/catroid/common/Backpack.java
+++ b/catroid/src/org/catrobat/catroid/common/Backpack.java
@@ -1,0 +1,46 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.common;
+
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class Backpack implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	public List<SoundInfo> backpackedSounds = new CopyOnWriteArrayList<>();
+	public List<LookData> backpackedLooks = new CopyOnWriteArrayList<>();
+	public HashMap<String, List<Script>> backpackedScripts = new HashMap<>();
+	public List<Sprite> backpackedSprites = new CopyOnWriteArrayList<>();
+
+	public List<SoundInfo> hiddenBackpackedSounds = new CopyOnWriteArrayList<>();
+	public List<LookData> hiddenBackpackedLooks = new CopyOnWriteArrayList<>();
+	public HashMap<String, List<Script>> hiddenBackpackedScripts = new HashMap<>();
+	public List<Sprite> hiddenBackpackedSprites = new CopyOnWriteArrayList<>();
+}

--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -29,7 +29,7 @@ public final class Constants {
 	// Reflection in testcases needed
 	// http://stackoverflow.com/questions/1615163/modifying-final-fields-in-java?answertab=votes#tab-top
 
-	public static final float CURRENT_CATROBAT_LANGUAGE_VERSION = Float.valueOf(0.99f);
+	public static final float CURRENT_CATROBAT_LANGUAGE_VERSION = Float.valueOf(0.98f);
 
 	public static final String PLATFORM_NAME = "Android";
 	public static final int APPLICATION_BUILD_NUMBER = 0; // updated from jenkins nightly/release build

--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -29,7 +29,7 @@ public final class Constants {
 	// Reflection in testcases needed
 	// http://stackoverflow.com/questions/1615163/modifying-final-fields-in-java?answertab=votes#tab-top
 
-	public static final float CURRENT_CATROBAT_LANGUAGE_VERSION = Float.valueOf(0.98f);
+	public static final float CURRENT_CATROBAT_LANGUAGE_VERSION = Float.valueOf(0.99f);
 
 	public static final String PLATFORM_NAME = "Android";
 	public static final int APPLICATION_BUILD_NUMBER = 0; // updated from jenkins nightly/release build

--- a/catroid/src/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/org/catrobat/catroid/common/LookData.java
@@ -57,14 +57,13 @@ public class LookData implements Serializable, Cloneable {
 	protected transient Pixmap pixmap = null;
 	protected transient Pixmap originalPixmap = null;
 	protected transient TextureRegion textureRegion = null;
+	public transient boolean isBackpackLookData = false;
 
 	public LookData() {
 	}
 
 	public void draw(Batch batch, float alpha) {
 	}
-
-	public transient boolean isBackpackLookData = false;
 
 	@Override
 	public boolean equals(Object obj) {

--- a/catroid/src/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/org/catrobat/catroid/content/Project.java
@@ -90,6 +90,7 @@ public class Project implements Serializable {
 			return;
 		}
 		Sprite background = new Sprite(context.getString(R.string.background));
+		background.isBackgroundObject = true;
 		background.look.setZIndex(0);
 		addSprite(background);
 	}
@@ -389,7 +390,7 @@ public class Project implements Serializable {
 		return spriteBySpriteName;
 	}
 
-	public boolean isBackgroundSprite(Sprite sprite) {
+	public boolean isBackgroundObject(Sprite sprite) {
 		if (spriteList.indexOf(sprite) == 0) {
 			return true;
 		}

--- a/catroid/src/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/org/catrobat/catroid/content/Sprite.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.actions.ParallelAction;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.BroadcastSequenceMap;
@@ -61,7 +62,7 @@ public class Sprite implements Serializable, Cloneable {
 
 	@XStreamAsAttribute
 	private String name;
-	@XStreamAsAttribute
+	@XStreamOmitField
 	public boolean isBackgroundObject = false;
 
 	private List<Script> scriptList = new ArrayList<>();

--- a/catroid/src/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/org/catrobat/catroid/content/Sprite.java
@@ -61,14 +61,17 @@ public class Sprite implements Serializable, Cloneable {
 
 	@XStreamAsAttribute
 	private String name;
+	@XStreamAsAttribute
+	public boolean isBackgroundObject = false;
+
 	private List<Script> scriptList = new ArrayList<>();
 	private List<LookData> lookList = new ArrayList<>();
 	private List<SoundInfo> soundList = new ArrayList<>();
 	private List<UserBrick> userBricks = new ArrayList<>();
 	private List<NfcTagData> nfcTagList = new ArrayList<>();
+
 	private transient int newUserBrickNext = 1;
-	public transient boolean isBackpackSprite = false;
-	public transient boolean isBackgroundSprite = false;
+	public transient boolean isBackpackObject = false;
 
 	private transient ActionFactory actionFactory = new ActionFactory();
 
@@ -270,7 +273,7 @@ public class Sprite implements Serializable, Cloneable {
 		final Sprite cloneSprite = new Sprite();
 
 		cloneSprite.setName(this.getName());
-		cloneSprite.isBackpackSprite = false;
+		cloneSprite.isBackpackObject = false;
 
 		Project currentProject = ProjectManager.getInstance().getCurrentProject();
 		if (currentProject == null || !currentProject.getSpriteList().contains(this)) {

--- a/catroid/src/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
@@ -352,7 +352,7 @@ public class PlaySoundBrick extends BrickBaseType implements OnItemSelectedListe
 	@Override
 	public void storeDataForBackPack(Sprite sprite) {
 		SoundInfo backPackedSoundInfo = SoundController.getInstance().backPackHiddenSound(this.getSound());
-		this.setSoundInfo(backPackedSoundInfo);
+		setSoundInfo(backPackedSoundInfo);
 		if (sprite != null && !sprite.getSoundList().contains(backPackedSoundInfo)) {
 			sprite.getSoundList().add(backPackedSoundInfo);
 		}

--- a/catroid/src/org/catrobat/catroid/content/bricks/SetLookBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/SetLookBrick.java
@@ -356,7 +356,7 @@ public class SetLookBrick extends BrickBaseType implements OnLookDataListChanged
 	@Override
 	public void storeDataForBackPack(Sprite sprite) {
 		LookData backPackedLookData = LookController.getInstance().backPackHiddenLook(this.getLook());
-		this.setLook(backPackedLookData);
+		setLook(backPackedLookData);
 		if (sprite != null && !sprite.getLookDataList().contains(backPackedLookData)) {
 			sprite.getLookDataList().add(backPackedLookData);
 		}

--- a/catroid/src/org/catrobat/catroid/content/bricks/UserListBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/UserListBrick.java
@@ -25,6 +25,8 @@ package org.catrobat.catroid.content.bricks;
 
 import android.widget.Spinner;
 
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Sprite;
@@ -37,7 +39,8 @@ public abstract class UserListBrick extends FormulaBrick implements NewDataDialo
 
 	protected UserList userList;
 
-	protected transient BackPackedData backPackedData;
+	@XStreamOmitField
+	protected BackPackedData backPackedData;
 
 	private void updateUserListIfDeleted(UserListAdapterWrapper userListAdapterWrapper) {
 		if (userList != null && (userListAdapterWrapper.getPositionOfItem(userList) == 0)) {
@@ -92,7 +95,6 @@ public abstract class UserListBrick extends FormulaBrick implements NewDataDialo
 	public class BackPackedData {
 		public UserList userList;
 		public Integer userListType;
-		public Project project;
 
 		public BackPackedData() {
 		}
@@ -101,7 +103,6 @@ public abstract class UserListBrick extends FormulaBrick implements NewDataDialo
 			if (backPackedData != null) {
 				this.userList = backPackedData.userList;
 				this.userListType = backPackedData.userListType;
-				this.project = backPackedData.project;
 			}
 		}
 	}
@@ -164,8 +165,7 @@ public abstract class UserListBrick extends FormulaBrick implements NewDataDialo
 		if (backPackedData == null) {
 			backPackedData = new BackPackedData();
 		}
-		this.backPackedData.project = currentProject;
-		this.backPackedData.userList = userList;
-		this.backPackedData.userListType = type;
+		backPackedData.userList = userList;
+		backPackedData.userListType = type;
 	}
 }

--- a/catroid/src/org/catrobat/catroid/content/bricks/UserVariableBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/UserVariableBrick.java
@@ -25,6 +25,8 @@ package org.catrobat.catroid.content.bricks;
 
 import android.widget.Spinner;
 
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Sprite;
@@ -37,7 +39,9 @@ public abstract class UserVariableBrick extends FormulaBrick implements NewDataD
 
 	protected UserVariable userVariable;
 	public boolean inUserBrick = false;
-	protected transient BackPackedData backPackedData;
+
+	@XStreamOmitField
+	protected BackPackedData backPackedData;
 
 	private void updateUserVariableIfDeleted(UserVariableAdapterWrapper userVariableAdapterWrapper) {
 		if (userVariable != null && (userVariableAdapterWrapper.getPositionOfItem(userVariable) == 0)) {
@@ -93,7 +97,6 @@ public abstract class UserVariableBrick extends FormulaBrick implements NewDataD
 	public class BackPackedData {
 		public UserVariable userVariable;
 		public Integer userVariableType;
-		public Project project;
 
 		public BackPackedData() {
 		}
@@ -102,7 +105,6 @@ public abstract class UserVariableBrick extends FormulaBrick implements NewDataD
 			if (backPackedData != null) {
 				this.userVariable = backPackedData.userVariable;
 				this.userVariableType = backPackedData.userVariableType;
-				this.project = backPackedData.project;
 			}
 		}
 	}
@@ -159,7 +161,6 @@ public abstract class UserVariableBrick extends FormulaBrick implements NewDataD
 		if (backPackedData == null) {
 			backPackedData = new BackPackedData();
 		}
-		this.backPackedData.project = currentProject;
 		this.backPackedData.userVariable = userVariable;
 		this.backPackedData.userVariableType = type;
 	}

--- a/catroid/src/org/catrobat/catroid/io/BackpackBrickSerializerAndDeserializer.java
+++ b/catroid/src/org/catrobat/catroid/io/BackpackBrickSerializerAndDeserializer.java
@@ -1,0 +1,71 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.io;
+
+import android.util.Log;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import org.catrobat.catroid.content.bricks.Brick;
+
+import java.lang.reflect.Type;
+
+public class BackpackBrickSerializerAndDeserializer implements JsonSerializer<Brick>, JsonDeserializer<Brick> {
+
+	private static final String TAG = BackpackBrickSerializerAndDeserializer.class.getSimpleName();
+	private static final String PACKAGE_NAME = "org.catrobat.catroid.content.bricks.";
+
+	private static final String TYPE = "bricktype";
+	private static final String PROPERTY = "properties";
+
+	@Override
+	public JsonElement serialize(Brick brick, Type typeOfSrc, JsonSerializationContext context) {
+		JsonObject jsonObject = new JsonObject();
+		jsonObject.add(TYPE, new JsonPrimitive(brick.getClass().getSimpleName()));
+		jsonObject.add(PROPERTY, context.serialize(brick, brick.getClass()));
+		return jsonObject;
+	}
+
+	@Override
+	public Brick deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+
+		JsonObject jsonObject = json.getAsJsonObject();
+		String type = jsonObject.get(TYPE).getAsString();
+		JsonElement element = jsonObject.get(PROPERTY);
+
+		try {
+			return context.deserialize(element, Class.forName(PACKAGE_NAME + type));
+		} catch (ClassNotFoundException e) {
+			Log.e(TAG, "Could not deserialize backpacked brick element!");
+			throw new JsonParseException("Unknown element type: " + type, e);
+		}
+	}
+}

--- a/catroid/src/org/catrobat/catroid/io/BackpackScriptSerializerAndDeserializer.java
+++ b/catroid/src/org/catrobat/catroid/io/BackpackScriptSerializerAndDeserializer.java
@@ -1,0 +1,71 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.io;
+
+import android.util.Log;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import org.catrobat.catroid.content.Script;
+
+import java.lang.reflect.Type;
+
+public class BackpackScriptSerializerAndDeserializer implements JsonSerializer<Script>, JsonDeserializer<Script> {
+
+	private static final String TAG = BackpackScriptSerializerAndDeserializer.class.getSimpleName();
+	private static final String PACKAGE_NAME = "org.catrobat.catroid.content.";
+
+	private static final String TYPE = "scripttype";
+	private static final String PROPERTY = "properties";
+
+	@Override
+	public JsonElement serialize(Script script, Type typeOfSrc, JsonSerializationContext context) {
+		JsonObject jsonObject = new JsonObject();
+		jsonObject.add(TYPE, new JsonPrimitive(script.getClass().getSimpleName()));
+		jsonObject.add(PROPERTY, context.serialize(script, script.getClass()));
+		return jsonObject;
+	}
+
+	@Override
+	public Script deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+
+		JsonObject jsonObject = json.getAsJsonObject();
+		String type = jsonObject.get(TYPE).getAsString();
+		JsonElement element = jsonObject.get(PROPERTY);
+
+		try {
+			return context.deserialize(element, Class.forName(PACKAGE_NAME + type));
+		} catch (ClassNotFoundException e) {
+			Log.e(TAG, "Could not deserialize backpacked script element!");
+			throw new JsonParseException("Unknown element type: " + type, e);
+		}
+	}
+}

--- a/catroid/src/org/catrobat/catroid/io/CatroidFieldKeySorter.java
+++ b/catroid/src/org/catrobat/catroid/io/CatroidFieldKeySorter.java
@@ -143,11 +143,11 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 				fieldKeyOrder[7] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("userBricks")) {
 				fieldKeyOrder[8] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("isBackgroundObject")) {
-				fieldKeyOrder[9] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("newUserBrickNext")) {
+				fieldKeyOrder[9] = fieldKey;
+			} else if (fieldKey.getFieldName().equals("isBackpackObject")) {
 				fieldKeyOrder[10] = fieldKey;
-			}  else if (fieldKey.getFieldName().equals("isBackpackObject")) {
+			} else if (fieldKey.getFieldName().equals("isBackgroundObject")) {
 				fieldKeyOrder[11] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("nfcTagList")) {
 				fieldKeyOrder[12] = fieldKey;

--- a/catroid/src/org/catrobat/catroid/io/CatroidFieldKeySorter.java
+++ b/catroid/src/org/catrobat/catroid/io/CatroidFieldKeySorter.java
@@ -143,11 +143,11 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 				fieldKeyOrder[7] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("userBricks")) {
 				fieldKeyOrder[8] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("newUserBrickNext")) {
+			} else if (fieldKey.getFieldName().equals("isBackgroundObject")) {
 				fieldKeyOrder[9] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("isBackpackSprite")) {
+			} else if (fieldKey.getFieldName().equals("newUserBrickNext")) {
 				fieldKeyOrder[10] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("isBackgroundSprite")) {
+			}  else if (fieldKey.getFieldName().equals("isBackpackObject")) {
 				fieldKeyOrder[11] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("nfcTagList")) {
 				fieldKeyOrder[12] = fieldKey;

--- a/catroid/src/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/org/catrobat/catroid/io/StorageHandler.java
@@ -143,9 +143,11 @@ import org.catrobat.catroid.content.bricks.TurnLeftBrick;
 import org.catrobat.catroid.content.bricks.TurnRightBrick;
 import org.catrobat.catroid.content.bricks.UserBrick;
 import org.catrobat.catroid.content.bricks.UserBrickParameter;
+import org.catrobat.catroid.content.bricks.UserListBrick;
 import org.catrobat.catroid.content.bricks.UserScriptDefinitionBrick;
 import org.catrobat.catroid.content.bricks.UserScriptDefinitionBrickElement;
 import org.catrobat.catroid.content.bricks.UserScriptDefinitionBrickElements;
+import org.catrobat.catroid.content.bricks.UserVariableBrick;
 import org.catrobat.catroid.content.bricks.VibrationBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
 import org.catrobat.catroid.content.bricks.WhenBrick;
@@ -242,9 +244,12 @@ public final class StorageHandler {
 	private void prepareProgramXstream() {
 		xstream = new XStreamToSupportCatrobatLanguageVersion098AndBefore(new PureJavaReflectionProvider(new FieldDictionary(new CatroidFieldKeySorter())));
 		xstream.processAnnotations(Project.class);
+		xstream.processAnnotations(Sprite.class);
 		xstream.processAnnotations(XmlHeader.class);
 		xstream.processAnnotations(DataContainer.class);
 		xstream.processAnnotations(Setting.class);
+		xstream.processAnnotations(UserVariableBrick.class);
+		xstream.processAnnotations(UserListBrick.class);
 		xstream.registerConverter(new XStreamConcurrentFormulaHashMapConverter());
 		xstream.registerConverter(new XStreamUserVariableConverter());
 		xstream.registerConverter(new XStreamBrickConverter(xstream.getMapper(), xstream.getReflectionProvider()));
@@ -573,7 +578,7 @@ public final class StorageHandler {
 		Log.d(TAG, json);
 
 		try {
-			File backpackFile =  new File(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, BACKPACK_FILENAME));
+			File backpackFile = new File(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, BACKPACK_FILENAME));
 			if (!backpackFile.exists()) {
 				backpackFile.createNewFile();
 			}
@@ -596,15 +601,15 @@ public final class StorageHandler {
 
 	public Backpack loadBackpack() {
 		Log.d(TAG, "Loading backpack json");
-		File backpackFile =  new File(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, BACKPACK_FILENAME));
+		File backpackFile = new File(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, BACKPACK_FILENAME));
 		if (!backpackFile.exists()) {
 			Log.d(TAG, "Backpack file does not exist!");
 			return null;
 		}
 
 		try {
-			BufferedReader br = new BufferedReader(new FileReader(backpackFile));
-			Backpack backpack = backpackGson.fromJson(br, Backpack.class);
+			BufferedReader bufferedBackpackReader = new BufferedReader(new FileReader(backpackFile));
+			Backpack backpack = backpackGson.fromJson(bufferedBackpackReader, Backpack.class);
 			return backpack;
 		} catch (FileNotFoundException e) {
 			Log.d(TAG, "Could not find backpack file!");
@@ -674,20 +679,11 @@ public final class StorageHandler {
 		File backPackDirectory = new File(DEFAULT_ROOT, BACKPACK_DIRECTORY);
 		backPackDirectory.mkdir();
 
-		//File noMediaFile = new File(backPackDirectory, NO_MEDIA_FILE);
-		//noMediaFile.createNewFile();
-
 		backPackSoundDirectory = new File(backPackDirectory, BACKPACK_SOUND_DIRECTORY);
 		backPackSoundDirectory.mkdir();
 
-		//noMediaFile = new File(backPackSoundDirectory, NO_MEDIA_FILE);
-		//noMediaFile.createNewFile();
-
 		backPackImageDirectory = new File(backPackDirectory, BACKPACK_IMAGE_DIRECTORY);
 		backPackImageDirectory.mkdir();
-
-		//noMediaFile = new File(backPackImageDirectory, NO_MEDIA_FILE);
-		//noMediaFile.createNewFile();
 	}
 
 	public void clearBackPackSoundDirectory() {

--- a/catroid/src/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/org/catrobat/catroid/io/StorageHandler.java
@@ -30,10 +30,15 @@ import android.util.Log;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
 import com.thoughtworks.xstream.converters.reflection.FieldDictionary;
 import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
 
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.Backpack;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.DroneVideoLookData;
 import org.catrobat.catroid.common.FileChecksumContainer;
@@ -162,11 +167,13 @@ import org.catrobat.catroid.utils.ImageEditing;
 import org.catrobat.catroid.utils.UtilFile;
 import org.catrobat.catroid.utils.Utils;
 
+import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
@@ -198,8 +205,10 @@ public final class StorageHandler {
 	private static final String TAG = StorageHandler.class.getSimpleName();
 	private static final String XML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?>\n";
 	private static final int JPG_COMPRESSION_SETTING = 95;
+	public static final String BACKPACK_FILENAME = "backpack.json";
 
 	private XStreamToSupportCatrobatLanguageVersion098AndBefore xstream;
+	private Gson backpackGson;
 
 	private FileInputStream fileInputStream;
 
@@ -217,6 +226,20 @@ public final class StorageHandler {
 		}
 	}
 	private StorageHandler() throws IOException {
+		prepareProgramXstream();
+		prepareBackpackGson();
+
+		if (!Utils.externalStorageAvailable()) {
+			throw new IOException("Could not read external storage");
+		}
+		createCatroidRoot();
+	}
+
+	public static StorageHandler getInstance() {
+		return INSTANCE;
+	}
+
+	private void prepareProgramXstream() {
 		xstream = new XStreamToSupportCatrobatLanguageVersion098AndBefore(new PureJavaReflectionProvider(new FieldDictionary(new CatroidFieldKeySorter())));
 		xstream.processAnnotations(Project.class);
 		xstream.processAnnotations(XmlHeader.class);
@@ -228,16 +251,14 @@ public final class StorageHandler {
 		xstream.registerConverter(new XStreamScriptConverter(xstream.getMapper(), xstream.getReflectionProvider()));
 		xstream.registerConverter(new XStreamSettingConverter(xstream.getMapper(), xstream.getReflectionProvider()));
 
-		setXstreamAliases();
-
-		if (!Utils.externalStorageAvailable()) {
-			throw new IOException("Could not read external storage");
-		}
-		createCatroidRoot();
+		setProgramXstreamAliases();
 	}
 
-	public static StorageHandler getInstance() {
-		return INSTANCE;
+	private void prepareBackpackGson() {
+		GsonBuilder gsonBuilder = new GsonBuilder().setPrettyPrinting();
+		gsonBuilder.registerTypeAdapter(Script.class, new BackpackScriptSerializerAndDeserializer());
+		gsonBuilder.registerTypeAdapter(Brick.class, new BackpackBrickSerializerAndDeserializer());
+		backpackGson = gsonBuilder.create();
 	}
 
 	public static void saveBitmapToImageFile(File outputFile, Bitmap bitmap) throws FileNotFoundException {
@@ -261,7 +282,7 @@ public final class StorageHandler {
 		}
 	}
 
-	private void setXstreamAliases() {
+	private void setProgramXstreamAliases() {
 		xstream.alias("look", LookData.class);
 		xstream.alias("droneLook", DroneVideoLookData.class);
 		xstream.alias("sound", SoundInfo.class);
@@ -402,6 +423,11 @@ public final class StorageHandler {
 		if (!catroidRoot.exists()) {
 			catroidRoot.mkdirs();
 		}
+		try {
+			createBackPackFileStructure();
+		} catch (IOException e) {
+			Log.e(TAG, "Creating backpack file structure failed");
+		}
 	}
 
 	public Project loadProject(String projectName) {
@@ -424,8 +450,7 @@ public final class StorageHandler {
 		try {
 			File projectCodeFile = new File(buildProjectPath(projectName), PROJECTCODE_NAME);
 			fileInputStream = new FileInputStream(projectCodeFile);
-			Project project = (Project) xstream.getProjectFromXML(projectCodeFile);
-			return project;
+			return (Project) xstream.getProjectFromXML(projectCodeFile);
 		} catch (FileNotFoundException e) {
 			Log.d(TAG, "Could not load project!");
 			deleteDirectory(file);
@@ -501,7 +526,7 @@ public final class StorageHandler {
 			}
 
 			File projectDirectory = new File(buildProjectPath(project.getName()));
-			createProjectDataStructure(projectDirectory);
+			createProgramFileStructure(projectDirectory);
 
 			writer = new BufferedWriter(new FileWriter(tmpCodeFile), Constants.BUFFER_8K);
 			writer.write(projectXml);
@@ -541,6 +566,56 @@ public final class StorageHandler {
 		}
 	}
 
+	public boolean saveBackpack(Backpack backpack) {
+		Log.d(TAG, "Saving backpack json");
+		FileWriter writer = null;
+		String json = backpackGson.toJson(backpack);
+		Log.d(TAG, json);
+
+		try {
+			File backpackFile =  new File(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, BACKPACK_FILENAME));
+			if (!backpackFile.exists()) {
+				backpackFile.createNewFile();
+			}
+			writer = new FileWriter(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, BACKPACK_FILENAME));
+			writer.write(json);
+			return true;
+		} catch (IOException e) {
+			Log.e(TAG, "Could not write backpack file", e);
+			return false;
+		} finally {
+			if (writer != null) {
+				try {
+					writer.close();
+				} catch (IOException ioException) {
+					Log.e(TAG, "Failed closing the buffered writer", ioException);
+				}
+			}
+		}
+	}
+
+	public Backpack loadBackpack() {
+		Log.d(TAG, "Loading backpack json");
+		File backpackFile =  new File(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, BACKPACK_FILENAME));
+		if (!backpackFile.exists()) {
+			Log.d(TAG, "Backpack file does not exist!");
+			return null;
+		}
+
+		try {
+			BufferedReader br = new BufferedReader(new FileReader(backpackFile));
+			Backpack backpack = backpackGson.fromJson(br, Backpack.class);
+			return backpack;
+		} catch (FileNotFoundException e) {
+			Log.d(TAG, "Could not find backpack file!");
+			return new Backpack();
+		} catch (JsonSyntaxException | JsonIOException jsonException) {
+			Log.d(TAG, "Could not load backpack file! File will be deleted!");
+			backpackFile.delete();
+			return new Backpack();
+		}
+	}
+
 	public boolean codeFileSanityCheck(String projectName) {
 		loadSaveLock.lock();
 
@@ -577,7 +652,7 @@ public final class StorageHandler {
 		return true;
 	}
 
-	private void createProjectDataStructure(File projectDirectory) throws IOException {
+	private void createProgramFileStructure(File projectDirectory) throws IOException {
 		Log.d(TAG, "create Project Data structure");
 		createCatroidRoot();
 		projectDirectory.mkdir();
@@ -593,24 +668,26 @@ public final class StorageHandler {
 
 		noMediaFile = new File(soundDirectory, NO_MEDIA_FILE);
 		noMediaFile.createNewFile();
+	}
 
+	private void createBackPackFileStructure() throws IOException {
 		File backPackDirectory = new File(DEFAULT_ROOT, BACKPACK_DIRECTORY);
 		backPackDirectory.mkdir();
 
-		noMediaFile = new File(backPackDirectory, NO_MEDIA_FILE);
-		noMediaFile.createNewFile();
+		//File noMediaFile = new File(backPackDirectory, NO_MEDIA_FILE);
+		//noMediaFile.createNewFile();
 
 		backPackSoundDirectory = new File(backPackDirectory, BACKPACK_SOUND_DIRECTORY);
 		backPackSoundDirectory.mkdir();
 
-		noMediaFile = new File(backPackSoundDirectory, NO_MEDIA_FILE);
-		noMediaFile.createNewFile();
+		//noMediaFile = new File(backPackSoundDirectory, NO_MEDIA_FILE);
+		//noMediaFile.createNewFile();
 
 		backPackImageDirectory = new File(backPackDirectory, BACKPACK_IMAGE_DIRECTORY);
 		backPackImageDirectory.mkdir();
 
-		noMediaFile = new File(backPackImageDirectory, NO_MEDIA_FILE);
-		noMediaFile.createNewFile();
+		//noMediaFile = new File(backPackImageDirectory, NO_MEDIA_FILE);
+		//noMediaFile.createNewFile();
 	}
 
 	public void clearBackPackSoundDirectory() {

--- a/catroid/src/org/catrobat/catroid/io/XStreamToSupportCatrobatLanguageVersion098AndBefore.java
+++ b/catroid/src/org/catrobat/catroid/io/XStreamToSupportCatrobatLanguageVersion098AndBefore.java
@@ -176,7 +176,7 @@ public class XStreamToSupportCatrobatLanguageVersion098AndBefore extends XStream
 			return;
 		}
 
-		brickInfoMap = new HashMap<String, BrickInfo>();
+		brickInfoMap = new HashMap<>();
 
 		BrickInfo brickInfo = new BrickInfo(BroadcastBrick.class.getSimpleName());
 		brickInfoMap.put("broadcastBrick", brickInfo);
@@ -543,7 +543,8 @@ public class XStreamToSupportCatrobatLanguageVersion098AndBefore extends XStream
 		if (scriptInfoMap != null) {
 			return;
 		}
-		scriptInfoMap = new HashMap<String, String>();
+
+		scriptInfoMap = new HashMap<>();
 		scriptInfoMap.put("startScript", StartScript.class.getSimpleName());
 		scriptInfoMap.put("whenScript", WhenScript.class.getSimpleName());
 		scriptInfoMap.put("broadcastScript", BroadcastScript.class.getSimpleName());
@@ -921,7 +922,7 @@ public class XStreamToSupportCatrobatLanguageVersion098AndBefore extends XStream
 
 		void addBrickFieldToMap(String oldFiledName, BrickField brickField) {
 			if (brickFieldMap == null) {
-				brickFieldMap = new HashMap<String, BrickField>();
+				brickFieldMap = new HashMap<>();
 			}
 			brickFieldMap.put(oldFiledName, brickField);
 		}

--- a/catroid/src/org/catrobat/catroid/ui/BaseActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/BaseActivity.java
@@ -35,7 +35,6 @@ import android.widget.AdapterView;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.ui.controller.BackPackListManager;
 import org.catrobat.catroid.ui.dialogs.AboutDialogFragment;
 import org.catrobat.catroid.ui.dialogs.TermsOfUseDialogFragment;
 import org.catrobat.catroid.utils.ToastUtil;
@@ -86,12 +85,10 @@ public class BaseActivity extends Activity {
 				if (returnToProjectsList) {
 					Intent intent = new Intent(this, MyProjectsActivity.class);
 					intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-					BackPackListManager.getInstance().setBackPackFlag(true);
 					startActivity(intent);
 				} else {
 					Intent intent = new Intent(this, MainMenuActivity.class);
 					intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-					BackPackListManager.getInstance().setBackPackFlag(true);
 					startActivity(intent);
 				}
 				break;

--- a/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -52,7 +52,6 @@ import org.catrobat.catroid.io.LoadProjectTask;
 import org.catrobat.catroid.io.LoadProjectTask.OnLoadProjectCompleteListener;
 import org.catrobat.catroid.stage.PreStageActivity;
 import org.catrobat.catroid.transfers.GetFacebookUserInfoTask;
-import org.catrobat.catroid.ui.controller.BackPackListManager;
 import org.catrobat.catroid.ui.dialogs.NewProjectDialog;
 import org.catrobat.catroid.ui.dialogs.SignInDialog;
 import org.catrobat.catroid.utils.DownloadUtil;
@@ -103,11 +102,6 @@ public class MainMenuActivity extends BaseActivity implements OnLoadProjectCompl
 
 		if (loadExternalProjectUri != null) {
 			loadProgramFromExternalSource(loadExternalProjectUri);
-		}
-
-		if (!BackPackListManager.getInstance().isBackpackFlag()) {
-			BackPackListManager.getInstance().clearBackPackSounds();
-			BackPackListManager.getInstance().clearBackPackLooks();
 		}
 	}
 

--- a/catroid/src/org/catrobat/catroid/ui/adapter/BackPackSpriteAdapter.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/BackPackSpriteAdapter.java
@@ -92,7 +92,7 @@ public class BackPackSpriteAdapter extends SpriteBaseAdapter implements ActionMo
 		handleHolderViews(position, holder);
 
 		if (selectMode != ListView.CHOICE_MODE_NONE) {
-			if (disableBackgroundSprites && getItem(position).isBackgroundSprite) {
+			if (disableBackgroundSprites && getItem(position).isBackgroundObject) {
 				holder.checkbox.setVisibility(View.INVISIBLE);
 				enableHolderViews(holder, false);
 				spriteView.setAlpha((float) 0.25);
@@ -173,7 +173,7 @@ public class BackPackSpriteAdapter extends SpriteBaseAdapter implements ActionMo
 	public int getCountWithBackgroundSprites() {
 		int numberOfBackgroundSprites = 0;
 		for (int position = 0; position < getCount(); position++) {
-			if (getItem(position).isBackgroundSprite) {
+			if (getItem(position).isBackgroundObject) {
 				numberOfBackgroundSprites++;
 			}
 		}

--- a/catroid/src/org/catrobat/catroid/ui/controller/BackPackListManager.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/BackPackListManager.java
@@ -22,57 +22,51 @@
  */
 package org.catrobat.catroid.ui.controller;
 
+import android.os.AsyncTask;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.Backpack;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.SoundInfo;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.ui.adapter.LookBaseAdapter;
 import org.catrobat.catroid.ui.adapter.SoundBaseAdapter;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 public final class BackPackListManager {
 	private static final BackPackListManager INSTANCE = new BackPackListManager();
 
+	private static Backpack backpack;
 	private static SoundBaseAdapter currentSoundAdapter;
 	private static LookBaseAdapter currentLookAdapter;
 
-	private static List<SoundInfo> backpackedSounds = new CopyOnWriteArrayList<>();
-	private static List<LookData> backpackedLooks = new CopyOnWriteArrayList<>();
-	private static HashMap<String, List<Script>> backpackedScripts = new HashMap<>();
-	private static List<Sprite> backpackedSprites = new CopyOnWriteArrayList<>();
-
-	private static List<SoundInfo> hiddenBackpackedSounds = new CopyOnWriteArrayList<>();
-	private static List<LookData> hiddenBackpackedLooks = new CopyOnWriteArrayList<>();
-	private static HashMap<String, List<Script>> hiddenBackpackedScripts = new HashMap<>();
-	private static List<Sprite> hiddenBackpackedSprites = new CopyOnWriteArrayList<>();
-
-	private static boolean backpackFlag;
-
-	private BackPackListManager() {
-	}
-
 	public static BackPackListManager getInstance() {
+		if (backpack == null) {
+			backpack = new Backpack();
+		}
 		return INSTANCE;
 	}
 
 	public void addLookToBackPack(LookData lookData) {
-		backpackedLooks.add(lookData);
+		getBackpack().backpackedLooks.add(lookData);
 	}
 
 	public List<LookData> getBackPackedLooks() {
-		return backpackedLooks;
+		return getBackpack().backpackedLooks;
 	}
 
 	public void clearBackPackScripts() {
-		backpackedScripts.clear();
+		getBackpack().backpackedScripts.clear();
+		getBackpack().hiddenBackpackedScripts.clear();
 	}
 
 	public void removeItemFromScriptBackPack(String scriptGroup) {
-		backpackedScripts.remove(scriptGroup);
+		getBackpack().backpackedScripts.remove(scriptGroup);
 	}
 
 	public void removeItemFromScriptBackPackByName(String name) {
@@ -84,23 +78,31 @@ public final class BackPackListManager {
 	}
 
 	public ArrayList<String> getBackPackedScriptGroups() {
-		return new ArrayList<>(backpackedScripts.keySet());
+		return new ArrayList<>(getBackpack().backpackedScripts.keySet());
 	}
 
 	public void addScriptToBackPack(String scriptGroup, List<Script> scripts) {
-		backpackedScripts.put(scriptGroup, scripts);
+		getBackpack().backpackedScripts.put(scriptGroup, scripts);
 	}
 
 	public HashMap<String, List<Script>> getBackPackedScripts() {
-		return backpackedScripts;
+		return getBackpack().backpackedScripts;
+	}
+
+	public HashMap<String, List<Script>> getAllBackPackedScripts() {
+		HashMap<String, List<Script>> allScripts = new HashMap<>();
+		allScripts.putAll(getBackpack().backpackedScripts);
+		allScripts.putAll(getBackpack().hiddenBackpackedScripts);
+		return allScripts;
 	}
 
 	public void clearBackPackLooks() {
-		backpackedLooks.clear();
+		getBackpack().backpackedLooks.clear();
+		getBackpack().hiddenBackpackedLooks.clear();
 	}
 
 	public void removeItemFromLookBackPack(LookData lookData) {
-		backpackedLooks.remove(lookData);
+		getBackpack().backpackedLooks.remove(lookData);
 	}
 
 	public void removeItemFromLookBackPackByLookName(String name) {
@@ -112,19 +114,20 @@ public final class BackPackListManager {
 	}
 
 	public List<SoundInfo> getBackPackedSounds() {
-		return backpackedSounds;
+		return getBackpack().backpackedSounds;
 	}
 
 	public void clearBackPackSounds() {
-		backpackedSounds.clear();
+		getBackpack().backpackedSounds.clear();
+		getBackpack().hiddenBackpackedSounds.clear();
 	}
 
 	public void addSoundToBackPack(SoundInfo soundInfo) {
-		backpackedSounds.add(soundInfo);
+		getBackpack().backpackedSounds.add(soundInfo);
 	}
 
 	public void removeItemFromSoundBackPack(SoundInfo currentSoundInfo) {
-		backpackedSounds.remove(currentSoundInfo);
+		getBackpack().backpackedSounds.remove(currentSoundInfo);
 	}
 
 	public void removeItemFromSoundBackPackBySoundTitle(String title) {
@@ -136,19 +139,20 @@ public final class BackPackListManager {
 	}
 
 	public List<Sprite> getBackPackedSprites() {
-		return backpackedSprites;
+		return getBackpack().backpackedSprites;
 	}
 
 	public void clearBackPackSprites() {
-		backpackedSprites.clear();
+		getBackpack().backpackedSprites.clear();
+		getBackpack().hiddenBackpackedSprites.clear();
 	}
 
 	public void addSpriteToBackPack(Sprite sprite) {
-		backpackedSprites.add(sprite);
+		getBackpack().backpackedSprites.add(sprite);
 	}
 
 	public void removeItemFromSpriteBackPack(Sprite sprite) {
-		backpackedSprites.remove(sprite);
+		getBackpack().backpackedSprites.remove(sprite);
 	}
 
 	public void removeItemFromSpriteBackPackByName(String name) {
@@ -160,47 +164,47 @@ public final class BackPackListManager {
 	}
 
 	public List<LookData> getHiddenBackpackedLooks() {
-		return hiddenBackpackedLooks;
+		return getBackpack().hiddenBackpackedLooks;
 	}
 
 	public void removeItemFromScriptHiddenBackpack(String scriptGroup) {
-		hiddenBackpackedScripts.remove(scriptGroup);
+		getBackpack().hiddenBackpackedScripts.remove(scriptGroup);
 	}
 
 	public void addScriptToHiddenBackpack(String scriptGroup, List<Script> scripts) {
-		hiddenBackpackedScripts.put(scriptGroup, scripts);
+		getBackpack().hiddenBackpackedScripts.put(scriptGroup, scripts);
 	}
 
 	public HashMap<String, List<Script>> getHiddenBackpackedScripts() {
-		return hiddenBackpackedScripts;
+		return getBackpack().hiddenBackpackedScripts;
 	}
 
 	public void removeItemFromLookHiddenBackpack(LookData lookData) {
-		hiddenBackpackedLooks.remove(lookData);
+		getBackpack().hiddenBackpackedLooks.remove(lookData);
 	}
 
 	public List<SoundInfo> getHiddenBackpackedSounds() {
-		return hiddenBackpackedSounds;
+		return getBackpack().hiddenBackpackedSounds;
 	}
 
 	public void addSoundToHiddenBackpack(SoundInfo soundInfo) {
-		hiddenBackpackedSounds.add(soundInfo);
+		getBackpack().hiddenBackpackedSounds.add(soundInfo);
 	}
 
 	public void removeItemFromSoundHiddenBackpack(SoundInfo currentSoundInfo) {
-		hiddenBackpackedSounds.remove(currentSoundInfo);
+		getBackpack().hiddenBackpackedSounds.remove(currentSoundInfo);
 	}
 
 	public List<Sprite> getHiddenBackpackedSprites() {
-		return hiddenBackpackedSprites;
+		return getBackpack().hiddenBackpackedSprites;
 	}
 
 	public void addSpriteToHiddenBackpack(Sprite sprite) {
-		hiddenBackpackedSprites.add(sprite);
+		getBackpack().hiddenBackpackedSprites.add(sprite);
 	}
 
 	public void removeItemFromSpriteHiddenBackpack(Sprite sprite) {
-		hiddenBackpackedSprites.remove(sprite);
+		getBackpack().hiddenBackpackedSprites.remove(sprite);
 	}
 
 	public boolean backPackedSoundsContain(SoundInfo soundInfo, boolean onlyVisible) {
@@ -235,29 +239,29 @@ public final class BackPackListManager {
 
 	public ArrayList<String> getAllBackPackedScriptGroups() {
 		ArrayList<String> allScriptGroups = new ArrayList<>();
-		allScriptGroups.addAll(new ArrayList<>(backpackedScripts.keySet()));
-		allScriptGroups.addAll(new ArrayList<>(backpackedScripts.keySet()));
+		allScriptGroups.addAll(new ArrayList<>(getBackpack().backpackedScripts.keySet()));
+		allScriptGroups.addAll(new ArrayList<>(getBackpack().backpackedScripts.keySet()));
 		return allScriptGroups;
 	}
 
 	public List<LookData> getAllBackPackedLooks() {
 		List<LookData> allLooks = new ArrayList<>();
-		allLooks.addAll(backpackedLooks);
-		allLooks.addAll(hiddenBackpackedLooks);
+		allLooks.addAll(getBackpack().backpackedLooks);
+		allLooks.addAll(getBackpack().hiddenBackpackedLooks);
 		return allLooks;
 	}
 
 	public List<SoundInfo> getAllBackPackedSounds() {
 		List<SoundInfo> allSounds = new ArrayList<>();
-		allSounds.addAll(backpackedSounds);
-		allSounds.addAll(hiddenBackpackedSounds);
+		allSounds.addAll(getBackpack().backpackedSounds);
+		allSounds.addAll(getBackpack().hiddenBackpackedSounds);
 		return allSounds;
 	}
 
 	public List<Sprite> getAllBackPackedSprites() {
 		List<Sprite> allSprites = new ArrayList<>();
-		allSprites.addAll(backpackedSprites);
-		allSprites.addAll(hiddenBackpackedSprites);
+		allSprites.addAll(getBackpack().backpackedSprites);
+		allSprites.addAll(getBackpack().hiddenBackpackedSprites);
 		return allSprites;
 	}
 
@@ -277,15 +281,65 @@ public final class BackPackListManager {
 		BackPackListManager.currentLookAdapter = currentLookAdapter;
 	}
 
-	public void setBackPackFlag(boolean currentBackpackFlag) {
-		backpackFlag = currentBackpackFlag;
-	}
-
-	public boolean isBackpackFlag() {
-		return backpackFlag;
-	}
-
 	public void addLookToHiddenBackPack(LookData newLookData) {
-		hiddenBackpackedLooks.add(newLookData);
+		getBackpack().hiddenBackpackedLooks.add(newLookData);
+	}
+
+	public boolean isBackpackEmpty() {
+		return getAllBackPackedLooks().isEmpty() && getAllBackPackedScriptGroups().isEmpty()
+				&& getAllBackPackedSounds().isEmpty() && getAllBackPackedSprites().isEmpty();
+	}
+
+	public void saveBackpack() {
+		SaveBackpackAsynchronousTask saveTask = new SaveBackpackAsynchronousTask();
+		saveTask.execute();
+	}
+
+	public void loadBackpack() {
+		LoadBackpackAsynchronousTask loadTask = new LoadBackpackAsynchronousTask();
+		loadTask.execute();
+	}
+
+	private class SaveBackpackAsynchronousTask extends AsyncTask<Void, Void, Void> {
+		@Override
+		protected Void doInBackground(Void... params) {
+			StorageHandler.getInstance().saveBackpack(getBackpack());
+			return null;
+		}
+	}
+
+	private class LoadBackpackAsynchronousTask extends AsyncTask<Void, Void, Void> {
+		@Override
+		protected Void doInBackground(Void... params) {
+			backpack = StorageHandler.getInstance().loadBackpack();
+			setBackPackFlags();
+			ProjectManager.getInstance().checkNestingBrickReferences(false, true);
+			return null;
+		}
+
+		private void setBackPackFlags() {
+			for (LookData lookData : getAllBackPackedLooks()) {
+				lookData.isBackpackLookData = true;
+			}
+			for (SoundInfo soundInfo : getAllBackPackedSounds()) {
+				soundInfo.isBackpackSoundInfo = true;
+			}
+			for (Sprite sprite : getAllBackPackedSprites()) {
+				sprite.isBackpackObject = true;
+				for (LookData lookData : sprite.getLookDataList()) {
+					lookData.isBackpackLookData = true;
+				}
+				for (SoundInfo soundInfo : sprite.getSoundList()) {
+					soundInfo.isBackpackSoundInfo = true;
+				}
+			}
+		}
+	}
+
+	public Backpack getBackpack() {
+		if (backpack == null) {
+			backpack = new Backpack();
+		}
+		return backpack;
 	}
 }

--- a/catroid/src/org/catrobat/catroid/ui/controller/BackPackListManager.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/BackPackListManager.java
@@ -69,14 +69,6 @@ public final class BackPackListManager {
 		getBackpack().backpackedScripts.remove(scriptGroup);
 	}
 
-	public void removeItemFromScriptBackPackByName(String name) {
-		for (String scriptGroup : backpackedScripts.keySet()) {
-			if (scriptGroup.equals(name)) {
-				backpackedScripts.remove(scriptGroup);
-			}
-		}
-	}
-
 	public ArrayList<String> getBackPackedScriptGroups() {
 		return new ArrayList<>(getBackpack().backpackedScripts.keySet());
 	}
@@ -106,9 +98,9 @@ public final class BackPackListManager {
 	}
 
 	public void removeItemFromLookBackPackByLookName(String name) {
-		for (LookData lookData : backpackedLooks) {
+		for (LookData lookData : getBackpack().backpackedLooks) {
 			if (lookData.getLookName().equals(name)) {
-				backpackedLooks.remove(lookData);
+				getBackpack().backpackedLooks.remove(lookData);
 			}
 		}
 	}
@@ -131,9 +123,9 @@ public final class BackPackListManager {
 	}
 
 	public void removeItemFromSoundBackPackBySoundTitle(String title) {
-		for (SoundInfo soundInfo : backpackedSounds) {
+		for (SoundInfo soundInfo : getBackpack().backpackedSounds) {
 			if (soundInfo.getTitle().equals(title)) {
-				backpackedSounds.remove(soundInfo);
+				getBackpack().backpackedSounds.remove(soundInfo);
 			}
 		}
 	}
@@ -156,9 +148,9 @@ public final class BackPackListManager {
 	}
 
 	public void removeItemFromSpriteBackPackByName(String name) {
-		for (Sprite sprite : backpackedSprites) {
+		for (Sprite sprite : getBackpack().backpackedSprites) {
 			if (sprite.getName().equals(name)) {
-				backpackedSprites.remove(sprite);
+				getBackpack().backpackedSprites.remove(sprite);
 			}
 		}
 	}

--- a/catroid/src/org/catrobat/catroid/ui/controller/BackPackSpriteController.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/BackPackSpriteController.java
@@ -143,8 +143,8 @@ public final class BackPackSpriteController {
 
 		String newSpriteName = Utils.getUniqueSpriteName(spriteToEdit);
 		backPackSprite.setName(newSpriteName);
-		backPackSprite.isBackpackSprite = true;
-		backPackSprite.isBackgroundSprite = ProjectManager.getInstance().getCurrentProject().isBackgroundSprite(spriteToEdit);
+		backPackSprite.isBackpackObject = true;
+		backPackSprite.isBackgroundObject = ProjectManager.getInstance().getCurrentProject().isBackgroundObject(spriteToEdit);
 
 		for (LookData lookData : spriteToEdit.getLookDataList()) {
 			if (!lookDataIsUsedInScript(lookData, ProjectManager.getInstance().getCurrentSprite())) {
@@ -192,7 +192,7 @@ public final class BackPackSpriteController {
 
 		BackPackScriptController.getInstance().unpack(selectedSprite.getName(), delete, false, null, true);
 
-		if (selectedSprite.isBackgroundSprite) {
+		if (selectedSprite.isBackgroundObject) {
 			ProjectManager.getInstance().getCurrentProject().replaceBackgroundSprite(unpackedSprite);
 		} else {
 			ProjectManager.getInstance().addSprite(unpackedSprite);

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackLookFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackLookFragment.java
@@ -442,6 +442,8 @@ public class BackPackLookFragment extends BackPackActivityFragment implements Di
 			projectManager.saveProject(getActivity().getApplicationContext());
 		}
 
+		BackPackListManager.getInstance().saveBackpack();
+
 		if (lookDeletedReceiver != null) {
 			getActivity().unregisterReceiver(lookDeletedReceiver);
 		}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackScriptFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackScriptFragment.java
@@ -454,6 +454,8 @@ public class BackPackScriptFragment extends BackPackActivityFragment implements 
 			projectManager.saveProject(getActivity().getApplicationContext());
 		}
 
+		BackPackListManager.getInstance().saveBackpack();
+
 		if (scriptGroupDeletedReceiver != null) {
 			getActivity().unregisterReceiver(scriptGroupDeletedReceiver);
 		}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSoundFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSoundFragment.java
@@ -276,6 +276,7 @@ public class BackPackSoundFragment extends BackPackActivityFragment implements S
 	public void onPause() {
 		super.onPause();
 
+		BackPackListManager.getInstance().saveBackpack();
 		SoundController.getInstance().stopSound(mediaPlayer, BackPackListManager.getInstance().getBackPackedSounds());
 		adapter.notifyDataSetChanged();
 

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSpriteFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSpriteFragment.java
@@ -219,7 +219,7 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 
 	private void checkForBackgroundUnpacking(Sprite selectedSprite, boolean delete, boolean keepCurrentSprite,
 			boolean fromHiddenBackPack) {
-		if (selectedSprite.isBackgroundSprite) {
+		if (selectedSprite.isBackgroundObject) {
 			ConfirmUnpackBackgroundDialog dialog = new ConfirmUnpackBackgroundDialog(selectedSprite, delete,
 					keepCurrentSprite, fromHiddenBackPack);
 			dialog.show(getFragmentManager(), ConfirmUnpackBackgroundDialog.DIALOG_FRAGMENT_TAG);
@@ -335,7 +335,7 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 					@Override
 					public void onClick(View view) {
 						for (int position = 0; position < adapter.getCount(); position++) {
-							if (adapter.getItem(position).isBackgroundSprite && actionModeTitle.equals(
+							if (adapter.getItem(position).isBackgroundObject && actionModeTitle.equals(
 									getString(R.string.unpack))) {
 								continue;
 							}
@@ -417,6 +417,8 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 	@Override
 	public void onPause() {
 		super.onPause();
+
+		BackPackListManager.getInstance().saveBackpack();
 
 		if (spriteDeletedReceiver != null) {
 			getActivity().unregisterReceiver(spriteDeletedReceiver);

--- a/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
@@ -382,6 +382,10 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 			return;
 		}
 
+		if (BackPackListManager.getInstance().isBackpackEmpty()) {
+			BackPackListManager.getInstance().loadBackpack();
+		}
+
 		if (lookRenamedReceiver == null) {
 			lookRenamedReceiver = new LookRenamedReceiver();
 		}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/ScriptFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/ScriptFragment.java
@@ -271,6 +271,10 @@ public class ScriptFragment extends ScriptActivityFragment implements OnCategory
 			return;
 		}
 
+		if (BackPackListManager.getInstance().isBackpackEmpty()) {
+			BackPackListManager.getInstance().loadBackpack();
+		}
+
 		if (brickListChangedReceiver == null) {
 			brickListChangedReceiver = new BrickListChangedReceiver();
 		}
@@ -282,7 +286,9 @@ public class ScriptFragment extends ScriptActivityFragment implements OnCategory
 		BottomBar.showPlayButton(getActivity());
 		BottomBar.showAddButton(getActivity());
 		initListeners();
-		adapter.resetAlphas();
+		if (adapter != null) {
+			adapter.resetAlphas();
+		}
 		handleInsertFromBackpack();
 	}
 
@@ -679,7 +685,8 @@ public class ScriptFragment extends ScriptActivityFragment implements OnCategory
 		int indexOfNumber = completeTitle.indexOf(' ') + 1;
 		Spannable completeSpannedTitle = new SpannableString(completeTitle);
 		if (!completeTitle.equals(getString(R.string.backpack))) {
-			completeSpannedTitle.setSpan(new ForegroundColorSpan(getResources().getColor(R.color.actionbar_title_color)),
+			completeSpannedTitle.setSpan(new ForegroundColorSpan(getResources().getColor(R.color
+							.actionbar_title_color)),
 					indexOfNumber, indexOfNumber + String.valueOf(numberOfSelectedItems).length(),
 					Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 		}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/ScriptFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/ScriptFragment.java
@@ -685,8 +685,7 @@ public class ScriptFragment extends ScriptActivityFragment implements OnCategory
 		int indexOfNumber = completeTitle.indexOf(' ') + 1;
 		Spannable completeSpannedTitle = new SpannableString(completeTitle);
 		if (!completeTitle.equals(getString(R.string.backpack))) {
-			completeSpannedTitle.setSpan(new ForegroundColorSpan(getResources().getColor(R.color
-							.actionbar_title_color)),
+			completeSpannedTitle.setSpan(new ForegroundColorSpan(getResources().getColor(R.color.actionbar_title_color)),
 					indexOfNumber, indexOfNumber + String.valueOf(numberOfSelectedItems).length(),
 					Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 		}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/SoundFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/SoundFragment.java
@@ -226,6 +226,10 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 			return;
 		}
 
+		if (BackPackListManager.getInstance().isBackpackEmpty()) {
+			BackPackListManager.getInstance().loadBackpack();
+		}
+
 		if (soundRenamedReceiver == null) {
 			soundRenamedReceiver = new SoundRenamedReceiver();
 		}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
@@ -70,6 +70,7 @@ import org.catrobat.catroid.ui.ScriptActivity;
 import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.ui.adapter.SpriteAdapter;
 import org.catrobat.catroid.ui.adapter.SpriteBaseAdapter;
+import org.catrobat.catroid.ui.controller.BackPackListManager;
 import org.catrobat.catroid.ui.controller.BackPackSpriteController;
 import org.catrobat.catroid.ui.dialogs.CustomAlertDialogBuilder;
 import org.catrobat.catroid.ui.dialogs.LegoNXTSensorConfigInfoDialog;
@@ -183,6 +184,10 @@ public class SpritesListFragment extends ScriptActivityFragment implements Sprit
 		}
 		if (!Utils.checkForExternalStorageAvailableAndDisplayErrorIfNot(getActivity())) {
 			return;
+		}
+
+		if (BackPackListManager.getInstance().isBackpackEmpty()) {
+			BackPackListManager.getInstance().loadBackpack();
 		}
 
 		StorageHandler.getInstance().fillChecksumContainer();

--- a/catroid/src/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/org/catrobat/catroid/utils/Utils.java
@@ -452,7 +452,7 @@ public final class Utils {
 	private static String searchForNonExistingSpriteName(Sprite sprite, int nextNumber) {
 		String newName;
 		List<Sprite> spriteList;
-		if (!sprite.isBackpackSprite) {
+		if (!sprite.isBackpackObject) {
 			spriteList = BackPackListManager.getInstance().getAllBackPackedSprites();
 		} else {
 			spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteList();

--- a/catroidTest/src/org/catrobat/catroid/test/content/project/ProjectManagerTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/content/project/ProjectManagerTest.java
@@ -208,7 +208,7 @@ public class ProjectManagerTest extends InstrumentationTestCase {
 		ProjectManager projectManager = ProjectManager.getInstance();
 		TestUtils.createTestProjectWithWrongIfClauseReferences();
 
-		projectManager.checkNestingBrickReferences(true);
+		projectManager.checkNestingBrickReferences(true, false);
 
 		List<Brick> newBrickList = projectManager.getCurrentProject().getSpriteList().get(0).getScript(0)
 				.getBrickList();

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
@@ -178,6 +178,7 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		projectManager.getCurrentProject().getXmlHeader().virtualScreenWidth = ScreenValues.SCREEN_WIDTH;
 		projectManager.getCurrentProject().getXmlHeader().virtualScreenHeight = ScreenValues.SCREEN_HEIGHT;
 
+		UiTestUtils.clearBackPackJson();
 		UiTestUtils.getIntoLooksFromMainMenu(solo, true);
 
 		Resources resources = getActivity().getBaseContext().getResources();

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/ScriptFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/ScriptFragmentTest.java
@@ -123,7 +123,7 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 		delete = solo.getString(R.string.delete);
 		deleteDialogTitle = solo.getString(R.string.dialog_confirm_delete_script_group_title);
 
-		UiTestUtils.clearBackPack();
+		UiTestUtils.clearBackPack(true);
 	}
 
 	public void testCopyScript() {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
@@ -717,6 +717,9 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 
 		clickOnContextMenuItem(SECOND_TEST_SOUND_NAME, backpackAdd);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
+		solo.waitForActivity(BackPackActivity.class);
+		solo.waitForFragmentByTag(BackPackSoundFragment.TAG);
+		solo.sleep(TIME_TO_WAIT);
 
 		assertTrue("BackPack title didn't show up",
 				solo.waitForText(backpackTitle, 0, TIME_TO_WAIT_BACKPACK));
@@ -747,6 +750,9 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		solo.goBack();
 		clickOnContextMenuItem(FIRST_TEST_SOUND_NAME, backpackAdd);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
+		solo.waitForActivity(BackPackActivity.class);
+		solo.waitForFragmentByTag(BackPackSoundFragment.TAG);
+		solo.sleep(TIME_TO_WAIT_BACKPACK);
 
 		assertTrue("BackPack title didn't show up",
 				solo.waitForText(backpackTitle, 0, TIME_TO_WAIT_BACKPACK));
@@ -758,6 +764,8 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		SoundAdapter adapter = getSoundAdapter();
 		assertNotNull("Could not get Adapter", adapter);
 		clickOnContextMenuItem(FIRST_TEST_SOUND_NAME, backpackAdd);
+		solo.waitForActivity(BackPackActivity.class);
+		solo.waitForFragmentByTag(BackPackSoundFragment.TAG);
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
 		assertTrue("Sound wasn't backpacked!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
 
@@ -779,8 +787,11 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		deleteSound(firstTestSoundNamePackedAndUnpacked);
 		solo.sleep(200);
 		UiTestUtils.openBackPack(solo, getActivity());
+		solo.waitForActivity(BackPackActivity.class);
+		solo.waitForFragmentByTag(BackPackSoundFragment.TAG);
+		solo.sleep(TIME_TO_WAIT);
 
-		assertTrue("Sound wasn't kept in backpack!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
+		assertTrue("Sound wasn't kept in backpack!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT_BACKPACK));
 		clickOnContextMenuItem(firstTestSoundNamePacked, unpack);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
 		assertTrue("Sound wasn't unpacked!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
@@ -858,8 +869,11 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		clickOnContextMenuItem(FIRST_TEST_SOUND_NAME, backpackAdd);
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
 		solo.goBack();
+		solo.sleep(TIME_TO_WAIT);
 		solo.goBack();
+		solo.sleep(TIME_TO_WAIT);
 		solo.goBack();
+		solo.sleep(TIME_TO_WAIT);
 		solo.clickOnText(SECOND_SPRITE_NAME);
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
 		solo.clickOnText(solo.getString(R.string.sounds));
@@ -1744,6 +1758,7 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		UiTestUtils.acceptAndCloseActionMode(solo);
 		solo.waitForDialogToOpen();
 		solo.waitForText(solo.getString(R.string.yes));
+		solo.sleep(TIME_TO_WAIT_BACKPACK);
 		solo.clickOnText(solo.getString(R.string.yes));
 		solo.waitForDialogToClose();
 	}

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
@@ -149,6 +149,7 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		externalSoundFile = UiTestUtils.createTestMediaFile(Constants.DEFAULT_ROOT + "/externalSoundFile.mp3",
 				RESOURCE_SOUND, getActivity());
 
+		UiTestUtils.clearBackPackJson();
 		UiTestUtils.getIntoSoundsFromMainMenu(solo);
 
 		firstTestSoundNamePacked = FIRST_TEST_SOUND_NAME;

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SpritesListFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SpritesListFragmentTest.java
@@ -845,7 +845,7 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 
 	public void testBackPackShowAndHideDetails() {
 		UiTestUtils.backPackAllItems(solo, getActivity(), SPRITE_NAME_BACKGROUND, SPRITE_NAME);
-		int timeToWait = 300;
+		int timeToWait = 500;
 
 		solo.sleep(timeToWait);
 		checkVisibilityOfViews(VISIBLE, VISIBLE, GONE, GONE);
@@ -861,6 +861,7 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		solo.sleep(timeToWait);
 		checkVisibilityOfViews(VISIBLE, VISIBLE, VISIBLE, GONE);
 
+		solo.sleep(timeToWait);
 		solo.clickOnMenuItem(solo.getString(R.string.hide_details));
 		solo.sleep(timeToWait);
 		checkVisibilityOfViews(VISIBLE, VISIBLE, GONE, GONE);

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SpritesListFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SpritesListFragmentTest.java
@@ -43,6 +43,7 @@ import org.catrobat.catroid.content.bricks.SetVariableBrick;
 import org.catrobat.catroid.formulaeditor.DataContainer;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.ui.BackPackActivity;
 import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.ui.ProjectActivity;
@@ -57,11 +58,16 @@ import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
 import org.catrobat.catroid.uitest.util.UiTestUtils;
 import org.catrobat.catroid.utils.Utils;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+
+import static org.catrobat.catroid.common.Constants.BACKPACK_DIRECTORY;
+import static org.catrobat.catroid.common.Constants.DEFAULT_ROOT;
+import static org.catrobat.catroid.utils.Utils.buildPath;
 
 public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
 
@@ -145,7 +151,7 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		backpackReplaceDialogSingle = resources.getString(R.string.backpack_replace_object, SPRITE_NAME);
 		backpackReplaceDialogMultiple = solo.getString(R.string.backpack_replace_object_multiple);
 
-		UiTestUtils.clearBackPack();
+		UiTestUtils.clearBackPack(true);
 		solo.clickOnText(solo.getString(R.string.main_menu_continue));
 
 		SpriteAdapter adapter = getSpriteAdapter();
@@ -1010,6 +1016,29 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		assertTrue("Sprite wasn't backpacked!", solo.waitForText(SPRITE_NAME, 0, TIME_TO_WAIT));
 		assertTrue("Sprite wasn't backpacked!", solo.waitForText(SPRITE_NAME2, 0, TIME_TO_WAIT));
 		assertTrue("Sprite was not replaced!", BackPackListManager.getInstance().getBackPackedSprites().size() == 3);
+	}
+
+	public void testBackPackSerializationAndDeserialization() {
+		File backPackFile = new File(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, StorageHandler.BACKPACK_FILENAME));
+		assertFalse("Backpack.json should not exist!", backPackFile.exists());
+		UiTestUtils.backPackAllItems(solo, getActivity(), SPRITE_NAME_BACKGROUND, SPRITE_NAME);
+		solo.goBack();
+		solo.sleep(TIME_TO_WAIT_BACKPACK);
+
+		assertTrue("No items have been backpacked!", !BackPackListManager.getInstance().getBackpack()
+				.backpackedSprites.isEmpty());
+		backPackFile = new File(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, StorageHandler.BACKPACK_FILENAME));
+		assertTrue("Backpack.json has not been saved!", backPackFile.exists());
+
+		UiTestUtils.clearBackPack(false);
+		solo.sleep(TIME_TO_WAIT);
+		assertTrue("Backpacked items not deleted!", BackPackListManager.getInstance().getBackpack()
+				.backpackedSprites.isEmpty());
+
+		BackPackListManager.getInstance().loadBackpack();
+		solo.sleep(TIME_TO_WAIT_BACKPACK);
+		assertTrue("Backpacked items haven't been restored from backpack.json!", !BackPackListManager.getInstance()
+				.getBackpack().backpackedSprites.isEmpty());
 	}
 
 	private String getSpriteName(int spriteIndex) {

--- a/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -172,6 +172,10 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
+import static org.catrobat.catroid.common.Constants.BACKPACK_DIRECTORY;
+import static org.catrobat.catroid.common.Constants.DEFAULT_ROOT;
+import static org.catrobat.catroid.utils.Utils.buildPath;
+
 public final class UiTestUtils {
 	private static ProjectManager projectManager = ProjectManager.getInstance();
 	private static SparseIntArray brickCategoryMap;
@@ -2439,13 +2443,21 @@ public final class UiTestUtils {
 		solo.sleep(300);
 	}
 
-	public static void clearBackPack() {
+	public static void clearBackPack(boolean deleteBackPackDirectories) {
 		BackPackListManager.getInstance().clearBackPackLooks();
-		StorageHandler.getInstance().clearBackPackLookDirectory();
 		BackPackListManager.getInstance().clearBackPackSounds();
-		StorageHandler.getInstance().clearBackPackSoundDirectory();
 		BackPackListManager.getInstance().clearBackPackScripts();
 		BackPackListManager.getInstance().clearBackPackSprites();
+		if (deleteBackPackDirectories) {
+			clearBackPackJson();
+			StorageHandler.getInstance().clearBackPackLookDirectory();
+			StorageHandler.getInstance().clearBackPackSoundDirectory();
+		}
+	}
+
+	public static void clearBackPackJson() {
+		File backPackFile = new File(buildPath(DEFAULT_ROOT, BACKPACK_DIRECTORY, StorageHandler.BACKPACK_FILENAME));
+		backPackFile.delete();
 	}
 
 	public static void prepareForSpecialBricksTest(Context instrumentationContext, int imageResource,

--- a/gradle/intellij_config_tasks.gradle
+++ b/gradle/intellij_config_tasks.gradle
@@ -24,6 +24,8 @@
 task gitSkipWorktreeForIntellijConfigFiles << {
     try {
         'git update-index --skip-worktree .idea/misc.xml'.execute().text.trim()
+        'git update-index --skip-worktree .idea/encodings.xml'.execute().text.trim()
+        'git update-index --skip-worktree .idea/vcs.xml'.execute().text.trim()
         'git update-index --skip-worktree Catroid.iml'.execute().text.trim()
         'git update-index --skip-worktree catroidSourceTest/catroidSourceTest.iml'.execute().text.trim()
         'git update-index --skip-worktree .idea/codeStyleSettings.xml'.execute().text.trim()


### PR DESCRIPTION
Introduces JSON-serialization and deserialization to make the backpack a permanent storage.

Therefore, it was necessary to move the backpack to a serializable class and provide custom serializers for bricks and scripts because they are abstract classes.

Fixes also a NullPointerException that has been introduced with https://github.com/Catrobat/Catroid/pull/1549, when UserVariableBricks or UserListBricks are unpacked. 