### PR TITLE
CAT-FIX Fix wrong scene reference

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
@@ -287,7 +287,7 @@ public class Formula implements Serializable {
 				return "ERROR";
 			}
 		} else if (formulaTree.isUserVariableWithTypeString(sprite)) {
-			DataContainer userVariables = ProjectManager.getInstance().getCurrentScene().getDataContainer();
+			DataContainer userVariables = ProjectManager.getInstance().getSceneToPlay().getDataContainer();
 			UserVariable userVariable = userVariables.getUserVariable(formulaTree.getValue(), sprite);
 			return (String) userVariable.getValue();
 		} else {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -283,8 +283,8 @@ public class FormulaElement implements Serializable {
 		Look firstLook;
 		Look secondLook;
 		try {
-			firstLook = ProjectManager.getInstance().getCurrentScene().getSpriteBySpriteName(firstSpriteName).look;
-			secondLook = ProjectManager.getInstance().getCurrentScene().getSpriteBySpriteName(secondSpriteName).look;
+			firstLook = ProjectManager.getInstance().getSceneToPlay().getSpriteBySpriteName(firstSpriteName).look;
+			secondLook = ProjectManager.getInstance().getSceneToPlay().getSpriteBySpriteName(secondSpriteName).look;
 		} catch (Resources.NotFoundException exception) {
 			return 0d;
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
@@ -287,7 +287,7 @@ public class InternFormulaParser {
 		boolean formulaOk;
 		int spriteCount = 0;
 
-		for (Sprite sprite : ProjectManager.getInstance().getCurrentScene().getSpriteList()) {
+		for (Sprite sprite : ProjectManager.getInstance().getSceneToPlay().getSpriteList()) {
 			if (sprite.getName().compareTo(firstSpriteName) == 0 || sprite.getName().compareTo(secondSpriteName) == 0) {
 				spriteCount++;
 			}


### PR DESCRIPTION
sceneToPlay always has to be used in Formulars because this member
represents the currently playing Scene in the Stage.