### PR TITLE
CAT-1824 Fixed Detail links on Marketing activity

### DIFF
--- a/buildAPK.gradle
+++ b/buildAPK.gradle
@@ -191,7 +191,7 @@ task buildStandalone(dependsOn: ':downloadProject') << {
 }
 
 task downloadProject() << {
-    def id = 824;//3143; //debugging purpose only
+    def id = 6760;//3143; //debugging purpose only
     def url = "";
     if (project.hasProperty("download")) {
         url = project["download"]

--- a/catroid/src/org/catrobat/catroid/ui/MarketingActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/MarketingActivity.java
@@ -84,6 +84,9 @@ public class MarketingActivity extends Activity {
 			@Override
 			public void onClick(View v) {
 				String url = ProjectManager.getInstance().getCurrentProject().getXmlHeader().getUrl();
+				if (!url.trim().startsWith("http://")) {
+					url = "https://share.catrob.at" + url;
+				}
 				startWebViewActivity(url);
 			}
 		});


### PR DESCRIPTION
For newer standalone apps the detail-link in the final marketing
activity stopped working as the url-tag in code.xml doesn't contain the
full url anymore.