### PR TITLE
Set look data when cloning

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -492,8 +492,9 @@ public class Sprite implements Serializable, Cloneable {
 	}
 
 	private void cloneLook(Sprite cloneSprite) {
-		if (cloneSprite.getLookDataList().size() > 0) {
-			cloneSprite.look.setLookData(cloneSprite.getLookDataList().get(0));
+		int currentLookDataIndex = this.lookList.indexOf(this.look.getLookData());
+		if (currentLookDataIndex != -1) {
+			cloneSprite.look.setLookData(cloneSprite.lookList.get(currentLookDataIndex));
 		}
 		cloneSprite.look = this.look.copyLookForSprite(cloneSprite);
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -492,10 +492,10 @@ public class Sprite implements Serializable, Cloneable {
 	}
 
 	private void cloneLook(Sprite cloneSprite) {
-		cloneSprite.look = this.look.copyLookForSprite(cloneSprite);
 		if (cloneSprite.getLookDataList().size() > 0) {
 			cloneSprite.look.setLookData(cloneSprite.getLookDataList().get(0));
 		}
+		cloneSprite.look = this.look.copyLookForSprite(cloneSprite);
 	}
 
 	private void cloneLooks(Sprite cloneSprite) {


### PR DESCRIPTION
This Pull Requests builds on https://github.com/Catrobat/Catroid/pull/1973 and is just a info that it should be merged before the next release. After https://github.com/Catrobat/Catroid/pull/1973 has been merged, I'll rebase and update the changes accordingly. I'll add a comment when everything is ready and also will remove this text.

###
When cloning a Sprite in the Stage or IDE [1], all current values of the
Sprite should be copied as well. This commit only addresses the current
LookData because it will fix a NullPointerException.

`E/BaseExceptionHandler: unhandled exception
  java.lang.NullPointerException: Attempt to invoke virtual method 'com.badlogic.gdx.graphics.g2d.TextureRegion org.catrobat.catroid.common.LookData.getTextureRegion()' on a null object reference
    at org.catrobat.catroid.content.Look.copyLookForSprite(`[Look.java:154](https://github.com/Catrobat/Catroid/blob/4de61c5d6e17c447abfbe18e5f76ac9377830e67/catroid/src/main/java/org/catrobat/catroid/content/Look.java#L154)`)`

[1] https://jira.catrob.at/browse/CAT-1384