### PR TITLE
CAT-1384 Copy all Look/PhysicsLook/PhysicsObject values when cloning

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/LookTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/LookTest.java
@@ -418,4 +418,36 @@ public class LookTest extends InstrumentationTestCase {
 		assertTrue("Look not touched", look.doTouchDown(0, 0, 0));
 		assertFalse("Look touched on alpha shouldn't trigger touch down", look.doTouchDown(1, 0, 0));
 	}
+
+	public void testCloneValues() {
+		Look origin = new Look(null);
+		origin.setSizeInUserInterfaceDimensionUnit(12);
+		origin.setPositionInUserInterfaceDimensionUnit(4, 12);
+		origin.setColorInUserInterfaceDimensionUnit(42);
+		origin.setTransparencyInUserInterfaceDimensionUnit(7);
+		origin.setRotationMode(Look.ROTATION_STYLE_LEFT_RIGHT_ONLY);
+		origin.setBrightnessInUserInterfaceDimensionUnit(3);
+		origin.setDirectionInUserInterfaceDimensionUnit(8);
+		origin.setLookVisible(false);
+
+		Look clone = new Look(null);
+		origin.copyTo(clone);
+
+		assertEquals("Size differs", origin.getSizeInUserInterfaceDimensionUnit(),
+				clone.getSizeInUserInterfaceDimensionUnit());
+		assertEquals("X position differs", origin.getXInUserInterfaceDimensionUnit(),
+				clone.getXInUserInterfaceDimensionUnit());
+		assertEquals("Y position differs", origin.getYInUserInterfaceDimensionUnit(),
+				clone.getYInUserInterfaceDimensionUnit());
+		assertEquals("Color differs", origin.getColorInUserInterfaceDimensionUnit(),
+				clone.getColorInUserInterfaceDimensionUnit());
+		assertEquals("Transparency differs", origin.getTransparencyInUserInterfaceDimensionUnit(), clone
+				.getTransparencyInUserInterfaceDimensionUnit());
+		assertEquals("Rotation mode differs", origin.getRotationMode(), clone.getRotationMode());
+		assertEquals("Brightness differs", origin.getBrightnessInUserInterfaceDimensionUnit(),
+				clone.getBrightnessInUserInterfaceDimensionUnit());
+		assertEquals("Direction differs", origin.getDirectionInUserInterfaceDimensionUnit(),
+				clone.getDirectionInUserInterfaceDimensionUnit());
+		assertEquals("Visibility differs", origin.isLookVisible(), clone.isLookVisible());
+	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsLookTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsLookTest.java
@@ -363,4 +363,28 @@ public class PhysicsLookTest extends InstrumentationTestCase {
 						+ look.getBrightnessInUserInterfaceDimensionUnit() + ".",
 				physicsLook.getBrightnessInUserInterfaceDimensionUnit(), look.getBrightnessInUserInterfaceDimensionUnit());
 	}
+
+	public void testCloneValues() {
+		PhysicsWorld world = new PhysicsWorld();
+
+		Sprite originSprite = new Sprite("Origin");
+		PhysicsLook originLook = new PhysicsLook(originSprite, world);
+		PhysicsObject originPhysicsObject = world.getPhysicsObject(originSprite);
+
+		Sprite cloneSprite = new Sprite("Clone");
+		PhysicsLook cloneLook = new PhysicsLook(cloneSprite, world);
+		PhysicsObject clonePhysicsObject = world.getPhysicsObject(cloneSprite);
+
+		originLook.setXInUserInterfaceDimensionUnit(10);
+		originLook.setBrightnessInUserInterfaceDimensionUnit(32);
+		originPhysicsObject.setMass(10);
+
+		originLook.copyTo(cloneLook);
+
+		assertEquals("X position differs", originLook.getXInUserInterfaceDimensionUnit(),
+				cloneLook.getXInUserInterfaceDimensionUnit());
+		assertEquals("Brightness differs", originLook.getBrightnessInUserInterfaceDimensionUnit(),
+				cloneLook.getBrightnessInUserInterfaceDimensionUnit());
+		assertEquals("Mass differs", originPhysicsObject.getMass(), clonePhysicsObject.getMass());
+	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsObjectTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsObjectTest.java
@@ -537,4 +537,28 @@ public class PhysicsObjectTest extends AndroidTestCase {
 			}
 		}
 	}
