### PR TITLE
CAT-FIX XStream sort by annotation with derived classes

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/io/CatroidFieldKeySorterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/io/CatroidFieldKeySorterTest.java
@@ -197,4 +197,39 @@ public class CatroidFieldKeySorterTest extends AndroidTestCase {
 		private int a;
 		private int b;
 	}
+
+	public void testSortByAnnotationIsInBaseClass() {
+		xstream.toXML(new SubClassWithoutAnnotation());
+
+		MoreAsserts.assertEquals("Sorted fields differ",
+				new String[] { "b", "a" }, fieldKeySorter.getFieldNames(SubClassWithoutAnnotation.class));
+	}
+
+	public void testMissingFieldInSubClassWithoutAnnotationThrowsException() {
+		try {
+			xstream.toXML(new SubClassWithNewMemberButWithoutAnnotation());
+			fail("XStream didn't throw an exception for missing field c in annotation");
+		} catch (XStreamMissingSerializableFieldException expected) {
+		}
+	}
+
+	// Remove checkstyle disable when https://github.com/checkstyle/checkstyle/issues/1349 is fixed
+	// CHECKSTYLE DISABLE IndentationCheck FOR 4 LINES
+	@XStreamFieldKeyOrder({
+			"b",
+			"a"
+	})
+	@SuppressWarnings("PMD.UnusedPrivateField")
+	private static class BaseClassWithAnnotation {
+		private int a;
+		private int b;
+	}
+
+	private static class SubClassWithoutAnnotation extends BaseClassWithAnnotation {
+	}
+
+	@SuppressWarnings("PMD.UnusedPrivateField")
+	private static class SubClassWithNewMemberButWithoutAnnotation extends BaseClassWithAnnotation {
+		private int c;
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/io/CatroidFieldKeySorter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/CatroidFieldKeySorter.java
@@ -28,6 +28,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.converters.reflection.FieldKey;
 import com.thoughtworks.xstream.converters.reflection.FieldKeySorter;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -42,13 +43,26 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 
 	@Override
 	public Map sort(final Class type, final Map keyedByFieldKey) {
-		XStreamFieldKeyOrder fieldKeyOrderAnnotation = (XStreamFieldKeyOrder) type.getAnnotation(XStreamFieldKeyOrder.class);
+		XStreamFieldKeyOrder fieldKeyOrderAnnotation = findAnnotationInClassHierarchy(type, XStreamFieldKeyOrder.class);
 		if (fieldKeyOrderAnnotation != null) {
 			List<String> fieldOrder = Arrays.asList(fieldKeyOrderAnnotation.value());
 			return sortByList(fieldOrder, keyedByFieldKey);
 		} else {
 			return sortAlphabeticallyByClassHierarchy(keyedByFieldKey);
 		}
+	}
+
+	private <E extends Annotation> E findAnnotationInClassHierarchy(Class<?> clazz, Class<? extends E> annotation) {
+		Class<?> currentClass = clazz;
+		while (currentClass != Object.class) {
+			E currentClassAnnotation = currentClass.getAnnotation(annotation);
+			if (currentClassAnnotation != null) {
+				return currentClassAnnotation;
+			} else {
+				currentClass = currentClass.getSuperclass();
+			}
+		}
+		return null;
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
CAT-FIX XStream sort by annotation with derived classes

Derived classes do not inherit annotations and therefore will always be
sorted alphabetically. The CatroidFieldKeySorter fixes this problem by
searching for the XStreamFieldKeyOrder annotation in the class hierarchy
now. If a derived class adds new members, which aren't specified in a
base class, a XStreamMissingSerializableFieldException is thrown.

This fix currently addresses only the Sprite and its subclasses. The
Sprite specifies a custom field order but the subclasses don't and
therefore the fields were always sorted alphabetically. Now, each
Subclass looks for the XStreamFieldKeyOrder annotation in a base class,
the Sprite, and sorts it accordingly.

The @Inherited would've also solved this problem but is easily forgotten
and more error-prone.

###END-OF-COMMIT

I didn't add a `XML change` label to this Pull Request because there is no need to increase the language version. XStream doesn't care about the order of XML tags and attributes*. However, since every currently uploaded project wrongly sorts the Sprite tags alphabetically, every team (ios, html5, windows phone, …) should be informed to test their XML parser.

The XML looks good now but please recheck.
```xml
<object type="SingleSprite" name="Background">
  <lookList>
    <look name="Background">
      <fileName>9eb91177d3dffb4acec24ecbdbb61c3e_Background.png</fileName>
    </look>
  </lookList>
  <soundList/>
  <scriptList/>
  <userBricks/>
  <nfcTagList/>
</object>
```

\* It just cares about not using [forward referencing](https://github.com/x-stream/xstream/issues/78).