### PR TITLE
CAT-1938 Clone Sprites Feature

### DIFF
--- a/catroid/res/layout/brick_clone.xml
+++ b/catroid/res/layout/brick_clone.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2016 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <CheckBox
+        android:id="@+id/brick_clone_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_clone_layout"
+        style="@style/BrickContainer.Control.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing">
+
+        <TextView
+            android:id="@+id/brick_clone_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_clone" />
+
+        <Spinner
+            android:id="@+id/brick_clone_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clickable="false"
+            android:focusable="false" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/res/layout/brick_delete_this_clone.xml
+++ b/catroid/res/layout/brick_delete_this_clone.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2016 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <CheckBox
+        android:id="@+id/brick_delete_clone_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_delete_clone_layout"
+        style="@style/BrickContainer.Control.Small"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing">
+
+        <TextView
+            android:id="@+id/brick_delete_clone_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_delete_this_clone" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/res/layout/brick_when_cloned.xml
+++ b/catroid/res/layout/brick_when_cloned.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2016 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <CheckBox
+        android:id="@+id/brick_when_cloned_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_when_cloned_layout"
+        style="@style/BrickContainer.Script.Small"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing">
+
+        <TextView
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_when_cloned">
+        </TextView>
+
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/res/values/strings.xml
+++ b/catroid/res/values/strings.xml
@@ -600,6 +600,10 @@
     <string name="brick_repeat">Repeat</string>
     <string name="brick_repeat_until">Repeat until</string>
     <string name="brick_when_touched">When screen is touched</string>
+    <string name="brick_clone">Create clone of</string>
+    <string name="brick_clone_this">myself</string>
+    <string name="brick_when_cloned">When I start as a clone</string>
+    <string name="brick_delete_this_clone">Delete this clone</string>
 
     <plurals name="time_plural">
         <item quantity="one">time</item>

--- a/catroid/src/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/org/catrobat/catroid/ProjectManager.java
@@ -429,15 +429,6 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 		return project.getSpriteList().indexOf(currentSprite);
 	}
 
