### PR TITLE
CAT-FIX Fix failing ui tests

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/GoToBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/GoToBrickTest.java
@@ -33,6 +33,7 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -107,7 +108,7 @@ public class GoToBrickTest extends ActivityInstrumentationTestCase2<ScriptActivi
 	private void createProject() {
 		project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 
-		Sprite sprite = new Sprite("sprite");
+		Sprite sprite = new SingleSprite("sprite");
 		Script script = new StartScript();
 		goToBrick = new GoToBrick();
 		script.addBrick(goToBrick);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/PenBricksTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/PenBricksTest.java
@@ -28,6 +28,7 @@ import com.robotium.solo.Condition;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.PenDownBrick;
@@ -85,7 +86,7 @@ public class PenBricksTest extends BaseActivityInstrumentationTestCase<MainMenuA
 
 	private void createProject() {
 		Project project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
-		sprite = new Sprite("cat");
+		sprite = new SingleSprite("cat");
 		Script script = new StartScript();
 		PenDownBrick penDownBrick = new PenDownBrick();
 		PenUpBrick penUpBrick = new PenUpBrick();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/PlaySoundAndWaitBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/PlaySoundAndWaitBrickTest.java
@@ -30,6 +30,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.SoundInfo;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.PlaySoundAndWaitBrick;
@@ -154,7 +155,7 @@ public class PlaySoundAndWaitBrickTest extends BaseActivityInstrumentationTestCa
 	private void createProject() {
 		ProjectManager projectManager = ProjectManager.getInstance();
 		Project project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
-		Sprite firstSprite = new Sprite("sprite");
+		Sprite firstSprite = new SingleSprite("sprite");
 		Script testScript = new StartScript();
 
 		PlaySoundAndWaitBrick playSoundAndWaitBrick = new PlaySoundAndWaitBrick();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SayBubbleTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SayBubbleTest.java
@@ -28,6 +28,7 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -101,7 +102,7 @@ public class SayBubbleTest extends BaseActivityInstrumentationTestCase<MainMenuA
 
 	private void createProject() {
 		project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
-		sprite = new Sprite("cat");
+		sprite = new SingleSprite("cat");
 		Script script = new StartScript();
 		sayBubbleBrick = new SayBubbleBrick();
 		script.addBrick(sayBubbleBrick);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SayForBubbleTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SayForBubbleTest.java
@@ -28,6 +28,7 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -134,7 +135,7 @@ public class SayForBubbleTest extends BaseActivityInstrumentationTestCase<MainMe
 
 	private void createProject() {
 		project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
-		sprite = new Sprite("cat");
+		sprite = new SingleSprite("cat");
 		Script script = new StartScript();
 		sayForBubbleBrick = new SayForBubbleBrick();
 		script.addBrick(sayForBubbleBrick);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SceneStartBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SceneStartBrickTest.java
@@ -27,6 +27,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.SceneStartBrick;
@@ -164,7 +165,7 @@ public class SceneStartBrickTest extends BaseActivityInstrumentationTestCase<Mai
 		Project project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 		Scene scene = new Scene(null, sceneName2, project);
 		project.addScene(scene);
-		Sprite firstSprite = new Sprite("cat");
+		Sprite firstSprite = new SingleSprite("cat");
 		Script testScript = new StartScript();
 
 		SceneStartBrick sceneStartBrick = new SceneStartBrick(sceneName2);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SceneTransitionBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SceneTransitionBrickTest.java
@@ -30,6 +30,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.SceneTransitionBrick;
@@ -153,7 +154,7 @@ public class SceneTransitionBrickTest extends BaseActivityInstrumentationTestCas
 		Project project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 		Scene scene = new Scene(null, sceneName2, project);
 		project.addScene(scene);
-		Sprite firstSprite = new Sprite("cat");
+		Sprite firstSprite = new SingleSprite("cat");
 		Script testScript = new StartScript();
 
 		SceneTransitionBrick sceneTransitionBrick = new SceneTransitionBrick(sceneName2);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SetRotationStyleTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SetRotationStyleTest.java
@@ -28,6 +28,7 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -77,7 +78,7 @@ public class SetRotationStyleTest extends BaseActivityInstrumentationTestCase<Sc
 
 	private void createProject() {
 		project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
-		Sprite sprite = new Sprite("cat");
+		Sprite sprite = new SingleSprite("cat");
 		Script script = new StartScript();
 		ProjectManager.getInstance().setProject(project);
 		script.addBrick(new SetRotationStyleBrick());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SpeakAndWaitBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/SpeakAndWaitBrickTest.java
@@ -29,6 +29,7 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -100,7 +101,7 @@ public class SpeakAndWaitBrickTest extends BaseActivityInstrumentationTestCase<M
 
 	private void createProject() {
 		project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
-		sprite = new Sprite("sprite");
+		sprite = new SingleSprite("sprite");
 		Script script = new StartScript();
 		speakAndWaitBrick = new SpeakAndWaitBrick("");
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/StopScriptBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/StopScriptBrickTest.java
@@ -30,6 +30,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -78,7 +79,7 @@ public class StopScriptBrickTest extends BaseActivityInstrumentationTestCase<Scr
 	private void createProject() {
 		project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
 
-		Sprite sprite = new Sprite("sprite");
+		Sprite sprite = new SingleSprite("sprite");
 		Script script = new StartScript();
 		script.addBrick(new StopScriptBrick(BrickValues.STOP_THIS_SCRIPT));
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/ThinkBubbleTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/ThinkBubbleTest.java
@@ -28,6 +28,7 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -101,7 +102,7 @@ public class ThinkBubbleTest extends BaseActivityInstrumentationTestCase<MainMen
 
 	private void createProject() {
 		project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
-		sprite = new Sprite("cat");
+		sprite = new SingleSprite("cat");
 		Script script = new StartScript();
 		thinkBubbleBrick = new ThinkBubbleBrick();
 		script.addBrick(thinkBubbleBrick);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/ThinkForBubbleTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/ThinkForBubbleTest.java
@@ -28,6 +28,7 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -134,7 +135,7 @@ public class ThinkForBubbleTest extends BaseActivityInstrumentationTestCase<Main
 
 	private void createProject() {
 		project = new Project(null, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
-		sprite = new Sprite("cat");
+		sprite = new SingleSprite("cat");
 		Script script = new StartScript();
 		thinkForBubbleBrick = new ThinkForBubbleBrick();
 		script.addBrick(thinkForBubbleBrick);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/stage/UserBricksExecutionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/stage/UserBricksExecutionTest.java
@@ -28,6 +28,7 @@ import android.widget.ListView;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.ChangeXByNBrick;
@@ -62,10 +63,10 @@ public class UserBricksExecutionTest extends BaseActivityInstrumentationTestCase
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		sprite = new Sprite("testSprite");
+		sprite = new SingleSprite("testSprite");
 		project = new Project(null, "testProject");
 
-		project.getDefaultScene().addSprite(new Sprite("background"));
+		project.getDefaultScene().addSprite(new SingleSprite("background"));
 		project.getDefaultScene().addSprite(sprite);
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(sprite);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/fragment/ScenesListFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/fragment/ScenesListFragmentTest.java
@@ -30,6 +30,7 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.io.StorageHandler;
@@ -98,8 +99,8 @@ public class ScenesListFragmentTest extends BaseActivityInstrumentationTestCase<
 		UiTestUtils.createTestProject();
 
 		project = ProjectManager.getInstance().getCurrentProject();
-		sprite = new Sprite(SPRITE_NAME);
-		Sprite sprite2 = new Sprite(SPRITE_NAME2);
+		sprite = new SingleSprite(SPRITE_NAME);
+		Sprite sprite2 = new SingleSprite(SPRITE_NAME2);
 		project.getDefaultScene().rename(SCENE_NAME, getActivity(), false);
 		project.getDefaultScene().addSprite(sprite);
 		project.getDefaultScene().addSprite(sprite2);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -149,9 +149,11 @@ import org.catrobat.catroid.ui.ProjectActivity;
 import org.catrobat.catroid.ui.ScriptActivity;
 import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.ui.UserBrickScriptActivity;
+import org.catrobat.catroid.ui.adapter.BrickAdapter;
 import org.catrobat.catroid.ui.controller.BackPackListManager;
 import org.catrobat.catroid.ui.dialogs.NewSpriteDialog;
 import org.catrobat.catroid.ui.dialogs.NewSpriteDialog.ActionAfterFinished;
+import org.catrobat.catroid.ui.dragndrop.DragAndDropListView;
 import org.catrobat.catroid.ui.fragment.AddBrickFragment;
 import org.catrobat.catroid.ui.fragment.FormulaEditorDataFragment;
 import org.catrobat.catroid.ui.fragment.ScriptFragment;
@@ -2219,13 +2221,13 @@ public final class UiTestUtils {
 	}
 
 	public static ListView getScriptListView(Solo solo) {
-		return getListView(solo, 0);
-	}
-
-	public static ListView getListView(Solo solo, int index) {
-		ArrayList<ListView> listOfListViews = solo.getCurrentViews(ListView.class);
-		assertTrue("no ListView found!", listOfListViews.size() > 0);
-		return listOfListViews.get(index);
+		for (ListView listView : solo.getCurrentViews(ListView.class)) {
+			if (listView instanceof DragAndDropListView && listView.getAdapter() instanceof BrickAdapter) {
+				return listView;
+			}
+		}
+		fail("Could not find a Script ListView");
+		return null;
 	}
 
 	public static void waitForFragment(Solo solo, int fragmentRootLayoutId) {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -1017,9 +1017,9 @@ public final class UiTestUtils {
 	public static List<Brick> createOldTestProjectWithSprites(String oldSpriteProject) {
 		Project project = new Project(null, oldSpriteProject);
 		project.setCatrobatLanguageVersion(0.99f);
-		Sprite firstSprite = new Sprite("cat");
-		Sprite secondSprite = new Sprite("testSprite1");
-		Sprite thirdSprite = new Sprite("third_sprite");
+		Sprite firstSprite = new SingleSprite("cat");
+		Sprite secondSprite = new SingleSprite("testSprite1");
+		Sprite thirdSprite = new SingleSprite("third_sprite");
 
 		Script testScript = new StartScript();
 		projectManager.setProject(project);
@@ -1241,7 +1241,7 @@ public final class UiTestUtils {
 
 	public static List<Brick> createTestProjectWithUserVariables() {
 		Project project = new Project(null, DEFAULT_TEST_PROJECT_NAME);
-		Sprite firstSprite = new Sprite("cat");
+		Sprite firstSprite = new SingleSprite("cat");
 
 		String globalVariableName = "global_var";
 		String spriteVariableName = "sprite_var";


### PR DESCRIPTION
Fixed failing ui tests cause by
* ClassCastException: android.widget.ExpandableListConnector cannot be cast to org.catrobat.catroid.ui.adapter.BrickAdapter
* Sprites not shown in the Sprites Fragment