### PR TITLE
Changing wording of Collision Formula. Fixes CAT-2179, CAT-2180, CAT-2181.

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/CollisionFormulaConversionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/CollisionFormulaConversionTest.java
@@ -1,0 +1,135 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2016 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.sensing;
+
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.test.AndroidTestCase;
+
+import org.catrobat.catroid.CatroidApplication;
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.content.bricks.FormulaBrick;
+import org.catrobat.catroid.test.utils.TestUtils;
+import org.catrobat.catroid.utils.UtilUi;
+
+import java.util.Locale;
+
+public class CollisionFormulaConversionTest extends AndroidTestCase {
+
+	private static final String COLLISION_TEST_PROJECT = "COLLISION_TEST_PROJECT";
+	private static final float OLD_CATROBAT_LANGUAGE_VERSION = 0.992f;
+	private ProjectManager projectManager;
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		UtilUi.updateScreenWidthAndHeight(getContext());
+		projectManager = ProjectManager.getInstance();
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		projectManager.setProject(null);
+		TestUtils.deleteTestProjects(COLLISION_TEST_PROJECT);
+		TestUtils.removeFromPreferences(getContext(), Constants.PREF_PROJECTNAME_KEY);
+	}
+
+	public void testCatrobatLanguageVersionUpdated() {
+		TestUtils.createTestProjectOnLocalStorageWithCatrobatLanguageVersion(OLD_CATROBAT_LANGUAGE_VERSION);
+		try {
+			projectManager.loadProject(TestUtils.DEFAULT_TEST_PROJECT_NAME, getContext());
+		} catch (Exception e) {
+			fail("couldn't load project");
+		}
+		assertTrue("Project not converted correctly!", projectManager.getCurrentProject().getCatrobatLanguageVersion() == Constants.CURRENT_CATROBAT_LANGUAGE_VERSION);
+		TestUtils.deleteTestProjects();
+	}
+
+	public void testFormulaUpdated() {
+		String firstSpriteName = "a";
+		String secondSpriteName = "b";
+		String thirdSpriteName = "ab";
+		String collisionTag = CatroidApplication.getAppContext().getString(R.string
+				.formula_editor_function_collision);
+		Project project = TestUtils.createProjectWithOldCollisionFormulas(COLLISION_TEST_PROJECT, getContext(),
+				firstSpriteName, secondSpriteName, thirdSpriteName, collisionTag);
+
+		project.updateCollisionFormulasToVersion(0.993f);
+
+		Sprite sprite1 = project.getDefaultScene().getSpriteBySpriteName(firstSpriteName);
+		Brick brick = sprite1.getScript(0).getBrick(0);
+		if (brick instanceof FormulaBrick) {
+			FormulaBrick formulaBrick = (FormulaBrick) brick;
+			String newFormula = formulaBrick.getFormulas().get(0).getDisplayString(getContext());
+			String expected = collisionTag + "(" + thirdSpriteName + ") ";
+			assertEquals("Converted formula String is wrong", expected, newFormula);
+		} else {
+			fail("brick is no instance of FormulaBrick");
+		}
+		TestUtils.deleteTestProjects();
+	}
+
+	public void testFormulaUpdatedWithLanguageConversion() {
+		String firstSpriteName = "sprite1";
+		String secondSpriteName = "sprite2";
+		String thirdSpriteName = "sprite3";
+
+		//Set to US locale
+		Resources res = CatroidApplication.getAppContext().getResources();
+		Configuration conf = res.getConfiguration();
+		Locale savedLocale = conf.locale;
+		conf.locale = Locale.US;
+		res.updateConfiguration(conf, null);
+		String collisionTag = res.getString(R.string.formula_editor_function_collision);
+
+		// restore original locale
+		conf.locale = savedLocale;
+		res.updateConfiguration(conf, null);
+
+		collisionTag = CatroidApplication.getAppContext().getString(R.string
+				.formula_editor_function_collision);
+
+		Project project = TestUtils.createProjectWithOldCollisionFormulas(COLLISION_TEST_PROJECT, getContext(),
+				firstSpriteName, secondSpriteName, thirdSpriteName, collisionTag);
+		project.updateCollisionFormulasToVersion(0.993f);
+
+		Sprite sprite1 = project.getDefaultScene().getSpriteBySpriteName(firstSpriteName);
+		Brick brick = sprite1.getScript(0).getBrick(0);
+		if (brick instanceof FormulaBrick) {
+			FormulaBrick formulaBrick = (FormulaBrick) brick;
+			String newFormula = formulaBrick.getFormulas().get(0).getDisplayString(getContext());
+			String expected = collisionTag + "(" + thirdSpriteName + ") ";
+			assertEquals("Converted formula String is wrong", expected, newFormula);
+		} else {
+			fail("brick is no instance of FormulaBrick");
+		}
+		TestUtils.deleteTestProjects();
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/TestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/TestUtils.java
@@ -57,6 +57,7 @@ import org.catrobat.catroid.content.bricks.UserBrick;
 import org.catrobat.catroid.content.bricks.UserScriptDefinitionBrick;
 import org.catrobat.catroid.exceptions.ProjectException;
 import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.io.StorageHandler;
@@ -436,6 +437,33 @@ public final class TestUtils {
 		project.getDefaultScene().getSpriteList().get(0).addScript(firstScript);
 		project.getDefaultScene().addSprite(sprite);
 
+		return project;
+	}
+
+	public static Project createProjectWithOldCollisionFormulas(String name, Context context, String firstSprite,
+			String secondSprite, String thirdSprite, String collisionTag) {
+		Project project = new Project(context, name);
+		project.setCatrobatLanguageVersion(0.992f);
+		Sprite sprite1 = new Sprite(firstSprite);
+		Sprite sprite2 = new Sprite(secondSprite);
+		Sprite sprite3 = new Sprite(thirdSprite);
+
+		Script firstScript = new StartScript();
+
+		FormulaElement element1 = new FormulaElement(FormulaElement.ElementType.COLLISION_FORMULA, firstSprite + " "
+				+ collisionTag + " " + thirdSprite, null);
+		Formula formula1 = new Formula(element1);
+		IfLogicBeginBrick ifBrick = new IfLogicBeginBrick(formula1);
+
+		firstScript.addBrick(ifBrick);
+		sprite1.addScript(firstScript);
+
+		project.getDefaultScene().addSprite(sprite1);
+		project.getDefaultScene().addSprite(sprite2);
+		project.getDefaultScene().addSprite(sprite3);
+
+		ProjectManager projectManager = ProjectManager.getInstance();
+		projectManager.setCurrentProject(project);
 		return project;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -231,6 +231,10 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 				project.setCatrobatLanguageVersion(0.992f);
 			}
 			if (project.getCatrobatLanguageVersion() == 0.992f) {
+				project.updateCollisionFormulasToVersion(0.993f);
+				project.setCatrobatLanguageVersion(0.993f);
+			}
+			if (project.getCatrobatLanguageVersion() == 0.993f) {
 				project.setCatrobatLanguageVersion(Constants.CURRENT_CATROBAT_LANGUAGE_VERSION);
 			}
 //			insert further conversions here

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -31,7 +31,7 @@ public final class Constants {
 	// Reflection in testcases needed
 	// http://stackoverflow.com/questions/1615163/modifying-final-fields-in-java?answertab=votes#tab-top
 
-	public static final float CURRENT_CATROBAT_LANGUAGE_VERSION = Float.valueOf(0.992f);
+	public static final float CURRENT_CATROBAT_LANGUAGE_VERSION = Float.valueOf(0.993f);
 
 	public static final String PLATFORM_NAME = "Android";
 	public static final int APPLICATION_BUILD_NUMBER = 0; // updated from jenkins nightly/release build

--- a/catroid/src/main/java/org/catrobat/catroid/content/GroupSprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/GroupSprite.java
@@ -22,6 +22,14 @@
  */
 package org.catrobat.catroid.content;
 
+import android.util.Log;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.LookData;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class GroupSprite extends Sprite {
 	private static final long serialVersionUID = 1L;
 
@@ -41,5 +49,37 @@ public class GroupSprite extends Sprite {
 
 	public void setExpanded(boolean expanded) {
 		isExpanded = expanded;
+	}
+
+	public static List<Sprite> getSpritesFromGroupWithGroupName(String groupName) {
+		List<Sprite> result = new ArrayList<Sprite>();
+		List<Sprite> spriteList = ProjectManager.getInstance().getSceneToPlay().getSpriteList();
+		int position = 0;
+		for (Sprite sprite : spriteList) {
+			if (groupName.equals(sprite.getName())) {
+				break;
+			}
+			position++;
+		}
+		for (int childPosition = position + 1; childPosition < spriteList.size(); childPosition++) {
+			Sprite spriteToCheck = spriteList.get(childPosition);
+			if (spriteToCheck instanceof GroupItemSprite) {
+				result.add(spriteToCheck);
+			} else {
+				break;
+			}
+		}
+		return result;
+	}
+
+	@Override
+	public void createCollisionPolygons() {
+		Log.i("GroupSprite", "Creating Collision Polygons for all Sprites of group!");
+		List<Sprite> groupSprites = getSpritesFromGroupWithGroupName(getName());
+		for (Sprite sprite : groupSprites) {
+			for (LookData lookData : sprite.getLookDataList()) {
+				lookData.getCollisionInformation().calculate();
+			}
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -449,4 +449,12 @@ public class Project implements Serializable {
 			scene.refreshSpriteReferences();
 		}
 	}
+
+	public void updateCollisionFormulasToVersion(float catroidLanguageVersion) {
+		for (Scene scene : sceneList) {
+			for (Sprite sprite : scene.getSpriteList()) {
+				sprite.updateCollisionFormulasToVersion(catroidLanguageVersion);
+			}
+		}
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -32,6 +32,7 @@ import com.badlogic.gdx.scenes.scene2d.actions.ParallelAction;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 
+import org.catrobat.catroid.CatroidApplication;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.common.BroadcastSequenceMap;
@@ -48,7 +49,6 @@ import org.catrobat.catroid.content.bricks.UserVariableBrick;
 import org.catrobat.catroid.content.bricks.WhenConditionBrick;
 import org.catrobat.catroid.formulaeditor.DataContainer;
 import org.catrobat.catroid.formulaeditor.Formula;
-import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
@@ -763,6 +763,9 @@ public class Sprite implements Serializable, Cloneable {
 				}
 			}
 		}
+		if (hasCollision()) {
+			renameSpriteInCollisionFormulas(newSpriteName, CatroidApplication.getAppContext());
+		}
 		setName(newSpriteName);
 	}
 
@@ -818,42 +821,10 @@ public class Sprite implements Serializable, Cloneable {
 		}
 	}
 
-	public void renameCopiedSpriteInCollisionFormulas(String oldName, String newName, Context context) {
-
-		for (Script currentScript : getScriptList()) {
-			if (currentScript == null) {
-				return;
-			}
-			List<Brick> brickList = currentScript.getBrickList();
-			for (Brick brick : brickList) {
-				if (brick instanceof UserBrick) {
-					List<Formula> formulaList = ((UserBrick) brick).getFormulas();
-					for (Formula formula : formulaList) {
-						formula.updateCollisionFormulas(oldName, newName, context);
-					}
-				}
-				if (brick instanceof FormulaBrick) {
-					List<Formula> formulaList = ((FormulaBrick) brick).getFormulas();
-					for (Formula formula : formulaList) {
-						formula.updateCollisionFormulas(oldName, newName, context);
-					}
-				}
-			}
-		}
-	}
-
 	public boolean hasCollision() {
-		for (Script script : getScriptList()) {
-			for (Brick brick : script.brickList) {
-				if (brick instanceof FormulaBrick) {
-					FormulaBrick formulaBrick = (FormulaBrick) brick;
-					for (Formula formula : formulaBrick.getFormulas()) {
-						if (formula.containsElement(FormulaElement.ElementType.COLLISION_FORMULA)) {
-							return true;
-						}
-					}
-				}
-			}
+		boolean hasCollision = (this.getRequiredResources() & Brick.COLLISION) > 0;
+		if (hasCollision) {
+			return true;
 		}
 		Scene scene = ProjectManager.getInstance().getCurrentScene();
 		for (Sprite sprite : scene.getSpriteList()) {
@@ -866,6 +837,15 @@ public class Sprite implements Serializable, Cloneable {
 
 	public boolean hasToCollideWith(Sprite other) {
 		for (Script script : getScriptList()) {
+			Brick scriptBrick = script.getScriptBrick();
+			if (scriptBrick instanceof FormulaBrick) {
+				FormulaBrick formulaBrick = (FormulaBrick) scriptBrick;
+				for (Formula formula : formulaBrick.getFormulas()) {
+					if (formula.containsSpriteInCollision(other.getName())) {
+						return true;
+					}
+				}
+			}
 			for (Brick brick : script.brickList) {
 				if (brick instanceof FormulaBrick) {
 					FormulaBrick formulaBrick = (FormulaBrick) brick;
@@ -878,6 +858,65 @@ public class Sprite implements Serializable, Cloneable {
 			}
 		}
 		return false;
+	}
+
+	public void updateCollisionFormulasToVersion(float catroidLanguageVersion) {
+		for (Script script : getScriptList()) {
+			Brick scriptBrick = script.getScriptBrick();
+			if (scriptBrick instanceof FormulaBrick) {
+				FormulaBrick formulaBrick = (FormulaBrick) scriptBrick;
+				for (Formula formula : formulaBrick.getFormulas()) {
+					formula.updateCollisionFormulasToVersion(catroidLanguageVersion);
+				}
+			}
+			for (Brick brick : script.getBrickList()) {
+				if (brick instanceof UserBrick) {
+					UserBrick formulaBrick = (UserBrick) brick;
+					for (Formula formula : formulaBrick.getFormulas()) {
+						formula.updateCollisionFormulasToVersion(catroidLanguageVersion);
+					}
+				} else if (brick instanceof FormulaBrick) {
+					FormulaBrick formulaBrick = (FormulaBrick) brick;
+					for (Formula formula : formulaBrick.getFormulas()) {
+						formula.updateCollisionFormulasToVersion(catroidLanguageVersion);
+					}
+				}
+			}
+		}
+	}
+
+	private void renameSpriteInCollisionFormulas(String newName, Context context) {
+		String oldName = getName();
+		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentScene().getSpriteList();
+		for (Sprite sprite : spriteList) {
+			for (Script currentScript : sprite.getScriptList()) {
+				if (currentScript == null) {
+					return;
+				}
+				Brick scriptBrick = currentScript.getScriptBrick();
+				if (scriptBrick instanceof FormulaBrick) {
+					FormulaBrick formulaBrick = (FormulaBrick) scriptBrick;
+					for (Formula formula : formulaBrick.getFormulas()) {
+						formula.updateCollisionFormulas(oldName, newName, context);
+					}
+				}
+				List<Brick> brickList = currentScript.getBrickList();
+				for (Brick brick : brickList) {
+					if (brick instanceof UserBrick) {
+						List<Formula> formulaList = ((UserBrick) brick).getFormulas();
+						for (Formula formula : formulaList) {
+							formula.updateCollisionFormulas(oldName, newName, context);
+						}
+					}
+					if (brick instanceof FormulaBrick) {
+						List<Formula> formulaList = ((FormulaBrick) brick).getFormulas();
+						for (Formula formula : formulaList) {
+							formula.updateCollisionFormulas(oldName, newName, context);
+						}
+					}
+				}
+			}
+		}
 	}
 
 	public void createCollisionPolygons() {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
@@ -27,6 +27,7 @@ import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.widget.TextView;
 
+import org.catrobat.catroid.CatroidApplication;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -101,6 +102,12 @@ public class Formula implements Serializable {
 	public void updateCollisionFormulas(String oldName, String newName, Context context) {
 		internFormula.updateCollisionFormula(oldName, newName, context);
 		formulaTree.updateCollisionFormula(oldName, newName);
+		displayText = null;
+	}
+
+	public void updateCollisionFormulasToVersion(float catroidLanguageVersion) {
+		internFormula.updateCollisionFormulaToVersion(CatroidApplication.getAppContext(), catroidLanguageVersion);
+		formulaTree.updateCollisionFormulaToVersion(catroidLanguageVersion);
 		displayText = null;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -25,13 +25,12 @@ package org.catrobat.catroid.formulaeditor;
 import android.content.res.Resources;
 import android.util.Log;
 
-import org.catrobat.catroid.CatroidApplication;
 import org.catrobat.catroid.ProjectManager;
-import org.catrobat.catroid.R;
 import org.catrobat.catroid.bluetooth.base.BluetoothDevice;
 import org.catrobat.catroid.common.CatroidService;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.ServiceProvider;
+import org.catrobat.catroid.content.GroupSprite;
 import org.catrobat.catroid.content.Look;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -194,14 +193,8 @@ public class FormulaElement implements Serializable {
 		if (rightChild != null) {
 			contained |= rightChild.containsSpriteInCollision(name);
 		}
-		if (type == ElementType.COLLISION_FORMULA) {
-			String collisionTag = CatroidApplication.getAppContext().getString(R.string
-					.formula_editor_function_collision);
-			String firstSprite = value.substring(0, value.indexOf(collisionTag) - 1);
-			String secondSprite = value.substring(value.indexOf(collisionTag) + collisionTag.length() + 1, value.length());
-			if (firstSprite.equals(name) || secondSprite.equals(name)) {
-				contained = true;
-			}
+		if (type == ElementType.COLLISION_FORMULA && value.equals(name)) {
+			contained = true;
 		}
 		return contained;
 	}
@@ -214,15 +207,24 @@ public class FormulaElement implements Serializable {
 		if (rightChild != null) {
 			rightChild.updateCollisionFormula(oldName, newName);
 		}
-		if (type == ElementType.COLLISION_FORMULA && value.contains(oldName)) {
-			String collisionTag = CatroidApplication.getAppContext().getString(R.string
-					.formula_editor_function_collision);
-			String firstSprite = value.substring(0, value.indexOf(collisionTag) - 1);
-			String secondSprite = value.substring(value.indexOf(collisionTag) + collisionTag.length() + 1, value.length());
-			if (firstSprite.equals(oldName)) {
-				value = newName + " " + collisionTag + " " + secondSprite;
-			} else if (secondSprite.equals(oldName)) {
-				value = firstSprite + " " + collisionTag + " " + newName;
+		if (type == ElementType.COLLISION_FORMULA && value.equals(oldName)) {
+			value = newName;
+		}
+	}
+
+	public void updateCollisionFormulaToVersion(float catroidLanguageVersion) {
+		if (catroidLanguageVersion == 0.993f) {
+			if (leftChild != null) {
+				leftChild.updateCollisionFormulaToVersion(catroidLanguageVersion);
+			}
+			if (rightChild != null) {
+				rightChild.updateCollisionFormulaToVersion(catroidLanguageVersion);
+			}
+			if (type == ElementType.COLLISION_FORMULA) {
+				String secondSpriteName = CollisionDetection.getSecondSpriteNameFromCollisionFormulaString(value);
+				if (secondSpriteName != null) {
+					value = secondSpriteName;
+				}
 			}
 		}
 	}
@@ -260,7 +262,7 @@ public class FormulaElement implements Serializable {
 				break;
 			case COLLISION_FORMULA:
 				try {
-					returnValue = interpretCollision(value);
+					returnValue = interpretCollision(sprite, value);
 				} catch (Exception exception) {
 					returnValue = 0d;
 					Log.e(getClass().getSimpleName(), Log.getStackTraceString(exception));
@@ -269,26 +271,29 @@ public class FormulaElement implements Serializable {
 		return normalizeDegeneratedDoubleValues(returnValue);
 	}
 
-	private Object interpretCollision(String formula) {
-		int start = 0;
-		String collidesWithTag = CatroidApplication.getAppContext().getString(R.string
-				.formula_editor_function_collision);
-		int end = formula.indexOf(collidesWithTag) - 1;
-		String firstSpriteName = formula.substring(start, end);
+	private Object interpretCollision(Sprite firstSprite, String formula) {
 
-		start = end + collidesWithTag.length() + 2;
-		end = formula.length();
-		String secondSpriteName = formula.substring(start, end);
-
-		Look firstLook;
-		Look secondLook;
+		String secondSpriteName = formula;
+		Sprite secondSprite;
 		try {
-			firstLook = ProjectManager.getInstance().getSceneToPlay().getSpriteBySpriteName(firstSpriteName).look;
-			secondLook = ProjectManager.getInstance().getSceneToPlay().getSpriteBySpriteName(secondSpriteName).look;
+			secondSprite = ProjectManager.getInstance().getSceneToPlay().getSpriteBySpriteName(secondSpriteName);
 		} catch (Resources.NotFoundException exception) {
 			return 0d;
 		}
+		Look firstLook = firstSprite.look;
+		Look secondLook;
+		if (secondSprite instanceof GroupSprite) {
+			List<Sprite> groupSprites = GroupSprite.getSpritesFromGroupWithGroupName(secondSpriteName);
+			for (Sprite sprite : groupSprites) {
+				secondLook = sprite.look;
+				if (CollisionDetection.checkCollisionBetweenLooks(firstLook, secondLook) == 1d) {
+					return 1d;
+				}
+			}
+			return 0d;
+		}
 
+		secondLook = secondSprite.look;
 		return CollisionDetection.checkCollisionBetweenLooks(firstLook, secondLook);
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
@@ -154,6 +154,13 @@ public class InternFormula {
 		generateExternFormulaStringAndInternExternMapping(context);
 	}
 
+	public void updateCollisionFormulaToVersion(Context context, float catroidLanguageVersion) {
+		for (InternToken internToken : internTokenFormulaList) {
+			internToken.updateCollisionFormulaToVersion(catroidLanguageVersion);
+		}
+		generateExternFormulaStringAndInternExternMapping(context);
+	}
+
 	public void removeVariableReferences(String name, Context context) {
 		LinkedList<InternToken> toRemove = new LinkedList<InternToken>();
 		for (InternToken internToken : internTokenFormulaList) {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
@@ -24,9 +24,7 @@ package org.catrobat.catroid.formulaeditor;
 
 import android.util.Log;
 
-import org.catrobat.catroid.CatroidApplication;
 import org.catrobat.catroid.ProjectManager;
-import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.UserBrick;
 
@@ -275,15 +273,9 @@ public class InternFormulaParser {
 	}
 
 	private FormulaElement collision() throws InternFormulaParserException {
-		int start = 0;
-		String collidesWithTag = CatroidApplication.getAppContext().getString(R.string
-				.formula_editor_function_collision);
-		int end = currentToken.getTokenStringValue().indexOf(collidesWithTag) - 1;
-		String firstSpriteName = currentToken.getTokenStringValue().substring(start, end);
-		start = end + collidesWithTag.length() + 2;
-		end = currentToken.getTokenStringValue().length();
-		String secondSpriteName = currentToken.getTokenStringValue().substring(start, end);
 
+		String firstSpriteName = ProjectManager.getInstance().getCurrentSprite().getName();
+		String secondSpriteName = currentToken.getTokenStringValue();
 		boolean formulaOk;
 		int spriteCount = 0;
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToExternGenerator.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToExternGenerator.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.formulaeditor;
 import android.content.Context;
 import android.util.Log;
 
+import org.catrobat.catroid.CatroidApplication;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.utils.Utils;
 
@@ -40,7 +41,6 @@ public class InternToExternGenerator {
 	private Context context;
 
 	private static final HashMap<String, Integer> INTERN_EXTERN_LANGUAGE_CONVERTER_MAP = new HashMap<String, Integer>();
-
 	static {
 		INTERN_EXTERN_LANGUAGE_CONVERTER_MAP.put(Operators.DIVIDE.name(), R.string.formula_editor_operator_divide);
 		INTERN_EXTERN_LANGUAGE_CONVERTER_MAP.put(Operators.MULT.name(), R.string.formula_editor_operator_mult);
@@ -192,7 +192,6 @@ public class InternToExternGenerator {
 		INTERN_EXTERN_LANGUAGE_CONVERTER_MAP.put(Operators.SMALLER_THAN.name(),
 				R.string.formula_editor_logic_lesserthan);
 	}
-
 	public InternToExternGenerator(Context context) {
 		this.context = context;
 		generatedExternFormulaString = "";
@@ -293,7 +292,9 @@ public class InternToExternGenerator {
 			case STRING:
 				return "\'" + internToken.getTokenStringValue() + "\'";
 			case COLLISION_FORMULA:
-				return internToken.getTokenStringValue();
+				String collisionTag = CatroidApplication.getAppContext().getString(R.string
+						.formula_editor_function_collision);
+				return collisionTag + "(" + internToken.getTokenStringValue() + ")";
 
 			default:
 				return getExternStringForInternTokenValue(internToken.getTokenStringValue(), context);

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
@@ -22,8 +22,7 @@
  */
 package org.catrobat.catroid.formulaeditor;
 
-import org.catrobat.catroid.CatroidApplication;
-import org.catrobat.catroid.R;
+import org.catrobat.catroid.sensing.CollisionDetection;
 
 import java.util.List;
 
@@ -65,15 +64,16 @@ public class InternToken {
 	}
 
 	public void updateCollisionFormula(String oldName, String newName) {
-		if (internTokenType == InternTokenType.COLLISION_FORMULA && tokenStringValue.contains(oldName)) {
-			String collisionTag = CatroidApplication.getAppContext().getString(R.string
-					.formula_editor_function_collision);
-			String firstSprite = tokenStringValue.substring(0, tokenStringValue.indexOf(collisionTag) - 1);
-			String secondSprite = tokenStringValue.substring(tokenStringValue.indexOf(collisionTag) + collisionTag.length() + 1, tokenStringValue.length());
-			if (firstSprite.equals(oldName)) {
-				tokenStringValue = newName + " " + collisionTag + " " + secondSprite;
-			} else if (secondSprite.equals(oldName)) {
-				tokenStringValue = firstSprite + " " + collisionTag + " " + newName;
+		if (internTokenType == InternTokenType.COLLISION_FORMULA && tokenStringValue.equals(oldName)) {
+			tokenStringValue = newName;
+		}
+	}
+
+	public void updateCollisionFormulaToVersion(float catroidLanguageVersion) {
+		if (catroidLanguageVersion == 0.993f && internTokenType == InternTokenType.COLLISION_FORMULA) {
+			String secondSpriteName = CollisionDetection.getSecondSpriteNameFromCollisionFormulaString(tokenStringValue);
+			if (secondSpriteName != null) {
+				tokenStringValue = secondSpriteName;
 			}
 		}
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionDetection.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionDetection.java
@@ -28,7 +28,10 @@ import com.badlogic.gdx.math.Polygon;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 
+import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Look;
+import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.content.Sprite;
 
 public final class CollisionDetection {
 
@@ -36,8 +39,7 @@ public final class CollisionDetection {
 	}
 
 	public static double checkCollisionBetweenLooks(Look firstLook, Look secondLook) {
-
-		if (!firstLook.isVisible() || !secondLook.isVisible()) {
+		if (!firstLook.isVisible() || !firstLook.isLookVisible() || !secondLook.isVisible() || !secondLook.isLookVisible()) {
 			return 0d;
 		}
 
@@ -118,5 +120,24 @@ public final class CollisionDetection {
 			}
 		}
 		return false;
+	}
+
+	public static String getSecondSpriteNameFromCollisionFormulaString(String formula) {
+
+		int indexOfSpriteInFormula = formula.length();
+		for (Scene scene : ProjectManager.getInstance().getCurrentProject().getSceneList()) {
+			for (Sprite sprite : scene.getSpriteList()) {
+				int index = formula.lastIndexOf(sprite.getName());
+				if (index > 0 && index + sprite.getName().length() == formula.length() && index
+						< indexOfSpriteInFormula) {
+					indexOfSpriteInFormula = index;
+				}
+			}
+		}
+		if (indexOfSpriteInFormula >= formula.length()) {
+			return null;
+		}
+		String secondSpriteName = formula.substring(indexOfSpriteInFormula, formula.length());
+		return secondSpriteName;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProgramMenuActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProgramMenuActivity.java
@@ -154,7 +154,7 @@ public class ProgramMenuActivity extends BaseActivity {
 		public void onReceive(Context context, Intent intent) {
 			if (intent.getAction().equals(ScriptActivity.ACTION_SPRITE_RENAMED)) {
 				String newSpriteName = intent.getExtras().getString(RenameSpriteDialog.EXTRA_NEW_SPRITE_NAME);
-				ProjectManager.getInstance().getCurrentSprite().setName(newSpriteName);
+				ProjectManager.getInstance().getCurrentSprite().rename(newSpriteName);
 				final ActionBar actionBar = getActionBar();
 				actionBar.setTitle(newSpriteName);
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorCategoryListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorCategoryListFragment.java
@@ -228,7 +228,7 @@ public class FormulaEditorCategoryListFragment extends ListFragment implements D
 					.findFragmentByTag(FormulaEditorFragment.FORMULA_EDITOR_FRAGMENT_TAG);
 			if (formulaEditor != null) {
 				if (itemsIds[position] == R.string.formula_editor_function_collision) {
-					showChooseSpriteDialog(formulaEditor, position);
+					showChooseSpriteDialog(formulaEditor);
 				} else {
 
 					formulaEditor.addResourceToActiveFormula(itemsIds[position]);
@@ -260,7 +260,7 @@ public class FormulaEditorCategoryListFragment extends ListFragment implements D
 		return false;
 	}
 
-	private void showChooseSpriteDialog(FormulaEditorFragment fragment, final int pos) {
+	private void showChooseSpriteDialog(FormulaEditorFragment fragment) {
 		final FormulaEditorFragment formulaEditor = fragment;
 		final FormulaEditorChooseSpriteDialog dialog = FormulaEditorChooseSpriteDialog.newInstance();
 		dialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
@@ -277,10 +277,7 @@ public class FormulaEditorCategoryListFragment extends ListFragment implements D
 						}
 					}
 					if (secondSprite != null) {
-						String formula = firstSprite.getName() + " "
-								+ getActivity().getString(itemsIds[pos]) + " " + dialog.getSprite();
-
-						formulaEditor.addCollideFormulaToActiveFormula(formula);
+						formulaEditor.addCollideFormulaToActiveFormula(secondSprite.getName());
 					}
 				}
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -791,9 +791,9 @@ public class FormulaEditorFragment extends Fragment implements OnKeyListener,
 				userVariableName);
 	}
 
-	public void addCollideFormulaToActiveFormula(String formula) {
+	public void addCollideFormulaToActiveFormula(String spriteName) {
 		formulaEditorEditText.handleKeyEvent(InternFormulaKeyboardAdapter.FORMULA_EDITOR_COLLIDE_RESOURCE_ID,
-				formula);
+				spriteName);
 	}
 
 	public void addStringToActiveFormula(String string) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
@@ -57,14 +57,9 @@ import org.catrobat.catroid.common.SoundInfo;
 import org.catrobat.catroid.content.GroupItemSprite;
 import org.catrobat.catroid.content.GroupSprite;
 import org.catrobat.catroid.content.Scene;
-import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
-import org.catrobat.catroid.content.bricks.Brick;
-import org.catrobat.catroid.content.bricks.FormulaBrick;
-import org.catrobat.catroid.content.bricks.UserBrick;
 import org.catrobat.catroid.formulaeditor.DataContainer;
-import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.ui.BackPackActivity;
 import org.catrobat.catroid.ui.BottomBar;
@@ -401,7 +396,6 @@ public class SpritesListFragment extends Fragment implements SpriteAdapter.OnSpr
 		copiedSprite.setName(getSpriteName(spriteToEdit.getName().concat(getString(R.string.copy_sprite_name_suffix)),
 				0));
 		String newName = copiedSprite.getName();
-		copiedSprite.renameCopiedSpriteInCollisionFormulas(oldName, newName, getActivity());
 		copiedSprite.updateCollisionBroadcastMessages(oldName, newName);
 
 		ProjectManager projectManager = ProjectManager.getInstance();
@@ -704,7 +698,6 @@ public class SpritesListFragment extends Fragment implements SpriteAdapter.OnSpr
 			if (intent.getAction().equals(ScriptActivity.ACTION_SPRITE_RENAMED)) {
 				String newSpriteName = intent.getExtras().getString(RenameSpriteDialog.EXTRA_NEW_SPRITE_NAME);
 				String oldSpriteName = spriteToEdit.getName();
-				renameSpritesInCollisionFormulas(oldSpriteName, newSpriteName, getActivity());
 				spriteToEdit.rename(newSpriteName);
 				spriteAdapter.replaceItemInIdMap(oldSpriteName, newSpriteName);
 			}
@@ -1071,32 +1064,5 @@ public class SpritesListFragment extends Fragment implements SpriteAdapter.OnSpr
 
 	private List<Sprite> getSpriteList() {
 		return spriteAdapter.getSpriteList();
-	}
-
-	private void renameSpritesInCollisionFormulas(String oldName, String newName, Context context) {
-
-		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentScene().getSpriteList();
-		for (Sprite sprite : spriteList) {
-			for (Script currentScript : sprite.getScriptList()) {
-				if (currentScript == null) {
-					return;
-				}
-				List<Brick> brickList = currentScript.getBrickList();
-				for (Brick brick : brickList) {
-					if (brick instanceof UserBrick) {
-						List<Formula> formulaList = ((UserBrick) brick).getFormulas();
-						for (Formula formula : formulaList) {
-							formula.updateCollisionFormulas(oldName, newName, context);
-						}
-					}
-					if (brick instanceof FormulaBrick) {
-						List<Formula> formulaList = ((FormulaBrick) brick).getFormulas();
-						for (Formula formula : formulaList) {
-							formula.updateCollisionFormulas(oldName, newName, context);
-						}
-					}
-				}
-			}
-		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/utils/ImageEditing.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/ImageEditing.java
@@ -314,7 +314,7 @@ public final class ImageEditing {
 		return "";
 	}
 
-	public static void writeMetaDataStringToPNG(String absolutePath, String key, String value) {
+	public static synchronized void writeMetaDataStringToPNG(String absolutePath, String key, String value) {
 		String tempFilename = absolutePath.substring(0, absolutePath.length() - 4) + "___temp.png";
 
 		File oldFile = new File(absolutePath);

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1265,7 +1265,7 @@
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_collision">touches</string>
+    <string name="formula_editor_function_collision">touches_object</string>
     <string name="formula_editor_sensor_x_acceleration">acceleration_x</string>
     <string name="formula_editor_sensor_y_acceleration">acceleration_y</string>
     <string name="formula_editor_sensor_z_acceleration">acceleration_z</string>


### PR DESCRIPTION
The wording of the collision formula changed from "object_a touches object_b" to "touches_object(object_b)"
To do this, the CatrobatLanguageVersion is now 0.993f (was 0.992f).
Old projects are converted to the new version when loaded.

This also fixes problems with downloaded programs, which where created by an android device with a different language.

Collision now also works with groups. (returns true if one of the sprites in the group collides)