-	public int getCurrentScriptPosition() {
-		int currentSpritePosition = this.getCurrentSpritePosition();
-		if (currentSpritePosition == -1) {
-			return -1;
-		}
-
-		return project.getSpriteList().get(currentSpritePosition).getScriptIndex(currentScript);
-	}
-
 	private String createTemporaryDirectoryName(String projectDirectoryName) {
 		String temporaryDirectorySuffix = "_tmp";
 		String temporaryDirectoryName = projectDirectoryName + temporaryDirectorySuffix;

--- a/catroid/src/org/catrobat/catroid/content/ActionFactory.java
+++ b/catroid/src/org/catrobat/catroid/content/ActionFactory.java
@@ -48,8 +48,10 @@ import org.catrobat.catroid.content.actions.ChangeXByNAction;
 import org.catrobat.catroid.content.actions.ChangeYByNAction;
 import org.catrobat.catroid.content.actions.ChooseCameraAction;
 import org.catrobat.catroid.content.actions.ClearGraphicEffectAction;
+import org.catrobat.catroid.content.actions.CloneAction;
 import org.catrobat.catroid.content.actions.ComeToFrontAction;
 import org.catrobat.catroid.content.actions.DeleteItemOfUserListAction;
+import org.catrobat.catroid.content.actions.DeleteThisCloneAction;
 import org.catrobat.catroid.content.actions.DroneEmergencyAction;
 import org.catrobat.catroid.content.actions.DroneFlipAction;
 import org.catrobat.catroid.content.actions.DroneMoveBackwardAction;
@@ -386,6 +388,18 @@ public class ActionFactory extends Actions {
 		PointToAction action = Actions.action(PointToAction.class);
 		action.setSprite(sprite);
 		action.setPointedSprite(pointedSprite);
+		return action;
+	}
+
+	public Action createCloneAction(Sprite sprite) {
+		CloneAction action = Actions.action(CloneAction.class);
+		action.setSprite(sprite);
+		return action;
+	}
+
+	public Action createDeleteThisCloneAction(Sprite sprite) {
+		DeleteThisCloneAction action = Actions.action(DeleteThisCloneAction.class);
+		action.setSprite(sprite);
 		return action;
 	}
 

--- a/catroid/src/org/catrobat/catroid/content/BroadcastHandler.java
+++ b/catroid/src/org/catrobat/catroid/content/BroadcastHandler.java
@@ -156,7 +156,7 @@ public final class BroadcastHandler {
 	private static boolean handleActionFromBroadcastWait(SequenceAction sequenceActionWithBroadcastNotifyAction) {
 		Action actualAction = sequenceActionWithBroadcastNotifyAction.getActions().get(0);
 
-		for (Sprite sprites : ProjectManager.getInstance().getCurrentProject().getSpriteList()) {
+		for (Sprite sprites : ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones()) {
 			for (Action actionOfLook : sprites.look.getActions()) {
 				Action actualActionOfLook = null;
 				if (actionOfLook instanceof SequenceAction && ((SequenceAction) actionOfLook).getActions().size > 0) {

--- a/catroid/src/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/org/catrobat/catroid/content/Project.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.content;
 
 import android.content.Context;
 import android.os.Build;
+import android.util.Log;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -41,6 +42,7 @@ import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.physics.PhysicsWorld;
 import org.catrobat.catroid.physics.content.ActionPhysicsFactory;
+import org.catrobat.catroid.stage.StageActivity;
 import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.utils.Utils;
 
@@ -116,6 +118,10 @@ public class Project implements Serializable {
 	}
 
 	public synchronized void addSprite(Sprite sprite) {
+		if (sprite.isClone) {
+			Log.e("Project", "Do NOT add clones to the projectmanager!");
+			return;
+		}
 		if (spriteList.contains(sprite)) {
 			return;
 		}
@@ -128,6 +134,14 @@ public class Project implements Serializable {
 
 	public List<Sprite> getSpriteList() {
 		return spriteList;
+	}
+
+	public List<Sprite> getSpriteListWithClones() {
+		if (StageActivity.stageListener != null) {
+			return StageActivity.stageListener.getSpritesFromStage();
+		} else { // e.g. for ActionTests there is no Stage, only use sprites from Project
+			return spriteList;
+		}
 	}
 
 	public void setName(String name) {

--- a/catroid/src/org/catrobat/catroid/content/WhenClonedScript.java
+++ b/catroid/src/org/catrobat/catroid/content/WhenClonedScript.java
@@ -20,34 +20,43 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.catroid.content.actions;
+package org.catrobat.catroid.content;
 
-import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
+import org.catrobat.catroid.content.bricks.ScriptBrick;
+import org.catrobat.catroid.content.bricks.WhenClonedBrick;
 
-import org.catrobat.catroid.ProjectManager;
-import org.catrobat.catroid.content.Sprite;
+public class WhenClonedScript extends Script {
 
-import java.util.List;
+	private static final long serialVersionUID = 1L;
 
-public class ComeToFrontAction extends TemporalAction {
-
-	private Sprite sprite;
-
-	@Override
-	protected void update(float delta) {
-
-		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones();
-		int actualSpriteZIndex = sprite.look.getZIndex();
-
-		for (int i = 0; i < spriteList.size(); i++) {
-			if (spriteList.get(i).look.getZIndex() > actualSpriteZIndex) {
-				spriteList.get(i).look.setZIndex(spriteList.get(i).look.getZIndex() - 1);
-			}
-		}
-		sprite.look.setZIndex(spriteList.size() - 1);
+	public WhenClonedScript() {
+		super();
 	}
 
-	public void setSprite(Sprite sprite) {
-		this.sprite = sprite;
+	public WhenClonedScript(WhenClonedBrick brick) {
+		this.brick = brick;
+	}
+
+	@Override
+	protected Object readResolve() {
+		super.readResolve();
+		return this;
+	}
+
+	@Override
+	public ScriptBrick getScriptBrick() {
+		if (brick == null) {
+			brick = new WhenClonedBrick(this);
+		}
+
+		return brick;
+	}
+
+	@Override
+	public Script copyScriptForSprite(Sprite copySprite) {
+		WhenClonedScript cloneScript = new WhenClonedScript();
+		doCopy(copySprite, cloneScript);
+
+		return cloneScript;
 	}
 }

--- a/catroid/src/org/catrobat/catroid/content/actions/BroadcastAction.java
+++ b/catroid/src/org/catrobat/catroid/content/actions/BroadcastAction.java
@@ -39,7 +39,7 @@ public class BroadcastAction extends Action {
 	@Override
 	public boolean act(float delta) {
 		if (executeOnce) {
-			List<Sprite> sprites = ProjectManager.getInstance().getCurrentProject().getSpriteList();
+			List<Sprite> sprites = ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones();
 			for (Sprite spriteOfList : sprites) {
 				spriteOfList.look.fire(event);
 			}

--- a/catroid/src/org/catrobat/catroid/content/actions/CloneAction.java
+++ b/catroid/src/org/catrobat/catroid/content/actions/CloneAction.java
@@ -20,31 +20,25 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.catrobat.catroid.content.actions;
 
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 
-import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.stage.StageActivity;
 
-import java.util.List;
-
-public class ComeToFrontAction extends TemporalAction {
+public class CloneAction extends TemporalAction {
 
 	private Sprite sprite;
 
 	@Override
-	protected void update(float delta) {
-
-		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones();
-		int actualSpriteZIndex = sprite.look.getZIndex();
-
-		for (int i = 0; i < spriteList.size(); i++) {
-			if (spriteList.get(i).look.getZIndex() > actualSpriteZIndex) {
-				spriteList.get(i).look.setZIndex(spriteList.get(i).look.getZIndex() - 1);
-			}
+	protected void update(float percent) {
+		if (sprite == null) {
+			return;
 		}
-		sprite.look.setZIndex(spriteList.size() - 1);
+
+		StageActivity.stageListener.cloneSpriteAndAddToStage(sprite);
 	}
 
 	public void setSprite(Sprite sprite) {

--- a/catroid/src/org/catrobat/catroid/content/actions/DeleteThisCloneAction.java
+++ b/catroid/src/org/catrobat/catroid/content/actions/DeleteThisCloneAction.java
@@ -20,31 +20,25 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.catrobat.catroid.content.actions;
 
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 
-import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.stage.StageActivity;
 
-import java.util.List;
-
-public class ComeToFrontAction extends TemporalAction {
+public class DeleteThisCloneAction extends TemporalAction {
 
 	private Sprite sprite;
 
 	@Override
-	protected void update(float delta) {
-
-		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones();
-		int actualSpriteZIndex = sprite.look.getZIndex();
-
-		for (int i = 0; i < spriteList.size(); i++) {
-			if (spriteList.get(i).look.getZIndex() > actualSpriteZIndex) {
-				spriteList.get(i).look.setZIndex(spriteList.get(i).look.getZIndex() - 1);
-			}
+	protected void update(float percent) {
+		if (sprite == null) {
+			return;
 		}
-		sprite.look.setZIndex(spriteList.size() - 1);
+
+		StageActivity.stageListener.removeClonedSpriteFromStage(sprite);
 	}
 
 	public void setSprite(Sprite sprite) {

--- a/catroid/src/org/catrobat/catroid/content/actions/GoNStepsBackAction.java
+++ b/catroid/src/org/catrobat/catroid/content/actions/GoNStepsBackAction.java
@@ -60,7 +60,7 @@ public class GoNStepsBackAction extends TemporalAction {
 
 	private void toFront() {
 
-		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteList();
+		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones();
 		int actualSpriteZIndex = sprite.look.getZIndex();
 
 		for (int i = 0; i < spriteList.size(); i++) {
@@ -80,7 +80,7 @@ public class GoNStepsBackAction extends TemporalAction {
 			newSpriteZIndex = 1;
 		}
 
-		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteList();
+		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones();
 
 		for (int i = 0; i < spriteList.size(); i++) {
 			if (steps > 0) {

--- a/catroid/src/org/catrobat/catroid/content/bricks/CloneBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/CloneBrick.java
@@ -1,0 +1,189 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.content.bricks;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.BaseAdapter;
+import android.widget.CompoundButton;
+import android.widget.CompoundButton.OnCheckedChangeListener;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.ui.controller.BackPackSpriteController;
+
+import java.util.Collections;
+import java.util.List;
+
+public class CloneBrick extends BrickBaseType {
+
+	private static final long serialVersionUID = 1L;
+	private Sprite objectToClone;
+
+	public CloneBrick(Sprite objectToClone) {
+		this.objectToClone = objectToClone;
+	}
+
+	public CloneBrick() {
+	}
+
+	@Override
+	public Brick copyBrickForSprite(Sprite sprite) {
+		CloneBrick copyBrick = (CloneBrick) clone();
+		return copyBrick;
+	}
+
+	@Override
+	public View getView(final Context context, int brickId, BaseAdapter baseAdapter) {
+		if (animationState) {
+			return view;
+		}
+
+		view = View.inflate(context, R.layout.brick_clone, null);
+		view = getViewWithAlpha(alphaValue);
+
+		setCheckboxView(R.id.brick_clone_checkbox);
+
+		final Brick brickInstance = this;
+		checkbox.setOnCheckedChangeListener(new OnCheckedChangeListener() {
+			@Override
+			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+				checked = isChecked;
+				adapter.handleCheck(brickInstance, isChecked);
+			}
+		});
+
+		setupValueSpinner(context);
+		return view;
+	}
+
+	@Override
+	public View getViewWithAlpha(int alphaValue) {
+
+		if (view != null) {
+
+			View layout = view.findViewById(R.id.brick_clone_layout);
+			layout.getBackground().setAlpha(alphaValue);
+
+			TextView textLabel = (TextView) view.findViewById(R.id.brick_clone_label);
+			textLabel.setTextColor(textLabel.getTextColors().withAlpha(alphaValue));
+			Spinner objectSpinner = (Spinner) view.findViewById(R.id.brick_clone_spinner);
+			objectSpinner.getBackground().setAlpha(alphaValue);
+
+			this.alphaValue = alphaValue;
+		}
+
+		return view;
+	}
+
+	@Override
+	public View getPrototypeView(Context context) {
+		View view = View.inflate(context, R.layout.brick_clone, null);
+		Spinner cloneSpinner = (Spinner) view.findViewById(R.id.brick_clone_spinner);
+		cloneSpinner.setFocusableInTouchMode(false);
+		cloneSpinner.setFocusable(false);
+		cloneSpinner.setEnabled(false);
+		cloneSpinner.setAdapter(getSpinnerArrayAdapter(context));
+
+		return view;
+	}
+
+	@Override
+	public Brick clone() {
+		return new CloneBrick(objectToClone);
+	}
+
+	@Override
+	public List<SequenceAction> addActionToSequence(Sprite thisObject, SequenceAction sequence) {
+		Sprite s = (objectToClone != null) ? objectToClone : thisObject;
+		sequence.addAction(thisObject.getActionFactory().createCloneAction(s));
+		return Collections.emptyList();
+	}
+
+	@Override
+	public void storeDataForBackPack(Sprite sprite) {
+		Sprite spriteToRestore = ProjectManager.getInstance().getCurrentSprite();
+		Sprite backPackedSprite = BackPackSpriteController.getInstance().backpackHiddenSprite(objectToClone);
+		objectToClone = backPackedSprite;
+		ProjectManager.getInstance().setCurrentSprite(spriteToRestore);
+	}
+
+	private void setupValueSpinner(final Context context) {
+
+		final Spinner valueSpinner = (Spinner) view.findViewById(R.id.brick_clone_spinner);
+		valueSpinner.setFocusableInTouchMode(false);
+		valueSpinner.setFocusable(false);
+		valueSpinner.setClickable(true);
+		valueSpinner.setEnabled(true);
+
+		final List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject()
+				.getSpriteList();
+
+		ArrayAdapter<String> valueAdapter = getSpinnerArrayAdapter(context);
+		valueSpinner.setAdapter(valueAdapter);
+		valueSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+			@Override
+			public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+				String selectedObject = valueSpinner.getSelectedItem().toString();
+
+				objectToClone = null;
+				for (Sprite sprite : spriteList) {
+					if (sprite.getName().equals(selectedObject)) {
+						objectToClone = sprite;
+						break;
+					}
+				}
+			}
+
+			@Override
+			public void onNothingSelected(AdapterView<?> parent) {
+			}
+		});
+		valueSpinner.setSelection(objectToClone != null ? valueAdapter.getPosition(objectToClone.getName()) : 0, true);
+	}
+
+	private ArrayAdapter<String> getSpinnerArrayAdapter(Context context) {
+		ArrayAdapter<String> messageAdapter = new ArrayAdapter<String>(context, android.R.layout.simple_spinner_item);
+		messageAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+		messageAdapter.add(context.getString(R.string.brick_clone_this));
+
+		final List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject()
+				.getSpriteList();
+
+		for (Sprite sprite : spriteList) {
+			if (sprite.getName().equals(context.getString(R.string.background))) {
+				continue;
+			}
+			messageAdapter.add(sprite.getName());
+		}
+
+		return messageAdapter;
+	}
+}

--- a/catroid/src/org/catrobat/catroid/content/bricks/DeleteThisCloneBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/DeleteThisCloneBrick.java
@@ -1,0 +1,112 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.content.bricks;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.Log;
+import android.view.View;
+import android.widget.BaseAdapter;
+import android.widget.CompoundButton;
+import android.widget.CompoundButton.OnCheckedChangeListener;
+import android.widget.TextView;
+
+import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Sprite;
+
+import java.util.Collections;
+import java.util.List;
+
+public class DeleteThisCloneBrick extends BrickBaseType {
+	private static final String TAG = DeleteThisCloneBrick.class.getSimpleName();
+	private static final long serialVersionUID = 1L;
+
+	public DeleteThisCloneBrick() {
+	}
+
+	@Override
+	public int getRequiredResources() {
+		return NO_RESOURCES;
+	}
+
+	@Override
+	public View getView(Context context, int brickId, BaseAdapter baseAdapter) {
+		if (animationState) {
+			return view;
+		}
+		view = View.inflate(context, R.layout.brick_delete_this_clone, null);
+		view = getViewWithAlpha(alphaValue);
+
+		setCheckboxView(R.id.brick_delete_clone_checkbox);
+		final Brick brickInstance = this;
+		checkbox.setOnCheckedChangeListener(new OnCheckedChangeListener() {
+			@Override
+			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+				checked = isChecked;
+				adapter.handleCheck(brickInstance, isChecked);
+			}
+		});
+
+		return view;
+	}
+
+	@Override
+	public Brick copyBrickForSprite(Sprite sprite) {
+		DeleteThisCloneBrick copyBrick = (DeleteThisCloneBrick) clone();
+		return copyBrick;
+	}
+
+	@Override
+	public View getViewWithAlpha(int alphaValue) {
+		if (view != null) {
+			Log.d(TAG, "VIEW != NULL");
+			View layout = view.findViewById(R.id.brick_delete_clone_layout);
+			Drawable background = layout.getBackground();
+			background.setAlpha(alphaValue);
+			this.alphaValue = alphaValue;
+
+			TextView hideLabel = (TextView) view.findViewById(R.id.brick_delete_clone_label);
+			hideLabel.setTextColor(hideLabel.getTextColors().withAlpha(alphaValue));
+		}
+
+		return view;
+	}
+
+	@Override
+	public Brick clone() {
+		return new DeleteThisCloneBrick();
+	}
+
+	@Override
+	public View getPrototypeView(Context context) {
+		return View.inflate(context, R.layout.brick_delete_this_clone, null);
+	}
+
+	@Override
+	public List<SequenceAction> addActionToSequence(Sprite sprite, SequenceAction sequence) {
+		sequence.addAction(sprite.getActionFactory().createDeleteThisCloneAction(sprite));
+		return Collections.emptyList();
+	}
+}

--- a/catroid/src/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
@@ -73,7 +73,7 @@ public class PlaySoundBrick extends BrickBaseType implements OnItemSelectedListe
 	public Brick copyBrickForSprite(Sprite sprite) {
 		PlaySoundBrick copyBrick = (PlaySoundBrick) clone();
 
-		if (sound != null && sound.isBackpackSoundInfo) {
+		if (sound != null && (sound.isBackpackSoundInfo || sprite.isClone)) {
 			copyBrick.sound = sound.clone();
 			copyBrick.sound.isBackpackSoundInfo = false;
 			return copyBrick;

--- a/catroid/src/org/catrobat/catroid/content/bricks/UserBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/UserBrick.java
@@ -369,6 +369,10 @@ public class UserBrick extends BrickBaseType implements OnClickListener {
 		sequence.addAction(actionFactory.createUserBrickAction(userSequence, this));
 		ProjectManager.getInstance().setCurrentUserBrick(this);
 
+		if (sprite.isClone) {
+			sprite.addUserBrick(this);
+		}
+
 		return returnActionList;
 	}
 

--- a/catroid/src/org/catrobat/catroid/content/bricks/WhenClonedBrick.java
+++ b/catroid/src/org/catrobat/catroid/content/bricks/WhenClonedBrick.java
@@ -1,0 +1,113 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.content.bricks;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.view.View;
+import android.widget.BaseAdapter;
+
+import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.WhenClonedScript;
+
+import java.util.Collections;
+import java.util.List;
+
+public class WhenClonedBrick extends ScriptBrick {
+	protected WhenClonedScript whenClonedScript;
+	private static final long serialVersionUID = 1L;
+
+	public WhenClonedBrick(WhenClonedScript whenScript) {
+		this.whenClonedScript = whenScript;
+	}
+
+	public WhenClonedBrick() {
+	}
+
+	@Override
+	public int getRequiredResources() {
+		return NO_RESOURCES;
+	}
+
+	@Override
+	public Brick copyBrickForSprite(Sprite sprite) {
+		WhenClonedBrick copyBrick = (WhenClonedBrick) clone();
+		copyBrick.whenClonedScript = whenClonedScript;
+		return copyBrick;
+	}
+
+	@Override
+	public View getView(final Context context, int brickId, final BaseAdapter baseAdapter) {
+		if (animationState) {
+			return view;
+		}
+
+		view = View.inflate(context, R.layout.brick_when_cloned, null);
+
+		setCheckboxView(R.id.brick_when_cloned_checkbox);
+
+		return view;
+	}
+
+	@Override
+	public View getViewWithAlpha(int alphaValue) {
+
+		if (view != null) {
+
+			View layout = view.findViewById(R.id.brick_when_cloned_layout);
+			Drawable background = layout.getBackground();
+			background.setAlpha(alphaValue);
+			this.alphaValue = alphaValue;
+		}
+
+		return view;
+	}
+
+	@Override
+	public View getPrototypeView(Context context) {
+		return getView(context, 0, null);
+	}
+
+	@Override
+	public Brick clone() {
+		return new WhenClonedBrick(null);
+	}
+
+	@Override
+	public Script getScriptSafe() {
+		if (whenClonedScript == null) {
+			whenClonedScript = new WhenClonedScript();
+		}
+
+		return whenClonedScript;
+	}
+
+	@Override
+	public List<SequenceAction> addActionToSequence(Sprite sprite, SequenceAction sequence) {
+		return Collections.emptyList();
+	}
+}

--- a/catroid/src/org/catrobat/catroid/formulaeditor/DataContainer.java
+++ b/catroid/src/org/catrobat/catroid/formulaeditor/DataContainer.java
@@ -267,6 +267,15 @@ public class DataContainer implements Serializable {
 		return variables;
 	}
 
+	public void removeVariableListForSprite(Sprite sprite) {
+		spriteVariables.remove(sprite);
+		spriteListOfLists.remove(sprite);
+
+		for (UserBrick userBrick : sprite.getUserBrickList()) {
+			userBrickVariables.remove(userBrick);
+		}
+	}
+
 	public List<UserVariable> getVariableListForSprite(Sprite sprite) {
 		List<UserVariable> variables = spriteVariables.get(sprite);
 

--- a/catroid/src/org/catrobat/catroid/io/CatroidFieldKeySorter.java
+++ b/catroid/src/org/catrobat/catroid/io/CatroidFieldKeySorter.java
@@ -149,8 +149,10 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 				fieldKeyOrder[10] = fieldKey;
 			} else if (fieldKey.getFieldName().equals("actionFactory")) {
 				fieldKeyOrder[11] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("$change")) {
+			} else if (fieldKey.getFieldName().equals("isClone")) {
 				fieldKeyOrder[12] = fieldKey;
+			} else if (fieldKey.getFieldName().equals("$change")) {
+				fieldKeyOrder[13] = fieldKey;
 			}
 		}
 		for (FieldKey fieldKey : fieldKeyOrder) {

--- a/catroid/src/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/org/catrobat/catroid/io/StorageHandler.java
@@ -54,6 +54,7 @@ import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Setting;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.WhenClonedScript;
 import org.catrobat.catroid.content.WhenNfcScript;
 import org.catrobat.catroid.content.WhenScript;
 import org.catrobat.catroid.content.WhenTouchDownScript;
@@ -77,8 +78,10 @@ import org.catrobat.catroid.content.bricks.ChangeXByNBrick;
 import org.catrobat.catroid.content.bricks.ChangeYByNBrick;
 import org.catrobat.catroid.content.bricks.ChooseCameraBrick;
 import org.catrobat.catroid.content.bricks.ClearGraphicEffectBrick;
+import org.catrobat.catroid.content.bricks.CloneBrick;
 import org.catrobat.catroid.content.bricks.ComeToFrontBrick;
 import org.catrobat.catroid.content.bricks.DeleteItemOfUserListBrick;
+import org.catrobat.catroid.content.bricks.DeleteThisCloneBrick;
 import org.catrobat.catroid.content.bricks.DroneEmergencyBrick;
 import org.catrobat.catroid.content.bricks.DroneFlipBrick;
 import org.catrobat.catroid.content.bricks.DroneMoveBackwardBrick;
@@ -157,6 +160,7 @@ import org.catrobat.catroid.content.bricks.VibrationBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
 import org.catrobat.catroid.content.bricks.WaitUntilBrick;
 import org.catrobat.catroid.content.bricks.WhenBrick;
+import org.catrobat.catroid.content.bricks.WhenClonedBrick;
 import org.catrobat.catroid.content.bricks.WhenNfcBrick;
 import org.catrobat.catroid.content.bricks.WhenStartedBrick;
 import org.catrobat.catroid.formulaeditor.DataContainer;
@@ -305,6 +309,7 @@ public final class StorageHandler {
 		xstream.alias("object", Sprite.class);
 
 		xstream.alias("script", StartScript.class);
+		xstream.alias("script", WhenClonedScript.class);
 		xstream.alias("script", WhenScript.class);
 		xstream.alias("script", WhenNfcScript.class);
 		xstream.alias("script", BroadcastScript.class);
@@ -324,8 +329,10 @@ public final class StorageHandler {
 		xstream.alias("brick", ChangeXByNBrick.class);
 		xstream.alias("brick", ChangeYByNBrick.class);
 		xstream.alias("brick", ClearGraphicEffectBrick.class);
+		xstream.alias("brick", CloneBrick.class);
 		xstream.alias("brick", ComeToFrontBrick.class);
 		xstream.alias("brick", DeleteItemOfUserListBrick.class);
+		xstream.alias("brick", DeleteThisCloneBrick.class);
 		xstream.alias("brick", ForeverBrick.class);
 		xstream.alias("brick", GlideToBrick.class);
 		xstream.alias("brick", GoNStepsBackBrick.class);
@@ -380,6 +387,7 @@ public final class StorageHandler {
 		xstream.alias("brick", WaitUntilBrick.class);
 		xstream.alias("brick", WhenBrick.class);
 		xstream.alias("brick", WhenStartedBrick.class);
+		xstream.alias("brick", WhenClonedBrick.class);
 
 		xstream.alias("brick", WhenNfcBrick.class);
 

--- a/catroid/src/org/catrobat/catroid/io/XStreamToSupportCatrobatLanguageVersion0991AndBefore.java
+++ b/catroid/src/org/catrobat/catroid/io/XStreamToSupportCatrobatLanguageVersion0991AndBefore.java
@@ -52,7 +52,9 @@ import org.catrobat.catroid.content.bricks.ChangeXByNBrick;
 import org.catrobat.catroid.content.bricks.ChangeYByNBrick;
 import org.catrobat.catroid.content.bricks.ChooseCameraBrick;
 import org.catrobat.catroid.content.bricks.ClearGraphicEffectBrick;
+import org.catrobat.catroid.content.bricks.CloneBrick;
 import org.catrobat.catroid.content.bricks.ComeToFrontBrick;
+import org.catrobat.catroid.content.bricks.DeleteThisCloneBrick;
 import org.catrobat.catroid.content.bricks.DroneEmergencyBrick;
 import org.catrobat.catroid.content.bricks.DroneFlipBrick;
 import org.catrobat.catroid.content.bricks.DroneMoveBackwardBrick;
@@ -120,6 +122,7 @@ import org.catrobat.catroid.content.bricks.TurnRightBrick;
 import org.catrobat.catroid.content.bricks.VibrationBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
 import org.catrobat.catroid.content.bricks.WhenBrick;
+import org.catrobat.catroid.content.bricks.WhenClonedBrick;
 import org.catrobat.catroid.content.bricks.WhenNfcBrick;
 import org.catrobat.catroid.content.bricks.WhenStartedBrick;
 import org.catrobat.catroid.physics.PhysicsCollision;
@@ -446,6 +449,15 @@ public class XStreamToSupportCatrobatLanguageVersion0991AndBefore extends XStrea
 
 		brickInfo = new BrickInfo(WhenNfcBrick.class.getSimpleName());
 		brickInfoMap.put("whenNfcBrick", brickInfo);
+
+		brickInfo = new BrickInfo(WhenClonedBrick.class.getSimpleName());
+		brickInfoMap.put("whenClonedBrick", brickInfo);
+
+		brickInfo = new BrickInfo(CloneBrick.class.getSimpleName());
+		brickInfoMap.put("cloneBrick", brickInfo);
+
+		brickInfo = new BrickInfo(DeleteThisCloneBrick.class.getSimpleName());
+		brickInfoMap.put("deleteThisCloneBrick", brickInfo);
 
 		brickInfo = new BrickInfo(DronePlayLedAnimationBrick.class.getSimpleName());
 		brickInfoMap.put("dronePlayLedAnimationBrick", brickInfo);

--- a/catroid/src/org/catrobat/catroid/nfc/NfcHandler.java
+++ b/catroid/src/org/catrobat/catroid/nfc/NfcHandler.java
@@ -54,7 +54,7 @@ public final class NfcHandler {
 		String uid = getUid(intent);
 		setLastNfcTagId(uid);
 
-		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteList();
+		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones();
 
 		for (Sprite sprite : spriteList) {
 			sprite.createWhenNfcScriptAction(uid);

--- a/catroid/src/org/catrobat/catroid/physics/PhysicsCollisionBroadcast.java
+++ b/catroid/src/org/catrobat/catroid/physics/PhysicsCollisionBroadcast.java
@@ -71,7 +71,7 @@ public class PhysicsCollisionBroadcast {
 		BroadcastEvent event = new BroadcastEvent();
 		event.setBroadcastMessage(message);
 		event.setType(BroadcastEvent.BroadcastType.broadcast);
-		List<Sprite> sprites = ProjectManager.getInstance().getCurrentProject().getSpriteList();
+		List<Sprite> sprites = ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones();
 		for (Sprite spriteOfList : sprites) {
 			spriteOfList.look.fire(event);
 		}

--- a/catroid/src/org/catrobat/catroid/physics/content/bricks/CollisionReceiverBrick.java
+++ b/catroid/src/org/catrobat/catroid/physics/content/bricks/CollisionReceiverBrick.java
@@ -39,7 +39,6 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.MessageContainer;
 import org.catrobat.catroid.content.BroadcastMessage;
 import org.catrobat.catroid.content.CollisionScript;
-import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -141,13 +140,12 @@ public class CollisionReceiverBrick extends ScriptBrick implements BroadcastMess
 	}
 
 	public ArrayAdapter<String> getCollisionObjectAdapter(Context context) {
-		Project project = ProjectManager.getInstance().getCurrentProject();
 		String spriteName = ProjectManager.getInstance().getCurrentSprite().getName();
 		messageAdapter = new ArrayAdapter<>(context, android.R.layout.simple_spinner_item);
 		messageAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 		messageAdapter.add(getDisplayedAnythingString(context));
 		int resources = Brick.NO_RESOURCES;
-		for (Sprite sprite : project.getSpriteList()) {
+		for (Sprite sprite : ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones()) {
 			if (!spriteName.equals(sprite.getName())) {
 				resources |= sprite.getRequiredResources();
 				if ((resources & Brick.PHYSICS) > 0 && messageAdapter.getPosition(sprite.getName()) < 0) {

--- a/catroid/src/org/catrobat/catroid/stage/StageActivity.java
+++ b/catroid/src/org/catrobat/catroid/stage/StageActivity.java
@@ -69,12 +69,16 @@ public class StageActivity extends AndroidApplication {
 	private StageDialog stageDialog;
 	private boolean resizePossible;
 
+	private static int numberOfSpritesCloned = 0;
+
 	AndroidApplicationConfiguration configuration = null;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		Log.d(TAG, "onCreate()");
+
+		numberOfSpritesCloned = 0;
 
 		if (ProjectManager.getInstance().isCurrentProjectLandscapeMode()) {
 			setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
@@ -349,5 +353,9 @@ public class StageActivity extends AndroidApplication {
 				}
 			}
 		});
+	}
+
+	public static int getAndIncrementNumberOfClonedSprites() {
+		return ++numberOfSpritesCloned;
 	}
 }

--- a/catroid/src/org/catrobat/catroid/ui/adapter/SpriteBaseAdapter.java
+++ b/catroid/src/org/catrobat/catroid/ui/adapter/SpriteBaseAdapter.java
@@ -34,12 +34,10 @@ import android.widget.ListView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.content.Sprite;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -89,14 +87,6 @@ public class SpriteBaseAdapter extends ArrayAdapter<Sprite> implements ActionMod
 	@Override
 	public Set<Integer> getCheckedItems() {
 		return checkedSprites;
-	}
-
-	public ArrayList<Sprite> getCheckedSprites() {
-		ArrayList<Sprite> result = new ArrayList<>();
-		for (Integer pos : checkedSprites) {
-			result.add(ProjectManager.getInstance().getCurrentProject().getSpriteList().get(pos));
-		}
-		return result;
 	}
 
 	@Override

--- a/catroid/src/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
+++ b/catroid/src/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
@@ -47,8 +47,10 @@ import org.catrobat.catroid.content.bricks.ChangeXByNBrick;
 import org.catrobat.catroid.content.bricks.ChangeYByNBrick;
 import org.catrobat.catroid.content.bricks.ChooseCameraBrick;
 import org.catrobat.catroid.content.bricks.ClearGraphicEffectBrick;
+import org.catrobat.catroid.content.bricks.CloneBrick;
 import org.catrobat.catroid.content.bricks.ComeToFrontBrick;
 import org.catrobat.catroid.content.bricks.DeleteItemOfUserListBrick;
+import org.catrobat.catroid.content.bricks.DeleteThisCloneBrick;
 import org.catrobat.catroid.content.bricks.DroneEmergencyBrick;
 import org.catrobat.catroid.content.bricks.DroneFlipBrick;
 import org.catrobat.catroid.content.bricks.DroneMoveBackwardBrick;
@@ -116,6 +118,7 @@ import org.catrobat.catroid.content.bricks.VibrationBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
 import org.catrobat.catroid.content.bricks.WaitUntilBrick;
 import org.catrobat.catroid.content.bricks.WhenBrick;
+import org.catrobat.catroid.content.bricks.WhenClonedBrick;
 import org.catrobat.catroid.content.bricks.WhenNfcBrick;
 import org.catrobat.catroid.content.bricks.WhenRaspiPinChangedBrick;
 import org.catrobat.catroid.content.bricks.WhenStartedBrick;
@@ -213,6 +216,10 @@ public class CategoryBricksFactory {
 		if (SettingsActivity.isNfcSharedPreferenceEnabled(context)) {
 			controlBrickList.add(new WhenNfcBrick());
 		}
+
+		controlBrickList.add(new WhenClonedBrick());
+		controlBrickList.add(new CloneBrick());
+		controlBrickList.add(new DeleteThisCloneBrick());
 
 		return controlBrickList;
 	}

--- a/catroid/src/org/catrobat/catroid/utils/TouchUtil.java
+++ b/catroid/src/org/catrobat/catroid/utils/TouchUtil.java
@@ -98,7 +98,7 @@ public final class TouchUtil {
 	}
 
 	private static void fireTouchEvent() {
-		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteList();
+		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones();
 
 		for (Sprite sprite : spriteList) {
 			sprite.createTouchDownAction();

--- a/catroidTest/src/org/catrobat/catroid/test/ui/CategoryBricksFactoryTest.java
+++ b/catroidTest/src/org/catrobat/catroid/test/ui/CategoryBricksFactoryTest.java
@@ -56,7 +56,7 @@ public class CategoryBricksFactoryTest extends AndroidTestCase {
 	}
 
 	public void testControlBricks() {
-		final int expectedBrickCount = 15;
+		final int expectedBrickCount = 18;
 		checkBrickCountInCategory(R.string.category_control, background, expectedBrickCount);
 		checkBrickCountInCategory(R.string.category_control, sprite, expectedBrickCount);
 	}


### PR DESCRIPTION
- create a clone of a Sprite (= Object) via a special Brick
- create a special "Clone" brick that clones the Object in which it is
    - all Scripts, Sounds, Variables etc are copied
- add a "When i start as a clone" brick
    - is a script-brick that is only executed when Object is cloned
    - "When started" ScriptBricks are NOT executed for the clone
- add "Delete this clone" brick
    - when executed, the cloned object containing this brick
      is deleted
- global variables are shared, local (=per object) variables are copied
  for clones.

[tests ok](https://jenkins.catrob.at/job/CatroidSinglePackageEmulatorTest/3646/) and [checkstyle ok](https://jenkins.catrob.at/view/LeeroyCatroid/job/CatroidCheck/300/)