### PR TITLE
CAT-1954 IF-Then brick without ELSE

### DIFF
--- a/catroid/res/layout/brick_if_begin_if.xml
+++ b/catroid/res/layout/brick_if_begin_if.xml
@@ -48,8 +48,7 @@
         <TextView
             android:id="@+id/if_label"
             style="@style/BrickText.Multiple"
-            android:text="@string/brick_if_begin" >
-        </TextView >
+            android:text="@string/brick_if_begin" />
 
         <TextView
             android:id="@+id/brick_if_begin_edit_text"
@@ -65,8 +64,26 @@
             android:id="@+id/if_label_second_part"
             style="@style/BrickText.Multiple"
             android:paddingLeft="5dip"
-            android:text="@string/brick_if_begin_second_part" >
-        </TextView >
+            android:text="@string/brick_if_begin_second_part" />
+
+        <TextView
+            android:id="@+id/if_else_prototype_punctuation"
+            style="@style/BrickText.Multiple"
+            app:layout_newLine="true"
+            android:paddingLeft="5dip"
+            android:text="@string/punctuation_mark" />
+
+         <TextView
+             android:id="@+id/if_prototype_else"
+             style="@style/BrickText.Multiple"
+             android:paddingLeft="5dip"
+             android:text="@string/brick_if_else" />
+
+       <TextView
+           android:id="@+id/if_else_prototype_punctuation2"
+           style="@style/BrickText.Multiple"
+           android:paddingLeft="5dip"
+           android:text="@string/punctuation_mark" />
     </org.catrobat.catroid.ui.BrickLayout >
 
 </LinearLayout>

--- a/catroid/res/values-de/strings.xml
+++ b/catroid/res/values-de/strings.xml
@@ -491,7 +491,7 @@
   <string name="brick_if_begin">Wenn</string>
   <string name="brick_if_begin_second_part">wahr ist, dann</string>
   <string name="brick_if_else">sonst</string>
-  <string name="brick_if_end">sonst Ende</string>
+  <string name="brick_if_end">Ende Wenn</string>
   <string name="brick_broadcast_invalid_symbol">"Die Nachricht ist reserviert für:\n\"Wenn physische Kollision zwischen\"-Brick\nBitte versuche es erneut!"</string>
   <string name="brick_set_variable">Setze Variable</string>
   <string name="brick_change_variable">Ändere Variable</string>

--- a/catroid/res/values/strings-global.xml
+++ b/catroid/res/values/strings-global.xml
@@ -36,6 +36,7 @@
     <string name="degree_symbol" translatable="false">°</string>
     <string name="percent_symbol" translatable="false">%</string>
     <string name="hertz_symbol" translatable="false">㎐</string>
+     <string name="punctuation_mark" translatable="false">…</string>
     <!--  -->
 
     <!-- Numbers -->

--- a/catroid/src/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/org/catrobat/catroid/ProjectManager.java
@@ -45,9 +45,10 @@ import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.IfLogicBeginBrick;
 import org.catrobat.catroid.content.bricks.IfLogicElseBrick;
 import org.catrobat.catroid.content.bricks.IfLogicEndBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicEndBrick;
 import org.catrobat.catroid.content.bricks.LoopBeginBrick;
 import org.catrobat.catroid.content.bricks.LoopEndBrick;
-import org.catrobat.catroid.content.bricks.PhiroIfLogicBeginBrick;
 import org.catrobat.catroid.content.bricks.UserBrick;
 import org.catrobat.catroid.exceptions.CompatibilityProjectException;
 import org.catrobat.catroid.exceptions.LoadingProjectException;
