### PR TITLE
CAT-FIX Set sceneToPlay to currentScene when leaving the Stage

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageActivity.java
@@ -383,6 +383,7 @@ public class StageActivity extends AndroidApplication {
 		CameraManager.getInstance().stopPreviewAsync();
 		CameraManager.getInstance().releaseCamera();
 		CameraManager.getInstance().setToDefaultCamera();
+		ProjectManager.getInstance().setSceneToPlay(ProjectManager.getInstance().getCurrentScene());
 		super.onDestroy();
 	}
 


### PR DESCRIPTION
Formulas are evaluated using the sceneToPlay. When in the IDE, the
sceneToPlay always has to be the currentScene so Formulas in the formula
editor are evaluated correctely. During the Stage, the sceneToPlay may
be set to a scene different from the currentScene in the IDE. So, when
leaving the Stage, the sceneToPlay has to be reset to the currentScene.