### PR TITLE
CAT-FIX Fix LookData reference in Bricks for clones

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -337,6 +337,8 @@ public class Sprite implements Serializable, Cloneable {
 		cloneUserBricks(cloneSprite);
 		cloneNfcTags(cloneSprite);
 		cloneScripts(cloneSprite);
+		cloneSprite.resetSprite();
+		cloneLook(cloneSprite);
 
 		setUserAndVariableBrickReferences(cloneSprite, userBricks);
 
@@ -359,11 +361,12 @@ public class Sprite implements Serializable, Cloneable {
 		Sprite originalSprite = ProjectManager.getInstance().getCurrentSprite();
 		ProjectManager.getInstance().setCurrentSprite(cloneSprite);
 
+		cloneLooks(cloneSprite);
 		cloneUserBricks(cloneSprite);
 		cloneSpriteVariables(ProjectManager.getInstance().getCurrentScene(), cloneSprite);
 		cloneScripts(cloneSprite);
 		cloneSprite.resetSprite();
-		cloneLooks(cloneSprite);
+		cloneLook(cloneSprite);
 		setUserAndVariableBrickReferences(cloneSprite, userBricks);
 
 		ProjectManager.getInstance().setCurrentSprite(originalSprite);
@@ -488,17 +491,19 @@ public class Sprite implements Serializable, Cloneable {
 		}
 	}
 
+	private void cloneLook(Sprite cloneSprite) {
+		cloneSprite.look = this.look.copyLookForSprite(cloneSprite);
+		if (cloneSprite.getLookDataList().size() > 0) {
+			cloneSprite.look.setLookData(cloneSprite.getLookDataList().get(0));
+		}
+	}
+
 	private void cloneLooks(Sprite cloneSprite) {
 		List<LookData> cloneLookList = new ArrayList<>();
 		for (LookData element : this.lookList) {
 			cloneLookList.add(element.clone());
 		}
 		cloneSprite.lookList = cloneLookList;
-
-		cloneSprite.look = this.look.copyLookForSprite(cloneSprite);
-		if (cloneSprite.getLookDataList().size() > 0) {
-			cloneSprite.look.setLookData(cloneSprite.getLookDataList().get(0));
-		}
 	}
 
 	private void cloneSounds(Sprite cloneSprite) {


### PR DESCRIPTION
It is important that the LookDatas are cloned before the Bricks are
cloned. Otherwise the SetLookBrick LookData would refer to an origin
LookData instead of a cloned one.

It is also important that the Look is created and cloned after the
Bricks are cloned. Otherwise always a Look instance is created instead
of a Look or PhysicsLook.

To fix this problem, first, the LookDatas are cloned, then the Bricks,
then the Look.

https://github.com/Catrobat/Catroid/pull/1973#issuecomment-256002440