### PR TITLE
Fix scene escaping

### DIFF
--- a/catroid/src/main/res/values-es/strings.xml
+++ b/catroid/src/main/res/values-es/strings.xml
@@ -727,7 +727,7 @@
   <string name="brick_replace_item_in_userlist_with_value">con</string>
   <!-- defaultValues -->
   <string name="default_project_name">Mi primer programa</string>
-  <string name="default_scene_name">Escena \"%1$d\"</string>
+  <string name="default_scene_name">Escena %1$d</string>
   <string name="default_project_background_name">Fondo</string>
   <string name="default_project_cloud_name">Nubes</string>
   <string name="default_project_cloud_sprite_name_1">Nubes1</string>


### PR DESCRIPTION
Scene names get escaped with \" in translation. This shouldn't happen and is only translated like that in Spanish.