### PR TITLE
Disable import on demand (.*) in Android Studio

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -16,8 +16,8 @@
           </value>
         </option>
         <option name="LINE_SEPARATOR" value="&#10;" />
-        <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-        <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+        <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
+        <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
         <option name="IMPORT_LAYOUT_TABLE">
           <value>
             <emptyLine />


### PR DESCRIPTION
Disable import on demand (.*) in Android Studio

The Android Studio Formatter converts imports to a star import if the
configured limit has been exceeded. Since it has in the StorageHandler,
the limit has been highly increased and can be considered disabled now.

https://github.com/Catrobat/Catroid/pull/1770/#issuecomment-228997145