### PR TITLE
Fix NOLB-versionName

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -110,8 +110,7 @@ android {
 
         createatschool {
             applicationId 'org.catrobat.catroid.createatschool'
-            versionCode 3
-            versionName '0.1.3'
+            versionCode 4
 
             buildConfigField "String", "START_PROJECT", "\"No Starting Project\""
             buildConfigField "String", "PROJECT_NAME", "\"No Standalone Project\""


### PR DESCRIPTION
The versionName 0.1.3 causes a failing upload (app version too old) --> There's no need to overwrite the versionName of Pocket Code in the create@school version