### PR TITLE
CAT-FIX release config

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -70,7 +70,6 @@ android {
             buildConfigField "boolean", "FEATURE_PHIRO_ENABLED", "true"
             buildConfigField "boolean", "FEATURE_PARROT_AR_DRONE_ENABLED", "false"
             buildConfigField "boolean", "FEATURE_SCRATCH_CONVERTER_ENABLED", "true"
-            buildConfigField "boolean", "FEATURE_ACCESSIBILITY_SETTINGS_ENABLED", "false"
             buildConfigField "boolean", "FEATURE_USERBRICKS_ENABLED", "false"
             buildConfigField "boolean", "FEATURE_ARDUINO_ENABLED", "true"
             buildConfigField "boolean", "FEATURE_RASPI_ENABLED", "true"


### PR DESCRIPTION
The FEATURE_ACCESSIBILITY_SETTINGS_ENABLED flag needs to be removed from the release config.

As from the documentation (http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Building-and-Tasks) values get overridden in the order:
1. assembleCreateatschoolDebug (flavor + build type)
2. assembleDebug / assembleRelease (build type)
3. assembleCreateatschool (flavor)

That's why we have to remove the flag from the release config = 3 (it overwrites the flavor config = 2).