### PR TITLE
CAT-FIX fix wait-until action

### DIFF
--- a/catroid/src/org/catrobat/catroid/content/actions/WaitUntilAction.java
+++ b/catroid/src/org/catrobat/catroid/content/actions/WaitUntilAction.java
@@ -73,8 +73,7 @@ public class WaitUntilAction extends Action {
 	}
 
 	@Override
-	public void reset() {
-		super.reset();
+	public void restart() {
 		completed = false;
 	}
 }


### PR DESCRIPTION
fixes an issue where WaitUntil actions did not always work correctly
at the second time they are executed (e.g. in a loop)

Attention: in a LibGDX action, reset() calls restart(), not the other way round ;-)