### PR TITLE
CAT-2087 fix for crash related to TRUE and FALSE in conditional brick

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
@@ -715,35 +715,28 @@ public class InternFormula {
 	private CursorTokenPropertiesAfterModification setCursorPositionAndSelectionAfterInput(int insertedInternTokenIndex) {
 		InternToken insertedInternToken = internTokenFormulaList.get(insertedInternTokenIndex);
 
-		switch (insertedInternToken.getInternTokenType()) {
-			case FUNCTION_NAME:
-				List<InternToken> functionInternTokenList = InternFormulaUtils.getFunctionByName(
-						internTokenFormulaList, insertedInternTokenIndex);
+		if (insertedInternToken.getInternTokenType() == InternTokenType.FUNCTION_NAME) {
+			List<InternToken> functionInternTokenList = InternFormulaUtils.getFunctionByName(
+					internTokenFormulaList, insertedInternTokenIndex);
 
-				if (functionInternTokenList.size() < 4) {
-					cursorPositionInternTokenIndex = insertedInternTokenIndex + functionInternTokenList.size() - 1;
-					cursorPositionInternToken = null;
-					return CursorTokenPropertiesAfterModification.RIGHT;
-				}
-
+			if (functionInternTokenList.size() >= 4) {
 				List<List<InternToken>> functionParameters = InternFormulaUtils
 						.getFunctionParameterInternTokensAsLists(functionInternTokenList);
-
 				List<InternToken> functionFirstParameter = functionParameters.get(0);
 
+				cursorPositionInternTokenIndex = internFormulaTokenSelection.getEndIndex();
 				internFormulaTokenSelection = new InternFormulaTokenSelection(TokenSelectionType.USER_SELECTION,
 						insertedInternTokenIndex + 2, insertedInternTokenIndex + functionFirstParameter.size() + 1);
-
-				cursorPositionInternTokenIndex = internFormulaTokenSelection.getEndIndex();
-				cursorPositionInternToken = null;
-				return CursorTokenPropertiesAfterModification.RIGHT;
-
-			default:
-				cursorPositionInternTokenIndex = insertedInternTokenIndex;
-				cursorPositionInternToken = null;
+			} else {
+				cursorPositionInternTokenIndex = insertedInternTokenIndex + functionInternTokenList.size() - 1;
 				internFormulaTokenSelection = null;
-				return CursorTokenPropertiesAfterModification.RIGHT;
+			}
+		} else {
+			cursorPositionInternTokenIndex = insertedInternTokenIndex;
+			internFormulaTokenSelection = null;
 		}
+		cursorPositionInternToken = null;
+		return CursorTokenPropertiesAfterModification.RIGHT;
 	}
 
 	private CursorTokenPropertiesAfterModification replaceCursorPositionInternTokenByTokenList(


### PR DESCRIPTION
`internFormulaTokenSelection = null` wasn't executed where needed, so FormulaEditor still thought something is highlighted although it wasn't. Added this line and refactored `setCursorPositionAndSelectionAfterInput` to make it a little bit more slim and understandable.
