### PR TITLE
CAT-2242 Add clone behind origin

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -258,7 +258,7 @@ public class StageListener implements ApplicationListener {
 	public void cloneSpriteAndAddToStage(Sprite cloneMe) {
 		Sprite copy = cloneMe.cloneForCloneBrick();
 		copy.look.createBrightnessContrastHueShader();
-		stage.addActor(copy.look);
+		stage.getRoot().addActorBefore(cloneMe.look, copy.look);
 		sprites.add(copy);
 		clonedSprites.add(copy);
 


### PR DESCRIPTION
To be compatible with Scratch, the clone is added behind the original
Object. Previously a clone was added to the top. I didn't add a test for
this behavior.

Beware, cloning will change the z-index of the original Look.