### PR TITLE
CAT-FIX Remove empty updateReferenceAfterMerge method overrides

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendDigitalValueBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendDigitalValueBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -133,9 +132,5 @@ public class ArduinoSendDigitalValueBrick extends FormulaBrick {
 				FormulaEditorFragment.showFragment(view, this, BrickField.ARDUINO_DIGITAL_PIN_NUMBER);
 				break;
 		}
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendPWMValueBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendPWMValueBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -129,9 +128,5 @@ public class ArduinoSendPWMValueBrick extends FormulaBrick {
 				FormulaEditorFragment.showFragment(view, this, BrickField.ARDUINO_ANALOG_PIN_NUMBER);
 				break;
 		}
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeBrightnessByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeBrightnessByNBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -103,9 +102,5 @@ public class ChangeBrightnessByNBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.BRIGHTNESS_CHANGE);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeColorByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeColorByNBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -102,9 +101,5 @@ public class ChangeColorByNBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.COLOR_CHANGE);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeSizeByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeSizeByNBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -103,9 +102,5 @@ public class ChangeSizeByNBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.SIZE_CHANGE);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeTransparencyByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeTransparencyByNBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -105,9 +104,5 @@ public class ChangeTransparencyByNBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.TRANSPARENCY_CHANGE);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeVolumeByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeVolumeByNBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -102,9 +101,5 @@ public class ChangeVolumeByNBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.VOLUME_CHANGE);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeXByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeXByNBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -102,9 +101,5 @@ public class ChangeXByNBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.X_POSITION_CHANGE);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeYByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeYByNBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -102,9 +101,5 @@ public class ChangeYByNBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.Y_POSITION_CHANGE);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveBackwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveBackwardBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 
@@ -56,9 +55,5 @@ public class DroneMoveBackwardBrick extends DroneMoveBrick {
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),
 				getFormulaWithBrickField(BrickField.DRONE_POWER_IN_PERCENT)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveDownBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveDownBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 
@@ -56,9 +55,5 @@ public class DroneMoveDownBrick extends DroneMoveBrick {
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),
 				getFormulaWithBrickField(BrickField.DRONE_POWER_IN_PERCENT)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveForwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveForwardBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 
@@ -56,9 +55,5 @@ public class DroneMoveForwardBrick extends DroneMoveBrick {
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),
 				getFormulaWithBrickField(BrickField.DRONE_POWER_IN_PERCENT)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveLeftBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveLeftBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 
@@ -56,9 +55,5 @@ public class DroneMoveLeftBrick extends DroneMoveBrick {
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),
 				getFormulaWithBrickField(BrickField.DRONE_POWER_IN_PERCENT)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveRightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveRightBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 
@@ -56,9 +55,5 @@ public class DroneMoveRightBrick extends DroneMoveBrick {
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),
 				getFormulaWithBrickField(BrickField.DRONE_POWER_IN_PERCENT)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveUpBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveUpBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 
@@ -56,9 +55,5 @@ public class DroneMoveUpBrick extends DroneMoveBrick {
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),
 				getFormulaWithBrickField(BrickField.DRONE_POWER_IN_PERCENT)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 
@@ -56,9 +55,5 @@ public class DroneTurnLeftBrick extends DroneMoveBrick {
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),
 				getFormulaWithBrickField(BrickField.DRONE_POWER_IN_PERCENT)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftMagnetoBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftMagnetoBrick.java
