### PR TITLE
CAT-2149 Fixes remix-data in header of merged programs

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/scratchconverter/WebSocketClientTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/scratchconverter/WebSocketClientTest.java
@@ -310,6 +310,7 @@ public class WebSocketClientTest extends AndroidTestCase {
 				connectCallback.onCompleted(new Exception(expectedCancelExceptionMessage), webSocketMock);
 				verify(connectAuthCallbackMock, times(1)).onConnectionFailure(any(ClientException.class));
 				verifyNoMoreInteractions(connectAuthCallbackMock);
+				verifyZeroInteractions(webSocketMock);
 				return null;
 			}
 		}).when(asyncHttpClientMock).websocket(anyString(), anyString(), any(WebSocketConnectCallback.class));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilsTest.java
@@ -35,6 +35,7 @@ import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.WhenScript;
+import org.catrobat.catroid.content.XmlHeader;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.HideBrick;
 import org.catrobat.catroid.content.bricks.SetLookBrick;
@@ -210,6 +211,188 @@ public class UtilsTest extends AndroidTestCase {
 			fail("Tried to load project which should not be loadable.");
 		}
 		TestUtils.removeFromPreferences(getContext(), Constants.PREF_PROJECTNAME_KEY);
+	}
+
+	public void testExtractRemixUrlsOfProgramHeaderUrlFieldContainingSingleAbsoluteUrl() {
+		final String expectedFirstProgramRemixUrl = "https://share.catrob.at/pocketcode/program/16267";
+		final String remixUrlsString = expectedFirstProgramRemixUrl;
+
+		List<String> result = Utils.extractRemixUrlsFromString(remixUrlsString);
+		assertEquals("Invalid number of remix URLs extracted", 1, result.size());
+		assertEquals("Failed to extract remix URL", expectedFirstProgramRemixUrl, result.get(0));
+	}
+
+	public void testExtractRemixUrlsOfProgramHeaderUrlFieldContainingSingleRelativeUrl() {
+		final String expectedFirstProgramRemixUrl = "/pocketcode/program/3570";
+		final String remixUrlsString = expectedFirstProgramRemixUrl;
+
+		List<String> result = Utils.extractRemixUrlsFromString(remixUrlsString);
+		assertEquals("Invalid number of remix URLs extracted", 1, result.size());
+		assertEquals("Failed to extract remix URL", expectedFirstProgramRemixUrl, result.get(0));
+	}
+
+	public void testExtractRemixUrlsOfMergedProgramHeaderUrlFieldContainingTwoAbsoluteUrls() {
+		final String expectedFirstProgramRemixUrl = "https://share.catrob.at/pocketcode/program/16267";
+		final String expectedSecondProgramRemixUrl = "https://scratch.mit.edu/projects/110380057/";
+
+		final XmlHeader headerOfFirstProgram = new XmlHeader();
+		headerOfFirstProgram.setProgramName("Catrobat program");
+		headerOfFirstProgram.setRemixParentsUrlString(expectedFirstProgramRemixUrl);
+
+		final XmlHeader headerOfSecondProgram = new XmlHeader();
+		headerOfSecondProgram.setProgramName("Scratch program");
+		headerOfSecondProgram.setRemixParentsUrlString(expectedSecondProgramRemixUrl);
+
+		final String remixUrlsString = Utils.generateRemixUrlsStringForMergedProgram(headerOfFirstProgram,
+				headerOfSecondProgram);
+		List<String> result = Utils.extractRemixUrlsFromString(remixUrlsString);
+		assertEquals("Invalid number of remix URLs extracted", 2, result.size());
+		assertEquals("Failed to extract URL of first program", expectedFirstProgramRemixUrl, result.get(0));
+		assertEquals("Failed to extract URL of second program", expectedSecondProgramRemixUrl, result.get(1));
+	}
+
+	public void testExtractRemixUrlsOfMergedProgramHeaderUrlFieldContainingTwoRelativeUrls() {
+		final String expectedFirstProgramRemixUrl = "/pocketcode/program/16267";
+		final String expectedSecondProgramRemixUrl = "/pocketcode/program/3570";
+
+		final XmlHeader headerOfFirstProgram = new XmlHeader();
+		headerOfFirstProgram.setProgramName("Program A");
+		headerOfFirstProgram.setRemixParentsUrlString(expectedFirstProgramRemixUrl);
+
+		final XmlHeader headerOfSecondProgram = new XmlHeader();
+		headerOfSecondProgram.setProgramName("Program B");
+		headerOfSecondProgram.setRemixParentsUrlString(expectedSecondProgramRemixUrl);
+
+		final String remixUrlsString = Utils.generateRemixUrlsStringForMergedProgram(headerOfFirstProgram,
+				headerOfSecondProgram);
+
+		List<String> result = Utils.extractRemixUrlsFromString(remixUrlsString);
+		assertEquals("Invalid number of remix URLs extracted", 2, result.size());
+		assertEquals("Failed to extract URL of first program", expectedFirstProgramRemixUrl, result.get(0));
+		assertEquals("Failed to extract URL of second program", expectedSecondProgramRemixUrl, result.get(1));
+	}
+
+	public void testExtractRemixUrlsOfMergedProgramHeaderUrlFieldContainingNoUrls() {
+		final XmlHeader headerOfFirstProgram = new XmlHeader();
+		headerOfFirstProgram.setProgramName("Program A");
+
+		final XmlHeader headerOfSecondProgram = new XmlHeader();
+		headerOfSecondProgram.setProgramName("Program B");
+
+		final String remixUrlsString = Utils.generateRemixUrlsStringForMergedProgram(headerOfFirstProgram,
+				headerOfSecondProgram);
+
+		List<String> result = Utils.extractRemixUrlsFromString(remixUrlsString);
+		assertEquals("Invalid number of remix URLs extracted", 0, result.size());
+	}
+
+	public void testExtractRemixUrlsOfMergedProgramHeaderUrlFieldContainingMultipleMixedUrls() {
+		final String expectedFirstProgramRemixUrl = "https://scratch.mit.edu/projects/117697631/";
+		final String expectedSecondProgramRemixUrl = "/pocketcode/program/3570";
+
+		final XmlHeader headerOfFirstProgram = new XmlHeader();
+		headerOfFirstProgram.setProgramName("My Scratch program");
+		headerOfFirstProgram.setRemixParentsUrlString(expectedFirstProgramRemixUrl);
+
+		final XmlHeader headerOfSecondProgram = new XmlHeader();
+		headerOfSecondProgram.setProgramName("The Periodic Table");
+		headerOfSecondProgram.setRemixParentsUrlString(expectedSecondProgramRemixUrl);
+
+		final String remixUrlsString = Utils.generateRemixUrlsStringForMergedProgram(headerOfFirstProgram,
+				headerOfSecondProgram);
+
+		List<String> result = Utils.extractRemixUrlsFromString(remixUrlsString);
+		assertEquals("Invalid number of remix URLs extracted", 2, result.size());
+		assertEquals("Failed to extract URL of first program", expectedFirstProgramRemixUrl, result.get(0));
+		assertEquals("Failed to extract URL of second program", expectedSecondProgramRemixUrl, result.get(1));
+	}
+
+	public void testExtractRemixUrlsOfRemergedProgramHeaderUrlFieldContainingMixedUrls() {
+		final String expectedFirstProgramRemixUrl = "https://scratch.mit.edu/projects/117697631/";
+		final String expectedSecondProgramRemixUrl = "/pocketcode/program/3570";
+		final String expectedThirdProgramRemixUrl = "https://scratch.mit.edu/projects/121648946/";
+		final String expectedFourthProgramRemixUrl = "https://share.catrob.at/pocketcode/program/16267";
+
+		final XmlHeader headerOfFirstProgram = new XmlHeader();
+		headerOfFirstProgram.setProgramName("My first Scratch program");
+		headerOfFirstProgram.setRemixParentsUrlString(expectedFirstProgramRemixUrl);
+
+		final XmlHeader headerOfSecondProgram = new XmlHeader();
+		headerOfSecondProgram.setProgramName("The Periodic Table");
+		headerOfSecondProgram.setRemixParentsUrlString(expectedSecondProgramRemixUrl);
+
+		final String firstMergedRemixUrlsString = Utils.generateRemixUrlsStringForMergedProgram(headerOfFirstProgram,
+				headerOfSecondProgram);
+
+		final XmlHeader headerOfFirstMergedProgram = new XmlHeader();
+		headerOfFirstMergedProgram.setProgramName("First merged Catrobat program");
+		headerOfFirstMergedProgram.setRemixParentsUrlString(firstMergedRemixUrlsString);
+
+		final XmlHeader headerOfThirdProgram = new XmlHeader();
+		headerOfThirdProgram.setProgramName("My second Scratch program");
+		headerOfThirdProgram.setRemixParentsUrlString(expectedThirdProgramRemixUrl);
+
+		final String secondMergedRemixUrlsString = Utils.generateRemixUrlsStringForMergedProgram(headerOfFirstMergedProgram,
+				headerOfThirdProgram);
+
+		final XmlHeader headerOfSecondMergedProgram = new XmlHeader();
+		headerOfSecondMergedProgram.setProgramName("Second merged Catrobat program");
+		headerOfSecondMergedProgram.setRemixParentsUrlString(secondMergedRemixUrlsString);
+
+		final XmlHeader headerOfFourthProgram = new XmlHeader();
+		headerOfFourthProgram.setProgramName("My third Catrobat program");
+		headerOfFourthProgram.setRemixParentsUrlString(expectedFourthProgramRemixUrl);
+
+		final String finalMergedRemixUrlsString = Utils.generateRemixUrlsStringForMergedProgram(headerOfSecondMergedProgram,
+				headerOfFourthProgram);
+
+		List<String> result = Utils.extractRemixUrlsFromString(finalMergedRemixUrlsString);
+		assertEquals("Invalid number of remix URLs extracted", 4, result.size());
+		assertEquals("Failed to extract URL of first program", expectedFirstProgramRemixUrl, result.get(0));
+		assertEquals("Failed to extract URL of second program", expectedSecondProgramRemixUrl, result.get(1));
+		assertEquals("Failed to extract URL of third program", expectedThirdProgramRemixUrl, result.get(2));
+		assertEquals("Failed to extract URL of fourth program", expectedFourthProgramRemixUrl, result.get(3));
+	}
+
+	public void testExtractRemixUrlsOfRemergedProgramHeaderUrlFieldContainingMissingUrls() {
+		final String expectedSecondProgramRemixUrl = "/pocketcode/program/3570";
+		final String expectedFourthProgramRemixUrl = "https://share.catrob.at/pocketcode/program/16267";
+
+		final XmlHeader headerOfFirstProgram = new XmlHeader();
+		headerOfFirstProgram.setProgramName("Program A");
+
+		final XmlHeader headerOfSecondProgram = new XmlHeader();
+		headerOfSecondProgram.setProgramName("Program B");
+		headerOfSecondProgram.setRemixParentsUrlString(expectedSecondProgramRemixUrl);
+
+		final String firstMergedRemixUrlsString = Utils.generateRemixUrlsStringForMergedProgram(headerOfFirstProgram,
+				headerOfSecondProgram);
+
+		final XmlHeader headerOfFirstMergedProgram = new XmlHeader();
+		headerOfFirstMergedProgram.setProgramName("First merged program");
+		headerOfFirstMergedProgram.setRemixParentsUrlString(firstMergedRemixUrlsString);
+
+		final XmlHeader headerOfThirdProgram = new XmlHeader();
+		headerOfThirdProgram.setProgramName("Program C");
+
+		final String secondMergedRemixUrlsString = Utils.generateRemixUrlsStringForMergedProgram(headerOfFirstMergedProgram,
+				headerOfThirdProgram);
+
+		final XmlHeader headerOfSecondMergedProgram = new XmlHeader();
+		headerOfSecondMergedProgram.setProgramName("Second merged program");
+		headerOfSecondMergedProgram.setRemixParentsUrlString(secondMergedRemixUrlsString);
+
+		final XmlHeader headerOfFourthProgram = new XmlHeader();
+		headerOfFourthProgram.setProgramName("Program D");
+		headerOfFourthProgram.setRemixParentsUrlString(expectedFourthProgramRemixUrl);
+
+		final String finalMergedRemixUrlsString = Utils.generateRemixUrlsStringForMergedProgram(headerOfSecondMergedProgram,
+				headerOfFourthProgram);
+
+		List<String> result = Utils.extractRemixUrlsFromString(finalMergedRemixUrlsString);
+		assertEquals("Invalid number of remix URLs extracted", 2, result.size());
+		assertEquals("Failed to extract remix URL of second program", expectedSecondProgramRemixUrl, result.get(0));
+		assertEquals("Failed to extract remix URL of fourth program", expectedFourthProgramRemixUrl, result.get(1));
 	}
 
 	private void addSpriteAndCompareToStandardProject() {

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -44,6 +44,12 @@ public final class Constants {
 	public static final String CATROBAT_EXTENSION = ".catrobat";
 	public static final String IMAGE_STANDARD_EXTENSION = ".png";
 	public static final String SOUND_STANDARD_EXTENSION = ".wav";
+	public static final char REMIX_URL_PREFIX_INDICATOR = '[';
+	public static final char REMIX_URL_SUFIX_INDICATOR = ']';
+	public static final char REMIX_URL_SEPARATOR = ',';
+	public static final char REMIX_URL_PREFIX_REPLACE_INDICATOR = '(';
+	public static final char REMIX_URL_SUFIX_REPLACE_INDICATOR = ')';
+	public static final char REMIX_URL_REPLACE_SEPARATOR = ';';
 
 	//Extensions:
 	public static final String[] IMAGE_EXTENSIONS = { ".png", ".jpg", ".jpeg", ".png", ".gif" };

--- a/catroid/src/main/java/org/catrobat/catroid/content/XmlHeader.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/XmlHeader.java
@@ -50,28 +50,58 @@ public class XmlHeader implements Serializable {
 	@SuppressWarnings("unused")
 	public boolean scenesEnabled = true;
 
-	// fields only used on the catrobat.org website so far
+	//==============================================================================================
+	// mutable fields only used by Catroweb (share.catrob.at website) so far
+	//==============================================================================================
 	private String applicationBuildName = "";
 	private int applicationBuildNumber = 0;
 	private String applicationName = "";
 	private String applicationVersion = "";
-	@SuppressWarnings("unused")
-	private String dateTimeUpload = "";
 	private String deviceName = "";
-	@SuppressWarnings("unused")
-	private String mediaLicense = "";
 	private String platform = "";
 	private double platformVersion = 0;
 	@SuppressWarnings("unused")
-	private String programLicense = "";
-	@SuppressWarnings("unused")
-	private String remixOf = "";
-	@SuppressWarnings("unused")
 	private String tags = "";
+	//----------------------------------------------------------------------------------------------
+
+	//==============================================================================================
+	// immutable (i.e. read-only) fields only used and updated by Catroweb during upload
+	//==============================================================================================
+	//
+	// ***  CATROBAT REMIX SPECIFICATION REQUIREMENT ***
+	//
+	//  Keep in mind that the remixGrandparentsUrlString-field (respectively remixOf-XML-field)
+	//  (see below) is used by Catroweb's web application "share.catrob.at" only.
+	//  Once new Catrobat programs get uploaded, Catroweb automatically updates this XML-field
+	//  and sets the program as being remixed!
+	//  In order to do so, Catroweb takes the value from the url-XML-field (see above) and assigns
+	//  it to this XML-field.
+	//
+	//  With that said, the only correct way to set a new remix-URL (e.g. when two programs get
+	//  merged locally) is to assign it to the remixParentsUrlString-field.
+	//
+	//  How to deal with re-merged programs?
+	//    If you plan to merge a program A with another (already) merged program B, you have to put
+	//    the url of A's parent and all urls of B's parents together into one single string
+	//    and assign it to the remixParentsUrlString-field.
+	//    The same process is repeated for successive re-merges...
+	//    For more details, please have a look at the generateRemixUrlsStringForMergedProgram()
+	//    method in Utils.java
+	//
 	@SuppressWarnings("unused")
-	private String url = "";
+	@XStreamAlias("remixOf")
+	private String remixGrandparentsUrlString = "";
+	@XStreamAlias("url")
+	private String remixParentsUrlString = "";
 	@SuppressWarnings("unused")
 	private String userHandle = "";
+	@SuppressWarnings("unused")
+	private String dateTimeUpload = "";
+	@SuppressWarnings("unused")
+	private String mediaLicense = "";
+	@SuppressWarnings("unused")
+	private String programLicense = "";
+	//----------------------------------------------------------------------------------------------
 
 	public XmlHeader() {
 	}
@@ -90,14 +120,6 @@ public class XmlHeader implements Serializable {
 
 	public void setVirtualScreenWidth(int width) {
 		virtualScreenWidth = width;
-	}
-
-	public String getRemixOf() {
-		return remixOf;
-	}
-
-	public void setRemixOf(String remixOf) {
-		this.remixOf = remixOf;
 	}
 
 	public String getProgramName() {
@@ -204,7 +226,11 @@ public class XmlHeader implements Serializable {
 		this.tags = TextUtils.join(",", tags);
 	}
 
-	public String getUrl() {
-		return this.url;
+	public String getRemixParentsUrlString() {
+		return this.remixParentsUrlString;
+	}
+
+	public void setRemixParentsUrlString(String remixParentsUrlString) {
+		this.remixParentsUrlString = remixParentsUrlString;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/merge/MergeTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/merge/MergeTask.java
@@ -261,16 +261,7 @@ public class MergeTask {
 		mergeHeader.setVirtualScreenWidth(mainHeader.virtualScreenWidth);
 		mergeHeader.setVirtualScreenHeight(mainHeader.virtualScreenHeight);
 
-		String name = mainHeader.getProgramName();
-		if (!mainHeader.getRemixOf().equals("")) {
-			name += "[" + mainHeader.getRemixOf() + "]";
-		}
-
-		name += ", " + subHeader.getProgramName();
-		if (!subHeader.getRemixOf().equals("")) {
-			name += "[" + subHeader.getRemixOf() + "]";
-		}
-		mergeHeader.setRemixOf(name);
+		mergeHeader.setRemixParentsUrlString(Utils.generateRemixUrlsStringForMergedProgram(mainHeader, subHeader));
 		mergedProject.setXmlHeader(mergeHeader);
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/MarketingActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/MarketingActivity.java
@@ -44,9 +44,14 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.ScreenValues;
 import org.catrobat.catroid.utils.ToastUtil;
+import org.catrobat.catroid.utils.Utils;
+
+import java.util.List;
 
 @SuppressLint("SetJavaScriptEnabled")
 public class MarketingActivity extends Activity {
+
+	private static final String TAG = MarketingActivity.class.getSimpleName();
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -83,11 +88,23 @@ public class MarketingActivity extends Activity {
 		website.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				String url = ProjectManager.getInstance().getCurrentProject().getXmlHeader().getUrl();
-				if (!url.trim().startsWith("http")) {
-					url = Constants.MAIN_URL_HTTPS + url;
+				String urlsString = ProjectManager.getInstance().getCurrentProject().getXmlHeader().getRemixParentsUrlString();
+				if (urlsString == null || urlsString.length() == 0) {
+					Log.w(TAG, "Header of program contains not even one valid detail url!");
+					return;
 				}
-				Log.d("MarketingActivity", "Program detail url: " + url);
+
+				List<String> extractedUrls = Utils.extractRemixUrlsFromString(urlsString);
+				if (extractedUrls.size() == 0) {
+					Log.w(TAG, "Header of program contains not even one valid detail url!");
+					return;
+				}
+
+				String url = extractedUrls.get(0);
+				if (!urlsString.trim().startsWith("http")) {
+					url = Constants.MAIN_URL_HTTPS + urlsString;
+				}
+				Log.d(TAG, "Program detail url: " + url);
 				startWebViewActivity(url);
 			}
 		});

--- a/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
@@ -65,6 +65,7 @@ import org.catrobat.catroid.common.SoundInfo;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.XmlHeader;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.exceptions.ProjectException;
 import org.catrobat.catroid.io.StorageHandler;
@@ -98,6 +99,10 @@ import java.util.Locale;
 public final class Utils {
 
 	private static final String TAG = Utils.class.getSimpleName();
+
+	private enum RemixUrlParsingState {
+		STARTING, TOKEN, BETWEEN
+	}
 
 	public static final int TRANSLATION_PLURAL_OTHER_INTEGER = 767676;
 
@@ -209,6 +214,92 @@ public final class Utils {
 		} catch (IOException e) {
 			return null;
 		}
+	}
+
+	public static String generateRemixUrlsStringForMergedProgram(XmlHeader headerOfFirstProgram, XmlHeader headerOfSecondProgram) {
+		String escapedFirstProgramName = headerOfFirstProgram.getProgramName();
+		escapedFirstProgramName = escapedFirstProgramName.replace(Constants.REMIX_URL_PREFIX_INDICATOR,
+				Constants.REMIX_URL_PREFIX_REPLACE_INDICATOR);
+		escapedFirstProgramName = escapedFirstProgramName.replace(Constants.REMIX_URL_SUFIX_INDICATOR,
+				Constants.REMIX_URL_SUFIX_REPLACE_INDICATOR);
+		escapedFirstProgramName = escapedFirstProgramName.replace(Constants.REMIX_URL_SEPARATOR,
+				Constants.REMIX_URL_REPLACE_SEPARATOR);
+
+		String escapedSecondProgramName = headerOfSecondProgram.getProgramName();
+		escapedSecondProgramName = escapedSecondProgramName.replace(Constants.REMIX_URL_PREFIX_INDICATOR,
+				Constants.REMIX_URL_PREFIX_REPLACE_INDICATOR);
+		escapedSecondProgramName = escapedSecondProgramName.replace(Constants.REMIX_URL_SUFIX_INDICATOR,
+				Constants.REMIX_URL_SUFIX_REPLACE_INDICATOR);
+		escapedSecondProgramName = escapedSecondProgramName.replace(Constants.REMIX_URL_SEPARATOR,
+				Constants.REMIX_URL_REPLACE_SEPARATOR);
+
+		StringBuilder remixUrlString = new StringBuilder(escapedFirstProgramName);
+
+		if (!headerOfFirstProgram.getRemixParentsUrlString().equals("")) {
+			remixUrlString
+					.append(' ')
+					.append(Constants.REMIX_URL_PREFIX_INDICATOR)
+					.append(headerOfFirstProgram.getRemixParentsUrlString())
+					.append(Constants.REMIX_URL_SUFIX_INDICATOR);
+		}
+
+		remixUrlString
+				.append(Constants.REMIX_URL_SEPARATOR)
+				.append(' ')
+				.append(escapedSecondProgramName);
+
+		if (!headerOfSecondProgram.getRemixParentsUrlString().equals("")) {
+			remixUrlString
+					.append(' ')
+					.append(Constants.REMIX_URL_PREFIX_INDICATOR)
+					.append(headerOfSecondProgram.getRemixParentsUrlString())
+					.append(Constants.REMIX_URL_SUFIX_INDICATOR);
+		}
+
+		return remixUrlString.toString();
+	}
+
+	// based on: http://stackoverflow.com/a/27295688
+	public static List<String> extractRemixUrlsFromString(String text) {
+		RemixUrlParsingState state = RemixUrlParsingState.STARTING;
+		ArrayList<String> extractedUrls = new ArrayList<>();
+		StringBuffer temp = new StringBuffer("");
+
+		for (int index = 0; index < text.length(); index++) {
+			char currentCharacter = text.charAt(index);
+			switch (currentCharacter) {
+				case Constants.REMIX_URL_PREFIX_INDICATOR:
+					if (state == RemixUrlParsingState.STARTING) {
+						state = RemixUrlParsingState.BETWEEN;
+					} else if (state == RemixUrlParsingState.TOKEN) {
+						temp.delete(0, temp.length());
+						state = RemixUrlParsingState.BETWEEN;
+					}
+					break;
+
+				case Constants.REMIX_URL_SUFIX_INDICATOR:
+					if (state == RemixUrlParsingState.TOKEN) {
+						String extractedUrl = temp.toString().trim();
+						if (!extractedUrl.contains(String.valueOf(Constants.REMIX_URL_SEPARATOR))
+								&& extractedUrl.length() > 0) {
+							extractedUrls.add(extractedUrl);
+						}
+						temp.delete(0, temp.length());
+						state = RemixUrlParsingState.BETWEEN;
+					}
+					break;
+
+				default:
+					state = RemixUrlParsingState.TOKEN;
+					temp.append(currentCharacter);
+			}
+		}
+
+		if (extractedUrls.size() == 0 && !text.contains(String.valueOf(Constants.REMIX_URL_SEPARATOR))) {
+			extractedUrls.add(text);
+		}
+
+		return extractedUrls;
 	}
 
 	public static Date getScratchSecondReleasePublishedDate() {

--- a/catroid/src/main/res/layout/fragment_scratch_search_projects_list.xml
+++ b/catroid/src/main/res/layout/fragment_scratch_search_projects_list.xml
@@ -49,8 +49,7 @@
     android:queryHint="@string/search_hint"
     android:iconifiedByDefault="false"
     android:focusable="true"
-    android:focusableInTouchMode="true"
-    android:privateImeOptions="nm" />
+    android:focusableInTouchMode="true" />
 
 <ImageButton
     android:id="@+id/mic_button_image_scratch"


### PR DESCRIPTION
For a detailed description about the issue, please see the following URL: https://jira.catrob.at/browse/CAT-2149
