### PR TITLE
CAT-FIX Fix touch down on flipped look 1 pixel off

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/LookTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/LookTest.java
@@ -24,6 +24,8 @@ package org.catrobat.catroid.test.content.sprite;
 
 import android.test.InstrumentationTestCase;
 
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
 
@@ -36,6 +38,7 @@ import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.test.utils.Reflection;
 import org.catrobat.catroid.test.utils.Reflection.ParameterList;
+import org.catrobat.catroid.test.utils.TestUtils;
 import org.catrobat.catroid.utils.TouchUtil;
 
 public class LookTest extends InstrumentationTestCase {
@@ -384,5 +387,41 @@ public class LookTest extends InstrumentationTestCase {
 		float squareRootOfScalar = (float) Math.sqrt(squareX + squareY);
 
 		assertEquals("Wrong distance to value!", touchPosition, squareRootOfScalar);
+	}
+
+	public void testTouchDownFlipped() {
+		final int width = 1;
+		final int height = 1;
+
+		Look look = new Look(sprite) {
+			{
+				pixmap = TestUtils.createRectanglePixmap(width, height, Color.RED);
+			}
+		};
+		look.setSize(width, height);
+		look.setFlipped(true);
+
+		assertTrue("Flipped look not touched", look.doTouchDown(0, 0, 0));
+	}
+
+	public void testTouchDownFlippedWithAlpha() {
+		final int width = 2;
+		final int height = 1;
+
+		Look look = new Look(sprite) {
+			{
+				pixmap = new Pixmap(width, height, Pixmap.Format.RGBA8888);
+				pixmap.drawPixel(0, 0, Color.RED.toIntBits());
+			}
+		};
+		look.setSize(width, height);
+
+		assertTrue("Look not touched", look.doTouchDown(0, 0, 0));
+		assertFalse("Look touched on alpha shouldn't trigger touch down", look.doTouchDown(1, 0, 0));
+
+		look.setFlipped(true);
+
+		assertTrue("Flipped look not touched", look.doTouchDown(1, 0, 0));
+		assertFalse("Flipped look touched on alpha shouldn't trigger touch down", look.doTouchDown(0, 0, 0));
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/TestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/TestUtils.java
@@ -29,6 +29,9 @@ import android.preference.PreferenceManager;
 import android.util.Log;
 import android.util.SparseArray;
 
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
+
 import junit.framework.Assert;
 
 import org.catrobat.catroid.ProjectManager;
@@ -442,5 +445,12 @@ public final class TestUtils {
 		} catch (InterruptedException e) {
 			Log.e(TAG, e.getMessage());
 		}
+	}
+
+	public static Pixmap createRectanglePixmap(int width, int height, Color color) {
+		Pixmap pixmap = new Pixmap(width, height, Pixmap.Format.RGBA8888);
+		pixmap.setColor(color);
+		pixmap.fillRectangle(0, 0, width, height);
+		return pixmap;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -165,7 +165,7 @@ public class Look extends Image {
 			return false;
 		}
 		if (isFlipped) {
-			x = -x + getWidth();
+			x = (getWidth() - 1) - x;
 		}
 
 		// We use Y-down, libgdx Y-up. This is the fix for accurate y-axis detection


### PR DESCRIPTION
Consider an image with width 1. Since 0 <= x < width, the value x can
only be 0. When the image is flipped, the x value has to be 0 as well.

Old formula: x = -x + width
New formula: x = (width - 1) - x

width = 1, x = 0
Old formula: -0 + 1 = 1 // Out of bounce!
New formula: (1 - 1) - 0 = 0 // Correct!

The valid x values for an image with width 2 are [0, 1].

width = 2, x = 0
Old formula: -0 + 2 = 2 // Out of bounce!
New formula: (2 - 1) - 0 = 1 // Correct!

width = 2, x = 1
Old formula: -1 + 2 = 1
New formula: (2 - 1) - 1 = 0 // Correct!