### PR TITLE
Cat 1877 - Prevent double backpacking of sounds, looks & objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,18 @@
  */
 
 buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
-        classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
+    buildscript {
+        repositories {
+            mavenCentral()
+            maven { url 'https://jitpack.io' }
+        }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:2.0.0'
+            //classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
+            //workaround for bug in sdkmanager sdk when working with AS 2.0:
+            //see http://stackoverflow.com/questions/33881984/errorcause-com-android-sdklib-repository-fullrevision
+            classpath 'com.github.JakeWharton:sdk-manager-plugin:220bf7a88a7072df3ed16dc8466fb144f2817070'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,18 +22,16 @@
  */
 
 buildscript {
-    buildscript {
-        repositories {
-            mavenCentral()
-            maven { url 'https://jitpack.io' }
-        }
-        dependencies {
-            classpath 'com.android.tools.build:gradle:2.0.0'
-            //classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
-            //workaround for bug in sdkmanager sdk when working with AS 2.0:
-            //see http://stackoverflow.com/questions/33881984/errorcause-com-android-sdklib-repository-fullrevision
-            classpath 'com.github.JakeWharton:sdk-manager-plugin:220bf7a88a7072df3ed16dc8466fb144f2817070'
-        }
+    repositories {
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.0.0'
+        //classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
+        //workaround for bug in sdkmanager sdk when working with gradle 2.0.0:
+        //see http://stackoverflow.com/questions/33881984/errorcause-com-android-sdklib-repository-fullrevision
+        classpath 'com.github.JakeWharton:sdk-manager-plugin:220bf7a88a7072df3ed16dc8466fb144f2817070'
     }
 }
 
@@ -54,6 +52,9 @@ check.dependsOn 'checkstyle'
 check.dependsOn 'pmd'
 
 android {
+    dexOptions {
+        javaMaxHeapSize "4g"
+    }
     buildTypes {
         debug {
             buildConfigField "boolean", "FEATURE_LEGO_NXT_ENABLED", "true"

--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -179,6 +179,8 @@
     <string name="dialog_confirm_delete_object_message">This cannot be undone!</string>
     <string name="select_all">Select all</string>
     <string name="deselect_all">Deselect all</string>
+    <string name="backpack_replace_object">The object "%1$s" already exists in the backpack. Do you want to replace it?</string>
+    <string name="backpack_replace_object_multiple">Objects already exist in the backpack. Do you want to replace them?</string>
     <!--  -->
 
 
@@ -196,8 +198,7 @@
     <string name="size">Size:</string>
     <string name="script_group">Script Group</string>
     <string name="script_groups">Script Groups</string>
-    <string name="script_group_name_given">Script Group with this name already exists. Please choose a different one
-        !</string>
+    <string name="script_group_name_given">Script Group with this name already exists. Please choose a different one!</string>
     <!--  -->
 
 
@@ -241,6 +242,8 @@
     <string name="dialog_confirm_delete_multiple_looks_title">Delete these Looks?</string>
     <string name="dialog_confirm_delete_look_message">This cannot be undone!</string>
     <string name="lookname">Look name:</string>
+    <string name="backpack_replace_look">The look "%1$s" already exists in the backpack. Do you want to replace it?</string>
+    <string name="backpack_replace_look_multiple">Looks already exist in the backpack. Do you want to replace them?</string>
     <!--  -->
 
 
@@ -261,6 +264,8 @@
     <string name="sound_name">Sound name:</string>
     <string name="new_sound_name">Sound name:</string>
     <string name="rename_sound_overwrite">Sound with this name already exists. Please choose a different one!</string>
+    <string name="backpack_replace_sound">The sound "%1$s" already exists in the backpack. Do you want to replace it?</string>
+    <string name="backpack_replace_sound_multiple">Sounds already exist in the backpack. Do you want to replace them?</string>
     <!--  -->
 
 

--- a/catroid/src/org/catrobat/catroid/CatroidApplication.java
+++ b/catroid/src/org/catrobat/catroid/CatroidApplication.java
@@ -23,6 +23,7 @@
 package org.catrobat.catroid;
 
 import android.content.Context;
+import android.support.multidex.MultiDex;
 import android.support.multidex.MultiDexApplication;
 import android.util.Log;
 
@@ -45,6 +46,12 @@ public class CatroidApplication extends MultiDexApplication {
 		Log.d(TAG, "CatroidApplication onCreate");
 		settings = new ApplicationSettings(this);
 		CatroidApplication.context = getApplicationContext();
+	}
+
+	@Override
+	protected void attachBaseContext(Context base) {
+		super.attachBaseContext(base);
+		MultiDex.install(this);
 	}
 
 	public ApplicationSettings getParrotApplicationSettings() {

--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -39,12 +39,12 @@ public final class Constants {
 	public static final String PROJECTCODE_NAME_TMP = "tmp_" + PROJECTCODE_NAME;
 
 	public static final String CATROBAT_EXTENSION = ".catrobat";
-	public static final String IMAGE_STANDARD_EXTENTION = ".png";
+	public static final String IMAGE_STANDARD_EXTENSION = ".png";
 	public static final String SOUND_STANDARD_EXTENSION = ".wav";
 
 	//Extensions:
-	public static final String[] IMAGE_EXTENTIONS = {".png", ".jpg", ".jpeg", ".png", ".gif"};
-	public static final String[] SOUND_EXTENTIONS = {".wav", ".mp3", ".mpga", ".wav", ".ogy"};
+	public static final String[] IMAGE_EXTENSIONS = { ".png", ".jpg", ".jpeg", ".png", ".gif" };
+	public static final String[] SOUND_EXTENSIONS = { ".wav", ".mp3", ".mpga", ".wav", ".ogy" };
 
 	public static final String DEFAULT_ROOT = Environment.getExternalStorageDirectory().getAbsolutePath()
 			+ "/Pocket Code";
@@ -84,7 +84,6 @@ public final class Constants {
 	public static final String RASPI_BROADCAST_PREFIX = "#RASPI#";
 	public static final String RASPI_BROADCAST_INTERRUPT_PREFIX = RASPI_BROADCAST_PREFIX + "interrupt ";
 	public static final String OPENING_BRACE = "(";
-	public static final String CLOSING_BRACE = ")";
 
 	//Web:
 	public static final String BASE_URL_HTTPS = "https://share.catrob.at/pocketcode/";

--- a/catroid/src/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorDefault.java
+++ b/catroid/src/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorDefault.java
@@ -96,30 +96,30 @@ public class DefaultProjectCreatorDefault extends DefaultProjectCreator {
 			backgroundImageScaleFactor = ImageEditing.calculateScaleFactorToScreenSize(
 					R.drawable.default_project_background_landscape, context);
 			cloudFile = UtilFile.copyImageFromResourceIntoProject(projectName, backgroundName
-							+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_project_clouds_landscape,
+							+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_project_clouds_landscape,
 					context, true,
 					backgroundImageScaleFactor);
 			backgroundFile = UtilFile.copyImageFromResourceIntoProject(projectName, backgroundName
-							+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_project_background_landscape,
+							+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_project_background_landscape,
 					context, true,
 					backgroundImageScaleFactor);
 		} else {
 			backgroundImageScaleFactor = ImageEditing.calculateScaleFactorToScreenSize(
 					R.drawable.default_project_background_portrait, context);
 			backgroundFile = UtilFile.copyImageFromResourceIntoProject(projectName, backgroundName
-							+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_project_background_portrait,
+							+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_project_background_portrait,
 					context, true,
 					backgroundImageScaleFactor);
 			cloudFile = UtilFile.copyImageFromResourceIntoProject(projectName, backgroundName
-							+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_project_clouds_portrait,
+							+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_project_clouds_portrait,
 					context, true,
 					backgroundImageScaleFactor);
 		}
 		File birdWingUpFile = UtilFile.copyImageFromResourceIntoProject(projectName, birdWingUpLookName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_project_bird_wing_up, context, true,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_project_bird_wing_up, context, true,
 				backgroundImageScaleFactor);
 		File birdWingDownFile = UtilFile.copyImageFromResourceIntoProject(projectName, birdWingDownLookName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_project_bird_wing_down, context, true,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_project_bird_wing_down, context, true,
 				backgroundImageScaleFactor);
 		try {
 			File soundFile1 = UtilFile.copySoundFromResourceIntoProject(projectName, tweet1

--- a/catroid/src/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorDrone.java
+++ b/catroid/src/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorDrone.java
@@ -72,7 +72,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 				R.drawable.drone_project_background, context);
 
 		File backgroundFile = UtilFile.copyImageFromResourceIntoProject(projectName, backgroundName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.drone_project_background, context, true,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.drone_project_background, context, true,
 				backgroundImageScaleFactor);
 
 		LookData backgroundLookData = new LookData();
@@ -95,7 +95,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String takeOffSpriteName = context.getString(R.string.default_drone_project_sprites_takeoff);
 
 		File takeOffArrowFile = UtilFile.copyImageFromResourceIntoProject(projectName, takeOffSpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_takeoff, context, true,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_takeoff, context, true,
 				backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneSprite(takeOffSpriteName, DroneBrickFactory.DroneBricks.DRONE_TAKE_OFF_LAND_BRICK,
@@ -105,7 +105,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String rotateSpriteName = context.getString(R.string.default_drone_project_sprites_rotate);
 
 		File rotateFile = UtilFile.copyImageFromResourceIntoProject(projectName, rotateSpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_rotate, context, true,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_rotate, context, true,
 				backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneSprite(rotateSpriteName, DroneBrickFactory.DroneBricks.DRONE_FLIP_BRICK,
@@ -117,7 +117,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 
 		//TODO Drone: add when PlayLedAnimationBrick works
 		//File playLedFile = UtilFile.copyImageFromResourceIntoProject(projectName, blinkLedSpriteName
-		//		+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_light_bulb, context,
+		//		+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_light_bulb, context,
 		//		true, backgroundImageScaleFactor);
 
 		//TODO Drone: add when PlayLedAnimationBrick works
@@ -128,7 +128,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String upSpriteName = context.getString(R.string.default_drone_project_sprites_up);
 
 		File upFile = UtilFile.copyImageFromResourceIntoProject(projectName, upSpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_arrow_up, context, true,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_arrow_up, context, true,
 				backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneSprite(upSpriteName, DroneBrickFactory.DroneBricks.DRONE_MOVE_UP_BRICK, -100,
@@ -138,7 +138,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String downSpriteName = context.getString(R.string.default_drone_project_sprites_down);
 
 		File downFile = UtilFile.copyImageFromResourceIntoProject(projectName, downSpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_arrow_down, context,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_arrow_down, context,
 				true, backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneSprite(downSpriteName, DroneBrickFactory.DroneBricks.DRONE_MOVE_DOWN_BRICK,
@@ -148,7 +148,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String forwardSpriteName = context.getString(R.string.default_drone_project_sprites_forward);
 
 		File forwardFile = UtilFile.copyImageFromResourceIntoProject(projectName, forwardSpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_go_forward, context,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_go_forward, context,
 				true, backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneSprite(forwardSpriteName,
@@ -158,7 +158,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String backwardSpriteName = context.getString(R.string.default_drone_project_sprites_back);
 
 		File backwardFile = UtilFile.copyImageFromResourceIntoProject(projectName, downSpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_go_back, context, true,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_go_back, context, true,
 				backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneSprite(backwardSpriteName,
@@ -168,7 +168,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String leftSpriteName = context.getString(R.string.default_drone_project_sprites_left);
 
 		File leftFile = UtilFile.copyImageFromResourceIntoProject(projectName, leftSpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_go_left, context, true,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_go_left, context, true,
 				backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneSprite(leftSpriteName, DroneBrickFactory.DroneBricks.DRONE_MOVE_LEFT_BRICK,
@@ -178,7 +178,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String rightSpriteName = context.getString(R.string.default_drone_project_sprites_right);
 
 		File rightFile = UtilFile.copyImageFromResourceIntoProject(projectName, rightSpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_go_right, context, true,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_go_right, context, true,
 				backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneSprite(rightSpriteName, DroneBrickFactory.DroneBricks.DRONE_MOVE_RIGHT_BRICK,
@@ -188,7 +188,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String turnLeftSpriteName = context.getString(R.string.default_drone_project_sprites_turn_left);
 
 		File turnLeftFile = UtilFile.copyImageFromResourceIntoProject(projectName, turnLeftSpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_turn_left, context, true,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_turn_left, context, true,
 				backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneSprite(turnLeftSpriteName,
@@ -198,7 +198,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String turnRightSpriteName = context.getString(R.string.default_drone_project_sprites_turn_right);
 
 		File turnRightFile = UtilFile.copyImageFromResourceIntoProject(projectName, turnRightSpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_turn_right, context,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_turn_right, context,
 				true, backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneSprite(turnRightSpriteName,
@@ -208,7 +208,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String emergencySpriteName = context.getString(R.string.default_drone_project_sprites_emergency);
 
 		File emergencyFile = UtilFile.copyImageFromResourceIntoProject(projectName, emergencySpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_go_emergency, context,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_go_emergency, context,
 				true, backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneSprite(emergencySpriteName,
@@ -218,7 +218,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		String videoSpriteName = context.getString(R.string.add_look_drone_video);
 
 		File videoFile = UtilFile.copyImageFromResourceIntoProject(projectName, videoSpriteName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.ic_video, context,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.ic_video, context,
 				true, backgroundImageScaleFactor);
 
 		defaultDroneProject.addSprite(createDroneVideoLookSprite(videoSpriteName, -200, 0, videoFile, context));
@@ -227,7 +227,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		//TODO Drone: add when PlayLedAnimationBrick works
 		//String blinkLedSpriteName = context.getString(R.string.default_drone_project_sprites_blink_led);
 		//File playLedFile = UtilFile.copyImageFromResourceIntoProject(projectName, blinkLedSpriteName
-		//		+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.default_drone_project_orange_light_bulb, context,
+		//		+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.default_drone_project_orange_light_bulb, context,
 		//		true, backgroundImageScaleFactor);
 		//defaultDroneProject.addSprite(createDroneSprite(blinkLedSpriteName,
 		//		DroneUtils.DroneBricks.DRONE_PLAY_LED_ANIMATION_BRICK, -100, -450, playLedFile));

--- a/catroid/src/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorPhysics.java
+++ b/catroid/src/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorPhysics.java
@@ -95,7 +95,7 @@ public class DefaultProjectCreatorPhysics extends DefaultProjectCreator {
 				R.drawable.physics_background_480_800, context);
 
 		File backgroundFile = UtilFile.copyImageFromResourceIntoProject(projectName, backgroundName
-						+ Constants.IMAGE_STANDARD_EXTENTION, R.drawable.physics_background_480_800, context, true,
+						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.physics_background_480_800, context, true,
 				backgroundImageScaleFactor);
 
 		LookData backgroundLookData = new LookData();

--- a/catroid/src/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
@@ -351,7 +351,7 @@ public class PlaySoundBrick extends BrickBaseType implements OnItemSelectedListe
 
 	@Override
 	public void storeDataForBackPack(Sprite sprite) {
-		SoundInfo backPackedSoundInfo = SoundController.getInstance().backPackSound(this.getSound(), true);
+		SoundInfo backPackedSoundInfo = SoundController.getInstance().backPackHiddenSound(this.getSound());
 		this.setSoundInfo(backPackedSoundInfo);
 		if (sprite != null && !sprite.getSoundList().contains(backPackedSoundInfo)) {
 			sprite.getSoundList().add(backPackedSoundInfo);

--- a/catroid/src/org/catrobat/catroid/content/bricks/PointToBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PointToBrick.java
@@ -409,7 +409,7 @@ public class PointToBrick extends BrickBaseType {
 	@Override
 	public void storeDataForBackPack(Sprite sprite) {
 		Sprite spriteToRestore = ProjectManager.getInstance().getCurrentSprite();
-		Sprite backPackedSprite = BackPackSpriteController.getInstance().backpack(getPointedObject(), true);
+		Sprite backPackedSprite = BackPackSpriteController.getInstance().backpackHiddenSprite(getPointedObject());
 		setPointedObject(backPackedSprite);
 		ProjectManager.getInstance().setCurrentSprite(spriteToRestore);
 	}

--- a/catroid/src/org/catrobat/catroid/content/bricks/SetLookBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/SetLookBrick.java
@@ -355,7 +355,7 @@ public class SetLookBrick extends BrickBaseType implements OnLookDataListChanged
 
 	@Override
 	public void storeDataForBackPack(Sprite sprite) {
-		LookData backPackedLookData = LookController.getInstance().backPackLook(this.getLook(), true);
+		LookData backPackedLookData = LookController.getInstance().backPackHiddenLook(this.getLook());
 		this.setLook(backPackedLookData);
 		if (sprite != null && !sprite.getLookDataList().contains(backPackedLookData)) {
 			sprite.getLookDataList().add(backPackedLookData);

--- a/catroid/src/org/catrobat/catroid/content/bricks/UserListBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/UserListBrick.java
@@ -165,6 +165,7 @@ public abstract class UserListBrick extends FormulaBrick implements NewDataDialo
 			backPackedData = new BackPackedData();
 		}
 		this.backPackedData.project = currentProject;
+		this.backPackedData.userList = userList;
 		this.backPackedData.userListType = type;
 	}
 }

--- a/catroid/src/org/catrobat/catroid/content/bricks/UserVariableBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/UserVariableBrick.java
@@ -160,6 +160,7 @@ public abstract class UserVariableBrick extends FormulaBrick implements NewDataD
 			backPackedData = new BackPackedData();
 		}
 		this.backPackedData.project = currentProject;
+		this.backPackedData.userVariable = userVariable;
 		this.backPackedData.userVariableType = type;
 	}
 }

--- a/catroid/src/org/catrobat/catroid/io/CatroidFieldKeySorter.java
+++ b/catroid/src/org/catrobat/catroid/io/CatroidFieldKeySorter.java
@@ -109,6 +109,8 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 				fieldKeyOrder[4] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("physicsWorld")) {
 				fieldKeyOrder[5] = fieldKey;
+			} else if (fieldKey.getFieldName().equals("$change")) {
+				fieldKeyOrder[6] = fieldKey;
 			}
 		}
 		for (FieldKey fieldKey : fieldKeyOrder) {
@@ -151,6 +153,8 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 				fieldKeyOrder[12] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("actionFactory")) {
 				fieldKeyOrder[13] = fieldKey;
+			} else if (fieldKey.getFieldName().equals("$change")) {
+				fieldKeyOrder[14] = fieldKey;
 			}
 		}
 		for (FieldKey fieldKey : fieldKeyOrder) {

--- a/catroid/src/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/org/catrobat/catroid/stage/StageListener.java
@@ -96,8 +96,8 @@ public class StageListener implements ApplicationListener {
 
 	private float deltaActionTimeDivisor = 10f;
 	public static final String SCREENSHOT_AUTOMATIC_FILE_NAME = "automatic_screenshot"
-			+ Constants.IMAGE_STANDARD_EXTENTION;
-	public static final String SCREENSHOT_MANUAL_FILE_NAME = "manual_screenshot" + Constants.IMAGE_STANDARD_EXTENTION;
+			+ Constants.IMAGE_STANDARD_EXTENSION;
+	public static final String SCREENSHOT_MANUAL_FILE_NAME = "manual_screenshot" + Constants.IMAGE_STANDARD_EXTENSION;
 	private FPSLogger fpsLogger;
 
 	private Stage stage;

--- a/catroid/src/org/catrobat/catroid/ui/WebViewActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/WebViewActivity.java
@@ -265,13 +265,13 @@ public class WebViewActivity extends BaseActivity {
 
 	private String getMediaTypeFromContentDisposition(String contentDisposition) {
 		String mediaType = null;
-		for (String extension : Constants.IMAGE_EXTENTIONS) {
+		for (String extension : Constants.IMAGE_EXTENSIONS) {
 			if (getExtentionFromContentDisposition(contentDisposition).compareTo(extension) == 0) {
 				mediaType = Constants.MEDIA_TYPE_LOOK;
 			}
 		}
 
-		for (String extention : Constants.SOUND_EXTENTIONS) {
+		for (String extention : Constants.SOUND_EXTENSIONS) {
 			if (getExtentionFromContentDisposition(contentDisposition).compareTo(extention) == 0) {
 				mediaType = Constants.MEDIA_TYPE_SOUND;
 			}

--- a/catroid/src/org/catrobat/catroid/ui/adapter/SoundAdapter.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/SoundAdapter.java
@@ -34,10 +34,11 @@ import org.catrobat.catroid.ui.BackPackActivity;
 import org.catrobat.catroid.ui.controller.SoundController;
 import org.catrobat.catroid.ui.fragment.SoundFragment;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-public class SoundAdapter extends SoundBaseAdapter implements ActionModeActivityAdapterInterface {
+public class SoundAdapter extends SoundBaseAdapter implements ActionModeActivityAdapterInterface, SoundController.OnBackpackSoundCompleteListener {
 
 	private SoundFragment soundFragment;
 
@@ -76,19 +77,26 @@ public class SoundAdapter extends SoundBaseAdapter implements ActionModeActivity
 	}
 
 	public void onDestroyActionModeBackPack() {
-		Iterator<Integer> iterator = checkedSounds.iterator();
-		while (iterator.hasNext()) {
-			int position = iterator.next();
-			SoundController.getInstance().backPackSound(soundInfoItems.get(position), false);
+		List<SoundInfo> soundInfoListToBackpack = new ArrayList<>();
+		for (Integer position : checkedSounds) {
+			soundInfoListToBackpack.add(soundInfoItems.get(position));
 		}
 
-		if (!checkedSounds.isEmpty()) {
-			Intent intent = new Intent(soundFragment.getActivity(), BackPackActivity.class);
-			intent.putExtra(BackPackActivity.EXTRA_FRAGMENT_POSITION, BackPackActivity.FRAGMENT_BACKPACK_SOUNDS);
-			soundFragment.getActivity().startActivity(intent);
-		}
+		boolean soundsAlreadyInBackpack = SoundController.getInstance().checkSoundReplaceInBackpack(soundInfoListToBackpack);
 
-		soundFragment.clearCheckedSoundsAndEnableButtons();
+		if (!soundInfoListToBackpack.isEmpty()) {
+			if (!soundsAlreadyInBackpack) {
+				for (SoundInfo soundInfoToBackpack : soundInfoListToBackpack) {
+					SoundController.getInstance().backPackVisibleSound(soundInfoToBackpack);
+					onBackpackSoundComplete(true);
+				}
+			} else {
+				SoundController.getInstance().setOnBackpackSoundCompleteListener(this);
+				SoundController.getInstance().showBackPackReplaceDialog(soundInfoListToBackpack, soundFragment.getActivity());
+			}
+		} else {
+			soundFragment.clearCheckedSoundsAndEnableButtons();
+		}
 	}
 
 	public void setSoundFragment(SoundFragment soundFragment) {
@@ -98,5 +106,15 @@ public class SoundAdapter extends SoundBaseAdapter implements ActionModeActivity
 	@Override
 	public List<SoundInfo> getSoundInfoItems() {
 		return soundInfoItems;
+	}
+
+	@Override
+	public void onBackpackSoundComplete(boolean startBackpackActivity) {
+		if (!checkedSounds.isEmpty() && startBackpackActivity) {
+			Intent intent = new Intent(soundFragment.getActivity(), BackPackActivity.class);
+			intent.putExtra(BackPackActivity.EXTRA_FRAGMENT_POSITION, BackPackActivity.FRAGMENT_BACKPACK_SOUNDS);
+			soundFragment.getActivity().startActivity(intent);
+		}
+		soundFragment.clearCheckedSoundsAndEnableButtons();
 	}
 }

--- a/catroid/src/org/catrobat/catroid/ui/adapter/SpriteAdapter.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/SpriteAdapter.java
@@ -196,7 +196,7 @@ public class SpriteAdapter extends SpriteBaseAdapter implements ActionModeActivi
 			@Override
 			public void onClick(DialogInterface dialog, int which) {
 				if (which == 0) {
-					BackPackSpriteController.getInstance().backpack(getItem(0), false);
+					BackPackSpriteController.getInstance().backpackVisibleSprite(getItem(0));
 					spritesListFragment.switchToBackPack();
 				}
 				dialog.dismiss();

--- a/catroid/src/org/catrobat/catroid/ui/controller/BackPackListManager.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/BackPackListManager.java
@@ -75,6 +75,14 @@ public final class BackPackListManager {
 		backpackedScripts.remove(scriptGroup);
 	}
 
+	public void removeItemFromScriptBackPackByName(String name) {
+		for (String scriptGroup : backpackedScripts.keySet()) {
+			if (scriptGroup.equals(name)) {
+				backpackedScripts.remove(scriptGroup);
+			}
+		}
+	}
+
 	public ArrayList<String> getBackPackedScriptGroups() {
 		return new ArrayList<>(backpackedScripts.keySet());
 	}
@@ -95,6 +103,14 @@ public final class BackPackListManager {
 		backpackedLooks.remove(lookData);
 	}
 
+	public void removeItemFromLookBackPackByLookName(String name) {
+		for (LookData lookData : backpackedLooks) {
+			if (lookData.getLookName().equals(name)) {
+				backpackedLooks.remove(lookData);
+			}
+		}
+	}
+
 	public List<SoundInfo> getBackPackedSounds() {
 		return backpackedSounds;
 	}
@@ -111,6 +127,14 @@ public final class BackPackListManager {
 		backpackedSounds.remove(currentSoundInfo);
 	}
 
+	public void removeItemFromSoundBackPackBySoundTitle(String title) {
+		for (SoundInfo soundInfo : backpackedSounds) {
+			if (soundInfo.getTitle().equals(title)) {
+				backpackedSounds.remove(soundInfo);
+			}
+		}
+	}
+
 	public List<Sprite> getBackPackedSprites() {
 		return backpackedSprites;
 	}
@@ -125,6 +149,14 @@ public final class BackPackListManager {
 
 	public void removeItemFromSpriteBackPack(Sprite sprite) {
 		backpackedSprites.remove(sprite);
+	}
+
+	public void removeItemFromSpriteBackPackByName(String name) {
+		for (Sprite sprite : backpackedSprites) {
+			if (sprite.getName().equals(name)) {
+				backpackedSprites.remove(sprite);
+			}
+		}
 	}
 
 	public List<LookData> getHiddenBackpackedLooks() {
@@ -171,8 +203,8 @@ public final class BackPackListManager {
 		hiddenBackpackedSprites.remove(sprite);
 	}
 
-	public boolean backPackedSoundsContain(SoundInfo soundInfo) {
-		List<SoundInfo> backPackedSounds = getAllBackPackedSounds();
+	public boolean backPackedSoundsContain(SoundInfo soundInfo, boolean onlyVisible) {
+		List<SoundInfo> backPackedSounds = onlyVisible ? getBackPackedSounds() : getAllBackPackedSounds();
 		for (SoundInfo backPackedSound : backPackedSounds) {
 			if (backPackedSound.equals(soundInfo)) {
 				return true;
@@ -181,8 +213,8 @@ public final class BackPackListManager {
 		return false;
 	}
 
-	public boolean backPackedLooksContain(LookData lookData) {
-		List<LookData> backPackedLooks = getAllBackPackedLooks();
+	public boolean backPackedLooksContain(LookData lookData, boolean onlyVisible) {
+		List<LookData> backPackedLooks = onlyVisible ? getBackPackedLooks() : getAllBackPackedLooks();
 		for (LookData backPackedLook : backPackedLooks) {
 			if (backPackedLook.equals(lookData)) {
 				return true;
@@ -191,8 +223,8 @@ public final class BackPackListManager {
 		return false;
 	}
 
-	public boolean backPackedSpritesContains(Sprite sprite) {
-		List<Sprite> backPackedSprites = getAllBackPackedSprites();
+	public boolean backPackedSpritesContains(Sprite sprite, boolean onlyVisible) {
+		List<Sprite> backPackedSprites = onlyVisible ? getBackPackedSprites() : getAllBackPackedSprites();
 		for (Sprite backPackedSprite : backPackedSprites) {
 			if (backPackedSprite.equals(sprite)) {
 				return true;

--- a/catroid/src/org/catrobat/catroid/ui/controller/BackPackSpriteController.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/BackPackSpriteController.java
@@ -22,7 +22,13 @@
  */
 package org.catrobat.catroid.ui.controller;
 
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.res.Resources;
+
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.SoundInfo;
 import org.catrobat.catroid.content.Script;
@@ -30,12 +36,15 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.PlaySoundBrick;
 import org.catrobat.catroid.content.bricks.SetLookBrick;
+import org.catrobat.catroid.ui.dialogs.CustomAlertDialogBuilder;
 import org.catrobat.catroid.utils.Utils;
 
 import java.util.List;
 
 public final class BackPackSpriteController {
 	private static final BackPackSpriteController INSTANCE = new BackPackSpriteController();
+
+	private OnBackpackSpriteCompleteListener onBackpackSpriteCompleteListener;
 
 	private BackPackSpriteController() {
 	}
@@ -44,12 +53,90 @@ public final class BackPackSpriteController {
 		return INSTANCE;
 	}
 
-	public Sprite backpack(Sprite spriteToEdit, boolean addToHiddenBackpack) {
+	public boolean checkSpriteReplaceInBackpack(List<Sprite> currentSpriteList) {
+		boolean spritesAlreadyInBackpack = false;
+		for (Sprite sprite : currentSpriteList) {
+			spritesAlreadyInBackpack = checkSpriteReplaceInBackpack(sprite);
+			if (spritesAlreadyInBackpack) {
+				return spritesAlreadyInBackpack;
+			}
+		}
+		return spritesAlreadyInBackpack;
+	}
 
-		if (addToHiddenBackpack && BackPackListManager.getInstance().backPackedSpritesContains(spriteToEdit)) {
+	public boolean checkSpriteReplaceInBackpack(Sprite currentSprite) {
+		return BackPackListManager.getInstance().backPackedSpritesContains(currentSprite, true);
+	}
+
+	public void showBackPackReplaceDialog(final List<Sprite> currentSpriteList, final Context context) {
+		Resources resources = context.getResources();
+		String replaceLookMessage = resources.getString(R.string.backpack_replace_object_multiple);
+
+		AlertDialog dialog = new CustomAlertDialogBuilder(context)
+				.setTitle(R.string.backpack)
+				.setMessage(replaceLookMessage)
+				.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						for (Sprite currentSprite : currentSpriteList) {
+							backpackVisibleSprite(currentSprite);
+						}
+						onBackpackSpriteCompleteListener.onBackpackSpriteComplete(true);
+						dialog.dismiss();
+					}
+				}).setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						onBackpackSpriteCompleteListener.onBackpackSpriteComplete(false);
+						dialog.dismiss();
+					}
+				}).create();
+		dialog.setCanceledOnTouchOutside(true);
+		dialog.show();
+	}
+
+	public void showBackPackReplaceDialog(final Sprite currentSprite, final Context context) {
+		Resources resources = context.getResources();
+		String replaceLookMessage = resources.getString(R.string.backpack_replace_object, currentSprite.getName());
+
+		AlertDialog dialog = new CustomAlertDialogBuilder(context)
+				.setTitle(R.string.backpack)
+				.setMessage(replaceLookMessage)
+				.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						backpackVisibleSprite(currentSprite);
+						onBackpackSpriteCompleteListener.onBackpackSpriteComplete(true);
+						dialog.dismiss();
+					}
+				}).setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						dialog.dismiss();
+					}
+				}).create();
+		dialog.setCanceledOnTouchOutside(true);
+		dialog.show();
+	}
+
+	public void backpackVisibleSprite(Sprite spriteToEdit) {
+		String spriteName = spriteToEdit.getName();
+		BackPackListManager.getInstance().removeItemFromSpriteBackPackByName(spriteName);
+
+		Sprite backPackSprite = backpack(spriteToEdit);
+		BackPackListManager.getInstance().addSpriteToBackPack(backPackSprite);
+	}
+
+	public Sprite backpackHiddenSprite(Sprite spriteToEdit) {
+		if (BackPackListManager.getInstance().backPackedSpritesContains(spriteToEdit, false)) {
 			return spriteToEdit;
 		}
+		Sprite backPackSprite = backpack(spriteToEdit);
+		BackPackListManager.getInstance().addSpriteToHiddenBackpack(backPackSprite);
+		return backPackSprite;
+	}
 
+	public Sprite backpack(Sprite spriteToEdit) {
 		ProjectManager.getInstance().setCurrentSprite(spriteToEdit);
 
 		Sprite backPackSprite = spriteToEdit.cloneForBackPack();
@@ -61,12 +148,12 @@ public final class BackPackSpriteController {
 
 		for (LookData lookData : spriteToEdit.getLookDataList()) {
 			if (!lookDataIsUsedInScript(lookData, ProjectManager.getInstance().getCurrentSprite())) {
-				backPackSprite.getLookDataList().add(LookController.getInstance().backPackLook(lookData, true));
+				backPackSprite.getLookDataList().add(LookController.getInstance().backPackHiddenLook(lookData));
 			}
 		}
 		for (SoundInfo soundInfo : spriteToEdit.getSoundList()) {
 			if (!soundInfoIsUsedInScript(soundInfo, ProjectManager.getInstance().getCurrentSprite())) {
-				backPackSprite.getSoundList().add(SoundController.getInstance().backPackSound(soundInfo, true));
+				backPackSprite.getSoundList().add(SoundController.getInstance().backPackHiddenSound(soundInfo));
 			}
 		}
 		List<Script> backPackedScripts = BackPackScriptController.getInstance().backpack(backPackSprite.getName(),
@@ -74,11 +161,6 @@ public final class BackPackSpriteController {
 
 		if (backPackedScripts != null && !backPackedScripts.isEmpty()) {
 			backPackSprite.getScriptList().addAll(backPackedScripts);
-		}
-		if (addToHiddenBackpack) {
-			BackPackListManager.getInstance().addSpriteToHiddenBackpack(backPackSprite);
-		} else {
-			BackPackListManager.getInstance().addSpriteToBackPack(backPackSprite);
 		}
 		return backPackSprite;
 	}
@@ -148,5 +230,13 @@ public final class BackPackSpriteController {
 			}
 		}
 		return false;
+	}
+
+	public void setOnBackpackSpriteCompleteListener(OnBackpackSpriteCompleteListener listener) {
+		onBackpackSpriteCompleteListener = listener;
+	}
+
+	public interface OnBackpackSpriteCompleteListener {
+		void onBackpackSpriteComplete(boolean startBackpackActivity);
 	}
 }

--- a/catroid/src/org/catrobat/catroid/ui/controller/LookController.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/LookController.java
@@ -25,12 +25,14 @@ package org.catrobat.catroid.ui.controller;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.FragmentTransaction;
+import android.content.Context;
 import android.content.CursorLoader;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.Loader;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.content.res.Resources;
 import android.database.Cursor;
 import android.database.CursorIndexOutOfBoundsException;
 import android.net.Uri;
@@ -81,6 +83,8 @@ public final class LookController {
 
 	private static final String TAG = LookController.class.getSimpleName();
 	private static final LookController INSTANCE = new LookController();
+
+	private OnBackpackLookCompleteListener onBackpackLookCompleteListener;
 
 	private LookController() {
 	}
@@ -508,11 +512,87 @@ public final class LookController {
 		activity.sendBroadcast(new Intent(ScriptActivity.ACTION_LOOK_DELETED));
 	}
 
-	public LookData backPackLook(LookData currentLookData, boolean addToHiddenBackpack) {
-		if (addToHiddenBackpack && BackPackListManager.getInstance().backPackedLooksContain(currentLookData)) {
+	public boolean checkLookReplaceInBackpack(List<LookData> currentLookDataList) {
+		boolean looksAlreadyInBackpack = false;
+		for (LookData lookData : currentLookDataList) {
+			looksAlreadyInBackpack = checkLookReplaceInBackpack(lookData);
+			if (looksAlreadyInBackpack) {
+				return looksAlreadyInBackpack;
+			}
+		}
+		return looksAlreadyInBackpack;
+	}
+
+	public boolean checkLookReplaceInBackpack(LookData currentLookData) {
+		return BackPackListManager.getInstance().backPackedLooksContain(currentLookData, true);
+	}
+
+	public void showBackPackReplaceDialog(final List<LookData> currentLookDataList, final Context context) {
+		Resources resources = context.getResources();
+		String replaceLookMessage = resources.getString(R.string.backpack_replace_look_multiple);
+
+		AlertDialog dialog = new CustomAlertDialogBuilder(context)
+				.setTitle(R.string.backpack)
+				.setMessage(replaceLookMessage)
+				.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						for (LookData currentLookData : currentLookDataList) {
+							backPackVisibleLook(currentLookData);
+						}
+						onBackpackLookCompleteListener.onBackpackLookComplete(true);
+						dialog.dismiss();
+					}
+				}).setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						onBackpackLookCompleteListener.onBackpackLookComplete(false);
+						dialog.dismiss();
+					}
+				}).create();
+		dialog.setCanceledOnTouchOutside(true);
+		dialog.show();
+	}
+
+	public void showBackPackReplaceDialog(final LookData currentLookData, final Context context) {
+		Resources resources = context.getResources();
+		String replaceLookMessage = resources.getString(R.string.backpack_replace_look, currentLookData.getLookName());
+
+		AlertDialog dialog = new CustomAlertDialogBuilder(context)
+				.setTitle(R.string.backpack)
+				.setMessage(replaceLookMessage)
+				.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						backPackVisibleLook(currentLookData);
+						onBackpackLookCompleteListener.onBackpackLookComplete(true);
+						dialog.dismiss();
+					}
+				}).setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						dialog.dismiss();
+					}
+				}).create();
+		dialog.setCanceledOnTouchOutside(true);
+		dialog.show();
+	}
+
+	public void backPackVisibleLook(LookData currentLookData) {
+		String lookDataName = currentLookData.getLookName();
+		BackPackListManager.getInstance().removeItemFromLookBackPackByLookName(lookDataName);
+		backPack(currentLookData, lookDataName, false);
+	}
+
+	public LookData backPackHiddenLook(LookData currentLookData) {
+		if (BackPackListManager.getInstance().backPackedLooksContain(currentLookData, false)) {
 			return currentLookData;
 		}
 		String newLookDataName = Utils.getUniqueLookName(currentLookData, true);
+		return backPack(currentLookData, newLookDataName, true);
+	}
+
+	public LookData backPack(LookData currentLookData, String newLookDataName, boolean addToHiddenBackpack) {
 		String existingFileNameInBackPackDirectory = lookFileAlreadyInBackPackDirectory(currentLookData);
 		if (existingFileNameInBackPackDirectory == null) {
 			copyLookBackPack(currentLookData, newLookDataName, false);
@@ -618,5 +698,13 @@ public final class LookController {
 
 		scriptActivity.setIsLookFragmentFromSetLookBrickNewFalse();
 		scriptActivity.setIsLookFragmentHandleAddButtonHandled(false);
+	}
+
+	public void setOnBackpackLookCompleteListener(OnBackpackLookCompleteListener listener) {
+		onBackpackLookCompleteListener = listener;
+	}
+
+	public interface OnBackpackLookCompleteListener {
+		void onBackpackLookComplete(boolean startBackpackActivity);
 	}
 }

--- a/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/LookFragment.java
@@ -97,14 +97,14 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 
 public class LookFragment extends ScriptActivityFragment implements LookBaseAdapter.OnLookEditListener,
-		LoaderManager.LoaderCallbacks<Cursor>, Dialog.OnKeyListener {
+		LoaderManager.LoaderCallbacks<Cursor>, Dialog.OnKeyListener, LookController.OnBackpackLookCompleteListener {
 
 	public static final String TAG = LookFragment.class.getSimpleName();
 	private static int selectedLookPosition = Constants.NO_POSITION;
 	private static String actionModeTitle;
 	private static String singleItemAppendixActionMode;
 	private static String multipleItemAppendixActionMode;
-	public Intent lastRecivedIntent = null;
+	public Intent lastReceivedIntent = null;
 	private LookBaseAdapter adapter;
 	private List<LookData> lookDataList;
 	private LookData selectedLookData;
@@ -466,7 +466,7 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
 		super.onActivityResult(requestCode, resultCode, data);
 
-		lastRecivedIntent = data;
+		lastReceivedIntent = data;
 		if (resultCode == Activity.RESULT_OK) {
 			switch (requestCode) {
 				case LookController.REQUEST_SELECT_OR_DRAW_IMAGE:
@@ -540,8 +540,14 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 				break;
 
 			case R.id.context_menu_backpack:
-				LookController.getInstance().backPackLook(selectedLookData, false);
-				openBackPack();
+				boolean lookAlreadyInBackpack = LookController.getInstance().checkLookReplaceInBackpack(selectedLookData);
+				if (!lookAlreadyInBackpack) {
+					LookController.getInstance().backPackVisibleLook(selectedLookData);
+					openBackPack();
+				} else {
+					LookController.getInstance().setOnBackpackLookCompleteListener(this);
+					LookController.getInstance().showBackPackReplaceDialog(selectedLookData, getActivity());
+				}
 				break;
 
 			case R.id.context_menu_cut:
@@ -1031,6 +1037,11 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 
 	public List<LookData> getLookDataList() {
 		return lookDataList;
+	}
+
+	@Override
+	public void onBackpackLookComplete(boolean startBackpackActivity) {
+		openBackPack();
 	}
 
 	public interface OnLookDataListChangedAfterNewListener {

--- a/catroid/src/org/catrobat/catroid/ui/fragment/SoundFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/SoundFragment.java
@@ -93,7 +93,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class SoundFragment extends ScriptActivityFragment implements SoundBaseAdapter.OnSoundEditListener,
-		LoaderManager.LoaderCallbacks<Cursor>, Dialog.OnKeyListener {
+		LoaderManager.LoaderCallbacks<Cursor>, Dialog.OnKeyListener, SoundController.OnBackpackSoundCompleteListener {
 
 	public static final String TAG = SoundFragment.class.getSimpleName();
 
@@ -520,8 +520,14 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 		switch (item.getItemId()) {
 
 			case R.id.context_menu_backpack:
-				SoundController.getInstance().backPackSound(selectedSoundInfo, false);
-				openBackPack();
+				boolean soundAlreadyInBackpack = SoundController.getInstance().checkSoundReplaceInBackpack(selectedSoundInfo);
+				if (!soundAlreadyInBackpack) {
+					SoundController.getInstance().backPackVisibleSound(selectedSoundInfo);
+					openBackPack();
+				} else {
+					SoundController.getInstance().setOnBackpackSoundCompleteListener(this);
+					SoundController.getInstance().showBackPackReplaceDialog(selectedSoundInfo, getActivity());
+				}
 				break;
 
 			case R.id.context_menu_copy:
@@ -684,6 +690,11 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 
 	public List<SoundInfo> getSoundInfoList() {
 		return soundInfoList;
+	}
+
+	@Override
+	public void onBackpackSoundComplete(boolean startBackpackActivity) {
+		openBackPack();
 	}
 
 	private class SoundRenamedReceiver extends BroadcastReceiver {

--- a/catroid/src/org/catrobat/catroid/utils/UtilFile.java
+++ b/catroid/src/org/catrobat/catroid/utils/UtilFile.java
@@ -285,8 +285,8 @@ public final class UtilFile {
 			throw new IllegalArgumentException("scale factor is smaller or equal zero");
 		}
 		outputFilename = UtilFile.encodeSpecialCharsForFileSystem(outputFilename);
-		if (!outputFilename.toLowerCase(Locale.US).endsWith(Constants.IMAGE_STANDARD_EXTENTION)) {
-			outputFilename = outputFilename + Constants.IMAGE_STANDARD_EXTENTION;
+		if (!outputFilename.toLowerCase(Locale.US).endsWith(Constants.IMAGE_STANDARD_EXTENSION)) {
+			outputFilename = outputFilename + Constants.IMAGE_STANDARD_EXTENSION;
 		}
 		File copiedFile = copyFromResourceIntoProject(projectName, Constants.IMAGE_DIRECTORY, outputFilename,
 				resourceId, context, false);

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
@@ -1846,7 +1846,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		UiTestUtils.clickOnTextInList(solo, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 
 		boolean screenshotExists = ProjectManager.getInstance().getCurrentProject()
-				.manualScreenshotExists("manual_screenshot" + Constants.IMAGE_STANDARD_EXTENTION);
+				.manualScreenshotExists("manual_screenshot" + Constants.IMAGE_STANDARD_EXTENSION);
 		assertEquals("there should be no manual screenshot", true, screenshotExists);
 		playTheProject(false, false, false); // green to green
 		byte[] greenPixel1 = createScreenshotBitmap();
@@ -1859,7 +1859,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		UiTestUtils.clickOnTextInList(solo, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 
 		screenshotExists = ProjectManager.getInstance().getCurrentProject()
-				.manualScreenshotExists("manual_screenshot" + Constants.IMAGE_STANDARD_EXTENTION);
+				.manualScreenshotExists("manual_screenshot" + Constants.IMAGE_STANDARD_EXTENSION);
 		assertEquals("there should be no manual screenshot", true, screenshotExists);
 		playTheProject(true, false, false); // green to red
 		byte[] redPixel1 = createScreenshotBitmap();
@@ -1868,7 +1868,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		UiTestUtils.clickOnTextInList(solo, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 
 		screenshotExists = ProjectManager.getInstance().getCurrentProject()
-				.manualScreenshotExists("manual_screenshot" + Constants.IMAGE_STANDARD_EXTENTION);
+				.manualScreenshotExists("manual_screenshot" + Constants.IMAGE_STANDARD_EXTENSION);
 		assertEquals("there should be no manual screenshot", true, screenshotExists);
 		playTheProject(false, true, true); // red to green + screenshot
 		byte[] greenPixel2 = createScreenshotBitmap();
@@ -1877,7 +1877,7 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		UiTestUtils.clickOnTextInList(solo, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 
 		screenshotExists = ProjectManager.getInstance().getCurrentProject()
-				.manualScreenshotExists("manual_screenshot" + Constants.IMAGE_STANDARD_EXTENTION);
+				.manualScreenshotExists("manual_screenshot" + Constants.IMAGE_STANDARD_EXTENSION);
 		assertEquals("there should be a manual screenshot", false, screenshotExists);
 		playTheProject(true, false, false); // green to red, screenshot must stay green
 		byte[] greenPixel3 = createScreenshotBitmap();

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.uitest.ui.fragment;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.util.Log;
@@ -84,7 +85,7 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 	private static final int TIME_TO_WAIT = 400;
 	private static final int TIME_TO_WAIT_BACKPACK = 1000;
 
-	private static final String FIRST_TEST_LOOK_NAME = "lookNameTest";
+	private static final String FIRST_TEST_LOOK_NAME = "catroid_sunglasses";
 	private static final String SECOND_TEST_LOOK_NAME = "lookNameTest2";
 	private static final String THIRD_TEST_LOOK_NAME = "lookNameTest3";
 	private static final String SPRITE_NAME = "cat";
@@ -120,6 +121,8 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 	private String backpack;
 	private String backpackAdd;
 	private String backpackTitle;
+	private String backpackReplaceDialogSingle;
+	private String backpackReplaceDialogMultiple;
 
 	public LookFragmentTest() {
 		super(MainMenuActivity.class);
@@ -177,6 +180,7 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		UiTestUtils.getIntoLooksFromMainMenu(solo, true);
 
+		Resources resources = getActivity().getBaseContext().getResources();
 		copy = solo.getString(R.string.copy);
 		rename = solo.getString(R.string.rename);
 		renameDialogTitle = solo.getString(R.string.rename_look_dialog);
@@ -187,6 +191,8 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		backpackAdd = solo.getString(R.string.backpack_add);
 		backpackTitle = solo.getString(R.string.backpack_title);
 		deleteDialogTitle = solo.getString(R.string.dialog_confirm_delete_look_title);
+		backpackReplaceDialogSingle = resources.getString(R.string.backpack_replace_look, FIRST_TEST_LOOK_NAME);
+		backpackReplaceDialogMultiple = solo.getString(R.string.backpack_replace_look_multiple);
 
 		if (getLookAdapter().getShowDetails()) {
 			solo.clickOnMenuItem(solo.getString(R.string.hide_details), true);
@@ -709,6 +715,47 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		checkVisibilityOfViews(VISIBLE, VISIBLE, GONE, GONE);
 	}
 
+	public void testBackPackAlreadyPackedDialogSingleItem() {
+		clickOnContextMenuItem(FIRST_TEST_LOOK_NAME, backpackAdd);
+		solo.sleep(TIME_TO_WAIT_BACKPACK);
+		assertTrue("Look wasn't backpacked!", solo.waitForText(firstTestLookNamePacked, 0, TIME_TO_WAIT));
+		solo.goBack();
+		solo.waitForActivity(ScriptActivity.class.getSimpleName());
+
+		clickOnContextMenuItem(FIRST_TEST_LOOK_NAME, backpackAdd);
+		solo.waitForDialogToOpen();
+		assertTrue("Look already exists backpack dialog not shown!", solo.waitForText(backpackReplaceDialogSingle, 0, TIME_TO_WAIT));
+		solo.clickOnButton(solo.getString(R.string.yes));
+		solo.sleep(200);
+
+		assertTrue("Should be in backpack!", solo.waitForText(backpackTitle, 0, TIME_TO_WAIT));
+		assertTrue("Look wasn't backpacked!", solo.waitForText(firstTestLookNamePacked, 0, TIME_TO_WAIT));
+		assertTrue("Look was not replaced!", BackPackListManager.getInstance().getBackPackedLooks().size() == 1);
+	}
+
+	public void testBackPackAlreadyPackedDialogMultipleItems() {
+		UiTestUtils.backPackAllItems(solo, getActivity(), firstTestLookNamePacked, secondTestLookNamePacked);
+		assertTrue("Look wasn't backpacked!", solo.waitForText(firstTestLookNamePacked, 0, TIME_TO_WAIT));
+		solo.goBack();
+		solo.waitForActivity(ScriptActivity.class.getSimpleName());
+
+		UiTestUtils.openBackPackActionMode(solo, getActivity());
+		String selectAll = solo.getString(R.string.select_all).toUpperCase(Locale.getDefault());
+		UiTestUtils.clickOnText(solo, selectAll);
+		UiTestUtils.acceptAndCloseActionMode(solo);
+
+		solo.waitForDialogToOpen();
+		assertTrue("Look already exists backpack dialog not shown!", solo.waitForText(backpackReplaceDialogMultiple, 0,
+				TIME_TO_WAIT));
+		solo.clickOnButton(solo.getString(R.string.yes));
+		solo.sleep(200);
+
+		assertTrue("Should be in backpack!", solo.waitForText(backpackTitle, 0, TIME_TO_WAIT));
+		assertTrue("Look wasn't backpacked!", solo.waitForText(firstTestLookNamePacked, 0, TIME_TO_WAIT));
+		assertTrue("Look wasn't backpacked!", solo.waitForText(secondTestLookNamePacked, 0, TIME_TO_WAIT));
+		assertTrue("Look was not replaced!", BackPackListManager.getInstance().getBackPackedLooks().size() == 2);
+	}
+
 	public void testCopyLookContextMenu() {
 		String testLookName = SECOND_TEST_LOOK_NAME;
 
@@ -1152,8 +1199,8 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		solo.sleep(200);
 		solo.waitForActivity(ScriptActivity.class.getSimpleName());
 		solo.sleep(200);
-		assertNotNull("there must be an Intent", getLookFragment().lastRecivedIntent);
-		Bundle bundle = getLookFragment().lastRecivedIntent.getExtras();
+		assertNotNull("there must be an Intent", getLookFragment().lastReceivedIntent);
+		Bundle bundle = getLookFragment().lastReceivedIntent.getExtras();
 		String pathOfPocketPaintImage = bundle.getString(Constants.EXTRA_PICTURE_PATH_POCKET_PAINT);
 		assertEquals("Image must by a temp copy", Constants.TMP_IMAGE_PATH, pathOfPocketPaintImage);
 	}

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/ScriptFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/ScriptFragmentTest.java
@@ -90,6 +90,7 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 	private String unpack;
 	private String unpackAndKeep;
 	private String backpack;
+	private String backpackAdd;
 	private String backpackTitle;
 
 	private String delete;
@@ -116,6 +117,7 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 		unpack = solo.getString(R.string.unpack);
 		unpackAndKeep = solo.getString(R.string.unpack_keep);
 		backpack = solo.getString(R.string.backpack);
+		backpackAdd = solo.getString(R.string.backpack_add);
 		backpackTitle = solo.getString(R.string.backpack_title);
 
 		delete = solo.getString(R.string.delete);
@@ -1534,8 +1536,8 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 		solo.waitForText(brickWhenStarted);
 		solo.clickOnText(brickWhenStarted);
 		solo.waitForDialogToOpen();
-		solo.waitForText(backpack);
-		solo.clickOnText(backpack);
+		solo.waitForText(backpackAdd);
+		solo.clickOnText(backpackAdd);
 
 		fillNewScriptGroupDialog(scriptGroupName);
 	}

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.uitest.ui.fragment;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.media.AudioManager;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
@@ -75,7 +76,7 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 	private static final int TIME_TO_WAIT = 200;
 	private static final int TIME_TO_WAIT_BACKPACK = 1000;
 
-	private static final String FIRST_TEST_SOUND_NAME = "testSound1";
+	private static final String FIRST_TEST_SOUND_NAME = "longsound";
 	private static final String SECOND_TEST_SOUND_NAME = "testSound2";
 	private static final String SECOND_SPRITE_NAME = "second_sprite";
 
@@ -110,6 +111,8 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 	private String backpackAdd;
 	private String backpackTitle;
 	private String deleteDialogTitle;
+	private String backpackReplaceDialogSingle;
+	private String backpackReplaceDialogMultiple;
 
 	public SoundFragmentTest() {
 		super(MainMenuActivity.class);
@@ -153,6 +156,7 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		secondTestSoundNamePacked = SECOND_TEST_SOUND_NAME;
 		secondTestSoundNamePackedAndUnpacked = SECOND_TEST_SOUND_NAME + "1";
 
+		Resources resources = getActivity().getBaseContext().getResources();
 		rename = solo.getString(R.string.rename);
 		renameDialogTitle = solo.getString(R.string.rename_sound_dialog);
 		backpackTitle = solo.getString(R.string.backpack_title);
@@ -163,6 +167,8 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		unpackAndKeep = solo.getString(R.string.unpack_keep);
 		backpack = solo.getString(R.string.backpack);
 		backpackAdd = solo.getString(R.string.backpack_add);
+		backpackReplaceDialogSingle = resources.getString(R.string.backpack_replace_sound, FIRST_TEST_SOUND_NAME);
+		backpackReplaceDialogMultiple = solo.getString(R.string.backpack_replace_sound_multiple);
 
 		if (getSoundAdapter().getShowDetails()) {
 			solo.clickOnMenuItem(solo.getString(R.string.hide_details), true);
@@ -1170,6 +1176,47 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		solo.clickOnMenuItem(solo.getString(R.string.hide_details));
 		solo.sleep(timeToWait);
 		checkVisibilityOfViews(VISIBLE, VISIBLE, GONE, GONE);
+	}
+
+	public void testBackPackAlreadyPackedDialogSingleItem() {
+		clickOnContextMenuItem(FIRST_TEST_SOUND_NAME, backpackAdd);
+		solo.sleep(TIME_TO_WAIT_BACKPACK);
+		assertTrue("Sound wasn't backpacked!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
+		solo.goBack();
+		solo.waitForActivity(ScriptActivity.class.getSimpleName());
+
+		clickOnContextMenuItem(FIRST_TEST_SOUND_NAME, backpackAdd);
+		solo.waitForDialogToOpen();
+		assertTrue("Sound already exists backpack dialog not shown!", solo.waitForText(backpackReplaceDialogSingle, 0, TIME_TO_WAIT));
+		solo.clickOnButton(solo.getString(R.string.yes));
+		solo.sleep(200);
+
+		assertTrue("Should be in backpack!", solo.waitForText(backpackTitle, 0, TIME_TO_WAIT));
+		assertTrue("Sound wasn't backpacked!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
+		assertTrue("Sound was not replaced!", BackPackListManager.getInstance().getBackPackedSounds().size() == 1);
+	}
+
+	public void testBackPackAlreadyPackedDialogMultipleItems() {
+		UiTestUtils.backPackAllItems(solo, getActivity(), firstTestSoundNamePacked, secondTestSoundNamePacked);
+		assertTrue("Sound wasn't backpacked!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
+		solo.goBack();
+		solo.waitForActivity(ScriptActivity.class.getSimpleName());
+
+		UiTestUtils.openBackPackActionMode(solo, getActivity());
+		String selectAll = solo.getString(R.string.select_all).toUpperCase(Locale.getDefault());
+		UiTestUtils.clickOnText(solo, selectAll);
+		UiTestUtils.acceptAndCloseActionMode(solo);
+
+		solo.waitForDialogToOpen();
+		assertTrue("Sound already exists backpack dialog not shown!", solo.waitForText(backpackReplaceDialogMultiple, 0,
+				TIME_TO_WAIT));
+		solo.clickOnButton(solo.getString(R.string.yes));
+		solo.sleep(200);
+
+		assertTrue("Should be in backpack!", solo.waitForText(backpackTitle, 0, TIME_TO_WAIT));
+		assertTrue("Sound wasn't backpacked!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
+		assertTrue("Sound wasn't backpacked!", solo.waitForText(secondTestSoundNamePacked, 0, TIME_TO_WAIT));
+		assertTrue("Sound was not replaced!", BackPackListManager.getInstance().getBackPackedSounds().size() == 2);
 	}
 
 	public void testRenameActionModeIfSomethingSelectedAndPressingBack() {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -26,4 +26,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
Prevents backpacking of sounds, looks & objects that are already in the backpack (same name). The users can decide whether they want to replace the existing items.

I've also updated to the newest gradle version and fixed the resulting exception of Jake Wharton's SDK Manager as well as the CatroidFieldKeySorter, as @robertpainsi described in CAT-1658.

For multidexing javaMaxHeapSize should be increased for faster apk builds.

Works like a charm with the new AS Instant Run! :)
