### PR TITLE
CAT-1078 Fix transparent passepartout issue

### DIFF
--- a/catroid/src/org/catrobat/catroid/stage/Passepartout.java
+++ b/catroid/src/org/catrobat/catroid/stage/Passepartout.java
@@ -33,6 +33,7 @@ public class Passepartout extends Actor {
 	private float virtualScreenWidth;
 	private float virtualScreenHeight;
 
+	private final Color passepartoutColor = Color.BLACK;
 	private float passepartoutHeight;
 	private float passepartoutWidth;
 
@@ -48,13 +49,14 @@ public class Passepartout extends Actor {
 		passepartoutWidth = ((screenWidth / (screenViewPortWidth / virtualScreenWidth)) - virtualScreenWidth) / 2f;
 
 		Pixmap pixmap = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
-		pixmap.setColor(Color.BLACK);
+		pixmap.setColor(passepartoutColor);
 		pixmap.fill();
 		texture = new Texture(pixmap);
 	}
 
 	@Override
 	public void draw(Batch batch, float parentAlpha) {
+		batch.setColor(passepartoutColor);
 		if (Float.compare(passepartoutWidth, 0f) != 0) {
 			batch.draw(texture, -virtualScreenWidth / 2f, -virtualScreenHeight / 2f, -passepartoutWidth,
 					virtualScreenHeight);


### PR DESCRIPTION
Looks and the passepartout share the same batch during drawing the
stage. Each Look sets the color and alpha value of the batch according
to its settings before drawing itself [1]. The passepartout however
doesn't and therefor uses the alpha value set by the previous Look. So,
when the previous Look sets the alpha value to 0.5, the passepartout
will also be drawn with an alpha value of 0.5 and the background and
other images are shining through it.

By explicitely setting the color of the batch to black and the alpha
value to 1 before drawing the passepartout, the passepartout will remain
black.

[1] https://github.com/libgdx/libgdx/blob/97d6e8d/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Image.java#L119

https://jira.catrob.at/browse/CAT-1078