### PR TITLE
HOT - change collision identifier from \0 to \t for XML v1.0

### DIFF
--- a/catroid/src/org/catrobat/catroid/physics/PhysicsCollision.java
+++ b/catroid/src/org/catrobat/catroid/physics/PhysicsCollision.java
@@ -35,7 +35,7 @@ import java.util.Map;
 
 public class PhysicsCollision implements ContactListener {
 
-	public static final String COLLISION_MESSAGE_ESCAPE_CHAR = "\0";
+	public static final String COLLISION_MESSAGE_ESCAPE_CHAR = "\t";
 	public static final String COLLISION_MESSAGE_CONNECTOR = "<" + COLLISION_MESSAGE_ESCAPE_CHAR
 			+ "-" + COLLISION_MESSAGE_ESCAPE_CHAR + ">";
 	public static final String COLLISION_WITH_ANYTHING_IDENTIFIER = COLLISION_MESSAGE_ESCAPE_CHAR

--- a/catroid/src/org/catrobat/catroid/physics/content/bricks/CollisionReceiverBrick.java
+++ b/catroid/src/org/catrobat/catroid/physics/content/bricks/CollisionReceiverBrick.java
@@ -50,6 +50,7 @@ import java.util.List;
 
 public class CollisionReceiverBrick extends ScriptBrick implements BroadcastMessage, Cloneable {
 	private static final long serialVersionUID = 1L;
+	public static final String ANYTHING_ESCAPE_CHAR = "\0";
 
 	private CollisionScript collisionScript;
 	private transient String selectedMessage;
@@ -219,8 +220,6 @@ public class CollisionReceiverBrick extends ScriptBrick implements BroadcastMess
 	}
 
 	private String getDisplayedAnythingString(Context context) {
-		return PhysicsCollision.COLLISION_MESSAGE_ESCAPE_CHAR
-				+ context.getString(R.string.collision_with_anything)
-				+ PhysicsCollision.COLLISION_MESSAGE_ESCAPE_CHAR;
+		return ANYTHING_ESCAPE_CHAR + context.getString(R.string.collision_with_anything) + ANYTHING_ESCAPE_CHAR;
 	}
 }


### PR DESCRIPTION
changing the Collision Identifier from the zero-byte to the byte with value 9 (\t) in order to be usable with xml 1.0

locally tested with https://share.catrob.at/pocketcode/program/9546 and https://share.catrob.at/pocketcode/program/9547. 