### PR TITLE
HOTFIX clone looks with physics bricks

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -359,10 +359,11 @@ public class Sprite implements Serializable, Cloneable {
 		Sprite originalSprite = ProjectManager.getInstance().getCurrentSprite();
 		ProjectManager.getInstance().setCurrentSprite(cloneSprite);
 
-		cloneLooks(cloneSprite);
 		cloneUserBricks(cloneSprite);
 		cloneSpriteVariables(ProjectManager.getInstance().getCurrentScene(), cloneSprite);
 		cloneScripts(cloneSprite);
+		cloneSprite.resetSprite();
+		cloneLooks(cloneSprite);
 		setUserAndVariableBrickReferences(cloneSprite, userBricks);
 
 		ProjectManager.getInstance().setCurrentSprite(originalSprite);

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -251,7 +251,6 @@ public class StageListener implements ApplicationListener {
 
 	public void cloneSpriteAndAddToStage(Sprite cloneMe) {
 		Sprite copy = cloneMe.cloneForCloneBrick();
-		//copy.resetSprite(); // can I safely remove this?
 		copy.look.createBrightnessContrastHueShader();
 		stage.addActor(copy.look);
 		copy.resume();


### PR DESCRIPTION
after a Sprite is cloned (using the clone brick), it is necessary to reset the sprite because it might contain Physics-bricks. This creates a PhysicsLook instead of a Look (otherwise Pocket Code would crash). The look properties have to be copied *after* the instantiation of the look.

After this PR, please also merge #1980 

suggested by @robertpainsi in #1972 