### PR TITLE
CAT-1868 Fix the camera front, flashlight, vibration bug

### DIFF
--- a/catroid/src/org/catrobat/catroid/stage/PreStageActivity.java
+++ b/catroid/src/org/catrobat/catroid/stage/PreStageActivity.java
@@ -287,6 +287,10 @@ public class PreStageActivity extends BaseActivity {
 			FaceDetectionHandler.stopFaceDetection();
 		}
 
+		if (VibratorUtil.isActive()) {
+			VibratorUtil.pauseVibrator();
+		}
+
 		RaspberryPiService.getInstance().disconnect();
 	}
 

--- a/catroid/src/org/catrobat/catroid/utils/VibratorUtil.java
+++ b/catroid/src/org/catrobat/catroid/utils/VibratorUtil.java
@@ -179,14 +179,18 @@ public final class VibratorUtil {
 	}
 
 	private static synchronized void startVibrate() {
-		Log.d(TAG, "startVibrate()");
-		startTime = SystemClock.uptimeMillis();
-		vibrator.vibrate(MAX_TIME_TO_VIBRATE);
-		Log.d(TAG, "start time was: " + Long.toString(startTime));
+		if (vibrator != null) {
+			Log.d(TAG, "startVibrate()");
+			startTime = SystemClock.uptimeMillis();
+			vibrator.vibrate(MAX_TIME_TO_VIBRATE);
+			Log.d(TAG, "start time was: " + Long.toString(startTime));
+		}
 	}
 
 	private static synchronized void stopVibrate() {
-		Log.d(TAG, "stopVibrate()");
-		vibrator.cancel();
+		if (vibrator != null) {
+			Log.d(TAG, "stopVibrate()");
+			vibrator.cancel();
+		}
 	}
 }


### PR DESCRIPTION
If you want to turn on the flashlight on the front camera, but you doesn't have a flashlight there and you also have an vibration brick in your program, you will get an error, the stage will be destroyed, but the vibrator doesn't stop. So i added an check to pause the vibration.