### PR TITLE
CAT-FIX Hotfix variables/lists for release

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ShowTextActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ShowTextActionTest.java
@@ -37,17 +37,18 @@ import org.catrobat.catroid.formulaeditor.UserVariable;
 public class ShowTextActionTest extends AndroidTestCase {
 
 	private static final String SPRITE_NAME = "Cat";
+	private static final String SECOND_SPRITE_NAME = "Dog";
 	private static final UserVariable USER_VARIABLE = new UserVariable("var");
-	private Project project;
 
 	public void testShowVariablesVisibilitySameVariableNameAcrossSprites() {
 		Sprite sprite = new Sprite(SPRITE_NAME);
-		project = new Project(null, "testProject");
+		Project project = new Project(null, "testProject");
 		project.getDefaultScene().addSprite(sprite);
 		ProjectManager.getInstance().setProject(project);
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 
 		Sprite secondSprite = sprite.clone();
+		secondSprite.setName(SECOND_SPRITE_NAME);
 		project.getDefaultScene().addSprite(secondSprite);
 
 		DataContainer dataContainer = project.getDefaultScene().getDataContainer();
@@ -68,7 +69,7 @@ public class ShowTextActionTest extends AndroidTestCase {
 				.getVariableListForSprite(sprite));
 		UserVariable variableOfSecondSprite = dataContainer.findUserVariable(USER_VARIABLE.getName(), dataContainer
 				.getVariableListForSprite(secondSprite));
-		assertTrue("Uservariable not set visible", variableOfFirstSprite.getVisible());
-		assertTrue("Uservariable not set visible", variableOfSecondSprite.getVisible());
+		assertTrue("UserVariable not set visible", variableOfFirstSprite.getVisible());
+		assertTrue("UserVariable not set visible", variableOfSecondSprite.getVisible());
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -226,7 +226,7 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 			}
 			if (project.getCatrobatLanguageVersion() == 0.991f) {
 				//With the introduction of grouping there are several Sprite-classes
-				convertSpritesToSingleSprites();
+				//This is simply done in XStreamSpriteConverter
 				project.setCatrobatLanguageVersion(0.992f);
 			}
 			if (project.getCatrobatLanguageVersion() == 0.992f) {
@@ -264,12 +264,6 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 			}
 			currentScene = project.getDefaultScene();
 			sceneToPlay = currentScene;
-		}
-	}
-
-	private void convertSpritesToSingleSprites() {
-		for (Scene scene : project.getSceneList()) {
-			scene.convertSpritesToSingleSprites();
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -36,6 +36,7 @@ import org.catrobat.catroid.common.ScreenValues;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.devices.mindstorms.nxt.sensors.NXTSensor;
 import org.catrobat.catroid.formulaeditor.DataContainer;
+import org.catrobat.catroid.formulaeditor.SupportDataContainer;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.io.XStreamFieldKeyOrder;
@@ -48,6 +49,7 @@ import org.catrobat.catroid.utils.Utils;
 import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 @XStreamAlias("program")
@@ -123,10 +125,37 @@ public class Project implements Serializable {
 			scene = new Scene(context, "Scene 1", this);
 		}
 		DataContainer container = new DataContainer(this);
+		removeInvalidVariablesAndLists(oldProject.dataContainer);
 		container.setSpriteVariablesForSupportContainer(oldProject.dataContainer);
 		scene.setDataContainer(container);
 		scene.setSpriteList(oldProject.spriteList);
 		sceneList.add(scene);
+	}
+
+	private void removeInvalidVariablesAndLists(SupportDataContainer dataContainer) {
+		if (dataContainer == null) {
+			return;
+		}
+
+		if (dataContainer.spriteListOfLists != null) {
+			Iterator listIterator = dataContainer.spriteListOfLists.keySet().iterator();
+			while (listIterator.hasNext()) {
+				Sprite sprite = (Sprite) listIterator.next();
+				if (sprite == null) {
+					listIterator.remove();
+				}
+			}
+		}
+
+		if (dataContainer.spriteVariables != null) {
+			Iterator variablesIterator = dataContainer.spriteVariables.keySet().iterator();
+			while (variablesIterator.hasNext()) {
+				Sprite sprite = (Sprite) variablesIterator.next();
+				if (sprite == null) {
+					variablesIterator.remove();
+				}
+			}
+		}
 	}
 
 	public List<Scene> getSceneList() {

--- a/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
@@ -119,13 +119,6 @@ public class Scene implements Serializable {
 		spriteList.add(sprite);
 	}
 
-	private synchronized void addSprite(int index, Sprite sprite) {
-		if (spriteList.contains(sprite)) {
-			return;
-		}
-		spriteList.add(index, sprite);
-	}
-
 	public synchronized boolean removeSprite(Sprite sprite) {
 		return spriteList.remove(sprite);
 	}
@@ -517,16 +510,5 @@ public class Scene implements Serializable {
 			result.addAll(sprite.getAllBricks());
 		}
 		return result;
-	}
-
-	public void convertSpritesToSingleSprites() {
-		for (int index = 0; index < spriteList.size(); index++) {
-			Sprite sprite = spriteList.get(index);
-			sprite.setConvertToSingleSprite(true);
-			Sprite convertedSprite = sprite.shallowClone();
-			removeSprite(sprite);
-			addSprite(index, convertedSprite);
-		}
-		project.refreshSpriteReferences();
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/SupportProject.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/SupportProject.java
@@ -35,7 +35,7 @@ public class SupportProject implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	@XStreamAlias("header")
-	public XmlHeader xmlHeader = new XmlHeader();
+	XmlHeader xmlHeader = new XmlHeader();
 	@XStreamAlias("objectList")
 	public List<Sprite> spriteList = new ArrayList<>();
 	@XStreamAlias("data")

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/DataContainer.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/DataContainer.java
@@ -40,6 +40,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -338,8 +339,23 @@ public class DataContainer implements Serializable {
 		if (variables == null) {
 			variables = new ArrayList<>();
 			spriteVariables.put(sprite, variables);
+			removeSpriteVariableWithSameSpriteName(sprite);
 		}
 		return variables;
+	}
+
+	private void removeSpriteVariableWithSameSpriteName(Sprite spriteToKeep) {
+		if (spriteVariables == null || spriteToKeep == null) {
+			return;
+		}
+
+		Iterator iterator = spriteVariables.keySet().iterator();
+		while (iterator.hasNext()) {
+			Sprite sprite = (Sprite) iterator.next();
+			if (sprite == null || !(sprite == spriteToKeep) && sprite.getName().equals(spriteToKeep.getName())) {
+				iterator.remove();
+			}
+		}
 	}
 
 	public void removeVariableListForSprite(Sprite sprite) {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/SupportDataContainer.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/SupportDataContainer.java
@@ -41,7 +41,7 @@ public class SupportDataContainer implements Serializable {
 	public Map<Sprite, List<UserVariable>> spriteVariables;
 
 	@XStreamAlias("userBrickVariableList")
-	public Map<UserBrick, List<UserVariable>> userBrickVariables = new HashMap<>();
+	Map<UserBrick, List<UserVariable>> userBrickVariables = new HashMap<>();
 
 	@XStreamAlias("programListOfLists")
 	public List<UserList> projectLists;

--- a/catroid/src/main/java/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/StorageHandler.java
@@ -580,7 +580,7 @@ public final class StorageHandler {
 		}
 
 		loadSaveLock.lock();
-		Project project = null;
+		Project project;
 		try {
 			project = (Project) xstream.getProjectFromXML(new File(buildProjectPath(projectName), PROJECTCODE_NAME));
 			for (String sceneName : project.getSceneOrder()) {

--- a/catroid/src/main/java/org/catrobat/catroid/io/XStreamSpriteConverter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/XStreamSpriteConverter.java
@@ -32,6 +32,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import com.thoughtworks.xstream.mapper.Mapper;
 
+import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 
 public class XStreamSpriteConverter extends ReflectionConverter {
@@ -66,6 +67,9 @@ public class XStreamSpriteConverter extends ReflectionConverter {
 			} catch (ClassNotFoundException exception) {
 				Log.e(TAG, "Sprite class not found : " + result.toString(), exception);
 			}
+		} else {
+			Sprite sprite = (Sprite) reflectionProvider.newInstance(SingleSprite.class);
+			return super.doUnmarshal(sprite, reader, context);
 		}
 		return super.doUnmarshal(result, reader, context);
 	}


### PR DESCRIPTION
- Hotfix variables/lists (remove null and double entries when loading old programs)
- Convert sprites of old programs to SingleSprites in XStreamSpriteConverter to prevent double entries in dataContainer