+
+	public void testCloneValues() {
+		PhysicsObject origin = PhysicsTestUtils.createPhysicsObject(physicsWorld);
+		origin.setBounceFactor(1);
+		origin.setFriction(2);
+		origin.setMass(3);
+		origin.setRotationSpeed(4);
+		origin.setType(PhysicsObject.Type.FIXED);
+		origin.setVelocity(5, 6);
+		origin.setPosition(7, 8);
+		origin.setDirection(9);
+
+		PhysicsObject clone = PhysicsTestUtils.createPhysicsObject(physicsWorld);
+		origin.copyTo(clone);
+
+		assertEquals("Bounce factor differs", origin.getBounceFactor(), clone.getBounceFactor());
+		assertEquals("Friction differs", origin.getFriction(), clone.getFriction());
+		assertEquals("Mass differs", origin.getMass(), clone.getMass());
+		assertEquals("Rotation speed differs", origin.getRotationSpeed(), clone.getRotationSpeed());
+		assertEquals("Type differs", origin.getType(), clone.getType());
+		assertEquals("Velocity differs", origin.getVelocity(), clone.getVelocity());
+		assertEquals("Position differs", origin.getPosition(), clone.getPosition());
+		assertEquals("Direction differs", origin.getDirection(), clone.getDirection());
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -129,26 +129,17 @@ public class Look extends Image {
 		Look.actionsToRestart.add(action);
 	}
 
-	public Look copyLookForSprite(final Sprite cloneSprite) {
-		Look cloneLook = cloneSprite.look;
-
-		cloneLook.alpha = this.alpha;
-		cloneLook.brightness = this.brightness;
-		cloneLook.setLookVisible(isLookVisible());
-		cloneLook.whenParallelAction = null;
-		cloneLook.allActionsAreFinished = this.allActionsAreFinished;
-
-		cloneLook.setPositionInUserInterfaceDimensionUnit(this.getXInUserInterfaceDimensionUnit(),
+	public void copyTo(final Look destination) {
+		destination.setLookVisible(this.isLookVisible());
+		destination.setPositionInUserInterfaceDimensionUnit(this.getXInUserInterfaceDimensionUnit(),
 				this.getYInUserInterfaceDimensionUnit());
-		cloneLook.setTransparencyInUserInterfaceDimensionUnit(this.getTransparencyInUserInterfaceDimensionUnit());
-		cloneLook.setColorInUserInterfaceDimensionUnit(this.getColorInUserInterfaceDimensionUnit());
+		destination.setSizeInUserInterfaceDimensionUnit(this.getSizeInUserInterfaceDimensionUnit());
+		destination.setTransparencyInUserInterfaceDimensionUnit(this.getTransparencyInUserInterfaceDimensionUnit());
+		destination.setColorInUserInterfaceDimensionUnit(this.getColorInUserInterfaceDimensionUnit());
 
-		int rotationMode = this.getRotationMode();
-		cloneLook.setRotationMode(rotationMode);
-		cloneLook.setDirectionInUserInterfaceDimensionUnit(this.getDirectionInUserInterfaceDimensionUnit());
-		cloneLook.setBrightnessInUserInterfaceDimensionUnit(this.getBrightnessInUserInterfaceDimensionUnit());
-
-		return cloneLook;
+		destination.setRotationMode(this.getRotationMode());
+		destination.setDirectionInUserInterfaceDimensionUnit(this.getDirectionInUserInterfaceDimensionUnit());
+		destination.setBrightnessInUserInterfaceDimensionUnit(this.getBrightnessInUserInterfaceDimensionUnit());
 	}
 
 	public boolean doTouchDown(float x, float y, int pointer) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -494,7 +494,7 @@ public class Sprite implements Serializable, Cloneable {
 		if (currentLookDataIndex != -1) {
 			cloneSprite.look.setLookData(cloneSprite.lookList.get(currentLookDataIndex));
 		}
-		cloneSprite.look = this.look.copyLookForSprite(cloneSprite);
+		this.look.copyTo(cloneSprite.look);
 	}
 
 	private void cloneLooks(Sprite cloneSprite) {

--- a/catroid/src/main/java/org/catrobat/catroid/physics/PhysicsLook.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/PhysicsLook.java
@@ -45,6 +45,14 @@ public class PhysicsLook extends Look {
 	}
 
 	@Override
+	public void copyTo(final Look destination) {
+		super.copyTo(destination);
+		if (destination instanceof PhysicsLook) {
+			this.physicsObject.copyTo(((PhysicsLook) destination).physicsObject);
+		}
+	}
+
+	@Override
 	public void setTransparencyInUserInterfaceDimensionUnit(float percent) {
 		super.setTransparencyInUserInterfaceDimensionUnit(percent);
 		updatePhysicsObjectState(true);

--- a/catroid/src/main/java/org/catrobat/catroid/physics/PhysicsObject.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/PhysicsObject.java
@@ -88,6 +88,17 @@ public class PhysicsObject {
 		tmpVertice = new Vector2();
 	}
 
+	public void copyTo(PhysicsObject destination) {
+		destination.setType(this.getType());
+		destination.setPosition(this.getPosition());
+		destination.setDirection(this.getDirection());
+		destination.setMass(this.getMass());
+		destination.setRotationSpeed(this.getRotationSpeed());
+		destination.setBounceFactor(this.getBounceFactor());
+		destination.setFriction(this.getFriction());
+		destination.setVelocity(this.getVelocity());
+	}
+
 	public void setShape(Shape[] shapes) {
 		if (Arrays.equals(this.shapes, shapes)) {
 			return;
@@ -218,6 +229,10 @@ public class PhysicsObject {
 	public void setVelocity(float x, float y) {
 		body.setLinearVelocity(PhysicsWorldConverter.convertNormalToBox2dCoordinate(x),
 				PhysicsWorldConverter.convertNormalToBox2dCoordinate(y));
+	}
+
+	public void setVelocity(Vector2 velocity) {
+		setVelocity(velocity.x, velocity.y);
 	}
 
 	public float getMass() {


### PR DESCRIPTION
When cloning a Sprite in the Stage or in the IDE, values like position,
direction, mass, etc have to be copied as well.

* Clone missing value size in Look. All other values are already cloned.
  [1][2]
* Clone all values in PhysicsLook and PhysicsObject

The LookData can't be cloned *in* the Look because each Look has to
refer to its Sprites LookData. It is already correctly cloned in the
Sprite. [2]

[1] https://github.com/Catrobat/Catroid/pull/1972
[2] https://github.com/Catrobat/Catroid/pull/1980
https://jira.catrob.at/browse/CAT-1384

###end-of-commit-message###

Please double-check if all values are copied now.