@@ -30,7 +30,6 @@ import android.widget.TextView;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 
@@ -79,9 +78,5 @@ public class DroneTurnLeftMagnetoBrick extends DroneMoveBrick {
 		TextView textView = (TextView) prototypeView.findViewById(R.id.brick_drone_move_text_view_power);
 		textView.setText(R.string.brick_drone_angle);
 		return prototypeView;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 
@@ -56,9 +55,5 @@ public class DroneTurnRightBrick extends DroneMoveBrick {
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),
 				getFormulaWithBrickField(BrickField.DRONE_POWER_IN_PERCENT)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightMagnetoBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightMagnetoBrick.java
@@ -30,7 +30,6 @@ import android.widget.TextView;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 
@@ -79,9 +78,5 @@ public class DroneTurnRightMagnetoBrick extends DroneMoveBrick {
 		TextView textView = (TextView) prototypeView.findViewById(R.id.brick_drone_move_text_view_power);
 		textView.setText(R.string.brick_drone_angle);
 		return prototypeView;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
@@ -111,7 +111,8 @@ public abstract class FormulaBrick extends BrickBaseType implements View.OnClick
 
 	public abstract void showFormulaEditorToEditFormula(View view);
 
-	public abstract void updateReferenceAfterMerge(Scene into, Scene from);
+	public void updateReferenceAfterMerge(Scene into, Scene from) {
+	}
 
 	@Override
 	public void storeDataForBackPack(Sprite sprite) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/GlideToBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/GlideToBrick.java
@@ -33,7 +33,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
@@ -171,9 +170,5 @@ public class GlideToBrick extends FormulaBrick {
 				FormulaEditorFragment.showFragment(view, this, BrickField.DURATION_IN_SECONDS);
 				break;
 		}
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/GoNStepsBackBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/GoNStepsBackBrick.java
@@ -33,7 +33,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
@@ -130,9 +129,5 @@ public class GoNStepsBackBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.STEPS);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfLogicBeginBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfLogicBeginBrick.java
@@ -33,7 +33,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -197,9 +196,5 @@ public class IfLogicBeginBrick extends FormulaBrick implements NestingBrick {
 		copyBrick.ifEndBrick = null;
 		this.copy = copyBrick;
 		return copyBrick;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorMoveBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorMoveBrick.java
@@ -34,7 +34,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -163,9 +162,5 @@ public class LegoEv3MotorMoveBrick extends FormulaBrick {
 		sequence.addAction(sprite.getActionFactory().createLegoEv3SingleMotorMoveAction(sprite, motorEnum,
 				getFormulaWithBrickField(BrickField.LEGO_EV3_SPEED)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorTurnAngleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorTurnAngleBrick.java
@@ -35,7 +35,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -165,9 +164,5 @@ public class LegoEv3MotorTurnAngleBrick extends FormulaBrick {
 		sequence.addAction(sprite.getActionFactory().createLegoEv3MotorTurnAngleAction(sprite, motorEnum,
 				getFormulaWithBrickField(BrickField.LEGO_EV3_DEGREES)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3PlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3PlayToneBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -151,9 +150,5 @@ public class LegoEv3PlayToneBrick extends FormulaBrick {
 				getFormulaWithBrickField(BrickField.LEGO_EV3_DURATION_IN_SECONDS),
 				getFormulaWithBrickField(BrickField.LEGO_EV3_VOLUME)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorMoveBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorMoveBrick.java
@@ -36,7 +36,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -164,9 +163,5 @@ public class LegoNxtMotorMoveBrick extends FormulaBrick {
 		sequence.addAction(sprite.getActionFactory().createLegoNxtMotorMoveAction(sprite, motorEnum,
 				getFormulaWithBrickField(BrickField.LEGO_NXT_SPEED)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorTurnAngleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorTurnAngleBrick.java
@@ -36,7 +36,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -165,9 +164,5 @@ public class LegoNxtMotorTurnAngleBrick extends FormulaBrick {
 		sequence.addAction(sprite.getActionFactory().createLegoNxtMotorTurnAngleAction(sprite, motorEnum,
 				getFormulaWithBrickField(BrickField.LEGO_NXT_DEGREES)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtPlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtPlayToneBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -133,9 +132,5 @@ public class LegoNxtPlayToneBrick extends FormulaBrick {
 				getFormulaWithBrickField(BrickField.LEGO_NXT_FREQUENCY),
 				getFormulaWithBrickField(BrickField.LEGO_NXT_DURATION_IN_SECONDS)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/MoveNStepsBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/MoveNStepsBrick.java
@@ -33,7 +33,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
@@ -129,9 +128,5 @@ public class MoveNStepsBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.STEPS);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/NoteBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/NoteBrick.java
@@ -31,7 +31,6 @@ import android.widget.TextView;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -94,9 +93,5 @@ public class NoteBrick extends FormulaBrick implements OnClickListener {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.NOTE);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorMoveBackwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorMoveBackwardBrick.java
@@ -35,7 +35,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
@@ -181,9 +180,5 @@ public class PhiroMotorMoveBackwardBrick extends FormulaBrick {
 	public List<SequenceAction> addActionToSequence(Sprite sprite, SequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createPhiroMotorMoveBackwardActionAction(sprite, motorEnum, getFormulaWithBrickField(BrickField.PHIRO_SPEED)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorMoveForwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorMoveForwardBrick.java
@@ -35,7 +35,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
@@ -184,9 +183,5 @@ public class PhiroMotorMoveForwardBrick extends FormulaBrick {
 		sequence.addAction(sprite.getActionFactory().createPhiroMotorMoveForwardActionAction(sprite, motorEnum,
 				getFormulaWithBrickField(BrickField.PHIRO_SPEED)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroPlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroPlayToneBrick.java
@@ -35,7 +35,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -164,9 +163,5 @@ public class PhiroPlayToneBrick extends FormulaBrick {
 		sequence.addAction(sprite.getActionFactory().createDelayAction(sprite, getFormulaWithBrickField(BrickField
 				.PHIRO_DURATION_IN_SECONDS)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroRGBLightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroRGBLightBrick.java
@@ -35,7 +35,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
@@ -229,9 +228,5 @@ public class PhiroRGBLightBrick extends FormulaBrick {
 				getFormulaWithBrickField(BrickField.PHIRO_LIGHT_GREEN),
 				getFormulaWithBrickField(BrickField.PHIRO_LIGHT_BLUE)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaceAtBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaceAtBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -129,9 +128,5 @@ public class PlaceAtBrick extends FormulaBrick {
 				FormulaEditorFragment.showFragment(view, this, BrickField.X_POSITION);
 				break;
 		}
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PointInDirectionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PointInDirectionBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -121,9 +120,5 @@ public class PointInDirectionBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.DEGREES);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiPwmBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiPwmBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -141,9 +140,5 @@ public class RaspiPwmBrick extends FormulaBrick {
 				FormulaEditorFragment.showFragment(view, this, BrickField.RASPI_DIGITAL_PIN_NUMBER);
 				break;
 		}
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiSendDigitalValueBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiSendDigitalValueBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -133,9 +132,5 @@ public class RaspiSendDigitalValueBrick extends FormulaBrick {
 				FormulaEditorFragment.showFragment(view, this, BrickField.RASPI_DIGITAL_PIN_NUMBER);
 				break;
 		}
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatBrick.java
@@ -34,7 +34,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
@@ -203,9 +202,5 @@ public class RepeatBrick extends FormulaBrick implements LoopBeginBrick {
 		nestingBrickList.add(loopEndBrick);
 
 		return nestingBrickList;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatUntilBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatUntilBrick.java
@@ -32,7 +32,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -172,9 +171,5 @@ public class RepeatUntilBrick extends FormulaBrick implements LoopBeginBrick {
 		nestingBrickList.add(loopEndBrick);
 
 		return nestingBrickList;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetBrightnessBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetBrightnessBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -103,9 +102,5 @@ public class SetBrightnessBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.BRIGHTNESS);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetColorBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetColorBrick.java
@@ -32,7 +32,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -104,9 +103,5 @@ public class SetColorBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.COLOR);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetNfcTagBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetNfcTagBrick.java
@@ -38,7 +38,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -148,10 +147,6 @@ public class SetNfcTagBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.NFC_NDEF_MESSAGE);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 
 	private ArrayAdapter<String> createArrayAdapter(Context context) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenColorBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenColorBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
@@ -181,9 +180,5 @@ public class SetPenColorBrick extends FormulaBrick {
 				getFormulaWithBrickField(BrickField.PHIRO_LIGHT_GREEN),
 				getFormulaWithBrickField(BrickField.PHIRO_LIGHT_BLUE)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenSizeBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenSizeBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -105,9 +104,5 @@ public class SetPenSizeBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.PEN_SIZE);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetSizeToBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetSizeToBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -102,9 +101,5 @@ public class SetSizeToBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.SIZE);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetTextBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetTextBrick.java
@@ -32,7 +32,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -152,10 +151,6 @@ public class SetTextBrick extends FormulaBrick implements View.OnClickListener {
 				FormulaEditorFragment.showFragment(view, this, BrickField.STRING);
 				break;
 		}
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetTransparencyBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetTransparencyBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -104,9 +103,5 @@ public class SetTransparencyBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.TRANSPARENCY);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetVolumeToBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetVolumeToBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -100,9 +99,5 @@ public class SetVolumeToBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.VOLUME);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetXBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetXBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -105,9 +104,5 @@ public class SetXBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.X_POSITION);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetYBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetYBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -100,9 +99,5 @@ public class SetYBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.Y_POSITION);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SpeakAndWaitBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SpeakAndWaitBrick.java
@@ -31,7 +31,6 @@ import android.widget.TextView;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.SpeakAction;
 import org.catrobat.catroid.formulaeditor.Formula;
@@ -123,9 +122,5 @@ public class SpeakAndWaitBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.SPEAK);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SpeakBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SpeakBrick.java
@@ -30,7 +30,6 @@ import android.widget.TextView;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -99,9 +98,5 @@ public class SpeakBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.SPEAK);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkBubbleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkBubbleBrick.java
@@ -32,7 +32,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -110,9 +109,5 @@ public class ThinkBubbleBrick extends FormulaBrick implements OnClickListener {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.STRING);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkForBubbleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkForBubbleBrick.java
@@ -34,7 +34,6 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.common.Constants;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
@@ -176,9 +175,5 @@ public class ThinkForBubbleBrick extends FormulaBrick {
 		} else {
 			FormulaEditorFragment.showFragment(view, this, BrickField.DURATION_IN_SECONDS);
 		}
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/TurnLeftBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/TurnLeftBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -102,9 +101,5 @@ public class TurnLeftBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.TURN_LEFT_DEGREES);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/TurnRightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/TurnRightBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -103,9 +102,5 @@ public class TurnRightBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.TURN_RIGHT_DEGREES);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserBrickParameter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserBrickParameter.java
@@ -30,7 +30,6 @@ import android.widget.TextView;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.ProjectManager;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.DataContainer;
 import org.catrobat.catroid.formulaeditor.Formula;
@@ -96,10 +95,6 @@ public class UserBrickParameter extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.USER_BRICK);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 
 	public void setParent(UserBrick parent) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/VibrationBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/VibrationBrick.java
@@ -33,7 +33,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
@@ -126,9 +125,5 @@ public class VibrationBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.VIBRATE_DURATION_IN_SECONDS);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WaitBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WaitBrick.java
@@ -33,7 +33,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
@@ -136,9 +135,5 @@ public class WaitBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.TIME_TO_WAIT_IN_SECONDS);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WaitUntilBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WaitUntilBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -48,10 +47,6 @@ public class WaitUntilBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.IF_CONDITION);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenConditionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenConditionBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.WhenConditionScript;
@@ -72,10 +71,6 @@ public class WhenConditionBrick extends FormulaBrick implements ScriptBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		FormulaEditorFragment.showFragment(view, this, BrickField.IF_CONDITION);
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetBounceBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetBounceBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
@@ -110,9 +109,5 @@ public class SetBounceBrick extends FormulaBrick {
 		sequence.addAction(sprite.getActionFactory().createSetBounceFactorAction(sprite,
 				getFormulaWithBrickField(BrickField.PHYSICS_BOUNCE_FACTOR)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetFrictionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetFrictionBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
@@ -114,9 +113,5 @@ public class SetFrictionBrick extends FormulaBrick {
 		sequence.addAction(sprite.getActionFactory().createSetFrictionAction(sprite,
 				getFormulaWithBrickField(BrickField.PHYSICS_FRICTION)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetGravityBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetGravityBrick.java
@@ -32,7 +32,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
@@ -129,9 +128,5 @@ public class SetGravityBrick extends FormulaBrick {
 				getFormulaWithBrickField(BrickField.PHYSICS_GRAVITY_X),
 				getFormulaWithBrickField(BrickField.PHYSICS_GRAVITY_Y)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetMassBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetMassBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
@@ -109,9 +108,5 @@ public class SetMassBrick extends FormulaBrick {
 		sequence.addAction(sprite.getActionFactory().createSetMassAction(sprite,
 				getFormulaWithBrickField(BrickField.PHYSICS_MASS)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetVelocityBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetVelocityBrick.java
@@ -32,7 +32,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
@@ -128,9 +127,5 @@ public class SetVelocityBrick extends FormulaBrick {
 				getFormulaWithBrickField(BrickField.PHYSICS_VELOCITY_X),
 				getFormulaWithBrickField(BrickField.PHYSICS_VELOCITY_Y)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/TurnLeftSpeedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/TurnLeftSpeedBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
@@ -109,9 +108,5 @@ public class TurnLeftSpeedBrick extends FormulaBrick {
 		sequence.addAction(sprite.getActionFactory().createTurnLeftSpeedAction(sprite,
 				getFormulaWithBrickField(BrickField.PHYSICS_TURN_LEFT_SPEED)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/TurnRightSpeedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/TurnRightSpeedBrick.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
@@ -109,9 +108,5 @@ public class TurnRightSpeedBrick extends FormulaBrick {
 		sequence.addAction(sprite.getActionFactory().createTurnRightSpeedAction(sprite,
 				getFormulaWithBrickField(BrickField.PHYSICS_TURN_RIGHT_SPEED)));
 		return null;
-	}
-
-	@Override
-	public void updateReferenceAfterMerge(Scene into, Scene from) {
 	}
 }


### PR DESCRIPTION
In most cases the updateReferenceAfterMerge is an empty implementation.
So doing something in this method is an exception, not the normal case.
Therefore I added a default empty implementation in the base class and
removed all empty overrides.