### PR TITLE
CAT-1384 HOTFIX cloned object look: copy all properties 

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -138,6 +138,25 @@ public class Look extends Image {
 		cloneLook.whenParallelAction = null;
 		cloneLook.allActionsAreFinished = this.allActionsAreFinished;
 
+		cloneLook.setPositionInUserInterfaceDimensionUnit(this.getXInUserInterfaceDimensionUnit(),
+				this.getYInUserInterfaceDimensionUnit());
+		cloneLook.setTransparencyInUserInterfaceDimensionUnit(this.getTransparencyInUserInterfaceDimensionUnit());
+		cloneLook.setColorInUserInterfaceDimensionUnit(this.getColorInUserInterfaceDimensionUnit());
+
+		int rotationMode = this.getRotationMode();
+		cloneLook.setRotationMode(rotationMode);
+		if (rotationMode != Look.ROTATION_STYLE_LEFT_RIGHT_ONLY && this.isFlipped()) {
+			cloneLook.getLookData().getTextureRegion().flip(true, false);
+			cloneLook.setFlipped(false);
+		}
+		boolean orientedLeft = this.getDirectionInUserInterfaceDimensionUnit() < 0;
+		if (rotationMode == Look.ROTATION_STYLE_LEFT_RIGHT_ONLY && orientedLeft) {
+			cloneLook.getLookData().getTextureRegion().flip(true, false);
+			cloneLook.setFlipped(true);
+		}
+		cloneLook.setDirectionInUserInterfaceDimensionUnit(this.getDirectionInUserInterfaceDimensionUnit());
+		cloneLook.setBrightnessInUserInterfaceDimensionUnit(this.getBrightnessInUserInterfaceDimensionUnit());
+
 		return cloneLook;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -251,7 +251,7 @@ public class StageListener implements ApplicationListener {
 
 	public void cloneSpriteAndAddToStage(Sprite cloneMe) {
 		Sprite copy = cloneMe.cloneForCloneBrick();
-		copy.resetSprite();
+		//copy.resetSprite(); // can I safely remove this?
 		copy.look.createBrightnessContrastHueShader();
 		stage.addActor(copy.look);
 		copy.resume();


### PR DESCRIPTION
Previously a cloned object always appeared at the origin of the coordinate
system. Now the position is copied as well.
Also copied: transparancy, rotation, color
Last minute request by @wslany for more scratch compatibility in clone brick

Edit: this seems to be an old ticket: [CAT-1384](https://jira.catrob.at/browse/CAT-1384)