### PR TITLE
Replace &#8230; by ellipsis character …

### DIFF
--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -52,12 +52,12 @@
     <string name="loading_check_facebook_data">Facebook data is retrieved…</string>
     <string name="loading_check_email">E-Mail availability is checked on our server…</string>
     <string name="loading_check_oauth_token">OAuth token is checked on our server…</string>
-    <string name="loading_check_facebook_token_validity">Facebook token validity is checked on our server&#8230;</string>
-    <string name="loading_check_oauth_username">Username availability is checked on our server&#8230;</string>
-    <string name="loading_facebook_exchange_token">Facebook token is exchanged on our server&#8230;</string>
-    <string name="loading_facebook_login">Facebook login is completed on our server&#8230;</string>
-    <string name="loading_google_exchange_code">Google+ code is exchanged on our server&#8230;</string>
-    <string name="loading_google_login">Google+ login is completed on our server&#8230;</string>
+    <string name="loading_check_facebook_token_validity">Facebook token validity is checked on our server…</string>
+    <string name="loading_check_oauth_username">Username availability is checked on our server…</string>
+    <string name="loading_facebook_exchange_token">Facebook token is exchanged on our server…</string>
+    <string name="loading_facebook_login">Facebook login is completed on our server…</string>
+    <string name="loading_google_exchange_code">Google+ code is exchanged on our server…</string>
+    <string name="loading_google_login">Google+ login is completed on our server…</string>
     <string name="background">Background</string>
     <string name="stage">Stage</string>
     <string name="ok">OK</string>
@@ -727,7 +727,7 @@
     <string name="error_screenshot_failed">An error occurred while saving the preview image.</string>
     <string name="error_load_image">An error occurred while loading the image.</string>
     <string name="error_load_image_special_chars">Cannot load image. Does the filename contain special
-        characters (e.g. &#36;, &#37;, &amp;, &#8230;)? </string>
+        characters (e.g. &#36;, &#37;, &amp;, …)? </string>
     <string name="error_load_sound">An error occurred while loading the sound.</string>
     <string name="error_internet_connection">An unknown error occurred. Check your Internet connection.</string>
     <string name="error_no_internet">Please establish an Internet connection.</string>
@@ -755,7 +755,7 @@
     <string name="notification_blueth_err">Bluetooth could not be enabled, closing stage</string>
     <string name="title_paired_devices">Paired devices</string>
     <string name="title_other_devices">New devices</string>
-    <string name="searching_devices">Looking for devices&#8230;</string>
+    <string name="searching_devices">Looking for devices…</string>
     <string name="button_scan">Search Bluetooth devices</string>
     <string name="select_device">Select Device:</string>
     <string name="connecting_please_wait">Connecting to your device.\nPlease wait…</string>


### PR DESCRIPTION
Lint suggests to use the ellipsis character … or the numeric character
reference `&#8230;` instead of three dots. The ellipsis character … is
much more readable and therefore all `&#8230;` have been replaced in the
default strings.xml.