### PR TITLE
CAT-2042 Select/deselect not shown properly

### DIFF
--- a/catroid/src/org/catrobat/catroid/ui/fragment/ProjectsListFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/ProjectsListFragment.java
@@ -410,6 +410,14 @@ public class ProjectsListFragment extends ListFragment implements OnProjectRenam
 
 	@Override
 	public void onProjectChecked() {
+		CapitalizedTextView selectAllView = (CapitalizedTextView) selectAllActionModeButton.findViewById(R.id.select_all);
+		if (projectList.size() == adapter.getCheckedProjects().size()) {
+			selectAll = false;
+			selectAllView.setText(R.string.deselect_all);
+		} else {
+			selectAll = true;
+			selectAllView.setText(R.string.select_all);
+		}
 		if (adapter.getSelectMode() == ListView.CHOICE_MODE_SINGLE || actionMode == null) {
 			return;
 		}

--- a/catroid/src/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
@@ -349,6 +349,20 @@ public class SpritesListFragment extends ScriptActivityFragment implements Sprit
 		if (isRenameActionMode || actionMode == null) {
 			return;
 		}
+		int totalNoOfSprites;
+		if (isBackPackActionMode) {
+			totalNoOfSprites = spriteList.size();
+		} else {
+			totalNoOfSprites = spriteList.size() - 1;
+		}
+		CapitalizedTextView selectAllView = (CapitalizedTextView) selectAllActionModeButton.findViewById(R.id.select_all);
+		if (spriteAdapter.getCheckedSprites().size() == totalNoOfSprites) {
+			selectAll = false;
+			selectAllView.setText(R.string.deselect_all);
+		} else {
+			selectAll = true;
+			selectAllView.setText(R.string.select_all);
+		}
 
 		updateActionModeTitle();
 	}


### PR DESCRIPTION
Fixes [CAT-2042](https://jira.catrob.at/browse/CAT-2042). This fixes only for programs and objects. For other items in issue, this is implemented in a slightly different way i.e `select all` is hidden after all items are selected and made visible if any of it is unselected. I just wanted to make sure if we want to override that.