### PR TITLE
CAT-1878 backpack unpacking background objects

### DIFF
--- a/catroid/res/menu/context_menu_unpacking.xml
+++ b/catroid/res/menu/context_menu_unpacking.xml
@@ -25,7 +25,8 @@
 
 	<item
         android:id="@+id/context_menu_unpacking_keep"
-        android:title="@string/unpack_keep" />
+        android:title="@string/unpack_keep"
+        android:visible="false"/>
 
     <item
         android:id="@+id/context_menu_unpacking"

--- a/catroid/res/menu/context_menu_unpacking_sprite.xml
+++ b/catroid/res/menu/context_menu_unpacking_sprite.xml
@@ -23,13 +23,12 @@
   -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android" >
     <item
-        android:id="@+id/context_menu_unpacking_keep"
-        android:title="@string/unpack_keep"
-        android:visible="false"/>
+        android:id="@+id/context_menu_unpacking_background"
+        android:title="@string/unpack_bg" />
 
     <item
-        android:id="@+id/context_menu_unpacking"
-        android:title="@string/unpack" />
+        android:id="@+id/context_menu_unpacking_object"
+        android:title="@string/unpack_object" />
 
     <item
         android:id="@+id/context_menu_delete"

--- a/catroid/res/menu/menu_current_project.xml
+++ b/catroid/res/menu/menu_current_project.xml
@@ -28,18 +28,6 @@
         android:showAsAction="never"
         android:visible="false"
         android:title="@string/backpack" />
-
-     <item
-         android:id="@+id/unpacking"
-         android:showAsAction="never"
-         android:visible="false"
-         android:title="@string/unpack" />
-
-    <item
-        android:id="@+id/unpacking_keep"
-        android:showAsAction="never"
-        android:visible="false"
-        android:title="@string/unpack_keep" />
     <item
         android:id="@+id/delete"
         android:icon="@drawable/ic_menu_delete"

--- a/catroid/res/menu/menu_script_activity.xml
+++ b/catroid/res/menu/menu_script_activity.xml
@@ -42,6 +42,12 @@
         android:title="@string/unpack" />
 
     <item
+        android:id="@+id/unpacking_object"
+        android:showAsAction="never"
+        android:title="@string/unpack_object"
+        android:visible="false"/>
+
+    <item
         android:id="@+id/copy"
         android:showAsAction="never"
         android:title="@string/copy"/>

--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -42,6 +42,8 @@
     <string name="packing">Pack</string>
     <string name="unpack">Unpack</string>
     <string name="unpack_keep">Unpack and keep</string>
+    <string name="unpack_bg">Unpack as background</string>
+    <string name="unpack_object">Unpack as object</string>
     <string name="copy_addition">copy</string>
     <string name="close">Close</string>
     <string name="error">Error</string>

--- a/catroid/src/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/org/catrobat/catroid/content/Project.java
@@ -90,7 +90,6 @@ public class Project implements Serializable {
 			return;
 		}
 		Sprite background = new Sprite(context.getString(R.string.background));
-		background.isBackgroundObject = true;
 		background.look.setZIndex(0);
 		addSprite(background);
 	}

