### PR TITLE
CAT-FIX WhenConditionBrick - small cosmetic fix

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenConditionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenConditionBrick.java
@@ -163,6 +163,6 @@ public class WhenConditionBrick extends FormulaBrick implements ScriptBrick {
 
 	@Override
 	public Brick clone() {
-		return new WhenConditionBrick();
+		return new WhenConditionBrick(getConditionFormula());
 	}
 }


### PR DESCRIPTION
the condition of the WhenConditionBrick was "0" after adding the ScriptBrick.
Now, the default-condition from the categorybricksfactory ("1<2") is used
instead.