### PR TITLE
HOTFIX conversion problems special chars in project name

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/StorageHandler.java
@@ -613,8 +613,6 @@ public final class StorageHandler {
 	}
 
 	private void fixFolderStructureForSupportProject(String projectName, String sceneName) throws IOException {
-		projectName = UtilFile.encodeSpecialCharsForFileSystem(projectName);
-		sceneName = UtilFile.encodeSpecialCharsForFileSystem(sceneName);
 		String projectPath = buildProjectPath(projectName);
 		String scenePath = buildScenePath(projectName, sceneName);
 		File looksDirectory = new File(buildPath(projectPath, IMAGE_DIRECTORY));


### PR DESCRIPTION
Programs of an older catrobat language version are converted to the new one.
For this purpose, it is necessary to create a DefaultScene.
The migration did not copy images and sounds due to double-escaping the path.
This led to situations where e.g. "Foo:bar" was first escaped to "Foo%3ABar" and then in the second
step, the '%' was (erroneously) escaped again, resulting in "Foo%253ABar", which is NOT a valid file path anymore. This commit fixes that issue.