### PR TITLE
CAT-1636 Order xstream fields by annotation

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/io/CatroidFieldKeySorterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/io/CatroidFieldKeySorterTest.java
@@ -33,6 +33,8 @@ import com.thoughtworks.xstream.converters.reflection.FieldKeySorter;
 import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
 
 import org.catrobat.catroid.io.CatroidFieldKeySorter;
+import org.catrobat.catroid.io.XStreamFieldKeyOrder;
+import org.catrobat.catroid.io.XStreamMissingSerializableFieldException;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -131,6 +133,68 @@ public class CatroidFieldKeySorterTest extends AndroidTestCase {
 		@XStreamAlias("x")
 		private int a;
 		private int y;
+		private int b;
+	}
+
+	public void testSortByAnnotation() {
+		xstream.toXML(new SortByAnnotation());
+
+		MoreAsserts.assertEquals("Sorted fields differ",
+				new String[] { "c", "a", "d", "b" }, fieldKeySorter.getFieldNames(SortByAnnotation.class));
+	}
+
+	// Remove checkstyle disable when https://github.com/checkstyle/checkstyle/issues/1349 is fixed
+	// CHECKSTYLE DISABLE IndentationCheck FOR 6 LINES
+	@XStreamFieldKeyOrder({
+			"c",
+			"a",
+			"d",
+			"b"
+	})
+	@SuppressWarnings("PMD.UnusedPrivateField")
+	private static class SortByAnnotation {
+		private int a;
+		private int b;
+		private int c;
+		private int d;
+	}
+
+	public void testSortByAnnotationWithAliases() {
+		xstream.toXML(new SortByAnnotationWithAliases());
+
+		MoreAsserts.assertEquals("Sorted fields differ",
+				new String[] { "x", "b" }, fieldKeySorter.getFieldNames(SortByAnnotationWithAliases.class));
+	}
+
+	// Remove checkstyle disable when https://github.com/checkstyle/checkstyle/issues/1349 is fixed
+	// CHECKSTYLE DISABLE IndentationCheck FOR 4 LINES
+	@XStreamFieldKeyOrder({
+			"x",
+			"b"
+	})
+	@SuppressWarnings("PMD.UnusedPrivateField")
+	private static class SortByAnnotationWithAliases {
+		private int b;
+		@XStreamAlias("x")
+		private int a;
+	}
+
+	public void testMissingFieldInAnnotationThrowsException() {
+		try {
+			xstream.toXML(new MissingFieldInAnnotation());
+			fail("XStream didn't throw an exception for missing field b in annotation");
+		} catch (XStreamMissingSerializableFieldException expected) {
+		}
+	}
+
+	// Remove checkstyle disable when https://github.com/checkstyle/checkstyle/issues/1349 is fixed
+	// CHECKSTYLE DISABLE IndentationCheck FOR 3 LINES
+	@XStreamFieldKeyOrder({
+			"a"
+	})
+	@SuppressWarnings("PMD.UnusedPrivateField")
+	private static class MissingFieldInAnnotation {
+		private int a;
 		private int b;
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/io/CatroidFieldKeySorterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/io/CatroidFieldKeySorterTest.java
@@ -1,0 +1,136 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.io;
+
+import android.test.AndroidTestCase;
+import android.test.MoreAsserts;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.converters.reflection.FieldDictionary;
+import com.thoughtworks.xstream.converters.reflection.FieldKey;
+import com.thoughtworks.xstream.converters.reflection.FieldKeySorter;
+import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
+
+import org.catrobat.catroid.io.CatroidFieldKeySorter;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CatroidFieldKeySorterTest extends AndroidTestCase {
+
+	private static class FieldKeySorterDecorator implements FieldKeySorter {
+
+		private final FieldKeySorter catroidFieldKeySorter = new CatroidFieldKeySorter();
+		private Map<Class, Map<FieldKey, Field>> sortResults = new HashMap<>();
+
+		@Override
+		public Map sort(Class type, Map keyedByFieldKey) {
+			Map sortResult = catroidFieldKeySorter.sort(type, keyedByFieldKey);
+			this.sortResults.put(type, sortResult);
+			return sortResult;
+		}
+
+		public String[] getFieldNames(Class type) {
+			return getFieldNames(sortResults.get(type));
+		}
+
+		public String[] getFieldNames(Map<FieldKey, Field> fieldKeys) {
+			List<String> fieldNames = new ArrayList<>();
+			for (Map.Entry<FieldKey, Field> fieldKeyEntry : fieldKeys.entrySet()) {
+				FieldKey fieldKey = fieldKeyEntry.getKey();
+				fieldNames.add(CatroidFieldKeySorter.getAliasOrFieldName(fieldKey));
+			}
+			return fieldNames.toArray(new String[fieldNames.size()]);
+		}
+	}
+
+	private XStream xstream;
+	private FieldKeySorterDecorator fieldKeySorter;
+	// CHECKSTYLE DISABLE MemberName FOR 1000 LINES
+
+	public void setUp() {
+		fieldKeySorter = new FieldKeySorterDecorator();
+		xstream = new XStream(new PureJavaReflectionProvider(new FieldDictionary(fieldKeySorter)));
+	}
+
+	public void testSortTagsAlphabetically() {
+		xstream.toXML(new BaseClass());
+
+		MoreAsserts.assertEquals("Sorted fields differ",
+				new String[] { "a", "x" }, fieldKeySorter.getFieldNames(BaseClass.class));
+	}
+
+	public void testSortTagsAlphabeticallyByClassHierarchy() {
+		xstream.toXML(new SubClass());
+
+		MoreAsserts.assertEquals("Sorted fields differ",
+				new String[] { "a", "x", "b", "y", "z" }, fieldKeySorter.getFieldNames(SubClass.class));
+	}
+
+	@SuppressWarnings("PMD.UnusedPrivateField")
+	private static class BaseClass {
+		private int x;
+		private int a;
+	}
+
+	@SuppressWarnings("PMD.UnusedPrivateField")
+	private static class SubClass extends BaseClass {
+		private int b;
+		private int z;
+		private int y;
+	}
+
+	public void testGetFieldName() {
+		FieldKey fieldKey = new FieldKey("b", SortAlphabeticallyWithAliases.class, 0);
+		String fieldName = CatroidFieldKeySorter.getAliasOrFieldName(fieldKey);
+
+		assertEquals("Wrong field name", "b", fieldName);
+	}
+
+	public void testGetFieldAlias() {
+		FieldKey fieldKeyWithAlias = new FieldKey("a", SortAlphabeticallyWithAliases.class, 0);
+		String fieldAlias = CatroidFieldKeySorter.getAliasOrFieldName(fieldKeyWithAlias);
+
+		assertEquals("Wrong field alias", "x", fieldAlias);
+	}
+
+	public void testSortAlphabeticallyWithAliases() {
+		xstream.processAnnotations(SortAlphabeticallyWithAliases.class);
+		xstream.toXML(new SortAlphabeticallyWithAliases());
+
+		MoreAsserts.assertEquals("Sorted fields differ",
+				new String[] { "b", "x", "y" }, fieldKeySorter.getFieldNames(SortAlphabeticallyWithAliases.class));
+	}
+
+	@SuppressWarnings("PMD.UnusedPrivateField")
+	private static class SortAlphabeticallyWithAliases {
+		@XStreamAlias("x")
+		private int a;
+		private int y;
+		private int b;
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -38,6 +38,7 @@ import org.catrobat.catroid.devices.mindstorms.nxt.sensors.NXTSensor;
 import org.catrobat.catroid.formulaeditor.DataContainer;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.io.XStreamFieldKeyOrder;
 import org.catrobat.catroid.physics.content.ActionPhysicsFactory;
 import org.catrobat.catroid.stage.StageActivity;
 import org.catrobat.catroid.ui.SettingsActivity;
@@ -50,6 +51,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 @XStreamAlias("program")
+// Remove checkstyle disable when https://github.com/checkstyle/checkstyle/issues/1349 is fixed
+// CHECKSTYLE DISABLE IndentationCheck FOR 7 LINES
+@XStreamFieldKeyOrder({
+		"header",
+		"settings",
+		"scenes",
+		"programVariableList",
+		"programListOfLists"
+})
 public class Project implements Serializable {
 
 	private static final long serialVersionUID = 1L;

--- a/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
@@ -43,6 +43,7 @@ import org.catrobat.catroid.formulaeditor.DataContainer;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.io.XStreamFieldKeyOrder;
 import org.catrobat.catroid.physics.PhysicsWorld;
 import org.catrobat.catroid.utils.ToastUtil;
 import org.catrobat.catroid.utils.Utils;
@@ -53,6 +54,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 @XStreamAlias("scene")
+// Remove checkstyle disable when https://github.com/checkstyle/checkstyle/issues/1349 is fixed
+// CHECKSTYLE DISABLE IndentationCheck FOR 7 LINES
+@XStreamFieldKeyOrder({
+		"name",
+		"objectList",
+		"data",
+		"originalWidth",
+		"originalHeight"
+})
 public class Scene implements Serializable {
 
 	private static final long serialVersionUID = 1L;

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -50,6 +50,7 @@ import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.io.XStreamFieldKeyOrder;
 import org.catrobat.catroid.physics.PhysicsLook;
 import org.catrobat.catroid.physics.PhysicsWorld;
 import org.catrobat.catroid.stage.StageActivity;
@@ -60,6 +61,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+// Remove checkstyle disable when https://github.com/checkstyle/checkstyle/issues/1349 is fixed
+// CHECKSTYLE DISABLE IndentationCheck FOR 8 LINES
+@XStreamFieldKeyOrder({
+		"name",
+		"lookList",
+		"soundList",
+		"scriptList",
+		"userBricks",
+		"nfcTagList"
+})
 public class Sprite implements Serializable, Cloneable {
 	private static final long serialVersionUID = 1L;
 	private static final String TAG = Sprite.class.getSimpleName();

--- a/catroid/src/main/java/org/catrobat/catroid/io/CatroidFieldKeySorter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/CatroidFieldKeySorter.java
@@ -27,39 +27,68 @@ import android.util.Log;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.converters.reflection.FieldKey;
 import com.thoughtworks.xstream.converters.reflection.FieldKeySorter;
-import com.thoughtworks.xstream.core.util.OrderRetainingMap;
-
-import org.catrobat.catroid.content.Project;
-import org.catrobat.catroid.content.Scene;
-import org.catrobat.catroid.content.Sprite;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 public class CatroidFieldKeySorter implements FieldKeySorter {
-
 	private static final String TAG = CatroidFieldKeySorter.class.getSimpleName();
 
 	@Override
-	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public Map sort(final Class type, final Map keyedByFieldKey) {
-		if (type.equals(Project.class)) {
-			return sortProjectFields(keyedByFieldKey);
+		XStreamFieldKeyOrder fieldKeyOrderAnnotation = (XStreamFieldKeyOrder) type.getAnnotation(XStreamFieldKeyOrder.class);
+		if (fieldKeyOrderAnnotation != null) {
+			List<String> fieldOrder = Arrays.asList(fieldKeyOrderAnnotation.value());
+			return sortByList(fieldOrder, keyedByFieldKey);
+		} else {
+			return sortAlphabeticallyByClassHierarchy(keyedByFieldKey);
 		}
+	}
 
-		if (type.equals(Scene.class)) {
-			return sortSceneFields(keyedByFieldKey);
-		}
-
-		if (type.equals(Sprite.class)) {
-			return sortSpriteFields(keyedByFieldKey);
-		}
-
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private Map sortByList(final List<String> fieldOrder, final Map keyedByFieldKey) {
+		checkMissingSerializableField(fieldOrder, keyedByFieldKey.entrySet());
 		final Map map = new TreeMap(new Comparator() {
 
+			@Override
+			public int compare(final Object objectOne, final Object objectTwo) {
+				final FieldKey fieldKeyOne = (FieldKey) objectOne;
+				final FieldKey fieldKeyTwo = (FieldKey) objectTwo;
+
+				int fieldKeyOneIndex = fieldOrder.indexOf(getAliasOrFieldName(fieldKeyOne));
+				int fieldKeyTwoIndex = fieldOrder.indexOf(getAliasOrFieldName(fieldKeyTwo));
+				return fieldKeyOneIndex - fieldKeyTwoIndex;
+			}
+		});
+		map.putAll(keyedByFieldKey);
+		return map;
+	}
+
+	private void checkMissingSerializableField(List<String> fieldOrder, Set<Map.Entry<FieldKey, Field>> fields) {
+		for (Map.Entry<FieldKey, Field> fieldEntry : fields) {
+			final FieldKey fieldKey = fieldEntry.getKey();
+			final String fieldKeyName = getAliasOrFieldName(fieldKey);
+			if (!fieldOrder.contains(fieldKeyName) && isSerializable(fieldEntry.getValue())) {
+				throw new XStreamMissingSerializableFieldException("Missing field '" + fieldKeyName
+						+ "' in XStreamFieldKeyOrder annotation for class " + fieldKey.getDeclaringClass());
+			}
+		}
+	}
+
+	private boolean isSerializable(Field field) {
+		int modifiers = field.getModifiers();
+		return !Modifier.isStatic(modifiers) && !Modifier.isTransient(modifiers);
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private Map sortAlphabeticallyByClassHierarchy(final Map keyedByFieldKey) {
+		final Map map = new TreeMap(new Comparator() {
 			@Override
 			public int compare(final Object objectOne, final Object objectTwo) {
 				final FieldKey fieldKeyOne = (FieldKey) objectOne;
@@ -92,131 +121,5 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 			Log.e(TAG, Log.getStackTraceString(exception));
 		}
 		return fieldName;
-	}
-
-	private Map sortProjectFields(Map map) {
-		Map orderedMap = new OrderRetainingMap();
-		FieldKey[] fieldKeyOrder = new FieldKey[map.size()];
-		Iterator<FieldKey> iterator = map.keySet().iterator();
-		int fieldPos = 0;
-		while (iterator.hasNext()) {
-			FieldKey fieldKey = iterator.next();
-			if (fieldKey.getFieldName().equals("xmlHeader")) {
-				fieldKeyOrder[fieldPos] = fieldKey;
-				fieldPos++;
-			} else if (fieldKey.getFieldName().equals("serialVersionUID")) {
-				fieldKeyOrder[fieldPos] = fieldKey;
-				fieldPos++;
-			} else if (fieldKey.getFieldName().equals("settings")) {
-				fieldKeyOrder[fieldPos] = fieldKey;
-				fieldPos++;
-			} else if (fieldKey.getFieldName().equals("$change")) {
-				fieldKeyOrder[fieldPos] = fieldKey;
-				fieldPos++;
-			} else if (fieldKey.getFieldName().equals("sceneList")) {
-				fieldKeyOrder[fieldPos] = fieldKey;
-				fieldPos++;
-			} else if (fieldKey.getFieldName().equals("projectVariables")) {
-				fieldKeyOrder[fieldPos] = fieldKey;
-				fieldPos++;
-			} else if (fieldKey.getFieldName().equals("projectLists")) {
-				fieldKeyOrder[fieldPos] = fieldKey;
-				fieldPos++;
-			}
-		}
-		for (FieldKey fieldKey : fieldKeyOrder) {
-			orderedMap.put(fieldKey, map.get(fieldKey));
-		}
-		return orderedMap;
-	}
-
-	private Map sortSceneFields(Map map) {
-		Map orderedMap = new OrderRetainingMap();
-		FieldKey[] fieldKeyOrder = new FieldKey[map.size()];
-		Iterator<FieldKey> iterator = map.keySet().iterator();
-		while (iterator.hasNext()) {
-			FieldKey fieldKey = iterator.next();
-			if (fieldKey.getFieldName().equals("sceneName")) {
-				fieldKeyOrder[0] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("spriteList")) {
-				fieldKeyOrder[1] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("dataContainer")) {
-				fieldKeyOrder[2] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("physicsWorld")) {
-				fieldKeyOrder[3] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("project")) {
-				fieldKeyOrder[4] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("serialVersionUID")) {
-				fieldKeyOrder[5] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("firstStart")) {
-				fieldKeyOrder[6] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("isBackPackScene")) {
-				fieldKeyOrder[7] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("originalWidth")) {
-				fieldKeyOrder[8] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("originalHeight")) {
-				fieldKeyOrder[9] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("$change")) {
-				fieldKeyOrder[10] = fieldKey;
-			}
-		}
-		for (FieldKey fieldKey : fieldKeyOrder) {
-			orderedMap.put(fieldKey, map.get(fieldKey));
-		}
-		return orderedMap;
-	}
-
-	private Map sortSpriteFields(Map map) {
-		Map orderedMap = new OrderRetainingMap();
-		FieldKey[] fieldKeyOrder = new FieldKey[map.size()];
-		Iterator<FieldKey> iterator = map.keySet().iterator();
-		while (iterator.hasNext()) {
-			FieldKey fieldKey = iterator.next();
-			if (fieldKey.getFieldName().equals("TAG")) {
-				fieldKeyOrder[0] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("serialVersionUID")) {
-				fieldKeyOrder[1] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("spriteFactory")) {
-				fieldKeyOrder[2] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("look")) {
-				fieldKeyOrder[3] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("name")) {
-				fieldKeyOrder[4] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("isPaused")) {
-				fieldKeyOrder[5] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("convertToSingleSprite")) {
-				fieldKeyOrder[6] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("convertToGroupItemSprite")) {
-				fieldKeyOrder[7] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("lookList")) {
-				fieldKeyOrder[8] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("soundList")) {
-				fieldKeyOrder[9] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("scriptList")) {
-				fieldKeyOrder[10] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("userBricks")) {
-				fieldKeyOrder[11] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("isClone")) {
-				fieldKeyOrder[12] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("isBackpackObject")) {
-				fieldKeyOrder[13] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("penConfiguration")) {
-				fieldKeyOrder[14] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("cloneForScene")) {
-				fieldKeyOrder[15] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("nfcTagList")) {
-				fieldKeyOrder[16] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("actionFactory")) {
-				fieldKeyOrder[17] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("isMobile")) {
-				fieldKeyOrder[18] = fieldKey;
-			} else if (fieldKey.getFieldName().equals("$change")) {
-				fieldKeyOrder[19] = fieldKey;
-			}
-		}
-		for (FieldKey fieldKey : fieldKeyOrder) {
-			orderedMap.put(fieldKey, map.get(fieldKey));
-		}
-		return orderedMap;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/io/CatroidFieldKeySorter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/CatroidFieldKeySorter.java
@@ -66,8 +66,8 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 				final FieldKey fieldKeyTwo = (FieldKey) objectTwo;
 				int fieldKeyComparator = fieldKeyOne.getDepth() - fieldKeyTwo.getDepth();
 				if (fieldKeyComparator == 0) {
-					String fieldNameOrAlias1 = getFieldNameOrAlias(fieldKeyOne);
-					String fieldNameOrAlias2 = getFieldNameOrAlias(fieldKeyTwo);
+					String fieldNameOrAlias1 = getAliasOrFieldName(fieldKeyOne);
+					String fieldNameOrAlias2 = getAliasOrFieldName(fieldKeyTwo);
 					fieldKeyComparator = fieldNameOrAlias1.compareTo(fieldNameOrAlias2);
 				}
 				return fieldKeyComparator;
@@ -77,7 +77,7 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 		return map;
 	}
 
-	private String getFieldNameOrAlias(FieldKey fieldKey) {
+	public static String getAliasOrFieldName(FieldKey fieldKey) {
 		String fieldName = fieldKey.getFieldName();
 		try {
 			Field field = fieldKey.getDeclaringClass().getDeclaredField(fieldName);

--- a/catroid/src/main/java/org/catrobat/catroid/io/XStreamFieldKeyOrder.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/XStreamFieldKeyOrder.java
@@ -1,0 +1,35 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.io;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface XStreamFieldKeyOrder {
+	String[] value();
+}

--- a/catroid/src/main/java/org/catrobat/catroid/io/XStreamMissingSerializableFieldException.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/XStreamMissingSerializableFieldException.java
@@ -1,0 +1,31 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.io;
+
+public class XStreamMissingSerializableFieldException extends RuntimeException {
+
+	public XStreamMissingSerializableFieldException(String detailMessage) {
+		super(detailMessage);
+	}
+}


### PR DESCRIPTION
See commit messages for more details.

> ...If there is an alias defined for the field, the alias has to be used in the annotation.

No real reason behind that. I just think that renaming an alias is less likely then renaming a member variable. So it would be less error prone... But if you guys prefer the member name, let me know.

I created two commits, because the CatroidFieldKeySorter wasn't tested at all. So I tested the general case and then **extended** it to work with annotation as well. I can create two separate Pull Requests if preferred.

@p4p4 :wink: 

Reopens https://github.com/Catrobat/Catroid/pull/1423