### PR TITLE
CAT-REF Add parameterized constructor to LookData and SoundInfo

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
@@ -66,6 +66,11 @@ public class LookData implements Serializable, Cloneable {
 	public LookData() {
 	}
 
+	public LookData(String name, String fileName) {
+		setLookName(name);
+		setLookFilename(fileName);
+	}
+
 	public void draw(Batch batch, float alpha) {
 	}
 
@@ -98,10 +103,8 @@ public class LookData implements Serializable, Cloneable {
 
 	@Override
 	public LookData clone() {
-		LookData cloneLookData = new LookData();
+		LookData cloneLookData = new LookData(this.name, this.fileName);
 
-		cloneLookData.name = this.name;
-		cloneLookData.fileName = this.fileName;
 		String filePath = getPathToImageDirectory() + "/" + fileName;
 		cloneLookData.isBackpackLookData = false;
 		try {

--- a/catroid/src/main/java/org/catrobat/catroid/common/SoundInfo.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/SoundInfo.java
@@ -44,6 +44,11 @@ public class SoundInfo implements Serializable, Comparable<SoundInfo>, Cloneable
 	public SoundInfo() {
 	}
 
+	public SoundInfo(String name, String fileName) {
+		setTitle(name);
+		setSoundFileName(fileName);
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (!(obj instanceof SoundInfo)) {
@@ -67,10 +72,7 @@ public class SoundInfo implements Serializable, Comparable<SoundInfo>, Cloneable
 
 	@Override
 	public SoundInfo clone() {
-		SoundInfo cloneSoundInfo = new SoundInfo();
-
-		cloneSoundInfo.name = this.name;
-		cloneSoundInfo.fileName = this.fileName;
+		SoundInfo cloneSoundInfo = new SoundInfo(this.name, this.fileName);
 
 		try {
 			ProjectManager.getInstance().getFileChecksumContainer().incrementUsage(getAbsolutePath());

--- a/catroid/src/main/java/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorDefault.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorDefault.java
@@ -141,32 +141,18 @@ public class DefaultProjectCreatorDefault extends DefaultProjectCreator {
 					projectName, backgroundFile.getName(), birdWingUpFile.getName(), birdWingDownFile.getName(),
 					soundFile1.getName(), soundFile2.getName()));
 
-			LookData backgroundLookData = new LookData();
-			backgroundLookData.setLookName(backgroundName);
-			backgroundLookData.setLookFilename(backgroundFile.getName());
+			LookData backgroundLookData = new LookData(backgroundName, backgroundFile.getName());
 
 			Sprite backgroundSprite = defaultProject.getDefaultScene().getSpriteList().get(0);
 			backgroundSprite.getLookDataList().add(backgroundLookData);
 
-			LookData birdWingUpLookData = new LookData();
-			birdWingUpLookData.setLookName(birdWingUpLookName);
-			birdWingUpLookData.setLookFilename(birdWingUpFile.getName());
+			LookData birdWingUpLookData = new LookData(birdWingUpLookName, birdWingUpFile.getName());
+			LookData birdWingDownLookData = new LookData(birdWingDownLookName, birdWingDownFile.getName());
 
-			LookData birdWingDownLookData = new LookData();
-			birdWingDownLookData.setLookName(birdWingDownLookName);
-			birdWingDownLookData.setLookFilename(birdWingDownFile.getName());
+			LookData cloudLookData = new LookData(cloudName, cloudFile.getName());
 
-			LookData cloudLookData = new LookData();
-			cloudLookData.setLookName(cloudName);
-			cloudLookData.setLookFilename(cloudFile.getName());
-
-			SoundInfo soundInfo1 = new SoundInfo();
-			soundInfo1.setTitle(tweet1);
-			soundInfo1.setSoundFileName(soundFile1.getName());
-
-			SoundInfo soundInfo2 = new SoundInfo();
-			soundInfo2.setTitle(tweet2);
-			soundInfo2.setSoundFileName(soundFile2.getName());
+			SoundInfo soundInfo1 = new SoundInfo(tweet1, soundFile1.getName());
+			SoundInfo soundInfo2 = new SoundInfo(tweet2, soundFile2.getName());
 
 			ProjectManager.getInstance().getFileChecksumContainer().addChecksum(soundInfo1.getChecksum(), soundInfo1.getAbsolutePath());
 			ProjectManager.getInstance().getFileChecksumContainer().addChecksum(soundInfo2.getChecksum(), soundInfo2.getAbsolutePath());

--- a/catroid/src/main/java/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorDrone.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorDrone.java
@@ -257,11 +257,7 @@ public class DefaultProjectCreatorDrone extends DefaultProjectCreator {
 		whenProjectStartsScript.addBrick(setSizeBrick);
 		whenProjectStartsScript.addBrick(turnLeftBrick);
 
-		LookData lookData = new LookData();
-		lookData.setLookName(spriteName + " icon");
-
-		lookData.setLookFilename(lookFile.getName());
-
+		LookData lookData = new LookData(spriteName + " icon", lookFile.getName());
 		sprite.getLookDataList().add(lookData);
 
 		sprite.addScript(whenSpriteTappedScript);

--- a/catroid/src/main/java/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorPhysics.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorPhysics.java
@@ -104,9 +104,7 @@ public class DefaultProjectCreatorPhysics extends DefaultProjectCreator {
 						+ Constants.IMAGE_STANDARD_EXTENSION, R.drawable.physics_background_480_800, context, true,
 				backgroundImageScaleFactor);
 
-		LookData backgroundLookData = new LookData();
-		backgroundLookData.setLookName(backgroundName);
-		backgroundLookData.setLookFilename(backgroundFile.getName());
+		LookData backgroundLookData = new LookData(backgroundName, backgroundFile.getName());
 
 		// Background sprite
 		Sprite backgroundSprite = defaultPhysicsProject.getDefaultScene().getSpriteList().get(0);
@@ -278,10 +276,7 @@ public class DefaultProjectCreatorPhysics extends DefaultProjectCreator {
 		File file = UtilFile.copyImageFromResourceIntoProject(projectName, sceneName, fileName, fileId, context, true,
 				backgroundImageScaleFactor);
 
-		LookData lookData = new LookData();
-		lookData.setLookName(fileName);
-		lookData.setLookFilename(file.getName());
-
+		LookData lookData = new LookData(fileName, file.getName());
 		List<LookData> looks = sprite.getLookDataList();
 		looks.add(lookData);
 
@@ -336,10 +331,7 @@ public class DefaultProjectCreatorPhysics extends DefaultProjectCreator {
 		String filename = "button_pressed";
 		File file = UtilFile.copyImageFromResourceIntoProject(projectName, sceneName, filename, R.drawable
 				.physics_button_pressed, context, true, backgroundImageScaleFactor);
-		LookData lookData = new LookData();
-		lookData.setLookName(filename);
-		lookData.setLookFilename(file.getName());
-
+		LookData lookData = new LookData(filename, file.getName());
 		List<LookData> looks = sprite.getLookDataList();
 		looks.add(lookData);
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
@@ -244,18 +244,16 @@ public final class LookController {
 
 	public LookData updateLookBackPackAfterUnpacking(LookData lookData, LookBaseAdapter adapter, String name, boolean
 			delete, String existingFileNameInProjectDirectory, boolean fromHiddenBackPack) {
-		LookData newLookData = new LookData();
-		newLookData.setLookName(name);
-
+		String fileName;
 		if (existingFileNameInProjectDirectory == null) {
-			String fileName = lookData.getLookFileName();
+			fileName = lookData.getLookFileName();
 			String fileFormat = fileName.substring(fileName.lastIndexOf('.'), fileName.length());
 			fileName = fileName.substring(0, fileName.indexOf('_') + 1) + name + fileFormat;
-			newLookData.setLookFilename(fileName);
 		} else {
-			newLookData.setLookFilename(existingFileNameInProjectDirectory);
+			fileName = existingFileNameInProjectDirectory;
 		}
 
+		LookData newLookData = new LookData(name, fileName);
 		ProjectManager.getInstance().getCurrentSprite().getLookDataList().add(newLookData);
 
 		if (delete) {
@@ -672,24 +670,23 @@ public final class LookController {
 	}
 
 	private LookData updateLookBackPackAfterInsertion(String title, LookData currentLookData, String existingFileNameInBackPackDirectory, boolean addToHiddenBackpack, File backPackedFile) {
-		LookData newLookData = new LookData();
-		newLookData.isBackpackLookData = true;
-		newLookData.setLookName(title);
-
+		String fileName = null;
 		if (existingFileNameInBackPackDirectory == null) {
 			if (currentLookData != null) {
-				String fileName = currentLookData.getLookFileName();
+				fileName = currentLookData.getLookFileName();
 				String hash = backPackedFile == null ? fileName.substring(0, 32) : Utils.md5Checksum(backPackedFile);
 				if (backPackedFile == null) {
 					Log.e(TAG, "backpacked file was null, file hash is possibly wrong");
 				}
 				String fileFormat = fileName.substring(fileName.lastIndexOf('.'), fileName.length());
 				fileName = hash + "_" + title + fileFormat;
-				newLookData.setLookFilename(fileName);
 			}
 		} else {
-			newLookData.setLookFilename(existingFileNameInBackPackDirectory);
+			fileName = existingFileNameInBackPackDirectory;
 		}
+
+		LookData newLookData = new LookData(title, fileName);
+		newLookData.isBackpackLookData = true;
 
 		if (addToHiddenBackpack) {
 			BackPackListManager.getInstance().addLookToHiddenBackPack(newLookData);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/SoundController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/SoundController.java
@@ -476,24 +476,23 @@ public final class SoundController {
 
 	private SoundInfo updateSoundBackPackAfterInsert(String title, SoundInfo currentSoundInfo, String
 			existingFileNameInBackPackDirectory, boolean addToHiddenBackpack, File backPackedFile) {
-		SoundInfo newSoundInfo = new SoundInfo();
-		newSoundInfo.setBackpackSoundInfo(true);
-		newSoundInfo.setTitle(title);
-
+		String fileName = null;
 		if (existingFileNameInBackPackDirectory == null) {
 			if (currentSoundInfo != null) {
-				String fileName = currentSoundInfo.getSoundFileName();
+				fileName = currentSoundInfo.getSoundFileName();
 				String hash = backPackedFile == null ? fileName.substring(0, 32) : Utils.md5Checksum(backPackedFile);
 				if (backPackedFile == null) {
 					Log.e(TAG, "backpacked file was null, file hash is possibly wrong");
 				}
 				String fileFormat = fileName.substring(fileName.lastIndexOf('.'), fileName.length());
 				fileName = hash + "_" + title + fileFormat;
-				newSoundInfo.setSoundFileName(fileName);
 			}
 		} else {
-			newSoundInfo.setSoundFileName(existingFileNameInBackPackDirectory);
+			fileName = existingFileNameInBackPackDirectory;
 		}
+
+		SoundInfo newSoundInfo = new SoundInfo(title, fileName);
+		newSoundInfo.setBackpackSoundInfo(true);
 
 		if (addToHiddenBackpack) {
 			BackPackListManager.getInstance().addSoundToHiddenBackpack(newSoundInfo);
@@ -506,12 +505,10 @@ public final class SoundController {
 
 	private SoundInfo updateSoundAdapter(SoundInfo soundInfo,
 			SoundBaseAdapter adapter, String title, boolean delete, boolean fromHiddenBackPack) {
-		SoundInfo newSoundInfo = new SoundInfo();
-		newSoundInfo.setTitle(title);
 		String fileName = soundInfo.getSoundFileName();
 		String fileFormat = fileName.substring(fileName.lastIndexOf('.'), fileName.length());
 		fileName = fileName.substring(0, fileName.indexOf('_') + 1) + title + fileFormat;
-		newSoundInfo.setSoundFileName(fileName);
+		SoundInfo newSoundInfo = new SoundInfo(title, fileName);
 		ProjectManager.getInstance().getCurrentSprite().getSoundList().add(newSoundInfo);
 
 		if (delete) {
@@ -676,14 +673,10 @@ public final class SoundController {
 
 	public SoundInfo updateSoundAdapter(String name, String fileName, List<SoundInfo> soundList, SoundFragment
 			fragment) {
-		SoundInfo soundInfoToCheck = new SoundInfo();
-		soundInfoToCheck.setSoundFileName(fileName);
-		soundInfoToCheck.setTitle(name);
+		SoundInfo soundInfoToCheck = new SoundInfo(name, fileName);
 		name = Utils.getUniqueSoundName(soundInfoToCheck, false);
 
-		SoundInfo soundInfo = new SoundInfo();
-		soundInfo.setSoundFileName(fileName);
-		soundInfo.setTitle(name);
+		SoundInfo soundInfo = new SoundInfo(name, fileName);
 		soundList.add(soundInfo);
 
 		fragment.updateSoundAdapter(soundInfo);


### PR DESCRIPTION
The name and file name are nearly always set immediately after creating
a LookData or SoundInfo. A parameterized constructor comes in handy to
remove these set calls.