@@ -627,7 +628,6 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 
 	private void correctAllNestedReferences(Script script) {
 		ArrayList<IfLogicBeginBrick> ifBeginList = new ArrayList<>();
-		ArrayList<PhiroIfLogicBeginBrick> ifSensorBeginList = new ArrayList<>();
 		ArrayList<LoopBeginBrick> loopBeginList = new ArrayList<>();
 		for (Brick currentBrick : script.getBrickList()) {
 			if (currentBrick instanceof IfLogicBeginBrick) {
@@ -643,6 +643,11 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 				IfLogicBeginBrick ifBeginBrick = ifBeginList.get(ifBeginList.size() - 1);
 				ifBeginBrick.setIfElseBrick((IfLogicElseBrick) currentBrick);
 				((IfLogicElseBrick) currentBrick).setIfBeginBrick(ifBeginBrick);
+			} else if (currentBrick instanceof IfThenLogicEndBrick) {
+				IfThenLogicBeginBrick ifBeginBrick = (IfThenLogicBeginBrick) ifBeginList.get(ifBeginList.size() - 1);
+				ifBeginBrick.setIfThenEndBrick((IfThenLogicEndBrick) currentBrick);
+				((IfThenLogicEndBrick) currentBrick).setIfThenBeginBrick(ifBeginBrick);
+				ifBeginList.remove(ifBeginBrick);
 			} else if (currentBrick instanceof IfLogicEndBrick) {
 				IfLogicBeginBrick ifBeginBrick = ifBeginList.get(ifBeginList.size() - 1);
 				IfLogicElseBrick elseBrick = ifBeginBrick.getIfElseBrick();
@@ -651,20 +656,6 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 				((IfLogicEndBrick) currentBrick).setIfBeginBrick(ifBeginBrick);
 				((IfLogicEndBrick) currentBrick).setIfElseBrick(elseBrick);
 				ifBeginList.remove(ifBeginBrick);
-			} else if (currentBrick instanceof PhiroIfLogicBeginBrick) {
-				ifSensorBeginList.add((PhiroIfLogicBeginBrick) currentBrick);
-			} else if (currentBrick instanceof IfLogicElseBrick) {
-				PhiroIfLogicBeginBrick phiroSensorBrick = ifSensorBeginList.get(ifSensorBeginList.size() - 1);
-				phiroSensorBrick.setIfElseBrick((IfLogicElseBrick) currentBrick);
-				((IfLogicElseBrick) currentBrick).setIfBeginBrick(phiroSensorBrick);
-			} else if (currentBrick instanceof IfLogicEndBrick) {
-				PhiroIfLogicBeginBrick phiroSensorBrick = ifSensorBeginList.get(ifSensorBeginList.size() - 1);
-				IfLogicElseBrick elseBrick = phiroSensorBrick.getIfElseBrick();
-				phiroSensorBrick.setIfEndBrick((IfLogicEndBrick) currentBrick);
-				elseBrick.setIfEndBrick((IfLogicEndBrick) currentBrick);
-				((IfLogicEndBrick) currentBrick).setIfBeginBrick(phiroSensorBrick);
-				((IfLogicEndBrick) currentBrick).setIfElseBrick(elseBrick);
-				ifSensorBeginList.remove(phiroSensorBrick);
 			}
 		}
 	}

--- a/catroid/src/org/catrobat/catroid/content/Script.java
+++ b/catroid/src/org/catrobat/catroid/content/Script.java
@@ -28,6 +28,8 @@ import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.IfLogicBeginBrick;
 import org.catrobat.catroid.content.bricks.IfLogicElseBrick;
 import org.catrobat.catroid.content.bricks.IfLogicEndBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicEndBrick;
 import org.catrobat.catroid.content.bricks.LoopBeginBrick;
 import org.catrobat.catroid.content.bricks.LoopEndBrick;
 import org.catrobat.catroid.content.bricks.NestingBrick;
