### PR TITLE
CAT-REF Remove duplicate range checks for friction

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/actions/SetFrictionAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/actions/SetFrictionAction.java
@@ -39,17 +39,12 @@ public class SetFrictionAction extends TemporalAction {
 
 	@Override
 	protected void update(float percent) {
-		Float newFriction;
 		try {
-			newFriction = friction == null ? Float.valueOf(0f) : friction.interpretFloat(sprite);
+			Float newFriction = friction == null ? Float.valueOf(0f) : friction.interpretFloat(sprite);
+			physicsObject.setFriction(newFriction / 100.0f);
 		} catch (InterpretationException interpretationException) {
 			Log.d(getClass().getSimpleName(), "Formula interpretation for this specific Brick failed.", interpretationException);
-			return;
 		}
-		if (newFriction < 0) {
-			newFriction = 0f;
-		}
-		physicsObject.setFriction(newFriction / 100.0f);
 	}
 
 	public void setSprite(Sprite sprite) {

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetFrictionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetFrictionBrick.java
@@ -50,11 +50,6 @@ public class SetFrictionBrick extends FormulaBrick {
 	}
 
 	public SetFrictionBrick(float friction) {
-		if (friction < 0) {
-			friction = 0;
-		} else if (friction > 100) {
-			friction = 100;
-		}
 		initializeBrickFields(new Formula(friction));
 	}
 


### PR DESCRIPTION
The PhysicsObject.setFriction trims the friction value to the correct
range [1]. All other places are just duplicate code, will lead to
inconsitancy and have been removed.

[1] [PhysicsObject.java#L268-L273](https://github.com/Catrobat/Catroid/blob/b10f22e2bd81e6f7ce70a7a2c68d0add6901c7ab/catroid/src/main/java/org/catrobat/catroid/physics/PhysicsObject.java#L268-L273)