### PR TITLE
Add checkstyle check to use ellipsis character … instead of &#8230;

### DIFF
--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -255,6 +255,13 @@
     <property name="message" value="Empty line contains whitespaces." />
   </module>
 
+  <module name="RegexpSingleline">
+    <property name="id" value="EllipsesCheck"/>
+    <property name="fileExtensions" value="java,xml" />
+    <property name="format" value="&amp;#8230;" />
+    <property name="message" value="Use ellipses character … instead of &amp;#8230;." />
+  </module>
+
   <module name="SuppressWithNearbyCommentFilter">
     <property name="commentFormat" value="CHECKSTYLE DISABLE ([\w\|]+) FOR (-?\d+) LINES" />
     <property name="checkFormat" value="$1" />
@@ -264,6 +271,10 @@
   <module name="SuppressionCommentFilter">
     <property name="offCommentFormat" value="@formatter\:off" />
     <property name="onCommentFormat" value="@formatter\:on" />
+  </module>
+
+  <module name="SuppressionFilter">
+    <property name="file" value="catroid/config/checkstyle_suppressions.xml" />
   </module>
 
 </module>

--- a/catroid/config/checkstyle_suppressions.xml
+++ b/catroid/config/checkstyle_suppressions.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2016 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+  <suppress id="EllipsesCheck" files=".*/res/values-.*/strings.xml"/>
+</suppressions>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="error">Error</string>
     <string name="please_wait">Please wait</string>
     <string name="loading">Loading…</string>
-    <string name="search_hint">Search&#8230;</string>
+    <string name="search_hint">Search…</string>
     <string name="no_internet">No Internet</string>
     <string name="loading_check_token">Token is checked on our server…</string>
     <string name="loading_check_facebook_data">Facebook data is retrieved…</string>
@@ -162,15 +162,15 @@
     <string name="authentication_failed">Authentication failed, please contact the Pocket Code team!</string>
     <plurals name="scratch_conversion_scheduled_x">
         <item quantity="zero">No Scratch programs scheduled!</item>
-        <item quantity="one">Scheduled 1 Scratch program&#8230;</item>
-        <item quantity="other">Scheduled %d Scratch programs&#8230;</item>
+        <item quantity="one">Scheduled 1 Scratch program…</item>
+        <item quantity="other">Scheduled %d Scratch programs…</item>
     </plurals>
-    <string name="scratch_conversion_started">Started to convert Scratch program&#8230;</string>
+    <string name="scratch_conversion_started">Started to convert Scratch program…</string>
     <string name="convert">Convert</string>
-    <string name="converting">Converting&#8230;</string>
+    <string name="converting">Converting…</string>
     <string name="status_scheduled">Scheduled</string>
-    <string name="status_waiting_for_worker">Looking for a free worker&#8230; Please wait&#8230;</string>
-    <string name="status_started">Started&#8230;</string>
+    <string name="status_waiting_for_worker">Looking for a free worker… Please wait…</string>
+    <string name="status_started">Started…</string>
     <string name="status_conversion_finished">Conversion finished</string>
     <plurals name="status_in_progress_x_jobs">
         <item quantity="one">In progress: 1 job</item>
@@ -182,7 +182,7 @@
     </plurals>
     <string name="status_conversion_failed">Conversion failed!</string>
     <string name="status_conversion_canceled">Conversion canceled!</string>
-    <string name="status_downloading">Downloading&#8230;</string>
+    <string name="status_downloading">Downloading…</string>
     <string name="status_download_finished">Download finished!</string>
     <string name="status_download_canceled">Download canceled!</string>
     <string name="list_view_section_title_in_progress">In progress</string>


### PR DESCRIPTION
The ellipsis character … is much more readable and therefore should be
used in java and xml files instead of `&#8230;`. Translated strings.xml
files are ignored because they are handled by Crowdin.
