### PR TITLE
CAT-REF Remove paused member from Script and Sprite

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/GlideToActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/GlideToActionTest.java
@@ -95,29 +95,6 @@ public class GlideToActionTest extends AndroidTestCase {
 				sprite.look.getYInUserInterfaceDimensionUnit());
 	}
 
-	public void testPauseResume() throws InterruptedException {
-		assertEquals("Unexpected initial sprite x position", 0f, sprite.look.getXInUserInterfaceDimensionUnit());
-		assertEquals("Unexpected initial sprite y position", 0f, sprite.look.getYInUserInterfaceDimensionUnit());
-		sprite.look.setWidth(100.0f);
-		sprite.look.setHeight(50.0f);
-
-		Action action = sprite.getActionFactory().createGlideToAction(sprite, xPosition, yPosition, duration);
-		long currentTimeDelta = System.currentTimeMillis();
-		do {
-			currentTimeDelta = System.currentTimeMillis() - currentTimeDelta;
-			if (currentTimeDelta > 400) {
-				sprite.pause();
-				Thread.sleep(200);
-				sprite.resume();
-			}
-		} while (!action.act(currentTimeDelta));
-
-		assertEquals("Incorrect sprite x position after GlideToBrick executed", X_POSITION,
-				sprite.look.getXInUserInterfaceDimensionUnit());
-		assertEquals("Incorrect sprite y position after GlideToBrick executed", Y_POSITION,
-				sprite.look.getYInUserInterfaceDimensionUnit());
-	}
-
 	public void testBrickWithStringFormula() {
 		Action action = sprite.getActionFactory().createGlideToAction(sprite, new Formula(String.valueOf(Y_POSITION)),
 				new Formula(String.valueOf(DURATION)), new Formula(String.valueOf(X_POSITION)));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/WaitActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/WaitActionTest.java
@@ -25,8 +25,6 @@ package org.catrobat.catroid.test.content.actions;
 import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.content.ActionFactory;
-import org.catrobat.catroid.content.SingleSprite;
-import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.WaitAction;
 import org.catrobat.catroid.formulaeditor.Formula;
 
@@ -42,26 +40,6 @@ public class WaitActionTest extends AndroidTestCase {
 		long currentTimeInMilliSeconds = System.currentTimeMillis();
 		do {
 			currentTimeInMilliSeconds = System.currentTimeMillis() - currentTimeInMilliSeconds;
-		} while (!action.act(currentTimeInMilliSeconds / 1000f));
-
-		assertTrue("Unexpected waited time!", (action.getTime() - waitOneSecond) > 0.5f);
-	}
-
-	public void testPauseResume() throws InterruptedException {
-		Sprite testSprite = new SingleSprite("testSprite");
-		float waitOneSecond = 1.0f;
-
-		ActionFactory factory = testSprite.getActionFactory();
-		WaitAction action = (WaitAction) factory.createDelayAction(testSprite, new Formula(waitOneSecond));
-		testSprite.look.addAction(action);
-		long currentTimeInMilliSeconds = System.currentTimeMillis();
-		do {
-			currentTimeInMilliSeconds = System.currentTimeMillis() - currentTimeInMilliSeconds;
-			if (currentTimeInMilliSeconds > 400) {
-				testSprite.pause();
-				Thread.sleep(200);
-				testSprite.resume();
-			}
 		} while (!action.act(currentTimeInMilliSeconds / 1000f));
 
 		assertTrue("Unexpected waited time!", (action.getTime() - waitOneSecond) > 0.5f);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/project/ProjectManagerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/project/ProjectManagerTest.java
@@ -237,7 +237,6 @@ public class ProjectManagerTest extends InstrumentationTestCase {
 		testScript.addBrick(comeToFrontBrick);
 
 		otherScript.addBrick(placeAtBrick);
-		otherScript.setPaused(true);
 
 		firstSprite.addScript(testScript);
 		secondSprite.addScript(otherScript);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/SpriteTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/SpriteTest.java
@@ -36,8 +36,6 @@ import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.ChangeBrightnessByNBrick;
 import org.catrobat.catroid.content.bricks.ChangeXByNBrick;
-import org.catrobat.catroid.content.bricks.HideBrick;
-import org.catrobat.catroid.content.bricks.ShowBrick;
 import org.catrobat.catroid.content.bricks.UserBrick;
 import org.catrobat.catroid.content.bricks.UserScriptDefinitionBrick;
 import org.catrobat.catroid.content.bricks.UserScriptDefinitionBrickElement;
@@ -48,7 +46,6 @@ import org.catrobat.catroid.formulaeditor.InterpretationException;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.test.utils.TestUtils;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -141,37 +138,6 @@ public class SpriteTest extends AndroidTestCase {
 		sprite.addScript(secondScript);
 		assertEquals("Indexes do not match", 0, sprite.getScriptIndex(firstScript));
 		assertEquals("Indexes do not match", 1, sprite.getScriptIndex(secondScript));
-	}
-
-	public void testPauseResume() throws InterruptedException {
-		Sprite testSprite = new SingleSprite("testSprite");
-		Script testScript = new StartScript();
-		HideBrick hideBrick = new HideBrick();
-		ShowBrick showBrick = new ShowBrick();
-
-		for (int i = 0; i < 10000; i++) {
-			testScript.addBrick(hideBrick);
-			testScript.addBrick(showBrick);
-		}
-
-		testSprite.addScript(testScript);
-
-		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
-
-		testSprite.look.act(1.0f);
-
-		testSprite.pause();
-		assertTrue("Sprite isn't paused", testSprite.isPaused);
-		assertTrue("Script isn't paused", testScript.isPaused());
-
-		testSprite.resume();
-
-		assertFalse("Sprite is paused", testSprite.isPaused);
-		assertFalse("Script is paused", testScript.isPaused());
-
-		while (!testSprite.look.getAllActionsAreFinished()) {
-			testSprite.look.act(1.0f);
-		}
 	}
 
 	public void testSpriteCloneWithLocalVariable() {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/StartScriptTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/StartScriptTest.java
@@ -30,15 +30,13 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.HideBrick;
 import org.catrobat.catroid.content.bricks.SetSizeToBrick;
-import org.catrobat.catroid.content.bricks.ShowBrick;
-import org.catrobat.catroid.content.bricks.WaitBrick;
 
 import java.util.HashMap;
 import java.util.List;
 
-public class StartResumeSpriteTest extends AndroidTestCase {
+public class StartScriptTest extends AndroidTestCase {
 
-	public void testStartThreads() throws InterruptedException {
+	public void testStartScript() throws InterruptedException {
 		double size = 300;
 		Sprite testSprite = new SingleSprite("testSprite");
 		Script testScript = new StartScript();
@@ -58,38 +56,5 @@ public class StartResumeSpriteTest extends AndroidTestCase {
 		assertFalse("Look is not hidden", testSprite.look.isLookVisible());
 		assertEquals("the size is not as expected", (float) size / 100, testSprite.look.getScaleX());
 		assertEquals("the size is not as expected", (float) size / 100, testSprite.look.getScaleY());
-	}
-
-	public void testResumeThreads() throws InterruptedException {
-		Sprite testSprite = new SingleSprite("testSprite");
-		Script testScript = new StartScript();
-		HideBrick hideBrick = new HideBrick();
-		WaitBrick waitBrick = new WaitBrick(500);
-		ShowBrick showBrick = new ShowBrick();
-
-		testScript.addBrick(hideBrick);
-		testScript.addBrick(waitBrick);
-		testScript.addBrick(showBrick);
-		testSprite.addScript(testScript);
-
-		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
-
-		testSprite.look.act(1.0f);
-		testSprite.look.act(1.0f);
-
-		testSprite.pause();
-		assertFalse("Look is not hidden", testSprite.look.isLookVisible());
-		testSprite.resume();
-
-		testSprite.look.act(1.0f);
-		testSprite.look.act(1.0f);
-
-		assertTrue("Look is hidden", testSprite.look.isLookVisible());
-
-		testScript.getBrickList().clear();
-		testScript.addBrick(hideBrick);
-		testSprite.createStartScriptActionSequenceAndPutToMap(new HashMap<String, List<String>>());
-
-		assertTrue("Look is hidden - this script shall not be execute", testSprite.look.isLookVisible());
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/io/StorageHandlerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/io/StorageHandlerTest.java
@@ -136,7 +136,6 @@ public class StorageHandlerTest extends InstrumentationTestCase {
 		testScript.addBrick(comeToFrontBrick);
 
 		otherScript.addBrick(placeAtBrick);
-		otherScript.setPaused(true);
 
 		firstSprite.addScript(testScript);
 		secondSprite.addScript(otherScript);
@@ -189,8 +188,6 @@ public class StorageHandlerTest extends InstrumentationTestCase {
 		assertEquals("YPosition was not deserialized right", yPosition,
 				interpretFormula(actualYPosition, null).intValue());
 
-		assertFalse("paused should not be set in script", preSpriteList.get(1).getScript(0).isPaused());
-
 		// Test version codes and names
 		//		final int preVersionCode = (Integer) TestUtils.getPrivateField("catroidVersionCode", project, false);
 		//		final int postVersionCode = (Integer) TestUtils.getPrivateField("catroidVersionCode", loadedProject, false);
@@ -225,7 +222,6 @@ public class StorageHandlerTest extends InstrumentationTestCase {
 		testScript.addBrick(comeToFrontBrick);
 
 		otherScript.addBrick(placeAtBrick);
-		otherScript.setPaused(true);
 
 		firstSprite.addScript(testScript);
 		secondSprite.addScript(otherScript);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/stage/PauseResumeInStageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/stage/PauseResumeInStageTest.java
@@ -1,0 +1,92 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uitest.stage;
+
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
+import com.robotium.solo.Condition;
+
+import org.catrobat.catroid.common.ScreenValues;
+import org.catrobat.catroid.stage.StageActivity;
+import org.catrobat.catroid.ui.MainMenuActivity;
+import org.catrobat.catroid.uitest.util.BaseActivityInstrumentationTestCase;
+import org.catrobat.catroid.uitest.util.UiTestUtils;
+
+public class PauseResumeInStageTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
+
+	public PauseResumeInStageTest() {
+		super(MainMenuActivity.class);
+	}
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		UiTestUtils.prepareStageForTest();
+		UiTestUtils.getIntoStageFromMainMenu(solo);
+		waitForStage();
+	}
+
+	public void testIgnoreTouchEventsWhenStagePaused() {
+		InputListenerMock touchListener = new InputListenerMock();
+		StageActivity.stageListener.getStage().addListener(touchListener);
+
+		assertFalse("Already clicked on the stage", touchListener.called);
+
+		clickOnStage();
+
+		assertTrue("Touch event not fired", touchListener.called);
+
+		UiTestUtils.pauseStage(solo);
+		touchListener.called = false;
+
+		assertFalse("Already clicked on the stage", touchListener.called);
+
+		clickOnStage();
+
+		assertFalse("Touch events shouldn't be fired when stage is paused", touchListener.called);
+	}
+
+	private void waitForStage() {
+		solo.waitForCondition(new Condition() {
+			@Override
+			public boolean isSatisfied() {
+				return StageActivity.stageListener != null && StageActivity.stageListener.getStage() != null;
+			}
+		}, 2000);
+	}
+
+	private void clickOnStage() {
+		solo.clickOnScreen(ScreenValues.SCREEN_WIDTH / 2f, ScreenValues.SCREEN_HEIGHT / 2f);
+		solo.sleep(500);
+	}
+
+	private static class InputListenerMock extends InputListener {
+		public boolean called;
+
+		@Override
+		public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+			called = true;
+			return super.touchDown(event, x, y, pointer, button);
+		}
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/activity/MainMenuActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/activity/MainMenuActivityTest.java
@@ -421,7 +421,6 @@ public class MainMenuActivityTest extends BaseActivityInstrumentationTestCase<Ma
 		testScript.addBrick(comeToFrontBrick);
 
 		otherScript.addBrick(placeAtBrick); // secondSprite
-		otherScript.setPaused(true);
 		// -------------------------------
 
 		firstSprite.addScript(testScript);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -141,6 +141,7 @@ import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.physics.content.bricks.SetMassBrick;
+import org.catrobat.catroid.stage.StageActivity;
 import org.catrobat.catroid.stage.StageListener;
 import org.catrobat.catroid.test.utils.Reflection;
 import org.catrobat.catroid.ui.MainMenuActivity;
@@ -2042,6 +2043,12 @@ public final class UiTestUtils {
 		solo.clickOnActionBarHomeButton();
 	}
 
+	public static void getIntoStageFromMainMenu(Solo solo) {
+		getIntoScenesFromMainMenu(solo);
+		clickOnPlayButton(solo);
+		solo.waitForActivity(StageActivity.class);
+	}
+
 	public static void getIntoSpritesFromMainMenu(Solo solo) {
 		getIntoSpritesFromMainMenu(solo, null);
 	}
@@ -2737,5 +2744,10 @@ public final class UiTestUtils {
 		UiTestUtils.clickOnBrickCategory(solo, solo.getCurrentActivity().getString(R.string.category_user_bricks));
 		solo.waitForActivity(UserBrickScriptActivity.class);
 		solo.waitForFragmentByTag(ScriptFragment.TAG);
+	}
+
+	public static void pauseStage(Solo solo) {
+		solo.goBack();
+		solo.waitForView(R.id.stage_dialog_menu);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -161,9 +161,6 @@ public class Look extends Image {
 	}
 
 	public boolean doTouchDown(float x, float y, int pointer) {
-		if (sprite.isPaused) {
-			return true;
-		}
 		if (!isLookVisible()) {
 			return false;
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/content/Script.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Script.java
@@ -50,11 +50,8 @@ public abstract class Script implements Serializable {
 
 	protected boolean commentedOut = false;
 
-	private transient volatile boolean paused;
-
 	public Script() {
 		brickList = new ArrayList<>();
-		init();
 	}
 
 	public abstract Script copyScriptForSprite(Sprite copySprite);
@@ -80,15 +77,10 @@ public abstract class Script implements Serializable {
 	}
 
 	protected Object readResolve() {
-		init();
 		return this;
 	}
 
 	public abstract ScriptBrick getScriptBrick();
-
-	private void init() {
-		paused = false;
-	}
 
 	public void run(Sprite sprite, SequenceAction sequence) {
 		if (this.isCommentedOut()) {
@@ -160,14 +152,6 @@ public abstract class Script implements Serializable {
 
 	public ArrayList<Brick> getBrickList() {
 		return brickList;
-	}
-
-	public void setPaused(boolean paused) {
-		this.paused = paused;
-	}
-
-	public boolean isPaused() {
-		return paused;
 	}
 
 	public int getRequiredResources() {

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -80,7 +80,6 @@ public class Sprite implements Serializable, Cloneable {
 	private static SpriteFactory spriteFactory = new SpriteFactory();
 
 	public transient Look look = new Look(this);
-	public transient boolean isPaused;
 	public transient boolean isBackpackObject = false;
 	public transient PenConfiguration penConfiguration = new PenConfiguration();
 	private transient boolean convertToSingleSprite = false;
@@ -386,7 +385,6 @@ public class Sprite implements Serializable, Cloneable {
 		cloneSprite.isBackpackObject = false;
 		cloneSprite.convertToSingleSprite = false;
 		cloneSprite.convertToGroupItemSprite = false;
-		cloneSprite.isPaused = false;
 		cloneSprite.isMobile = this.isMobile;
 
 		cloneSprite.look = this.look;
@@ -632,20 +630,6 @@ public class Sprite implements Serializable, Cloneable {
 			}
 		}
 		look.addAction(whenParallelAction);
-	}
-
-	public void pause() {
-		for (Script s : scriptList) {
-			s.setPaused(true);
-		}
-		this.isPaused = true;
-	}
-
-	public void resume() {
-		for (Script s : scriptList) {
-			s.setPaused(false);
-		}
-		this.isPaused = false;
 	}
 
 	public String getName() {

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -225,7 +225,6 @@ public class StageListener implements ApplicationListener {
 				stage.addActor(penActor);
 				addPenActor = false;
 			}
-			sprite.resume();
 		}
 		passepartout = new Passepartout(ScreenValues.SCREEN_WIDTH, ScreenValues.SCREEN_HEIGHT, maximizeViewPortWidth,
 				maximizeViewPortHeight, virtualWidth, virtualHeight);
@@ -253,7 +252,6 @@ public class StageListener implements ApplicationListener {
 		Sprite copy = cloneMe.cloneForCloneBrick();
 		copy.look.createBrightnessContrastHueShader();
 		stage.addActor(copy.look);
-		copy.resume();
 		sprites.add(copy);
 		clonedSprites.add(copy);
 
@@ -278,7 +276,6 @@ public class StageListener implements ApplicationListener {
 
 		BroadcastHandler.getScriptSpriteMap().remove(sprite);
 
-		sprite.pause();
 		sprite.look.setLookVisible(false);
 		sprite.look.remove();
 		sprites.remove(sprite);
@@ -328,9 +325,6 @@ public class StageListener implements ApplicationListener {
 		paused = false;
 		FaceDetectionHandler.resumeFaceDetection();
 		SoundManager.getInstance().resume();
-		for (Sprite sprite : sprites) {
-			sprite.resume();
-		}
 	}
 
 	void menuPause() {
@@ -341,9 +335,6 @@ public class StageListener implements ApplicationListener {
 		try {
 			paused = true;
 			SoundManager.getInstance().pause();
-			for (Sprite sprite : sprites) {
-				sprite.pause();
-			}
 		} catch (Exception exception) {
 			Log.e(TAG, "Pausing menu failed!", exception);
 		}
@@ -413,9 +404,6 @@ public class StageListener implements ApplicationListener {
 		if (!paused) {
 			FaceDetectionHandler.resumeFaceDetection();
 			SoundManager.getInstance().resume();
-			for (Sprite sprite : sprites) {
-				sprite.resume();
-			}
 		}
 
 		for (Sprite sprite : sprites) {
@@ -431,9 +419,6 @@ public class StageListener implements ApplicationListener {
 		if (!paused) {
 			FaceDetectionHandler.pauseFaceDetection();
 			SoundManager.getInstance().pause();
-			for (Sprite sprite : sprites) {
-				sprite.pause();
-			}
 		}
 	}
 
@@ -457,9 +442,6 @@ public class StageListener implements ApplicationListener {
 		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		if (reloadProject) {
 			int spriteSize = sprites.size();
-			for (int i = 0; i < spriteSize; i++) {
-				sprites.get(i).pause();
-			}
 			stage.clear();
 			SoundManager.getInstance().clear();
 
@@ -479,7 +461,6 @@ public class StageListener implements ApplicationListener {
 					stage.addActor(penActor);
 					addPenActor = false;
 				}
-				sprite.pause();
 			}
 			stage.addActor(passepartout);
 			initStageInputListener();


### PR DESCRIPTION
The paused member was used in the old implementation when we handled the
action execution by threads. A long time ago we switched to libGDX
actions. So there is no need for the member anymore.

The only case where the member is used, is in Look.doTouchDown [1].
However, when pausing the stage, a grey overlay covers the whole stage.
All touch events are captured by this overlay and no stage touch events
are fired.

It's important that no touch events are fired when the stage is paused
for Sprites and TouchUtil.

[1] [Look.java#L164-L166](https://github.com/Catrobat/Catroid/blob/2ce3242fda5f8c020757a9e31fd6d78f111822c5/catroid/src/main/java/org/catrobat/catroid/content/Look.java#L164-L166)

###end-of-commit-message###

Do not ask me what all the pause tests did because the pause/resume logic in the Script and Sprite did nothing.