### PR TITLE
CAT-NOLB RatingDialog & Backpacked data

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
@@ -26,6 +26,8 @@ import android.content.Context;
 import android.view.View;
 import android.widget.BaseAdapter;
 
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
+
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
@@ -41,6 +43,8 @@ import java.util.List;
 public abstract class FormulaBrick extends BrickBaseType implements View.OnClickListener {
 
 	ConcurrentFormulaHashMap formulaMap;
+
+	@XStreamOmitField
 	private List<BackPackedData> backPackedDataList;
 
 	public Formula getFormulaWithBrickField(BrickField brickField) throws IllegalArgumentException {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProgressDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProgressDialog.java
@@ -40,6 +40,7 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 
+import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
@@ -210,7 +211,7 @@ public class UploadProgressDialog extends DialogFragment {
 		int numberOfUploadedProjects = sharedPreferences.getInt(NUMBER_OF_UPLOADED_PROJECTS, 0);
 		numberOfUploadedProjects = numberOfUploadedProjects + 1;
 
-		if (numberOfUploadedProjects == 2) {
+		if (numberOfUploadedProjects == 2 && !BuildConfig.CREATE_AT_SCHOOL) {
 			RatingDialog dialog = new RatingDialog();
 			dialog.show(getFragmentManager(), RatingDialog.TAG);
 		}


### PR DESCRIPTION
Prevent call to RatingDialog when two programs have been uploaded
Prevent xstream-serialization of backpacked data