### PR TITLE
Changing wording of Collision Formula. Fixes CAT-2179, CAT-2180, CAT-2181.

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -243,6 +243,10 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 				project.setCatrobatLanguageVersion(0.992f);
 			}
 			if (project.getCatrobatLanguageVersion() == 0.992f) {
+				project.updateCollisionFormulasToNewVersion();
+				project.setCatrobatLanguageVersion(0.993f);
+			}
+			if (project.getCatrobatLanguageVersion() == 0.993f) {
 				project.setCatrobatLanguageVersion(Constants.CURRENT_CATROBAT_LANGUAGE_VERSION);
 			}
 //			insert further conversions here

--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -245,6 +245,10 @@ public final class ProjectManager implements OnLoadProjectCompleteListener, OnCh
 			if (project.getCatrobatLanguageVersion() == 0.992f) {
 				project.updateCollisionFormulasToNewVersion();
 				project.setCatrobatLanguageVersion(0.993f);
+				asynchronousTask = false;
+				saveProject(context);
+				loadProject(projectName, context);
+				asynchronousTask = true;
 			}
 			if (project.getCatrobatLanguageVersion() == 0.993f) {
 				project.setCatrobatLanguageVersion(Constants.CURRENT_CATROBAT_LANGUAGE_VERSION);

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -31,7 +31,7 @@ public final class Constants {
 	// Reflection in testcases needed
 	// http://stackoverflow.com/questions/1615163/modifying-final-fields-in-java?answertab=votes#tab-top
 
-	public static final float CURRENT_CATROBAT_LANGUAGE_VERSION = Float.valueOf(0.992f);
+	public static final float CURRENT_CATROBAT_LANGUAGE_VERSION = Float.valueOf(0.993f);
 
 	public static final String PLATFORM_NAME = "Android";
 	public static final int APPLICATION_BUILD_NUMBER = 0; // updated from jenkins nightly/release build

--- a/catroid/src/main/java/org/catrobat/catroid/content/GroupSprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/GroupSprite.java
@@ -22,6 +22,14 @@
  */
 package org.catrobat.catroid.content;
 
+import android.util.Log;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.LookData;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class GroupSprite extends Sprite {
 	private static final long serialVersionUID = 1L;
 
@@ -41,5 +49,37 @@ public class GroupSprite extends Sprite {
 
 	public void setExpanded(boolean expanded) {
 		isExpanded = expanded;
+	}
+
+	public static List<Sprite> getSpritesFromGroupWithGroupName(String groupName) {
+		List<Sprite> result = new ArrayList<Sprite>();
+		List<Sprite> spriteList = ProjectManager.getInstance().getSceneToPlay().getSpriteList();
+		int position = 0;
+		for (Sprite sprite : spriteList) {
+			if (groupName.equals(sprite.getName())) {
+				break;
+			}
+			position++;
+		}
+		for (int childPosition = position + 1; childPosition < spriteList.size(); childPosition++) {
+			Sprite spriteToCheck = spriteList.get(childPosition);
+			if (spriteToCheck instanceof GroupItemSprite) {
+				result.add(spriteToCheck);
+			} else {
+				break;
+			}
+		}
+		return result;
+	}
+
+	@Override
+	public void createCollisionPolygons() {
+		Log.i("GroupSprite", "Creating Collision Polygons for all Sprites of group!");
+		List<Sprite> groupSprites = getSpritesFromGroupWithGroupName(getName());
+		for (Sprite sprite : groupSprites) {
+			for (LookData lookData : sprite.getLookDataList()) {
+				lookData.getCollisionInformation().calculate();
+			}
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -23,7 +23,6 @@
 package org.catrobat.catroid.content;
 
 import android.graphics.PointF;
-import android.util.Log;
 
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.g2d.Batch;

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -23,6 +23,7 @@
 package org.catrobat.catroid.content;
 
 import android.graphics.PointF;
+import android.util.Log;
 
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.g2d.Batch;

--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -413,8 +413,8 @@ public class Project implements Serializable {
 			scene.refreshSpriteReferences();
 		}
 	}
-	public void updateCollisionFormulasToNewVersion()
-	{
+
+	public void updateCollisionFormulasToNewVersion() {
 		for (Scene scene : sceneList) {
 			for (Sprite sprite : scene.getSpriteList()) {
 				sprite.updateCollisionFormulasToNewVersion();

--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -413,4 +413,12 @@ public class Project implements Serializable {
 			scene.refreshSpriteReferences();
 		}
 	}
+	public void updateCollisionFormulasToNewVersion()
+	{
+		for (Scene scene : sceneList) {
+			for (Sprite sprite : scene.getSpriteList()) {
+				sprite.updateCollisionFormulasToNewVersion();
+			}
+		}
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -880,6 +880,21 @@ public class Sprite implements Serializable, Cloneable {
 		return false;
 	}
 
+	public void updateCollisionFormulasToNewVersion()
+	{
+		for (Script script : getScriptList()) {
+			for (Brick brick : script.brickList) {
+				if (brick instanceof FormulaBrick) {
+					FormulaBrick formulaBrick = (FormulaBrick) brick;
+					for (Formula formula : formulaBrick.getFormulas()) {
+							formula.updateCollsionFormulasToNewVersion();
+					}
+				}
+			}
+		}
+	}
+
+
 	public void createCollisionPolygons() {
 		for (LookData lookData : getLookDataList()) {
 			lookData.getCollisionInformation().calculate();

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
@@ -104,6 +104,11 @@ public class Formula implements Serializable {
 		displayText = null;
 	}
 
+	public void updateCollsionFormulasToNewVersion()
+	{
+		formulaTree.updateCollisionFormulaToNewVersion();
+	}
+
 	public boolean containsSpriteInCollision(String name) {
 		return formulaTree.containsSpriteInCollision(name);
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
@@ -27,6 +27,7 @@ import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.widget.TextView;
 
+import org.catrobat.catroid.CatroidApplication;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -104,9 +105,10 @@ public class Formula implements Serializable {
 		displayText = null;
 	}
 
-	public void updateCollsionFormulasToNewVersion()
-	{
+	public void updateCollisionFormulasToNewVersion() {
 		formulaTree.updateCollisionFormulaToNewVersion();
+		internFormula.generateExternFormulaStringAndInternExternMapping(CatroidApplication.getAppContext());
+		displayText = null;
 	}
 
 	public boolean containsSpriteInCollision(String name) {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -197,9 +197,10 @@ public class FormulaElement implements Serializable {
 		if (type == ElementType.COLLISION_FORMULA) {
 			String collisionTag = CatroidApplication.getAppContext().getString(R.string
 					.formula_editor_function_collision);
-			String firstSprite = value.substring(0, value.indexOf(collisionTag) - 1);
-			String secondSprite = value.substring(value.indexOf(collisionTag) + collisionTag.length() + 1, value.length());
-			if (firstSprite.equals(name) || secondSprite.equals(name)) {
+			int start = collisionTag.length() + 1;
+			int end = value.length()-1;
+			String secondSprite = value.substring(start, end);
+			if (secondSprite.equals(name)) {
 				contained = true;
 			}
 		}
@@ -225,6 +226,25 @@ public class FormulaElement implements Serializable {
 				value = firstSprite + " " + collisionTag + " " + newName;
 			}
 		}
+	}
+
+	public void updateCollisionFormulaToNewVersion()
+	{
+		if (leftChild != null) {
+			leftChild.updateCollisionFormulaToNewVersion();
+		}
+		if (rightChild != null) {
+			rightChild.updateCollisionFormulaToNewVersion();
+		}
+		if (type == ElementType.COLLISION_FORMULA)
+		{
+			String collisionTag = CatroidApplication.getAppContext().getString(R.string
+				.formula_editor_function_collision);
+			String secondSpriteName = value.substring(value.indexOf(collisionTag) + collisionTag.length() + 1, value
+					.length());
+			value = collisionTag + "(" + secondSpriteName + ")";
+		}
+
 	}
 
 	public Object interpretRecursive(Sprite sprite) {
@@ -260,7 +280,7 @@ public class FormulaElement implements Serializable {
 				break;
 			case COLLISION_FORMULA:
 				try {
-					returnValue = interpretCollision(value);
+					returnValue = interpretCollision(sprite, value);
 				} catch (Exception exception) {
 					returnValue = 0d;
 					Log.e(getClass().getSimpleName(), Log.getStackTraceString(exception));
@@ -269,8 +289,8 @@ public class FormulaElement implements Serializable {
 		return normalizeDegeneratedDoubleValues(returnValue);
 	}
 
-	private Object interpretCollision(String formula) {
-		int start = 0;
+	private Object interpretCollision(Sprite firstSprite, String formula) {
+		/*int start = 0;
 		String collidesWithTag = CatroidApplication.getAppContext().getString(R.string
 				.formula_editor_function_collision);
 		int end = formula.indexOf(collidesWithTag) - 1;
@@ -279,11 +299,15 @@ public class FormulaElement implements Serializable {
 		start = end + collidesWithTag.length() + 2;
 		end = formula.length();
 		String secondSpriteName = formula.substring(start, end);
-
-		Look firstLook;
+*/
+		String collidesWithTag = CatroidApplication.getAppContext().getString(R.string
+				.formula_editor_function_collision);
+		int start = collidesWithTag.length() + 1;
+		int end = formula.length() - 1;
+		String secondSpriteName = formula.substring(start,end);
+		Look firstLook = firstSprite.look;
 		Look secondLook;
 		try {
-			firstLook = ProjectManager.getInstance().getSceneToPlay().getSpriteBySpriteName(firstSpriteName).look;
 			secondLook = ProjectManager.getInstance().getSceneToPlay().getSpriteBySpriteName(secondSpriteName).look;
 		} catch (Resources.NotFoundException exception) {
 			return 0d;

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -25,14 +25,14 @@ package org.catrobat.catroid.formulaeditor;
 import android.content.res.Resources;
 import android.util.Log;
 
-import org.catrobat.catroid.CatroidApplication;
 import org.catrobat.catroid.ProjectManager;
-import org.catrobat.catroid.R;
 import org.catrobat.catroid.bluetooth.base.BluetoothDevice;
 import org.catrobat.catroid.common.CatroidService;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.ServiceProvider;
+import org.catrobat.catroid.content.GroupSprite;
 import org.catrobat.catroid.content.Look;
+import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.devices.arduino.Arduino;
@@ -194,15 +194,8 @@ public class FormulaElement implements Serializable {
 		if (rightChild != null) {
 			contained |= rightChild.containsSpriteInCollision(name);
 		}
-		if (type == ElementType.COLLISION_FORMULA) {
-			String collisionTag = CatroidApplication.getAppContext().getString(R.string
-					.formula_editor_function_collision);
-			int start = collisionTag.length() + 1;
-			int end = value.length()-1;
-			String secondSprite = value.substring(start, end);
-			if (secondSprite.equals(name)) {
-				contained = true;
-			}
+		if (type == ElementType.COLLISION_FORMULA && value.equals(name)) {
+			contained = true;
 		}
 		return contained;
 	}
@@ -215,36 +208,37 @@ public class FormulaElement implements Serializable {
 		if (rightChild != null) {
 			rightChild.updateCollisionFormula(oldName, newName);
 		}
-		if (type == ElementType.COLLISION_FORMULA && value.contains(oldName)) {
-			String collisionTag = CatroidApplication.getAppContext().getString(R.string
-					.formula_editor_function_collision);
-			String firstSprite = value.substring(0, value.indexOf(collisionTag) - 1);
-			String secondSprite = value.substring(value.indexOf(collisionTag) + collisionTag.length() + 1, value.length());
-			if (firstSprite.equals(oldName)) {
-				value = newName + " " + collisionTag + " " + secondSprite;
-			} else if (secondSprite.equals(oldName)) {
-				value = firstSprite + " " + collisionTag + " " + newName;
-			}
+		if (type == ElementType.COLLISION_FORMULA && value.equals(oldName)) {
+			value = newName;
 		}
 	}
 
-	public void updateCollisionFormulaToNewVersion()
-	{
+	public void updateCollisionFormulaToNewVersion() {
 		if (leftChild != null) {
 			leftChild.updateCollisionFormulaToNewVersion();
 		}
 		if (rightChild != null) {
 			rightChild.updateCollisionFormulaToNewVersion();
 		}
-		if (type == ElementType.COLLISION_FORMULA)
-		{
-			String collisionTag = CatroidApplication.getAppContext().getString(R.string
-				.formula_editor_function_collision);
-			String secondSpriteName = value.substring(value.indexOf(collisionTag) + collisionTag.length() + 1, value
-					.length());
-			value = collisionTag + "(" + secondSpriteName + ")";
+		if (type == ElementType.COLLISION_FORMULA) {
+			int indexOfSpriteInFormula = -1;
+			for (Scene scene : ProjectManager.getInstance().getCurrentProject().getSceneList()) {
+				for (Sprite sprite : scene.getSpriteList()) {
+					int index = value.indexOf(sprite.getName());
+					if (index > indexOfSpriteInFormula) {
+						indexOfSpriteInFormula = index;
+					}
+				}
+			}
+			if (indexOfSpriteInFormula < 0) {
+				return;
+			}
+			String secondSpriteName = value.substring(indexOfSpriteInFormula, value.length());
+			for (InternToken token : getInternTokenList()) {
+				token.updateCollisionFormula(value, secondSpriteName);
+			}
+			value = secondSpriteName;
 		}
-
 	}
 
 	public Object interpretRecursive(Sprite sprite) {
@@ -290,29 +284,28 @@ public class FormulaElement implements Serializable {
 	}
 
 	private Object interpretCollision(Sprite firstSprite, String formula) {
-		/*int start = 0;
-		String collidesWithTag = CatroidApplication.getAppContext().getString(R.string
-				.formula_editor_function_collision);
-		int end = formula.indexOf(collidesWithTag) - 1;
-		String firstSpriteName = formula.substring(start, end);
 
-		start = end + collidesWithTag.length() + 2;
-		end = formula.length();
-		String secondSpriteName = formula.substring(start, end);
-*/
-		String collidesWithTag = CatroidApplication.getAppContext().getString(R.string
-				.formula_editor_function_collision);
-		int start = collidesWithTag.length() + 1;
-		int end = formula.length() - 1;
-		String secondSpriteName = formula.substring(start,end);
-		Look firstLook = firstSprite.look;
-		Look secondLook;
+		String secondSpriteName = formula;
+		Sprite secondSprite;
 		try {
-			secondLook = ProjectManager.getInstance().getSceneToPlay().getSpriteBySpriteName(secondSpriteName).look;
+			secondSprite = ProjectManager.getInstance().getSceneToPlay().getSpriteBySpriteName(secondSpriteName);
 		} catch (Resources.NotFoundException exception) {
 			return 0d;
 		}
+		Look firstLook = firstSprite.look;
+		Look secondLook;
+		if (secondSprite instanceof GroupSprite) {
+			List<Sprite> groupSprites = GroupSprite.getSpritesFromGroupWithGroupName(secondSpriteName);
+			for (Sprite sprite : groupSprites) {
+				secondLook = sprite.look;
+				if (CollisionDetection.checkCollisionBetweenLooks(firstLook, secondLook) == 1d) {
+					return 1d;
+				}
+			}
+			return 0d;
+		}
 
+		secondLook = secondSprite.look;
 		return CollisionDetection.checkCollisionBetweenLooks(firstLook, secondLook);
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
@@ -24,9 +24,7 @@ package org.catrobat.catroid.formulaeditor;
 
 import android.util.Log;
 
-import org.catrobat.catroid.CatroidApplication;
 import org.catrobat.catroid.ProjectManager;
-import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.UserBrick;
 
@@ -275,21 +273,9 @@ public class InternFormulaParser {
 	}
 
 	private FormulaElement collision() throws InternFormulaParserException {
-		/*int start = 0;
-		String collidesWithTag = CatroidApplication.getAppContext().getString(R.string
-				.formula_editor_function_collision);
-		int end = currentToken.getTokenStringValue().indexOf(collidesWithTag) - 1;
-		String firstSpriteName = currentToken.getTokenStringValue().substring(start, end);
-		start = end + collidesWithTag.length() + 2;
-		end = currentToken.getTokenStringValue().length();
-		String secondSpriteName = currentToken.getTokenStringValue().substring(start, end);
-		*/
-		String collidesWithTag = CatroidApplication.getAppContext().getString(R.string
-				.formula_editor_function_collision);
+
 		String firstSpriteName = ProjectManager.getInstance().getCurrentSprite().getName();
-		int start = collidesWithTag.length() + 1;
-		int end = currentToken.getTokenStringValue().length()-1;
-		String secondSpriteName = currentToken.getTokenStringValue().substring(start,end);
+		String secondSpriteName = currentToken.getTokenStringValue();
 		boolean formulaOk;
 		int spriteCount = 0;
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
@@ -275,7 +275,7 @@ public class InternFormulaParser {
 	}
 
 	private FormulaElement collision() throws InternFormulaParserException {
-		int start = 0;
+		/*int start = 0;
 		String collidesWithTag = CatroidApplication.getAppContext().getString(R.string
 				.formula_editor_function_collision);
 		int end = currentToken.getTokenStringValue().indexOf(collidesWithTag) - 1;
@@ -283,7 +283,13 @@ public class InternFormulaParser {
 		start = end + collidesWithTag.length() + 2;
 		end = currentToken.getTokenStringValue().length();
 		String secondSpriteName = currentToken.getTokenStringValue().substring(start, end);
-
+		*/
+		String collidesWithTag = CatroidApplication.getAppContext().getString(R.string
+				.formula_editor_function_collision);
+		String firstSpriteName = ProjectManager.getInstance().getCurrentSprite().getName();
+		int start = collidesWithTag.length() + 1;
+		int end = currentToken.getTokenStringValue().length()-1;
+		String secondSpriteName = currentToken.getTokenStringValue().substring(start,end);
 		boolean formulaOk;
 		int spriteCount = 0;
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToExternGenerator.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToExternGenerator.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.formulaeditor;
 import android.content.Context;
 import android.util.Log;
 
+import org.catrobat.catroid.CatroidApplication;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.utils.Utils;
 
@@ -40,7 +41,6 @@ public class InternToExternGenerator {
 	private Context context;
 
 	private static final HashMap<String, Integer> INTERN_EXTERN_LANGUAGE_CONVERTER_MAP = new HashMap<String, Integer>();
-
 	static {
 		INTERN_EXTERN_LANGUAGE_CONVERTER_MAP.put(Operators.DIVIDE.name(), R.string.formula_editor_operator_divide);
 		INTERN_EXTERN_LANGUAGE_CONVERTER_MAP.put(Operators.MULT.name(), R.string.formula_editor_operator_mult);
@@ -187,7 +187,6 @@ public class InternToExternGenerator {
 		INTERN_EXTERN_LANGUAGE_CONVERTER_MAP.put(Operators.SMALLER_THAN.name(),
 				R.string.formula_editor_logic_lesserthan);
 	}
-
 	public InternToExternGenerator(Context context) {
 		this.context = context;
 		generatedExternFormulaString = "";
@@ -288,7 +287,9 @@ public class InternToExternGenerator {
 			case STRING:
 				return "\'" + internToken.getTokenStringValue() + "\'";
 			case COLLISION_FORMULA:
-				return internToken.getTokenStringValue();
+				String collisionTag = CatroidApplication.getAppContext().getString(R.string
+						.formula_editor_function_collision);
+				return collisionTag + "(" + internToken.getTokenStringValue() + ")";
 
 			default:
 				return getExternStringForInternTokenValue(internToken.getTokenStringValue(), context);

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
@@ -22,9 +22,6 @@
  */
 package org.catrobat.catroid.formulaeditor;
 
-import org.catrobat.catroid.CatroidApplication;
-import org.catrobat.catroid.R;
-
 import java.util.List;
 
 public class InternToken {
@@ -67,15 +64,7 @@ public class InternToken {
 
 	public void updateCollisionFormula(String oldName, String newName) {
 		if (internTokenType == InternTokenType.COLLISION_FORMULA && tokenStringValue.contains(oldName)) {
-			String collisionTag = CatroidApplication.getAppContext().getString(R.string
-					.formula_editor_function_collision);
-			String firstSprite = tokenStringValue.substring(0, tokenStringValue.indexOf(collisionTag) - 1);
-			String secondSprite = tokenStringValue.substring(tokenStringValue.indexOf(collisionTag) + collisionTag.length() + 1, tokenStringValue.length());
-			if (firstSprite.equals(oldName)) {
-				tokenStringValue = newName + " " + collisionTag + " " + secondSprite;
-			} else if (secondSprite.equals(oldName)) {
-				tokenStringValue = firstSprite + " " + collisionTag + " " + newName;
-			}
+			tokenStringValue = newName;
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionDetection.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionDetection.java
@@ -23,8 +23,6 @@
 
 package org.catrobat.catroid.sensing;
 
-import android.util.Log;
-
 import com.badlogic.gdx.math.Intersector;
 import com.badlogic.gdx.math.Polygon;
 import com.badlogic.gdx.math.Rectangle;
@@ -38,7 +36,7 @@ public final class CollisionDetection {
 	}
 
 	public static double checkCollisionBetweenLooks(Look firstLook, Look secondLook) {
-		if (!firstLook.isVisible() || !secondLook.isVisible()) {
+		if (!firstLook.isVisible() || !firstLook.isLookVisible() || !secondLook.isVisible() || !secondLook.isLookVisible()) {
 			return 0d;
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionDetection.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionDetection.java
@@ -23,6 +23,8 @@
 
 package org.catrobat.catroid.sensing;
 
+import android.util.Log;
+
 import com.badlogic.gdx.math.Intersector;
 import com.badlogic.gdx.math.Polygon;
 import com.badlogic.gdx.math.Rectangle;
@@ -36,7 +38,6 @@ public final class CollisionDetection {
 	}
 
 	public static double checkCollisionBetweenLooks(Look firstLook, Look secondLook) {
-
 		if (!firstLook.isVisible() || !secondLook.isVisible()) {
 			return 0d;
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProgramMenuActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProgramMenuActivity.java
@@ -163,7 +163,7 @@ public class ProgramMenuActivity extends BaseActivity {
 		public void onReceive(Context context, Intent intent) {
 			if (intent.getAction().equals(ScriptActivity.ACTION_SPRITE_RENAMED)) {
 				String newSpriteName = intent.getExtras().getString(RenameSpriteDialog.EXTRA_NEW_SPRITE_NAME);
-				ProjectManager.getInstance().getCurrentSprite().setName(newSpriteName);
+				ProjectManager.getInstance().getCurrentSprite().rename(newSpriteName);
 				final ActionBar actionBar = getActionBar();
 				actionBar.setTitle(newSpriteName);
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorCategoryListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorCategoryListFragment.java
@@ -260,8 +260,7 @@ public class FormulaEditorCategoryListFragment extends ListFragment implements D
 						}
 					}
 					if (secondSprite != null) {
-						String formula = firstSprite.getName() + " "
-								+ getActivity().getString(itemsIds[pos]) + " " + dialog.getSprite();
+						String formula = getActivity().getString(itemsIds[pos]) + "(" + dialog.getSprite() +")";
 
 						formulaEditor.addCollideFormulaToActiveFormula(formula);
 					}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorCategoryListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorCategoryListFragment.java
@@ -221,7 +221,7 @@ public class FormulaEditorCategoryListFragment extends ListFragment implements D
 					.findFragmentByTag(FormulaEditorFragment.FORMULA_EDITOR_FRAGMENT_TAG);
 			if (formulaEditor != null) {
 				if (itemsIds[position] == R.string.formula_editor_function_collision) {
-					showChooseSpriteDialog(formulaEditor, position);
+					showChooseSpriteDialog(formulaEditor);
 				} else {
 
 					formulaEditor.addResourceToActiveFormula(itemsIds[position]);
@@ -243,7 +243,7 @@ public class FormulaEditorCategoryListFragment extends ListFragment implements D
 		return false;
 	}
 
-	private void showChooseSpriteDialog(FormulaEditorFragment fragment, final int pos) {
+	private void showChooseSpriteDialog(FormulaEditorFragment fragment) {
 		final FormulaEditorFragment formulaEditor = fragment;
 		final FormulaEditorChooseSpriteDialog dialog = FormulaEditorChooseSpriteDialog.newInstance();
 		dialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
@@ -260,9 +260,7 @@ public class FormulaEditorCategoryListFragment extends ListFragment implements D
 						}
 					}
 					if (secondSprite != null) {
-						String formula = getActivity().getString(itemsIds[pos]) + "(" + dialog.getSprite() +")";
-
-						formulaEditor.addCollideFormulaToActiveFormula(formula);
+						formulaEditor.addCollideFormulaToActiveFormula(secondSprite.getName());
 					}
 				}
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SpritesListFragment.java
@@ -57,14 +57,9 @@ import org.catrobat.catroid.common.TrackingConstants;
 import org.catrobat.catroid.content.GroupItemSprite;
 import org.catrobat.catroid.content.GroupSprite;
 import org.catrobat.catroid.content.Scene;
-import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
-import org.catrobat.catroid.content.bricks.Brick;
-import org.catrobat.catroid.content.bricks.FormulaBrick;
-import org.catrobat.catroid.content.bricks.UserBrick;
 import org.catrobat.catroid.formulaeditor.DataContainer;
-import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.ui.BackPackActivity;
 import org.catrobat.catroid.ui.BottomBar;
@@ -405,7 +400,6 @@ public class SpritesListFragment extends Fragment implements SpriteAdapter.OnSpr
 		String oldName = copiedSprite.getName();
 		copiedSprite.setName(getSpriteName(spriteToEdit.getName().concat(getString(R.string.copy_sprite_name_suffix)), 0));
 		String newName = copiedSprite.getName();
-		copiedSprite.renameCopiedSpriteInCollisionFormulas(oldName, newName, getActivity());
 		copiedSprite.updateCollisionBroadcastMessages(oldName, newName);
 
 		ProjectManager projectManager = ProjectManager.getInstance();
@@ -710,7 +704,6 @@ public class SpritesListFragment extends Fragment implements SpriteAdapter.OnSpr
 			if (intent.getAction().equals(ScriptActivity.ACTION_SPRITE_RENAMED)) {
 				String newSpriteName = intent.getExtras().getString(RenameSpriteDialog.EXTRA_NEW_SPRITE_NAME);
 				String oldSpriteName = spriteToEdit.getName();
-				renameSpritesInCollisionFormulas(oldSpriteName, newSpriteName, getActivity());
 				spriteToEdit.rename(newSpriteName);
 				spriteAdapter.replaceItemInIdMap(oldSpriteName, newSpriteName);
 			}
@@ -1090,32 +1083,5 @@ public class SpritesListFragment extends Fragment implements SpriteAdapter.OnSpr
 
 	private List<Sprite> getSpriteList() {
 		return spriteAdapter.getSpriteList();
-	}
-
-	private void renameSpritesInCollisionFormulas(String oldName, String newName, Context context) {
-
-		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentScene().getSpriteList();
-		for (Sprite sprite : spriteList) {
-			for (Script currentScript : sprite.getScriptList()) {
-				if (currentScript == null) {
-					return;
-				}
-				List<Brick> brickList = currentScript.getBrickList();
-				for (Brick brick : brickList) {
-					if (brick instanceof UserBrick) {
-						List<Formula> formulaList = ((UserBrick) brick).getFormulas();
-						for (Formula formula : formulaList) {
-							formula.updateCollisionFormulas(oldName, newName, context);
-						}
-					}
-					if (brick instanceof FormulaBrick) {
-						List<Formula> formulaList = ((FormulaBrick) brick).getFormulas();
-						for (Formula formula : formulaList) {
-							formula.updateCollisionFormulas(oldName, newName, context);
-						}
-					}
-				}
-			}
-		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/utils/ImageEditing.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/ImageEditing.java
@@ -314,7 +314,7 @@ public final class ImageEditing {
 		return "";
 	}
 
-	public static void writeMetaDataStringToPNG(String absolutePath, String key, String value) {
+	public static synchronized void writeMetaDataStringToPNG(String absolutePath, String key, String value) {
 		String tempFilename = absolutePath.substring(0, absolutePath.length() - 4) + "___temp.png";
 
 		File oldFile = new File(absolutePath);

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1265,7 +1265,7 @@
     <string name="formula_editor_function_list_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_contains">contains</string>
     <string name="formula_editor_function_contains_parameter">(*list name*,1)</string>
-    <string name="formula_editor_function_collision">touches</string>
+    <string name="formula_editor_function_collision">touches_object</string>
     <string name="formula_editor_sensor_x_acceleration">acceleration_x</string>
     <string name="formula_editor_sensor_y_acceleration">acceleration_y</string>
     <string name="formula_editor_sensor_z_acceleration">acceleration_z</string>


### PR DESCRIPTION
The wording of the collision formula changed from "object_a touches object_b" to "touches_object(object_b)"
To do this, the CatrobatLanguageVersion is now 0.993f (was 0.992f).
Old projects are converted to the new version when loaded.

This also fixes problems with downloaded programs, which where created by an android device with a different language.

Collision now also works with groups. (returns true if one of the sprites in the group collides)