### PR TITLE
CAT-FIX Fix wrong assert check in SetLookActionTest

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/SetLookActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/SetLookActionTest.java
@@ -98,6 +98,6 @@ public class SetLookActionTest extends InstrumentationTestCase {
 		ActionFactory factory = sprite.getActionFactory();
 		Action action = factory.createSetLookAction(sprite, lookData);
 		action.act(1.0f);
-		assertNotNull("current Look is null", sprite.look);
+		assertEquals("Action didn't set the LookData", lookData, sprite.look.getLookData());
 	}
 }


### PR DESCRIPTION
Previously the test checked if the Sprites Look is not null which has
nothing to do with the SetLookAction itself. Now, the test checks if
the correct LookData has been set for the Look.