--- a/catroid/src/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/org/catrobat/catroid/content/Sprite.java
@@ -28,7 +28,6 @@ import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.actions.ParallelAction;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
-import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.BroadcastSequenceMap;
@@ -62,8 +61,6 @@ public class Sprite implements Serializable, Cloneable {
 
 	@XStreamAsAttribute
 	private String name;
-	@XStreamOmitField
-	public boolean isBackgroundObject = false;
 
 	private List<Script> scriptList = new ArrayList<>();
 	private List<LookData> lookList = new ArrayList<>();

--- a/catroid/src/org/catrobat/catroid/io/CatroidFieldKeySorter.java
+++ b/catroid/src/org/catrobat/catroid/io/CatroidFieldKeySorter.java
@@ -147,14 +147,12 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 				fieldKeyOrder[9] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("isBackpackObject")) {
 				fieldKeyOrder[10] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("isBackgroundObject")) {
-				fieldKeyOrder[11] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("nfcTagList")) {
-				fieldKeyOrder[12] = fieldKey;
+				fieldKeyOrder[11] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("actionFactory")) {
-				fieldKeyOrder[13] = fieldKey;
+				fieldKeyOrder[12] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("$change")) {
-				fieldKeyOrder[14] = fieldKey;
+				fieldKeyOrder[13] = fieldKey;
 			}
 		}
 		for (FieldKey fieldKey : fieldKeyOrder) {

--- a/catroid/src/org/catrobat/catroid/ui/BackPackActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/BackPackActivity.java
@@ -141,6 +141,10 @@ public class BackPackActivity extends BaseActivity {
 				currentFragment.startUnPackingActionMode(false);
 				break;
 
+			case R.id.unpacking_object:
+				currentFragment.startUnPackingActionMode(false);
+				break;
+
 			case R.id.delete:
 				currentFragment.startDeleteActionMode();
 				break;

--- a/catroid/src/org/catrobat/catroid/ui/BackPackActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/BackPackActivity.java
@@ -134,7 +134,7 @@ public class BackPackActivity extends BaseActivity {
 				break;
 
 			case R.id.unpacking:
-				currentFragment.startUnPackingActionMode(true);
+				currentFragment.startUnPackingActionMode(false);
 				break;
 
 			case R.id.unpacking_keep:

--- a/catroid/src/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/ProjectActivity.java
@@ -130,8 +130,6 @@ public class ProjectActivity extends BaseActivity {
 	public boolean onCreateOptionsMenu(Menu menu) {
 		if (spritesListFragment != null) {
 			getMenuInflater().inflate(R.menu.menu_current_project, menu);
-			menu.findItem(R.id.unpacking).setVisible(false);
-			menu.findItem(R.id.unpacking_keep).setVisible(false);
 			menu.findItem(R.id.backpack).setVisible(true);
 		}
 		return super.onCreateOptionsMenu(menu);

--- a/catroid/src/org/catrobat/catroid/ui/adapter/BackPackSpriteAdapter.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/BackPackSpriteAdapter.java
@@ -47,7 +47,6 @@ import java.util.List;
 public class BackPackSpriteAdapter extends SpriteBaseAdapter implements ActionModeActivityAdapterInterface {
 
 	private final BackPackSpriteFragment backpackSpriteFragment;
-	private boolean disableBackgroundSprites;
 
 	public BackPackSpriteAdapter(Context context, int resource, int textViewResourceId, List<Sprite> objects,
 			BackPackSpriteFragment backpackSpriteFragment) {
@@ -92,13 +91,7 @@ public class BackPackSpriteAdapter extends SpriteBaseAdapter implements ActionMo
 		handleHolderViews(position, holder);
 
 		if (selectMode != ListView.CHOICE_MODE_NONE) {
-			if (disableBackgroundSprites && getItem(position).isBackgroundObject) {
-				holder.checkbox.setVisibility(View.INVISIBLE);
-				enableHolderViews(holder, false);
-				spriteView.setAlpha((float) 0.25);
-			} else {
-				holder.checkbox.setVisibility(View.VISIBLE);
-			}
+			holder.checkbox.setVisibility(View.VISIBLE);
 			holder.background.setBackgroundResource(R.drawable.button_background_shadowed);
 		} else {
 			holder.background.setBackgroundResource(R.drawable.button_background_selector);
@@ -149,12 +142,11 @@ public class BackPackSpriteAdapter extends SpriteBaseAdapter implements ActionMo
 		}
 
 		for (Sprite sprite : spritesToUnpack) {
-			BackPackSpriteController.getInstance().unpack(sprite, delete, false, false);
+			BackPackSpriteController.getInstance().unpack(sprite, delete, false, false, false);
 		}
 
 		boolean returnToProjectActivity = !checkedSprites.isEmpty();
 		clearCheckedItems();
-		this.disableBackgroundSprites = false;
 		if (returnToProjectActivity) {
 			returnToProjectActivity();
 		}
@@ -164,19 +156,5 @@ public class BackPackSpriteAdapter extends SpriteBaseAdapter implements ActionMo
 		Intent intent = new Intent(getContext(), ProjectActivity.class);
 		intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 		getContext().startActivity(intent);
-	}
-
-	public void disableBackgroundSprites() {
-		this.disableBackgroundSprites = true;
-	}
-
-	public int getCountWithBackgroundSprites() {
-		int numberOfBackgroundSprites = 0;
-		for (int position = 0; position < getCount(); position++) {
-			if (getItem(position).isBackgroundObject) {
-				numberOfBackgroundSprites++;
-			}
-		}
-		return getCount() - numberOfBackgroundSprites;
 	}
 }

--- a/catroid/src/org/catrobat/catroid/ui/controller/BackPackScriptController.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/BackPackScriptController.java
@@ -193,7 +193,7 @@ public final class BackPackScriptController {
 			} else if (brickOfScript instanceof PointToBrick) {
 				PointToBrick brick = (PointToBrick) brickOfScript;
 				Sprite unpackedPointToSprite = BackPackSpriteController.getInstance().unpack(brick.getPointedObject(),
-						deleteUnpackedItems, true, true);
+						deleteUnpackedItems, true, true, false);
 				brick.setPointedObject(unpackedPointToSprite);
 			}
 		}

--- a/catroid/src/org/catrobat/catroid/ui/controller/BackPackSpriteController.java
+++ b/catroid/src/org/catrobat/catroid/ui/controller/BackPackSpriteController.java
@@ -144,7 +144,6 @@ public final class BackPackSpriteController {
 		String newSpriteName = Utils.getUniqueSpriteName(spriteToEdit);
 		backPackSprite.setName(newSpriteName);
 		backPackSprite.isBackpackObject = true;
-		backPackSprite.isBackgroundObject = ProjectManager.getInstance().getCurrentProject().isBackgroundObject(spriteToEdit);
 
 		for (LookData lookData : spriteToEdit.getLookDataList()) {
 			if (!lookDataIsUsedInScript(lookData, ProjectManager.getInstance().getCurrentSprite())) {
@@ -165,7 +164,8 @@ public final class BackPackSpriteController {
 		return backPackSprite;
 	}
 
-	public Sprite unpack(Sprite selectedSprite, boolean delete, boolean keepCurrentSprite, boolean fromHiddenBackPack) {
+	public Sprite unpack(Sprite selectedSprite, boolean delete, boolean keepCurrentSprite, boolean
+			fromHiddenBackPack, boolean asBackground) {
 
 		if (fromHiddenBackPack && ProjectManager.getInstance().getCurrentProject().containsSprite(selectedSprite)) {
 			return selectedSprite;
@@ -192,7 +192,7 @@ public final class BackPackSpriteController {
 
 		BackPackScriptController.getInstance().unpack(selectedSprite.getName(), delete, false, null, true);
 
-		if (selectedSprite.isBackgroundObject) {
+		if (asBackground) {
 			ProjectManager.getInstance().getCurrentProject().replaceBackgroundSprite(unpackedSprite);
 		} else {
 			ProjectManager.getInstance().addSprite(unpackedSprite);

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/ConfirmUnpackBackgroundDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/ConfirmUnpackBackgroundDialog.java
@@ -54,12 +54,14 @@ public class ConfirmUnpackBackgroundDialog extends DialogFragment {
 	private boolean delete;
 	private boolean keepCurrentSprite;
 	private boolean fromHiddenBackPack;
+	private boolean asBackground;
 
-	public ConfirmUnpackBackgroundDialog(Sprite selectedSprite, boolean delete, boolean keepCurrentSprite, boolean fromHiddenBackPack) {
+	public ConfirmUnpackBackgroundDialog(Sprite selectedSprite, boolean delete, boolean keepCurrentSprite, boolean fromHiddenBackPack, boolean asBackground) {
 		this.selectedSprite = selectedSprite;
 		this.delete = delete;
 		this.keepCurrentSprite = keepCurrentSprite;
 		this.fromHiddenBackPack = fromHiddenBackPack;
+		this.asBackground = asBackground;
 	}
 
 	@Override
@@ -110,7 +112,7 @@ public class ConfirmUnpackBackgroundDialog extends DialogFragment {
 		}
 
 		Sprite unpackedSprite = BackPackSpriteController.getInstance().unpack(selectedSprite, delete,
-				keepCurrentSprite, fromHiddenBackPack);
+				keepCurrentSprite, fromHiddenBackPack, asBackground);
 		unpackedSprite.setName(getActivity().getString(R.string.background));
 		returnToProjectActivity();
 

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackLookFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackLookFragment.java
@@ -192,8 +192,8 @@ public class BackPackLookFragment extends BackPackActivityFragment implements Di
 		menu.findItem(R.id.copy).setVisible(false);
 		if (!BackPackListManager.getInstance().getBackPackedLooks().isEmpty()) {
 			menu.findItem(R.id.unpacking).setVisible(true);
-			menu.findItem(R.id.unpacking_keep).setVisible(false);
 		}
+		menu.findItem(R.id.unpacking_keep).setVisible(false);
 		BottomBar.hideBottomBar(getActivity());
 		super.onPrepareOptionsMenu(menu);
 	}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackLookFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackLookFragment.java
@@ -192,7 +192,7 @@ public class BackPackLookFragment extends BackPackActivityFragment implements Di
 		menu.findItem(R.id.copy).setVisible(false);
 		if (!BackPackListManager.getInstance().getBackPackedLooks().isEmpty()) {
 			menu.findItem(R.id.unpacking).setVisible(true);
-			menu.findItem(R.id.unpacking_keep).setVisible(true);
+			menu.findItem(R.id.unpacking_keep).setVisible(false);
 		}
 		BottomBar.hideBottomBar(getActivity());
 		super.onPrepareOptionsMenu(menu);
@@ -217,7 +217,7 @@ public class BackPackLookFragment extends BackPackActivityFragment implements Di
 				contextMenuUnpacking(false);
 				break;
 			case R.id.context_menu_unpacking:
-				contextMenuUnpacking(true);
+				contextMenuUnpacking(false);
 				break;
 			case R.id.context_menu_delete:
 				deleteLooks();

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackScriptFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackScriptFragment.java
@@ -124,8 +124,8 @@ public class BackPackScriptFragment extends BackPackActivityFragment implements 
 		menu.findItem(R.id.copy).setVisible(false);
 		if (!BackPackListManager.getInstance().getBackPackedScripts().isEmpty()) {
 			menu.findItem(R.id.unpacking).setVisible(true);
-			menu.findItem(R.id.unpacking_keep).setVisible(false);
 		}
+		menu.findItem(R.id.unpacking_keep).setVisible(false);
 		BottomBar.hideBottomBar(getActivity());
 		super.onPrepareOptionsMenu(menu);
 	}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackScriptFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackScriptFragment.java
@@ -124,7 +124,7 @@ public class BackPackScriptFragment extends BackPackActivityFragment implements 
 		menu.findItem(R.id.copy).setVisible(false);
 		if (!BackPackListManager.getInstance().getBackPackedScripts().isEmpty()) {
 			menu.findItem(R.id.unpacking).setVisible(true);
-			menu.findItem(R.id.unpacking_keep).setVisible(true);
+			menu.findItem(R.id.unpacking_keep).setVisible(false);
 		}
 		BottomBar.hideBottomBar(getActivity());
 		super.onPrepareOptionsMenu(menu);
@@ -146,10 +146,12 @@ public class BackPackScriptFragment extends BackPackActivityFragment implements 
 		switch (item.getItemId()) {
 
 			case R.id.context_menu_unpacking_keep:
-				BackPackScriptController.getInstance().unpack(selectedScriptGroupBackPack, false, true, getActivity(), false);
+				BackPackScriptController.getInstance().unpack(selectedScriptGroupBackPack, false, true, getActivity(),
+						false);
 				break;
 			case R.id.context_menu_unpacking:
-				BackPackScriptController.getInstance().unpack(selectedScriptGroupBackPack, true, true, getActivity(), false);
+				BackPackScriptController.getInstance().unpack(selectedScriptGroupBackPack, false, true, getActivity(),
+						false);
 				break;
 			case R.id.context_menu_delete:
 				showConfirmDeleteDialog();

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSoundFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSoundFragment.java
@@ -198,7 +198,7 @@ public class BackPackSoundFragment extends BackPackActivityFragment implements S
 		menu.findItem(R.id.copy).setVisible(false);
 		if (!BackPackListManager.getInstance().getBackPackedSounds().isEmpty()) {
 			menu.findItem(R.id.unpacking).setVisible(true);
-			menu.findItem(R.id.unpacking_keep).setVisible(true);
+			menu.findItem(R.id.unpacking_keep).setVisible(false);
 		}
 		BottomBar.hideBottomBar(getActivity());
 		super.onPrepareOptionsMenu(menu);
@@ -227,7 +227,7 @@ public class BackPackSoundFragment extends BackPackActivityFragment implements S
 				contextMenuUnpacking(false);
 				break;
 			case R.id.context_menu_unpacking:
-				contextMenuUnpacking(true);
+				contextMenuUnpacking(false);
 				break;
 			case R.id.context_menu_delete:
 				deleteSounds();

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSoundFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSoundFragment.java
@@ -198,8 +198,8 @@ public class BackPackSoundFragment extends BackPackActivityFragment implements S
 		menu.findItem(R.id.copy).setVisible(false);
 		if (!BackPackListManager.getInstance().getBackPackedSounds().isEmpty()) {
 			menu.findItem(R.id.unpacking).setVisible(true);
-			menu.findItem(R.id.unpacking_keep).setVisible(false);
 		}
+		menu.findItem(R.id.unpacking_keep).setVisible(false);
 		BottomBar.hideBottomBar(getActivity());
 		super.onPrepareOptionsMenu(menu);
 	}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSpriteFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSpriteFragment.java
@@ -127,11 +127,11 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 			setSelectMode(ListView.CHOICE_MODE_MULTIPLE);
 			setActionModeActive(true);
 
-			mode.setTitle(R.string.unpack);
-
 			actionModeTitle = getString(R.string.unpack);
-			singleItemAppendixActionMode = getString(R.string.category_looks);
-			multipleItemAppendixActionMode = getString(R.string.looks);
+			singleItemAppendixActionMode = getString(R.string.sprite);
+			multipleItemAppendixActionMode = getString(R.string.sprites);
+
+			mode.setTitle(actionModeTitle);
 			addSelectAllActionModeButton(mode, menu);
 
 			return true;
@@ -181,10 +181,13 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 	@Override
 	public void onPrepareOptionsMenu(Menu menu) {
 		menu.findItem(R.id.copy).setVisible(false);
+
 		if (!BackPackListManager.getInstance().getBackPackedSprites().isEmpty()) {
-			menu.findItem(R.id.unpacking).setVisible(true);
-			menu.findItem(R.id.unpacking_keep).setVisible(false);
+			menu.findItem(R.id.unpacking_object).setVisible(true);
 		}
+
+		menu.findItem(R.id.unpacking_keep).setVisible(false);
+		menu.findItem(R.id.unpacking).setVisible(false);
 		BottomBar.hideBottomBar(getActivity());
 		super.onPrepareOptionsMenu(menu);
 	}
@@ -197,18 +200,17 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 		menu.setHeaderTitle(selectedSpriteBackPack.getName());
 		adapter.addCheckedSprite(((AdapterView.AdapterContextMenuInfo) menuInfo).position);
 
-		getActivity().getMenuInflater().inflate(R.menu.context_menu_unpacking, menu);
+		getActivity().getMenuInflater().inflate(R.menu.context_menu_unpacking_sprite, menu);
 	}
 
 	@Override
 	public boolean onContextItemSelected(MenuItem item) {
 		switch (item.getItemId()) {
-
-			case R.id.context_menu_unpacking_keep:
-				checkForBackgroundUnpacking(selectedSpriteBackPack, false, false, false);
+			case R.id.context_menu_unpacking_background:
+				checkForBackgroundUnpacking(selectedSpriteBackPack, false, false, false, true);
 				break;
-			case R.id.context_menu_unpacking:
-				checkForBackgroundUnpacking(selectedSpriteBackPack, false, false, false);
+			case R.id.context_menu_unpacking_object:
+				checkForBackgroundUnpacking(selectedSpriteBackPack, false, false, false, false);
 				break;
 			case R.id.context_menu_delete:
 				showConfirmDeleteDialog();
@@ -218,14 +220,14 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 	}
 
 	private void checkForBackgroundUnpacking(Sprite selectedSprite, boolean delete, boolean keepCurrentSprite,
-			boolean fromHiddenBackPack) {
-		if (selectedSprite.isBackgroundObject) {
+			boolean fromHiddenBackPack, boolean asBackground) {
+		if (asBackground) {
 			ConfirmUnpackBackgroundDialog dialog = new ConfirmUnpackBackgroundDialog(selectedSprite, delete,
-					keepCurrentSprite, fromHiddenBackPack);
+					keepCurrentSprite, fromHiddenBackPack, true);
 			dialog.show(getFragmentManager(), ConfirmUnpackBackgroundDialog.DIALOG_FRAGMENT_TAG);
 		} else {
 			BackPackSpriteController.getInstance().unpack(selectedSprite, delete,
-					keepCurrentSprite, fromHiddenBackPack);
+					keepCurrentSprite, fromHiddenBackPack, false);
 			adapter.returnToProjectActivity();
 		}
 	}
@@ -335,10 +337,6 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 					@Override
 					public void onClick(View view) {
 						for (int position = 0; position < adapter.getCount(); position++) {
-							if (adapter.getItem(position).isBackgroundObject && actionModeTitle.equals(
-									getString(R.string.unpack))) {
-								continue;
-							}
 							adapter.addCheckedSprite(position);
 						}
 						adapter.notifyDataSetChanged();
@@ -368,22 +366,23 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 	}
 
 	private void startActionMode(ActionMode.Callback actionModeCallback, boolean deleteUnpackedItems) {
-		if (actionMode == null) {
-			if (adapter.isEmpty()) {
-				if (actionModeCallback.equals(unpackingModeCallBack)) {
-					((BackPackActivity) getActivity()).showEmptyActionModeDialog(getString(R.string.unpack));
-				} else if (actionModeCallback.equals(deleteModeCallBack)) {
-					((BackPackActivity) getActivity()).showEmptyActionModeDialog(getString(R.string.delete));
-				}
-			} else {
-				if (actionModeCallback.equals(unpackingModeCallBack)) {
-					this.deleteUnpackedItems = deleteUnpackedItems;
-					adapter.disableBackgroundSprites();
-				}
-				actionMode = getActivity().startActionMode(actionModeCallback);
-				unregisterForContextMenu(listView);
-				BottomBar.hideBottomBar(getActivity());
+		if (actionMode != null) {
+			return;
+		}
+
+		if (adapter.isEmpty()) {
+			if (actionModeCallback.equals(unpackingModeCallBack)) {
+				((BackPackActivity) getActivity()).showEmptyActionModeDialog(getString(R.string.unpack));
+			} else if (actionModeCallback.equals(deleteModeCallBack)) {
+				((BackPackActivity) getActivity()).showEmptyActionModeDialog(getString(R.string.delete));
 			}
+		} else {
+			if (actionModeCallback.equals(unpackingModeCallBack)) {
+				this.deleteUnpackedItems = deleteUnpackedItems;
+			}
+			actionMode = getActivity().startActionMode(actionModeCallback);
+			unregisterForContextMenu(listView);
+			BottomBar.hideBottomBar(getActivity());
 		}
 	}
 
@@ -490,13 +489,8 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 	@Override
 	public void onSpriteChecked() {
 		updateActionModeTitle();
-		if (actionModeTitle.equals(getString(R.string.unpack))) {
-			Utils.setSelectAllActionModeButtonVisibility(selectAllActionModeButton,
-					adapter.getCount() > 0 && adapter.getAmountOfCheckedItems() != adapter.getCountWithBackgroundSprites());
-		} else {
-			Utils.setSelectAllActionModeButtonVisibility(selectAllActionModeButton,
-					adapter.getCount() > 0 && adapter.getAmountOfCheckedItems() != adapter.getCount());
-		}
+		Utils.setSelectAllActionModeButtonVisibility(selectAllActionModeButton,
+				adapter.getCount() > 0 && adapter.getAmountOfCheckedItems() != adapter.getCount());
 	}
 
 	@Override

--- a/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSpriteFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/BackPackSpriteFragment.java
@@ -183,7 +183,7 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 		menu.findItem(R.id.copy).setVisible(false);
 		if (!BackPackListManager.getInstance().getBackPackedSprites().isEmpty()) {
 			menu.findItem(R.id.unpacking).setVisible(true);
-			menu.findItem(R.id.unpacking_keep).setVisible(true);
+			menu.findItem(R.id.unpacking_keep).setVisible(false);
 		}
 		BottomBar.hideBottomBar(getActivity());
 		super.onPrepareOptionsMenu(menu);
@@ -208,7 +208,7 @@ public class BackPackSpriteFragment extends BackPackActivityFragment implements 
 				checkForBackgroundUnpacking(selectedSpriteBackPack, false, false, false);
 				break;
 			case R.id.context_menu_unpacking:
-				checkForBackgroundUnpacking(selectedSpriteBackPack, true, false, false);
+				checkForBackgroundUnpacking(selectedSpriteBackPack, false, false, false);
 				break;
 			case R.id.context_menu_delete:
 				showConfirmDeleteDialog();

--- a/catroid/src/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
@@ -137,7 +137,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-
 public class CategoryBricksFactory {
 
 	public List<Brick> getBricks(String category, Sprite sprite, Context context) {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
@@ -44,7 +44,6 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.ScreenValues;
-import org.catrobat.catroid.content.Look;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.stage.StageActivity;

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
@@ -44,6 +44,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.ScreenValues;
+import org.catrobat.catroid.content.Look;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.stage.StageActivity;
@@ -117,7 +118,6 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 	private ProjectManager projectManager;
 
 	private String unpack;
-	private String unpackAndKeep;
 	private String backpack;
 	private String backpackAdd;
 	private String backpackTitle;
@@ -187,7 +187,6 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		renameDialogTitle = solo.getString(R.string.rename_look_dialog);
 		delete = solo.getString(R.string.delete);
 		unpack = solo.getString(R.string.unpack);
-		unpackAndKeep = solo.getString(R.string.unpack_keep);
 		backpack = solo.getString(R.string.backpack);
 		backpackAdd = solo.getString(R.string.backpack_add);
 		backpackTitle = solo.getString(R.string.backpack_title);
@@ -277,6 +276,8 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		clickOnContextMenuItem(SECOND_TEST_LOOK_NAME, backpackAdd);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
+		solo.waitForActivity(BackPackActivity.class);
+		solo.waitForFragmentByTag(BackPackLookFragment.TAG);
 
 		assertTrue("BackPack title didn't show up",
 				solo.waitForText(backpackTitle, 0, TIME_TO_WAIT_BACKPACK));
@@ -288,7 +289,13 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		assertNotNull("Could not get Adapter", adapter);
 		clickOnContextMenuItem(SECOND_TEST_LOOK_NAME, backpackAdd);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
+		solo.waitForActivity(BackPackActivity.class);
+		solo.waitForFragmentByTag(BackPackLookFragment.TAG);
+
 		solo.goBack();
+		solo.waitForActivity(ScriptActivity.class);
+		solo.waitForFragmentByTag(LookFragment.TAG);
+		solo.sleep(200);
 		clickOnContextMenuItem(FIRST_TEST_LOOK_NAME, backpackAdd);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
 
@@ -309,27 +316,6 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
 
 		assertTrue("Look wasn't unpacked!", solo.waitForText(firstTestLookNamePackedAndUnpacked, 0, TIME_TO_WAIT));
-	}
-
-	public void testBackPackLookSimpleUnpackingAndUnpackingAndKeepContextMenu() {
-		LookAdapter adapter = getLookAdapter();
-		assertNotNull("Could not get Adapter", adapter);
-		clickOnContextMenuItem(FIRST_TEST_LOOK_NAME, backpackAdd);
-		solo.sleep(TIME_TO_WAIT_BACKPACK);
-
-		clickOnContextMenuItem(firstTestLookNamePacked, unpackAndKeep);
-		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
-		assertTrue("Look wasn't unpacked!", solo.waitForText(firstTestLookNamePackedAndUnpacked, 0, TIME_TO_WAIT));
-		deleteLook(firstTestLookNamePackedAndUnpacked);
-		solo.sleep(200);
-		UiTestUtils.openBackPack(solo, getActivity());
-
-		assertTrue("Look wasn't kept in backpack!", solo.waitForText(firstTestLookNamePacked, 0, TIME_TO_WAIT));
-		clickOnContextMenuItem(firstTestLookNamePacked, unpack);
-		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
-		assertTrue("Look wasn't unpacked!", solo.waitForText(firstTestLookNamePacked, 0, TIME_TO_WAIT));
-		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
-		assertFalse("Backpack isn't empty!", solo.searchText(unpack));
 	}
 
 	public void testBackPackLookSimpleUnpackingAndDelete() {
@@ -402,10 +388,17 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		assertNotNull("Could not get Adapter", adapter);
 		clickOnContextMenuItem(FIRST_TEST_LOOK_NAME, backpackAdd);
+		solo.waitForActivity(BackPackActivity.class);
+		solo.waitForFragmentByTag(BackPackLookFragment.TAG);
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
 		solo.goBack();
+		solo.sleep(200);
 		solo.goBack();
+		solo.sleep(200);
 		solo.goBack();
+		solo.sleep(200);
+
+		solo.waitForText(SECOND_SPRITE_NAME, 1, 1000);
 		solo.clickOnText(SECOND_SPRITE_NAME);
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
 		solo.clickOnText(solo.getString(R.string.look));
@@ -566,7 +559,7 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
 
-		UiTestUtils.openActionMode(solo, unpackAndKeep, R.id.unpacking_keep, getActivity());
+		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
 		String selectAll = solo.getString(R.string.select_all).toUpperCase(Locale.getDefault());
 		UiTestUtils.clickOnText(solo, selectAll);
 		UiTestUtils.acceptAndCloseActionMode(solo);
@@ -577,19 +570,6 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		UiTestUtils.deleteAllItems(solo, getActivity());
 		assertFalse("Look wasn't deleted!", solo.waitForText(FIRST_TEST_LOOK_NAME, 1, 1000));
 		assertFalse("Look wasn't deleted!", solo.waitForText(SECOND_TEST_LOOK_NAME, 1, 1000));
-
-		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
-
-		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
-		UiTestUtils.clickOnText(solo, selectAll);
-		UiTestUtils.acceptAndCloseActionMode(solo);
-		solo.waitForActivity(ScriptActivity.class);
-
-		assertTrue("Look wasn't unpacked!", solo.waitForText(FIRST_TEST_LOOK_NAME, 1, 1000));
-		assertTrue("Look wasn't unpacked!", solo.waitForText(SECOND_TEST_LOOK_NAME, 1, 1000));
-
-		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
-		assertFalse("Backpack items were not cleared!", solo.waitForText(unpack, 1, 1000));
 	}
 
 	public void testBackPackDeleteActionModeCheckingAndTitle() {
@@ -739,6 +719,7 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		assertTrue("Look wasn't backpacked!", solo.waitForText(firstTestLookNamePacked, 0, TIME_TO_WAIT));
 		solo.goBack();
 		solo.waitForActivity(ScriptActivity.class.getSimpleName());
+		solo.waitForFragmentByTag(LookFragment.TAG);
 
 		UiTestUtils.openBackPackActionMode(solo, getActivity());
 		String selectAll = solo.getString(R.string.select_all).toUpperCase(Locale.getDefault());
@@ -749,8 +730,11 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		assertTrue("Look already exists backpack dialog not shown!", solo.waitForText(backpackReplaceDialogMultiple, 0,
 				TIME_TO_WAIT));
 		solo.clickOnButton(solo.getString(R.string.yes));
-		solo.sleep(200);
+		solo.waitForDialogToClose();
 
+		solo.waitForActivity(BackPackActivity.class.getSimpleName());
+		solo.waitForFragmentByTag(BackPackLookFragment.TAG);
+		solo.sleep(200);
 		assertTrue("Should be in backpack!", solo.waitForText(backpackTitle, 0, TIME_TO_WAIT));
 		assertTrue("Look wasn't backpacked!", solo.waitForText(firstTestLookNamePacked, 0, TIME_TO_WAIT));
 		assertTrue("Look wasn't backpacked!", solo.waitForText(secondTestLookNamePacked, 0, TIME_TO_WAIT));
@@ -2092,11 +2076,6 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 		solo.clickOnButton(0);
 		solo.waitForDialogToClose();
 
-		UiTestUtils.openActionMode(solo, unpackAndKeep, R.id.unpacking_keep, getActivity());
-		solo.waitForDialogToOpen();
-		assertTrue("Nothing to unpack dialog not shown", solo.waitForText(solo.getString(R.string
-				.nothing_to_unpack)));
-
 		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
 		solo.waitForDialogToOpen();
 		assertTrue("Nothing to unpack dialog not shown", solo.waitForText(solo.getString(R.string
@@ -2206,13 +2185,11 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 	}
 
 	private void clickOnContextMenuItem(String lookName, String menuItemName) {
-		int match = 1;
-		if (menuItemName.equals(unpack)) {
-			match = 2;
-		}
 		solo.clickLongOnText(lookName);
 		solo.waitForText(menuItemName);
-		solo.clickOnText(menuItemName, match);
+		solo.clickOnText(menuItemName);
+		solo.waitForActivity(BackPackActivity.class);
+		solo.waitForFragmentByTag(BackPackLookFragment.TAG);
 	}
 
 	private String getLookName(int lookIndex) {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/ScriptFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/ScriptFragmentTest.java
@@ -88,7 +88,6 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 	private static final int GONE = View.GONE;
 
 	private String unpack;
-	private String unpackAndKeep;
 	private String backpack;
 	private String backpackAdd;
 	private String backpackTitle;
@@ -115,7 +114,6 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 		super.setUp();
 
 		unpack = solo.getString(R.string.unpack);
-		unpackAndKeep = solo.getString(R.string.unpack_keep);
 		backpack = solo.getString(R.string.backpack);
 		backpackAdd = solo.getString(R.string.backpack_add);
 		backpackTitle = solo.getString(R.string.backpack_title);
@@ -914,35 +912,10 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 				.getCount());
 		assertEquals("Brick count in current sprite not correct", numberOfBricksInBrickList + 6,
 				ProjectManager.getInstance().getCurrentSprite().getNumberOfBricks());
-	}
-
-	public void testBackPackScriptsSimpleUnpackingAndUnpackingAndKeepContextMenu() {
-		UiTestUtils.createTestProject();
-		UiTestUtils.getIntoScriptActivityFromMainMenu(solo);
-		int brickCountInView = UiTestUtils.getScriptListView(solo).getCount();
-		int numberOfBricksInBrickList = ProjectManager.getInstance().getCurrentSprite().getNumberOfBricks();
-
-		backPackFirstScriptWithContextMenu(DEFAULT_SCRIPT_GROUP_NAME);
-		assertTrue("Script wasn't backpacked!", solo.waitForText(DEFAULT_SCRIPT_GROUP_NAME, 0, TIME_TO_WAIT_BACKPACK));
-		unpackScriptGroup(DEFAULT_SCRIPT_GROUP_NAME, unpackAndKeep);
-
-		assertEquals("Brick count in list view not correct", brickCountInView + 7, UiTestUtils.getScriptListView(solo)
-				.getCount());
-		assertEquals("Brick count in current sprite not correct", numberOfBricksInBrickList + 6,
-				ProjectManager.getInstance().getCurrentSprite().getNumberOfBricks());
 
 		UiTestUtils.openBackPack(solo, getActivity());
 		assertTrue("Script wasn't kept in backpack!", solo.waitForText(DEFAULT_SCRIPT_GROUP_NAME, 0,
 				TIME_TO_WAIT_BACKPACK));
-
-		unpackScriptGroup(DEFAULT_SCRIPT_GROUP_NAME, unpack);
-
-		assertEquals("Brick count in list view not correct", brickCountInView + 14, UiTestUtils.getScriptListView(solo)
-				.getCount());
-		assertEquals("Brick count in current sprite not correct", numberOfBricksInBrickList + 12,
-				ProjectManager.getInstance().getCurrentSprite().getNumberOfBricks());
-		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
-		assertFalse("Backpack isn't empty!", solo.searchText(unpack));
 	}
 
 	public void testBackPackAndUnPackFromDifferentProgrammes() {
@@ -1167,7 +1140,7 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 		UiTestUtils.openBackPack(solo, getActivity());
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
 
-		UiTestUtils.openActionMode(solo, unpackAndKeep, R.id.unpacking_keep, getActivity());
+		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
 		String selectAll = solo.getString(R.string.select_all).toUpperCase(Locale.getDefault());
 		UiTestUtils.clickOnText(solo, selectAll);
 		UiTestUtils.acceptAndCloseActionMode(solo);
@@ -1186,21 +1159,7 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 				ProjectManager.getInstance().getCurrentSprite().getNumberOfBricks());
 
 		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
-		solo.sleep(TIME_TO_WAIT_BACKPACK);
-
-		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
-		UiTestUtils.clickOnText(solo, selectAll);
-		UiTestUtils.acceptAndCloseActionMode(solo);
-
-		solo.waitForActivity(ScriptActivity.class);
-		solo.sleep(TIME_TO_WAIT_BACKPACK);
-		assertEquals("Brick count in list view not correct", brickCountInView, UiTestUtils.getScriptListView(solo)
-				.getCount());
-		assertEquals("Brick count in current sprite not correct", numberOfBricksInBrickList,
-				ProjectManager.getInstance().getCurrentSprite().getNumberOfBricks());
-
-		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
-		assertFalse("Backpack items were not cleared!", solo.waitForText(unpack, 1, 1000));
+		assertTrue("Backpack items were cleared!", solo.waitForText(backpackTitle, 1, 1000));
 	}
 
 	public void testBackPackDeleteActionModeCheckingAndTitle() {
@@ -1404,6 +1363,8 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
 		clickOnContextMenuItem(DEFAULT_SCRIPT_GROUP_NAME, unpack);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
+		solo.waitForActivity(ScriptActivity.class);
+		solo.waitForFragmentByTag(ScriptFragment.TAG);
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
 
 		listView = solo.getCurrentViews(ListView.class).get(solo.getCurrentViews(ListView.class).size() - 1);
@@ -1496,11 +1457,6 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 		solo.clickOnButton(0);
 		solo.waitForDialogToClose();
 
-		UiTestUtils.openActionMode(solo, unpackAndKeep, R.id.unpacking_keep, getActivity());
-		solo.waitForDialogToOpen();
-		assertTrue("Nothing to unpack dialog not shown", solo.waitForText(solo.getString(R.string
-				.nothing_to_unpack)));
-
 		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
 		solo.waitForDialogToOpen();
 		assertTrue("Nothing to unpack dialog not shown", solo.waitForText(solo.getString(R.string
@@ -1567,13 +1523,9 @@ public class ScriptFragmentTest extends BaseActivityInstrumentationTestCase<Main
 	}
 
 	private void clickOnContextMenuItem(String scriptGroupName, String menuItemName) {
-		int match = 1;
-		if (menuItemName.equals(unpack)) {
-			match = 2;
-		}
 		solo.clickLongOnText(scriptGroupName);
 		solo.waitForText(menuItemName);
-		solo.clickOnText(menuItemName, match);
+		solo.clickOnText(menuItemName);
 	}
 
 	private void unpackScriptGroup(String scriptGroupName, String menuItemName) {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
@@ -730,8 +730,11 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		assertNotNull("Could not get Adapter", adapter);
 		clickOnContextMenuItem(FIRST_TEST_SOUND_NAME, backpackAdd);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
+		solo.waitForActivity(BackPackActivity.class);
+		solo.waitForFragmentByTag(BackPackSoundFragment.TAG);
+		solo.sleep(TIME_TO_WAIT_BACKPACK);
 
-		assertTrue("BackPack title didn't show up", solo.waitForText(backpackTitle, 0, TIME_TO_WAIT));
+		assertTrue("BackPack title didn't show up", solo.waitForText(backpackTitle, 0, TIME_TO_WAIT_BACKPACK));
 		soundInfoList = backPackListManager.getBackPackedSounds();
 		SoundInfo soundInfo = soundInfoList.get(0);
 		solo.clickOnView(playAndStopImageButton);
@@ -752,8 +755,7 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		solo.waitForFragmentByTag(BackPackSoundFragment.TAG);
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
 
-		assertTrue("BackPack title didn't show up",
-				solo.waitForText(backpackTitle, 0, TIME_TO_WAIT_BACKPACK));
+		assertTrue("BackPack title didn't show up", solo.waitForText(backpackTitle, 0, TIME_TO_WAIT_BACKPACK));
 		assertTrue("Sound wasn't backpacked!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
 		assertTrue("Sound wasn't backpacked!", solo.waitForText(secondTestSoundNamePacked, 0, TIME_TO_WAIT));
 	}
@@ -772,11 +774,11 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 
 		assertTrue("Sound wasn't unpacked!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
 		deleteSound(firstTestSoundNamePackedAndUnpacked);
-		solo.sleep(200);
+		solo.sleep(TIME_TO_WAIT_BACKPACK);
 		UiTestUtils.openBackPack(solo, getActivity());
 		solo.waitForActivity(BackPackActivity.class);
 		solo.waitForFragmentByTag(BackPackSoundFragment.TAG);
-		solo.sleep(TIME_TO_WAIT);
+		solo.sleep(TIME_TO_WAIT_BACKPACK);
 
 		assertTrue("Sound wasn't kept in backpack!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT_BACKPACK));
 	}

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
@@ -106,7 +106,6 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 	private BackPackListManager backPackListManager;
 
 	private String unpack;
-	private String unpackAndKeep;
 	private String backpack;
 	private String backpackAdd;
 	private String backpackTitle;
@@ -165,7 +164,6 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		delete = solo.getString(R.string.delete);
 		copy = solo.getString(R.string.copy);
 		unpack = solo.getString(R.string.unpack);
-		unpackAndKeep = solo.getString(R.string.unpack_keep);
 		backpack = solo.getString(R.string.backpack);
 		backpackAdd = solo.getString(R.string.backpack_add);
 		backpackReplaceDialogSingle = resources.getString(R.string.backpack_replace_sound, FIRST_TEST_SOUND_NAME);
@@ -773,17 +771,6 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
 
 		assertTrue("Sound wasn't unpacked!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
-	}
-
-	public void testBackPackSoundSimpleUnpackingAndUnpackingAndKeepContextMenu() {
-		SoundAdapter adapter = getSoundAdapter();
-		assertNotNull("Could not get Adapter", adapter);
-		clickOnContextMenuItem(FIRST_TEST_SOUND_NAME, backpackAdd);
-		solo.sleep(TIME_TO_WAIT_BACKPACK);
-
-		clickOnContextMenuItem(firstTestSoundNamePacked, unpackAndKeep);
-		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
-		assertTrue("Sound wasn't unpacked!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
 		deleteSound(firstTestSoundNamePackedAndUnpacked);
 		solo.sleep(200);
 		UiTestUtils.openBackPack(solo, getActivity());
@@ -792,11 +779,6 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		solo.sleep(TIME_TO_WAIT);
 
 		assertTrue("Sound wasn't kept in backpack!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT_BACKPACK));
-		clickOnContextMenuItem(firstTestSoundNamePacked, unpack);
-		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
-		assertTrue("Sound wasn't unpacked!", solo.waitForText(firstTestSoundNamePacked, 0, TIME_TO_WAIT));
-		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
-		assertFalse("Backpack isn't empty!", solo.searchText(unpack));
 	}
 
 	public void testBackPackSoundSimpleUnpackingAndDelete() {
@@ -1036,12 +1018,13 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 
 		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
 
-		UiTestUtils.openActionMode(solo, unpackAndKeep, R.id.unpacking_keep, getActivity());
+		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
 		String selectAll = solo.getString(R.string.select_all).toUpperCase(Locale.getDefault());
 		UiTestUtils.clickOnText(solo, selectAll);
 		UiTestUtils.acceptAndCloseActionMode(solo);
 
 		solo.waitForActivity(ScriptActivity.class);
+		solo.waitForFragmentByTag(SoundFragment.TAG);
 		assertTrue("Sound wasn't unpacked!", solo.waitForText(FIRST_TEST_SOUND_NAME, 1, 1000));
 		assertTrue("Sound wasn't unpacked!", solo.waitForText(SECOND_TEST_SOUND_NAME, 1, 1000));
 		UiTestUtils.deleteAllItems(solo, getActivity());
@@ -1049,17 +1032,7 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		assertFalse("Sound wasn't deleted!", solo.waitForText(SECOND_TEST_SOUND_NAME, 1, 1000));
 
 		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
-
-		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
-		UiTestUtils.clickOnText(solo, selectAll);
-		UiTestUtils.acceptAndCloseActionMode(solo);
-		solo.waitForActivity(ScriptActivity.class);
-
-		assertTrue("Sound wasn't unpacked!", solo.waitForText(FIRST_TEST_SOUND_NAME, 1, 1000));
-		assertTrue("Sound wasn't unpacked!", solo.waitForText(SECOND_TEST_SOUND_NAME, 1, 1000));
-
-		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
-		assertFalse("Backpack items were not cleared!", solo.waitForText(unpack, 1, 1000));
+		assertTrue("Backpack items were cleared!", solo.waitForText(backpackTitle, 1, 1000));
 	}
 
 	public void testBackPackDeleteActionModeCheckingAndTitle() {
@@ -1696,11 +1669,6 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		solo.clickOnButton(0);
 		solo.waitForDialogToClose();
 
-		UiTestUtils.openActionMode(solo, unpackAndKeep, R.id.unpacking_keep, getActivity());
-		solo.waitForDialogToOpen();
-		assertTrue("Nothing to unpack dialog not shown", solo.waitForText(solo.getString(R.string
-				.nothing_to_unpack)));
-
 		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
 		solo.waitForDialogToOpen();
 		assertTrue("Nothing to unpack dialog not shown", solo.waitForText(solo.getString(R.string
@@ -1823,13 +1791,9 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 	}
 
 	private void clickOnContextMenuItem(String soundName, String menuItemName) {
-		int match = 1;
-		if (menuItemName.equals(unpack)) {
-			match = 2;
-		}
 		solo.clickLongOnText(soundName);
 		solo.waitForText(menuItemName);
-		solo.clickOnText(menuItemName, match);
+		solo.clickOnText(menuItemName);
 	}
 
 	private void checkIfNumberOfSoundsIsEqual(int expectedNumber) {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SpritesListFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SpritesListFragmentTest.java
@@ -109,7 +109,6 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 	private String copy;
 
 	private String unpack;
-	private String unpackAndKeep;
 	private String backpack;
 	private String backpackAdd;
 	private String backpackTitle;
@@ -145,7 +144,6 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		delete = solo.getString(R.string.delete);
 		copy = solo.getString(R.string.copy);
 		unpack = solo.getString(R.string.unpack);
-		unpackAndKeep = solo.getString(R.string.unpack_keep);
 		backpack = solo.getString(R.string.backpack);
 		backpackAdd = solo.getString(R.string.backpack_add);
 		backpackReplaceDialogSingle = resources.getString(R.string.backpack_replace_object, SPRITE_NAME);
@@ -376,11 +374,6 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		solo.clickOnButton(0);
 		solo.waitForDialogToClose();
 
-		UiTestUtils.openActionMode(solo, unpackAndKeep, R.id.unpacking_keep, getActivity());
-		solo.waitForDialogToOpen();
-		assertTrue("Nothing to unpack dialog not shown", solo.waitForText(solo.getString(R.string
-				.nothing_to_unpack)));
-
 		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
 		solo.waitForDialogToOpen();
 		assertTrue("Nothing to unpack dialog not shown", solo.waitForText(solo.getString(R.string
@@ -473,25 +466,12 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
 
 		assertTrue("Sprite wasn't unpacked!", solo.waitForText(SPRITE_NAME_UNPACKED, 0, TIME_TO_WAIT));
-	}
-
-	public void testBackPackSpriteSimpleUnpackingAndUnpackingAndKeepContextMenu() {
-		clickOnContextMenuItem(SPRITE_NAME, backpackAdd);
-		solo.sleep(TIME_TO_WAIT_BACKPACK);
-
-		clickOnContextMenuItem(SPRITE_NAME, unpackAndKeep);
-		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
-		assertTrue("Sprite wasn't unpacked!", solo.waitForText(SPRITE_NAME, 0, TIME_TO_WAIT));
 		deleteSprite(SPRITE_NAME2);
 		solo.sleep(TIME_TO_WAIT);
 		UiTestUtils.openBackPack(solo, getActivity());
 
+		assertTrue("Backpack is empty!", solo.searchText(backpackTitle));
 		assertTrue("Sprite wasn't kept in backpack!", solo.waitForText(SPRITE_NAME, 0, TIME_TO_WAIT));
-		clickOnContextMenuItem(SPRITE_NAME, unpack);
-		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
-		assertTrue("Sprite wasn't unpacked!", solo.waitForText(SPRITE_NAME, 0, TIME_TO_WAIT));
-		UiTestUtils.openBackPackActionModeWhenEmtpy(solo, getActivity());
-		assertFalse("Backpack isn't empty!", solo.searchText(unpack));
 	}
 
 	public void testBackPackSpriteSimpleUnpackingAndDelete() {
@@ -712,7 +692,7 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 
 		UiTestUtils.openBackPack(solo, getActivity());
 
-		UiTestUtils.openActionMode(solo, unpackAndKeep, R.id.unpacking_keep, getActivity());
+		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
 		String selectAll = solo.getString(R.string.select_all).toUpperCase(Locale.getDefault());
 		UiTestUtils.clickOnText(solo, selectAll);
 		UiTestUtils.acceptAndCloseActionMode(solo);
@@ -724,18 +704,6 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		UiTestUtils.deleteAllItems(solo, getActivity());
 		assertFalse("Sprite wasn't deleted!", solo.waitForText(SPRITE_NAME, 1, 1000));
 		assertFalse("Sprite wasn't deleted!", solo.waitForText(SPRITE_NAME2, 1, 1000));
-
-		UiTestUtils.openBackPack(solo, getActivity());
-
-		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
-		UiTestUtils.clickOnText(solo, selectAll);
-		UiTestUtils.acceptAndCloseActionMode(solo);
-		solo.waitForActivity(ProjectActivity.class);
-
-		assertFalse("Background sprite was unpacked, but shouldn't be!", solo.waitForText(SPRITE_NAME_BACKGROUND, 1,
-				1000));
-		assertTrue("Sprite wasn't unpacked!", solo.waitForText(SPRITE_NAME, 1, 1000));
-		assertTrue("Sprite wasn't unpacked!", solo.waitForText(SPRITE_NAME2, 1, 1000));
 	}
 
 	public void testBackPackDeleteActionModeCheckingAndTitle() {
@@ -988,6 +956,9 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		solo.waitForDialogToOpen();
 		assertTrue("Sprite already exists backpack dialog not shown!", solo.waitForText(backpackReplaceDialogSingle, 0, TIME_TO_WAIT));
 		solo.clickOnButton(solo.getString(R.string.yes));
+		solo.waitForDialogToClose();
+		solo.waitForActivity(BackPackActivity.class);
+		solo.waitForFragmentByTag(SpritesListFragment.TAG);
 		solo.sleep(200);
 
 		assertTrue("Should be in backpack!", solo.waitForText(backpackTitle, 0, TIME_TO_WAIT));
@@ -1010,6 +981,9 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		assertTrue("Sprite already exists backpack dialog not shown!", solo.waitForText(backpackReplaceDialogMultiple, 0,
 				TIME_TO_WAIT));
 		solo.clickOnButton(solo.getString(R.string.yes));
+		solo.waitForDialogToClose();
+		solo.waitForActivity(BackPackActivity.class);
+		solo.waitForFragmentByTag(SpritesListFragment.TAG);
 		solo.sleep(200);
 
 		assertTrue("Should be in backpack!", solo.waitForText(backpackTitle, 0, TIME_TO_WAIT));
@@ -1048,13 +1022,9 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 	}
 
 	private void clickOnContextMenuItem(String spriteName, String menuItemName) {
-		int match = 1;
-		if (menuItemName.equals(unpack)) {
-			match = 2;
-		}
 		solo.clickLongOnText(spriteName);
 		solo.waitForText(menuItemName);
-		solo.clickOnText(menuItemName, match);
+		solo.clickOnText(menuItemName);
 	}
 
 	private BackPackSpriteFragment getBackPackSpriteFragment() {

--- a/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SpritesListFragmentTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/ui/fragment/SpritesListFragmentTest.java
@@ -109,6 +109,8 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 	private String copy;
 
 	private String unpack;
+	private String unpackAsObject;
+	private String unpackAsBackGround;
 	private String backpack;
 	private String backpackAdd;
 	private String backpackTitle;
@@ -144,6 +146,8 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		delete = solo.getString(R.string.delete);
 		copy = solo.getString(R.string.copy);
 		unpack = solo.getString(R.string.unpack);
+		unpackAsObject = solo.getString(R.string.unpack_object);
+		unpackAsBackGround = solo.getString(R.string.unpack_bg);
 		backpack = solo.getString(R.string.backpack);
 		backpackAdd = solo.getString(R.string.backpack_add);
 		backpackReplaceDialogSingle = resources.getString(R.string.backpack_replace_object, SPRITE_NAME);
@@ -374,7 +378,7 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		solo.clickOnButton(0);
 		solo.waitForDialogToClose();
 
-		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
+		UiTestUtils.openActionMode(solo, unpackAsObject, R.id.unpacking_object, getActivity());
 		solo.waitForDialogToOpen();
 		assertTrue("Nothing to unpack dialog not shown", solo.waitForText(solo.getString(R.string
 				.nothing_to_unpack)));
@@ -462,7 +466,7 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
 		assertTrue("Sprite wasn't backpacked!", solo.waitForText(SPRITE_NAME, 0, TIME_TO_WAIT));
 
-		clickOnContextMenuItem(SPRITE_NAME, unpack);
+		clickOnContextMenuItem(SPRITE_NAME, unpackAsObject);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
 
 		assertTrue("Sprite wasn't unpacked!", solo.waitForText(SPRITE_NAME_UNPACKED, 0, TIME_TO_WAIT));
@@ -488,7 +492,7 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		solo.sleep(TIME_TO_WAIT);
 		UiTestUtils.openBackPack(solo, getActivity());
 
-		clickOnContextMenuItem(SPRITE_NAME2, unpack);
+		clickOnContextMenuItem(SPRITE_NAME2, unpackAsObject);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
 
 		assertTrue("Sprite wasn't unpacked!", solo.waitForText(SPRITE_NAME2, 0, TIME_TO_WAIT));
@@ -505,14 +509,14 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 		assertNotNull("Could not get Adapter", adapter);
 		clickOnContextMenuItem(SPRITE_NAME, backpackAdd);
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
-		clickOnContextMenuItem(SPRITE_NAME, solo.getString(R.string.unpack));
+		clickOnContextMenuItem(SPRITE_NAME, unpackAsObject);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
 
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
 		assertTrue("Sprite wasn't unpacked!", solo.waitForText(SPRITE_NAME_UNPACKED, 0, TIME_TO_WAIT));
 		clickOnContextMenuItem(SPRITE_NAME2, backpackAdd);
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
-		clickOnContextMenuItem(SPRITE_NAME2, solo.getString(R.string.unpack));
+		clickOnContextMenuItem(SPRITE_NAME2, unpackAsObject);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
 
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
@@ -534,7 +538,7 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 
 		UiTestUtils.openBackPack(solo, getActivity());
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
-		clickOnContextMenuItem(SPRITE_NAME, unpack);
+		clickOnContextMenuItem(SPRITE_NAME, unpackAsObject);
 		solo.waitForDialogToClose(TIME_TO_WAIT_BACKPACK);
 
 		assertTrue("Sprite wasn't unpacked!", solo.waitForText(SPRITE_NAME, 1, 3000));
@@ -545,7 +549,7 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 
 		UiTestUtils.backPackAllItems(solo, getActivity(), SPRITE_NAME_BACKGROUND, SPRITE_NAME);
 
-		clickOnContextMenuItem(SPRITE_NAME_BACKGROUND, unpack);
+		clickOnContextMenuItem(SPRITE_NAME_BACKGROUND, unpackAsBackGround);
 		solo.waitForDialogToOpen(TIME_TO_WAIT_BACKPACK);
 		assertTrue("No replace background dialog was shown", solo.waitForText(solo.getString(R.string.unpack_background)));
 		solo.clickOnText(solo.getString(R.string.ok));
@@ -692,7 +696,7 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 
 		UiTestUtils.openBackPack(solo, getActivity());
 
-		UiTestUtils.openActionMode(solo, unpack, R.id.unpacking, getActivity());
+		UiTestUtils.openActionMode(solo, unpackAsObject, R.id.unpacking_object, getActivity());
 		String selectAll = solo.getString(R.string.select_all).toUpperCase(Locale.getDefault());
 		UiTestUtils.clickOnText(solo, selectAll);
 		UiTestUtils.acceptAndCloseActionMode(solo);
@@ -890,7 +894,7 @@ public class SpritesListFragmentTest extends BaseActivityInstrumentationTestCase
 
 		UiTestUtils.openBackPack(solo, getActivity());
 		solo.sleep(TIME_TO_WAIT_BACKPACK);
-		clickOnContextMenuItem(SPRITE_NAME_BACKGROUND, unpack);
+		clickOnContextMenuItem(SPRITE_NAME_BACKGROUND, unpackAsObject);
 		solo.waitForDialogToOpen();
 		solo.waitForText(solo.getString(R.string.unpack_background));
 		solo.clickOnText(solo.getString(R.string.ok));

--- a/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -2415,6 +2415,7 @@ public final class UiTestUtils {
 		solo.sleep(100);
 		solo.waitForText(solo.getString(R.string.unpack));
 		solo.clickOnText(solo.getString(R.string.unpack));
+		solo.waitForDialogToClose();
 		solo.sleep(500);
 	}
 


### PR DESCRIPTION
Removes the "unpack and keep" option for the look/sound/sprite/script backpack as discussed in CAT-1878 and adds the possibility to unpack sprites either as object or background (users can choose).