@@ -62,6 +64,8 @@ public abstract class Script implements Serializable {
 
 			if (copiedBrick instanceof IfLogicEndBrick) {
 				setIfBrickReferences((IfLogicEndBrick) copiedBrick, (IfLogicEndBrick) brick);
+			} else if (copiedBrick instanceof IfThenLogicEndBrick) {
+				setIfThenBrickReferences((IfThenLogicEndBrick) copiedBrick, (IfThenLogicEndBrick) brick);
 			} else if (copiedBrick instanceof LoopEndBrick) {
 				setLoopBrickReferences((LoopEndBrick) copiedBrick, (LoopEndBrick) brick);
 			}
@@ -218,6 +222,15 @@ public abstract class Script implements Serializable {
 		copiedIfElseBrick.setIfEndBrick(copiedIfEndBrick);
 		copiedIfEndBrick.setIfBeginBrick(copiedIfBeginBrick);
 		copiedIfEndBrick.setIfElseBrick(copiedIfElseBrick);
+	}
+
+	protected void setIfThenBrickReferences(IfThenLogicEndBrick copiedIfEndBrick, IfThenLogicEndBrick
+			originalIfEndBrick) {
+		List<NestingBrick> ifBrickList = originalIfEndBrick.getAllNestingBrickParts(true);
+		IfThenLogicBeginBrick copiedIfBeginBrick = (IfThenLogicBeginBrick) ((IfThenLogicBeginBrick) ifBrickList.get(0)).getCopy();
+
+		copiedIfBeginBrick.setIfThenEndBrick(copiedIfEndBrick);
+		copiedIfEndBrick.setIfThenBeginBrick(copiedIfBeginBrick);
 	}
 
 	protected void setLoopBrickReferences(LoopEndBrick copiedBrick, LoopEndBrick originalBrick) {

--- a/catroid/src/org/catrobat/catroid/content/actions/IfLogicAction.java
+++ b/catroid/src/org/catrobat/catroid/content/actions/IfLogicAction.java
@@ -70,6 +70,9 @@ public class IfLogicAction extends Action {
 		if (ifConditionValue) {
 			return ifAction.act(delta);
 		} else {
+			if (elseAction == null) {
+				return true;
+			}
 			return elseAction.act(delta);
 		}
 	}
@@ -77,7 +80,9 @@ public class IfLogicAction extends Action {
 	@Override
 	public void restart() {
 		ifAction.restart();
-		elseAction.restart();
+		if (elseAction != null) {
+			elseAction.restart();
+		}
 		isInitialized = false;
 		super.restart();
 	}
@@ -102,6 +107,8 @@ public class IfLogicAction extends Action {
 	public void setActor(Actor actor) {
 		super.setActor(actor);
 		ifAction.setActor(actor);
-		elseAction.setActor(actor);
+		if (elseAction != null) {
+			elseAction.setActor(actor);
+		}
 	}
 }

--- a/catroid/src/org/catrobat/catroid/content/bricks/IfLogicBeginBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/IfLogicBeginBrick.java
@@ -48,10 +48,9 @@ import java.util.List;
 public class IfLogicBeginBrick extends FormulaBrick implements NestingBrick {
 	private static final long serialVersionUID = 1L;
 	private static final String TAG = IfLogicBeginBrick.class.getSimpleName();
-	public static final int EXECUTE_ELSE_PART = -1;
 	protected transient IfLogicElseBrick ifElseBrick;
 	protected transient IfLogicEndBrick ifEndBrick;
-	private transient IfLogicBeginBrick copy;
+	protected transient IfLogicBeginBrick copy;
 
 	public IfLogicBeginBrick() {
 		addAllowedBrickField(BrickField.IF_CONDITION);
@@ -65,7 +64,7 @@ public class IfLogicBeginBrick extends FormulaBrick implements NestingBrick {
 		initializeBrickFields(condition);
 	}
 
-	private void initializeBrickFields(Formula ifCondition) {
+	protected void initializeBrickFields(Formula ifCondition) {
 		addAllowedBrickField(BrickField.IF_CONDITION);
 		setFormulaWithBrickField(BrickField.IF_CONDITION, ifCondition);
 	}
@@ -139,7 +138,18 @@ public class IfLogicBeginBrick extends FormulaBrick implements NestingBrick {
 
 		ifBeginTextView.setOnClickListener(this);
 
+		removePrototypeElseTextViews(view);
+
 		return view;
+	}
+
+	protected void removePrototypeElseTextViews(View view) {
+		TextView prototypeTextPunctuation = (TextView) view.findViewById(R.id.if_else_prototype_punctuation);
+		TextView prototypeTextElse = (TextView) view.findViewById(R.id.if_prototype_else);
+		TextView prototypeTextPunctuation2 = (TextView) view.findViewById(R.id.if_else_prototype_punctuation2);
+		prototypeTextPunctuation.setVisibility(View.GONE);
+		prototypeTextElse.setVisibility(View.GONE);
+		prototypeTextPunctuation2.setVisibility(View.GONE);
 	}
 
 	@Override

--- a/catroid/src/org/catrobat/catroid/content/bricks/IfThenLogicBeginBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/IfThenLogicBeginBrick.java
@@ -1,0 +1,105 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.content.bricks;
+
+import android.content.Context;
+import android.view.View;
+
+import com.badlogic.gdx.scenes.scene2d.Action;
+import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
+
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.formulaeditor.Formula;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+public class IfThenLogicBeginBrick extends IfLogicBeginBrick implements NestingBrick {
+	private static final long serialVersionUID = 1L;
+	protected transient IfThenLogicEndBrick ifEndBrick;
+
+	public IfThenLogicBeginBrick(int condition) {
+		initializeBrickFields(new Formula(condition));
+	}
+
+	public IfThenLogicBeginBrick(Formula condition) {
+		initializeBrickFields(condition);
+	}
+
+	public void setIfThenEndBrick(IfThenLogicEndBrick ifEndBrick) {
+		this.ifEndBrick = ifEndBrick;
+	}
+
+	@Override
+	public Brick clone() {
+		return new IfThenLogicBeginBrick(getFormulaWithBrickField(BrickField.IF_CONDITION).clone());
+	}
+
+	@Override
+	public View getPrototypeView(Context context) {
+		View prototypeView = super.getPrototypeView(context);
+		removePrototypeElseTextViews(prototypeView);
+		return prototypeView;
+	}
+
+	@Override
+	public void initialize() {
+		ifEndBrick = new IfThenLogicEndBrick(this);
+	}
+
+	@Override
+	public List<NestingBrick> getAllNestingBrickParts(boolean sorted) {
+		List<NestingBrick> nestingBrickList = new ArrayList<>();
+		nestingBrickList.add(this);
+		nestingBrickList.add(ifEndBrick);
+		return nestingBrickList;
+	}
+
+	@Override
+	public boolean isDraggableOver(Brick brick) {
+		return brick != ifEndBrick;
+	}
+
+	@Override
+	public Brick copyBrickForSprite(Sprite sprite) {
+		IfThenLogicBeginBrick copyBrick = (IfThenLogicBeginBrick) clone();
+		copyBrick.ifEndBrick = null; // will be set in copyBrickForSprite method of IfThenLogicEndBrick
+
+		this.copy = copyBrick;
+		return copyBrick;
+	}
+
+	@Override
+	public List<SequenceAction> addActionToSequence(Sprite sprite, SequenceAction sequence) {
+		SequenceAction ifAction = (SequenceAction) sprite.getActionFactory().createSequence();
+		Action action = sprite.getActionFactory().createIfLogicAction(sprite,
+				getFormulaWithBrickField(BrickField.IF_CONDITION), ifAction, null);
+		sequence.addAction(action);
+
+		LinkedList<SequenceAction> returnActionList = new LinkedList<>();
+		returnActionList.add(ifAction);
+
+		return returnActionList;
+	}
+}

--- a/catroid/src/org/catrobat/catroid/content/bricks/IfThenLogicEndBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/IfThenLogicEndBrick.java
@@ -40,19 +40,15 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-public class IfLogicEndBrick extends BrickBaseType implements NestingBrick, AllowedAfterDeadEndBrick {
+public class IfThenLogicEndBrick extends BrickBaseType implements NestingBrick, AllowedAfterDeadEndBrick {
 
 	private static final long serialVersionUID = 1L;
-	private static final String TAG = IfLogicEndBrick.class.getSimpleName();
-	private transient IfLogicElseBrick ifElseBrick;
+	private static final String TAG = IfThenLogicEndBrick.class.getSimpleName();
+	private transient IfThenLogicBeginBrick ifBeginBrick;
 
-	private transient IfLogicBeginBrick ifBeginBrick;
-
-	public IfLogicEndBrick(IfLogicElseBrick elseBrick, IfLogicBeginBrick beginBrick) {
-		this.ifElseBrick = elseBrick;
+	public IfThenLogicEndBrick(IfThenLogicBeginBrick beginBrick) {
 		this.ifBeginBrick = beginBrick;
-		beginBrick.setIfEndBrick(this);
-		elseBrick.setIfEndBrick(this);
+		beginBrick.setIfThenEndBrick(this);
 	}
 
 	@Override
@@ -60,19 +56,7 @@ public class IfLogicEndBrick extends BrickBaseType implements NestingBrick, Allo
 		return NO_RESOURCES;
 	}
 
-	public IfLogicElseBrick getIfElseBrick() {
-		return ifElseBrick;
-	}
-
-	public IfLogicBeginBrick getIfBeginBrick() {
-		return ifBeginBrick;
-	}
-
-	public void setIfElseBrick(IfLogicElseBrick ifElseBrick) {
-		this.ifElseBrick = ifElseBrick;
-	}
-
-	public void setIfBeginBrick(IfLogicBeginBrick ifBeginBrick) {
+	public void setIfThenBeginBrick(IfThenLogicBeginBrick ifBeginBrick) {
 		this.ifBeginBrick = ifBeginBrick;
 	}
 
@@ -121,7 +105,7 @@ public class IfLogicEndBrick extends BrickBaseType implements NestingBrick, Allo
 
 	@Override
 	public Brick clone() {
-		return new IfLogicEndBrick(ifElseBrick, ifBeginBrick);
+		return new IfThenLogicEndBrick(ifBeginBrick);
 	}
 
 	@Override
@@ -131,12 +115,12 @@ public class IfLogicEndBrick extends BrickBaseType implements NestingBrick, Allo
 
 	@Override
 	public boolean isDraggableOver(Brick brick) {
-		return brick != ifElseBrick;
+		return brick != ifBeginBrick;
 	}
 
 	@Override
 	public boolean isInitialized() {
-		return ifElseBrick != null;
+		return ifBeginBrick != null;
 	}
 
 	@Override
@@ -146,18 +130,9 @@ public class IfLogicEndBrick extends BrickBaseType implements NestingBrick, Allo
 
 	@Override
 	public List<NestingBrick> getAllNestingBrickParts(boolean sorted) {
-		//TODO: handle sorting
 		List<NestingBrick> nestingBrickList = new ArrayList<NestingBrick>();
-		if (sorted) {
-			nestingBrickList.add(ifBeginBrick);
-			nestingBrickList.add(ifElseBrick);
-			nestingBrickList.add(this);
-		} else {
-			nestingBrickList.add(this);
-			nestingBrickList.add(ifBeginBrick);
-			//nestingBrickList.add(ifElseBrick);
-		}
-
+		nestingBrickList.add(ifBeginBrick);
+		nestingBrickList.add(this);
 		return nestingBrickList;
 	}
 
@@ -175,12 +150,10 @@ public class IfLogicEndBrick extends BrickBaseType implements NestingBrick, Allo
 
 	@Override
 	public Brick copyBrickForSprite(Sprite sprite) {
-		IfLogicEndBrick copyBrick = (IfLogicEndBrick) clone(); //Using the clone method because of its flexibility if new fields are added
-		ifBeginBrick.setIfEndBrick(this);
-		ifElseBrick.setIfEndBrick(this);
+		IfThenLogicEndBrick copyBrick = (IfThenLogicEndBrick) clone(); //Using the clone method because of its flexibility if new fields are added
+		ifBeginBrick.setIfThenEndBrick(this);
 
 		copyBrick.ifBeginBrick = null;
-		copyBrick.ifElseBrick = null;
 		return copyBrick;
 	}
 }

--- a/catroid/src/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/org/catrobat/catroid/io/StorageHandler.java
@@ -103,6 +103,8 @@ import org.catrobat.catroid.content.bricks.IfLogicBeginBrick;
 import org.catrobat.catroid.content.bricks.IfLogicElseBrick;
 import org.catrobat.catroid.content.bricks.IfLogicEndBrick;
 import org.catrobat.catroid.content.bricks.IfOnEdgeBounceBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicEndBrick;
 import org.catrobat.catroid.content.bricks.InsertItemIntoUserListBrick;
 import org.catrobat.catroid.content.bricks.LegoNxtMotorMoveBrick;
 import org.catrobat.catroid.content.bricks.LegoNxtMotorStopBrick;
@@ -330,6 +332,8 @@ public final class StorageHandler {
 		xstream.alias("brick", IfLogicBeginBrick.class);
 		xstream.alias("brick", IfLogicElseBrick.class);
 		xstream.alias("brick", IfLogicEndBrick.class);
+		xstream.alias("brick", IfThenLogicBeginBrick.class);
+		xstream.alias("brick", IfThenLogicEndBrick .class);
 		xstream.alias("brick", IfOnEdgeBounceBrick.class);
 		xstream.alias("brick", InsertItemIntoUserListBrick.class);
 		xstream.alias("brick", FlashBrick.class);

--- a/catroid/src/org/catrobat/catroid/io/XStreamToSupportCatrobatLanguageVersion099AndBefore.java
+++ b/catroid/src/org/catrobat/catroid/io/XStreamToSupportCatrobatLanguageVersion099AndBefore.java
@@ -76,6 +76,8 @@ import org.catrobat.catroid.content.bricks.IfLogicBeginBrick;
 import org.catrobat.catroid.content.bricks.IfLogicElseBrick;
 import org.catrobat.catroid.content.bricks.IfLogicEndBrick;
 import org.catrobat.catroid.content.bricks.IfOnEdgeBounceBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicEndBrick;
 import org.catrobat.catroid.content.bricks.LegoNxtMotorMoveBrick;
 import org.catrobat.catroid.content.bricks.LegoNxtMotorStopBrick;
 import org.catrobat.catroid.content.bricks.LegoNxtMotorTurnAngleBrick;
@@ -253,6 +255,13 @@ public class XStreamToSupportCatrobatLanguageVersion099AndBefore extends XStream
 
 		brickInfo = new BrickInfo(IfLogicEndBrick.class.getSimpleName());
 		brickInfoMap.put("ifLogicEndBrick", brickInfo);
+
+		brickInfo = new BrickInfo(IfThenLogicBeginBrick.class.getSimpleName());
+		brickInfo.addBrickFieldToMap("ifCondition", BrickField.IF_CONDITION);
+		brickInfoMap.put("ifThenLogicBeginBrick", brickInfo);
+
+		brickInfo = new BrickInfo(IfThenLogicEndBrick.class.getSimpleName());
+		brickInfoMap.put("ifThenLogicEndBrick", brickInfo);
 
 		brickInfo = new BrickInfo(IfOnEdgeBounceBrick.class.getSimpleName());
 		brickInfoMap.put("ifOnEdgeBounceBrick", brickInfo);

--- a/catroid/src/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
@@ -69,6 +69,7 @@ import org.catrobat.catroid.content.bricks.HideBrick;
 import org.catrobat.catroid.content.bricks.HideTextBrick;
 import org.catrobat.catroid.content.bricks.IfLogicBeginBrick;
 import org.catrobat.catroid.content.bricks.IfOnEdgeBounceBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicBeginBrick;
 import org.catrobat.catroid.content.bricks.InsertItemIntoUserListBrick;
 import org.catrobat.catroid.content.bricks.LegoNxtMotorMoveBrick;
 import org.catrobat.catroid.content.bricks.LegoNxtMotorStopBrick;
@@ -200,6 +201,7 @@ public class CategoryBricksFactory {
 		defaultIf.setLeftChild(new FormulaElement(ElementType.NUMBER, "1", null));
 		defaultIf.setRightChild(new FormulaElement(ElementType.NUMBER, "2", null));
 		controlBrickList.add(new IfLogicBeginBrick(new Formula(defaultIf)));
+		controlBrickList.add(new IfThenLogicBeginBrick(new Formula(defaultIf)));
 		controlBrickList.add(new WaitUntilBrick(new Formula(defaultIf)));
 		controlBrickList.add(new RepeatBrick(BrickValues.REPEAT));
 		controlBrickList.add(new RepeatUntilBrick(new Formula(defaultIf)));

--- a/catroidTest/src/org/catrobat/catroid/test/ui/CategoryBricksFactoryTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/ui/CategoryBricksFactoryTest.java
@@ -56,7 +56,7 @@ public class CategoryBricksFactoryTest extends AndroidTestCase {
 	}
 
 	public void testControlBricks() {
-		final int expectedBrickCount = 14;
+		final int expectedBrickCount = 15;
 		checkBrickCountInCategory(R.string.category_control, background, expectedBrickCount);
 		checkBrickCountInCategory(R.string.category_control, sprite, expectedBrickCount);
 	}

--- a/catroidTest/src/org/catrobat/catroid/uitest/content/brick/IfThenBrickTest.java
+++ b/catroidTest/src/org/catrobat/catroid/uitest/content/brick/IfThenBrickTest.java
@@ -1,0 +1,105 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uitest.content.brick;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.content.bricks.ChangeYByNBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicEndBrick;
+import org.catrobat.catroid.ui.MainMenuActivity;
+import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+
+import java.util.ArrayList;
+
+public class IfThenBrickTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
+	private Project project;
+	private IfThenLogicBeginBrick ifBrick;
+
+	public IfThenBrickTest() {
+		super(MainMenuActivity.class);
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		createProject();
+		UiTestUtils.getIntoScriptActivityFromMainMenu(solo);
+	}
+
+	private void createProject() {
+		project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
+		Sprite sprite = new Sprite("cat");
+		Script script = new StartScript();
+		ifBrick = new IfThenLogicBeginBrick(0);
+		IfThenLogicEndBrick ifEndBrick = new IfThenLogicEndBrick(ifBrick);
+		ifBrick.setIfThenEndBrick(ifEndBrick);
+
+		script.addBrick(ifBrick);
+		script.addBrick(new ChangeYByNBrick(-10));
+		script.addBrick(ifEndBrick);
+
+		sprite.addScript(script);
+		sprite.addScript(new StartScript());
+		project.addSprite(sprite);
+
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+		ProjectManager.getInstance().setCurrentScript(script);
+	}
+
+	public void testCopyIfLogicBeginBrick() {
+		UiTestUtils.openActionMode(solo, solo.getString(R.string.copy), R.id.copy, getActivity());
+		solo.clickOnCheckBox(1);
+		UiTestUtils.acceptAndCloseActionMode(solo);
+
+		ArrayList<Brick> projectBrickList = project.getSpriteList().get(0).getScript(0).getBrickList();
+
+		assertEquals("Incorrect number of bricks.", 5, projectBrickList.size());
+		assertTrue("Wrong Brick instance.", projectBrickList.get(0) instanceof IfThenLogicBeginBrick);
+		assertTrue("Wrong Brick instance.", projectBrickList.get(1) instanceof ChangeYByNBrick);
+		assertTrue("Wrong Brick instance.", projectBrickList.get(2) instanceof IfThenLogicEndBrick);
+		assertTrue("Wrong Brick instance.", projectBrickList.get(3) instanceof IfThenLogicBeginBrick);
+		assertTrue("Wrong Brick instance.", projectBrickList.get(4) instanceof IfThenLogicEndBrick);
+	}
+
+	public void testCopyIfLogicEndBrick() {
+		UiTestUtils.openActionMode(solo, solo.getString(R.string.copy), R.id.copy, getActivity());
+		solo.clickOnCheckBox(3);
+		UiTestUtils.acceptAndCloseActionMode(solo);
+
+		ArrayList<Brick> projectBrickList = project.getSpriteList().get(0).getScript(0).getBrickList();
+		assertEquals("Incorrect number of bricks.", 5, projectBrickList.size());
+		assertTrue("Wrong Brick instance.", projectBrickList.get(0) instanceof IfThenLogicBeginBrick);
+		assertTrue("Wrong Brick instance.", projectBrickList.get(1) instanceof ChangeYByNBrick);
+		assertTrue("Wrong Brick instance.", projectBrickList.get(2) instanceof IfThenLogicEndBrick);
+		assertTrue("Wrong Brick instance.", projectBrickList.get(3) instanceof IfThenLogicBeginBrick);
+		assertTrue("Wrong Brick instance.", projectBrickList.get(4) instanceof IfThenLogicEndBrick);
+	}
+}


### PR DESCRIPTION
**this reopens PR #1766 after rebasing** as requested by @thmq 

New Brick:
- IF-then without ELSE

reuses a lot of the standard if-else brick via inheritance. uses the same Action as the existing brick

This PR includes a TestCase

reviewed & refactored


Tests:
- [jenkins package 'test' results](https://jenkins.catrob.at/job/CatroidSinglePackageEmulatorTest/2170/)
- this pull does not break any tests
-- the two failing tests already fail in the current develop branch (June 23rd): [results for 'develop' branch](https://jenkins.catrob.at/job/CatroidSinglePackageEmulatorTest/2170/)
