### PR TITLE
ARDUINO-FIX Raspberry Pi change URL in settings-activity

### DIFF
--- a/catroid/res/values/strings-global.xml
+++ b/catroid/res/values/strings-global.xml
@@ -55,7 +55,7 @@
 
     <string name="about_link_template" translatable="false">&lt;a href="%1$s">%2$s&lt;/a></string>
     <string name="terms_of_use_link_template" translatable="false">&lt;a href="%1$s">%2$s&lt;/a></string>
-    <string name="preference_raspi_help_link">https://confluence.catrob.at/display/CATARDUINO/RaspberryPi+GPIO+Tutorial%3A+LEDs+and+buttons</string>
+    <string name="preference_raspi_help_link">https://catrob.at/RaspberryPi</string>
 
     <!-- Settings, some overridden in values-v14 -->
     <string name="scrolling_cache_enabled">false</string>


### PR DESCRIPTION
as requsted by @wslany 

the Raspberry Pi feature contains a link to a help page in the preferences.xml (SettingsActivity).

This changes the link from a confluence Wiki-Page to the shortened URL
[http://catrob.at/RaspberryPi](http://catrob.at/RaspberryPi)
which can be easily redirected to other pages (without touching the Pocket Code app).
