### PR TITLE
CAT-FIX Don't serialize spinner values of StopScriptBrick

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/StopScriptBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/StopScriptBrick.java
@@ -42,15 +42,12 @@ public class StopScriptBrick extends BrickBaseType {
 
 	private static final long serialVersionUID = 1L;
 
-	private String[] spinnerValue;
 	private int spinnerSelection;
 
 	public StopScriptBrick() {
-		this.spinnerValue = new String[3];
 	}
 
 	public StopScriptBrick(int spinnerSelection) {
-		this.spinnerValue = new String[3];
 		this.spinnerSelection = spinnerSelection;
 	}
 
@@ -110,6 +107,7 @@ public class StopScriptBrick extends BrickBaseType {
 	}
 
 	private ArrayAdapter<String> createArrayAdapter(Context context) {
+		String[] spinnerValue = new String[3];
 		spinnerValue[BrickValues.STOP_THIS_SCRIPT] = context.getString(R.string.brick_stop_this_script);
 		spinnerValue[BrickValues.STOP_ALL_SCRIPTS] = context.getString(R.string.brick_stop_all_scripts);
 		spinnerValue[BrickValues.STOP_OTHER_SCRIPTS] = context.getString(R.string.brick_stop_other_scripts);

--- a/catroid/src/main/java/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/StorageHandler.java
@@ -311,6 +311,8 @@ public final class StorageHandler {
 		xstream.registerConverter(new XStreamSpriteConverter(xstream.getMapper(), xstream.getReflectionProvider()));
 		xstream.registerConverter(new XStreamSettingConverter(xstream.getMapper(), xstream.getReflectionProvider()));
 
+		xstream.omitField(StopScriptBrick.class, "spinnerValue");
+
 		setProgramXstreamAliases();
 	}
 


### PR DESCRIPTION
The language version also has to be increased in the next release, I guess.

Old XML

``` xml
<brick type="StopScriptBrick">
  <commentedOut>false</commentedOut>
  <spinnerSelection>1</spinnerSelection>
  <spinnerValue>
    <string>Stop this script</string>
    <string>Stop all scripts</string>
    <string>Stop other scripts of this object</string>
  </spinnerValue>
</brick>
```

New XML

``` xml
<brick type="StopScriptBrick">
  <commentedOut>false</commentedOut>
  <spinnerSelection>1</spinnerSelection>
</brick>
```
