### PR TITLE
HOTFIX GoTo brick crash with clone - spinner value not copied

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/GoToBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/GoToBrick.java
@@ -43,6 +43,7 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.ui.controller.BackPackSpriteController;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class GoToBrick extends BrickBaseType {
@@ -51,8 +52,6 @@ public class GoToBrick extends BrickBaseType {
 
 	private Sprite destinationSprite;
 	private transient String oldSelectedObject;
-	private String touchPositionLabel;
-	private String randomPositionLabel;
 
 	private transient SpinnerAdapterWrapper spinnerAdapterWrapper;
 	private int spinnerSelection;
@@ -86,9 +85,6 @@ public class GoToBrick extends BrickBaseType {
 
 		view = View.inflate(context, R.layout.brick_go_to, null);
 		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		this.touchPositionLabel = context.getString(R.string.brick_go_to_touch_position);
-		this.randomPositionLabel = context.getString(R.string.brick_go_to_random_position);
 
 		setCheckboxView(R.id.brick_go_to_checkbox);
 
@@ -129,7 +125,7 @@ public class GoToBrick extends BrickBaseType {
 			}
 		});
 
-		setSpinnerSelection(goToSpinner);
+		setSpinnerSelection(goToSpinner, context);
 
 		return view;
 	}
@@ -143,7 +139,7 @@ public class GoToBrick extends BrickBaseType {
 		SpinnerAdapter goToSpinnerAdapter = createArrayAdapter(context);
 
 		goToSpinner.setAdapter(goToSpinnerAdapter);
-		setSpinnerSelection(goToSpinner);
+		setSpinnerSelection(goToSpinner, context);
 
 		return prototypeView;
 	}
@@ -152,19 +148,19 @@ public class GoToBrick extends BrickBaseType {
 	public List<SequenceAction> addActionToSequence(Sprite sprite, SequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createGoToAction(sprite, destinationSprite, spinnerSelection));
 
-		return null;
+		return Collections.emptyList();
 	}
 
-	private void setSpinnerSelection(Spinner spinner) {
+	private void setSpinnerSelection(Spinner spinner, Context context) {
 		final ArrayList<Sprite> spriteList = (ArrayList<Sprite>) ProjectManager.getInstance().getCurrentScene()
 				.getSpriteList();
 
 		if (spinnerSelection == BrickValues.GO_TO_TOUCH_POSITION) {
 			spinner.setSelection(0, true);
-			oldSelectedObject = touchPositionLabel;
+			oldSelectedObject = context.getString(R.string.brick_go_to_touch_position);
 		} else if (spinnerSelection == BrickValues.GO_TO_RANDOM_POSITION) {
 			spinner.setSelection(1, true);
-			oldSelectedObject = randomPositionLabel;
+			oldSelectedObject = context.getString(R.string.brick_go_to_random_position);
 		} else if (spriteList.contains(destinationSprite)) {
 			oldSelectedObject = destinationSprite.getName();
 			spinner.setSelection(
@@ -305,7 +301,9 @@ public class GoToBrick extends BrickBaseType {
 
 	@Override
 	public Brick clone() {
-		return new GoToBrick(destinationSprite);
+		GoToBrick copy = new GoToBrick(destinationSprite);
+		copy.spinnerSelection = spinnerSelection;
+		return copy;
 	}
 
 	public Sprite getDestinationSprite() {


### PR DESCRIPTION
The GoTo brick did not copy the spinner-selection, which caused crashes when
appearing in a WhenCloned script (and potentially also in other features
like backpack, copy brick etc). This should fix the issue.

This is a very HOT HotFix ;)