### PR TITLE
Disable distance to in formula editor

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorCategoryListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorCategoryListFragment.java
@@ -76,8 +76,8 @@ public class FormulaEditorCategoryListFragment extends ListFragment implements D
 	private CategoryListAdapter adapter;
 
 	private static final int[] OBJECT_GENERAL_PROPERTIES_ITEMS = { R.string.formula_editor_object_transparency,
-			R.string.formula_editor_object_brightness, R.string.formula_editor_object_color,
-			R.string.formula_editor_object_distance_to };
+			R.string.formula_editor_object_brightness, R.string.formula_editor_object_color/*,
+			R.string.formula_editor_object_distance_to*/ };
 
 	private static final int[] OBJECT_PHYSICAL_PROPERTIES_ITEMS = { R.string.formula_editor_object_x,
 			R.string.formula_editor_object_y, R.string.formula_editor_object_size,


### PR DESCRIPTION
Disable 'distance to' in formula editor until the possibility to choose other sprites via menu is added.