### PR TITLE
CAT-2073 fix renamed downloaded project not modifiable

### DIFF
--- a/catroid/src/org/catrobat/catroid/transfers/ProjectDownloadService.java
+++ b/catroid/src/org/catrobat/catroid/transfers/ProjectDownloadService.java
@@ -30,6 +30,8 @@ import android.util.Log;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.utils.DownloadUtil;
 import org.catrobat.catroid.utils.ToastUtil;
 import org.catrobat.catroid.utils.UtilZip;
@@ -47,6 +49,7 @@ public class ProjectDownloadService extends IntentService {
 	public static final String DOWNLOAD_NAME_TAG = "downloadName";
 	public static final String URL_TAG = "url";
 	public static final String ID_TAG = "notificationId";
+	public static final String RENAME_AFTER_DOWNLOAD = "renameAfterDownload";
 
 	private static final String DOWNLOAD_FILE_NAME = "down" + Constants.CATROBAT_EXTENSION;
 
@@ -76,6 +79,15 @@ public class ProjectDownloadService extends IntentService {
 		try {
 			ServerCalls.getInstance().downloadProject(url, zipFileString, receiver, notificationId);
 			result = UtilZip.unZipFile(zipFileString, Utils.buildProjectPath(projectName));
+
+			boolean renameProject = intent.getBooleanExtra(RENAME_AFTER_DOWNLOAD, false);
+			if (renameProject) {
+				Project projectTBRenamed = StorageHandler.getInstance().loadProject(projectName);
+				if (projectTBRenamed != null) {
+					projectTBRenamed.setName(projectName);
+					StorageHandler.getInstance().saveProject(projectTBRenamed);
+				}
+			}
 			Log.v(TAG, "url: " + url + ", zip-file: " + zipFileString + ", notificationId: " + notificationId);
 		} catch (IOException ioException) {
 			Log.e(TAG, Log.getStackTraceString(ioException));

--- a/catroid/src/org/catrobat/catroid/ui/dialogs/OverwriteRenameDialog.java
+++ b/catroid/src/org/catrobat/catroid/ui/dialogs/OverwriteRenameDialog.java
@@ -165,7 +165,7 @@ public class OverwriteRenameDialog extends DialogFragment implements OnClickList
 				return false;
 			}
 
-			DownloadUtil.getInstance().startDownload(context, url, newProgramName);
+			DownloadUtil.getInstance().startDownload(context, url, newProgramName, true);
 		}
 		dismiss();
 

--- a/catroid/src/org/catrobat/catroid/utils/DownloadUtil.java
+++ b/catroid/src/org/catrobat/catroid/utils/DownloadUtil.java
@@ -140,11 +140,16 @@ public final class DownloadUtil {
 	}
 
 	public void startDownload(Context context, String url, String programName) {
+		startDownload(context, url, programName, false);
+	}
+
+	public void startDownload(Context context, String url, String programName, boolean renameProject) {
 		programDownloadQueue.add(programName.toLowerCase(Locale.getDefault()));
 		Intent downloadIntent = new Intent(context, ProjectDownloadService.class);
 		downloadIntent.putExtra(ProjectDownloadService.RECEIVER_TAG, new DownloadProjectReceiver(new Handler()));
 		downloadIntent.putExtra(ProjectDownloadService.DOWNLOAD_NAME_TAG, programName);
 		downloadIntent.putExtra(ProjectDownloadService.URL_TAG, url);
+		downloadIntent.putExtra(ProjectDownloadService.RENAME_AFTER_DOWNLOAD, renameProject);
 		StatusBarNotificationManager manager = StatusBarNotificationManager.getInstance();
 		int notificationId = manager.createDownloadNotification(context, programName);
 		downloadIntent.putExtra(ProjectDownloadService.ID_TAG, notificationId);


### PR DESCRIPTION
When downloading a project that already exists, the downloaded, renamed
project did not save any changes and could not be modified since
project name was never updated in project xml.