### PR TITLE
CAT-2006 Handle WhatsApp custom URI scheme in WebView

### DIFF
--- a/catroid/src/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/org/catrobat/catroid/common/Constants.java
@@ -143,6 +143,8 @@ public final class Constants {
 	public static final String FLAVOR_DEFAULT = "PocketCode";
 	public static final String PLATFORM_DEFAULT = "Android";
 
+	public static final String WHATSAPP_URI = "whatsapp://";
+
 	// Pocket Paint
 	public static final String EXTRA_PICTURE_PATH_POCKET_PAINT = "org.catrobat.extra.PAINTROID_PICTURE_PATH";
 	public static final String EXTRA_PICTURE_NAME_POCKET_PAINT = "org.catrobat.extra.PAINTROID_PICTURE_NAME";

--- a/catroid/src/org/catrobat/catroid/ui/WebViewActivity.java
+++ b/catroid/src/org/catrobat/catroid/ui/WebViewActivity.java
@@ -183,7 +183,13 @@ public class WebViewActivity extends BaseActivity {
 
 		@Override
 		public boolean shouldOverrideUrlLoading(WebView view, String url) {
-			if (checkIfWebViewVisitExternalWebsite(url)) {
+			if (url != null && url.startsWith(Constants.WHATSAPP_URI)) {
+				Uri uri = Uri.parse(url);
+				Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+				intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+				startActivity(intent);
+				return true;
+			} else if (checkIfWebViewVisitExternalWebsite(url)) {
 				Uri uri = Uri.parse(url);
 				Intent intent = new Intent(Intent.ACTION_VIEW, uri);
 				startActivity(intent);


### PR DESCRIPTION
There's a problem with the WhatsApp sharing link on the Website when started from Pocket Code in WebView. When the share button is clicked, an error is triggered because the WebView doesn't handle custom URI's and start external apps by default.