### PR TITLE
CAT-2173 fixed Layer order

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/GoNStepsBackActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/GoNStepsBackActionTest.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.Group;
 
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.content.ActionFactory;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.SingleSprite;
@@ -144,8 +145,9 @@ public class GoNStepsBackActionTest extends AndroidTestCase {
 		ProjectManager.getInstance().setProject(project);
 
 		sprite.getActionFactory().createGoNStepsBackAction(sprite, new Formula(Integer.MAX_VALUE)).act(1.0f);
-		assertEquals("GoNStepsBackBrick execution failed. Z position should be zero.", 1, sprite.look.getZIndex());
-		assertEquals("Unexpected sprite Z position", 2, sprite2.look.getZIndex());
+		assertEquals("GoNStepsBackBrick execution failed. Z position should be zero.", Constants.Z_INDEX_FIRST_SPRITE, sprite.look
+				.getZIndex());
+		assertEquals("Unexpected sprite Z position", 1, sprite2.look.getZIndex());
 
 		sprite.getActionFactory().createGoNStepsBackAction(sprite, new Formula(Integer.MIN_VALUE)).act(1.0f);
 		assertEquals("An unwanted Integer overflow occured during GoNStepsBackBrick execution.", 2,
@@ -155,13 +157,13 @@ public class GoNStepsBackActionTest extends AndroidTestCase {
 	public void testBrickWithStringFormula() {
 		sprite.getActionFactory().createGoNStepsBackAction(sprite2, new Formula(String.valueOf(STEPS))).act(1.0f);
 		assertEquals("Unexpected initial sprite Z position", 0, background.look.getZIndex());
-		assertEquals("Unexpected sprite Z position", 1, sprite2.look.getZIndex());
-		assertEquals("Unexpected sprite Z position", 2, sprite.look.getZIndex());
+		assertEquals("Unexpected sprite Z position", Constants.Z_INDEX_FIRST_SPRITE, sprite2.look.getZIndex());
+		assertEquals("Unexpected sprite Z position", 1, sprite.look.getZIndex());
 
 		sprite.getActionFactory().createGoNStepsBackAction(sprite, new Formula(String.valueOf(NOT_NUMERICAL_STRING))).act(1.0f);
 		assertEquals("Unexpected initial sprite Z position", 0, background.look.getZIndex());
-		assertEquals("Unexpected sprite Z position", 1, sprite2.look.getZIndex());
-		assertEquals("Unexpected sprite Z position", 2, sprite.look.getZIndex());
+		assertEquals("Unexpected sprite Z position", Constants.Z_INDEX_FIRST_SPRITE, sprite2.look.getZIndex());
+		assertEquals("Unexpected sprite Z position", 1, sprite.look.getZIndex());
 	}
 
 	public void testNullFormula() {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/LookSensorValuesInterpretationTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/LookSensorValuesInterpretationTest.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.test.formulaeditor;
 
 import android.test.AndroidTestCase;
 
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
@@ -96,7 +97,7 @@ public class LookSensorValuesInterpretationTest extends AndroidTestCase {
 
 			Formula lookZPositionFormula = getFormulaBySensor(Sensors.OBJECT_LAYER);
 			assertEquals("Formula interpretation is not as expected (z-index)", testSprite.look.getZIndex(),
-					lookZPositionFormula.interpretInteger(testSprite).intValue());
+					lookZPositionFormula.interpretInteger(testSprite).intValue() + Constants.Z_INDEX_NUMBER_VIRTUAL_LAYERS);
 		} catch (InterpretationException interpretationException) {
 			fail("Could not interprete Formula.");
 		}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestObject.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestObject.java
@@ -26,6 +26,7 @@ import android.test.AndroidTestCase;
 import android.util.Log;
 
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
@@ -98,7 +99,7 @@ public class ParserTestObject extends AndroidTestCase {
 		assertEquals("Formula interpretation is not as expected (rotation)", LOOK_ROTATION,
 				interpretSensor(Sensors.OBJECT_ROTATION), DELTA);
 		assertEquals("Formula interpretation is not as expected (z-index)", testSprite.look.getZIndex(),
-				interpretSensor(Sensors.OBJECT_LAYER).intValue());
+				interpretSensor(Sensors.OBJECT_LAYER).intValue() + Constants.Z_INDEX_NUMBER_VIRTUAL_LAYERS);
 	}
 
 	public void testNotExistingLookSensorValues() {

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -196,6 +196,7 @@ public final class Constants {
 	public static final String POCKET_PAINT_PACKAGE_NAME = "org.catrobat.paintroid";
 	public static final String POCKET_PAINT_DOWNLOAD_LINK = "market://details?id=" + POCKET_PAINT_PACKAGE_NAME;
 	public static final String POCKET_PAINT_INTENT_ACTIVITY_NAME = "org.catrobat.paintroid.MainActivity";
+
 	//Various:
 	public static final int BUFFER_8K = 8 * 1024;
 	public static final String PREF_PROJECTNAME_KEY = "projectName";
@@ -208,6 +209,16 @@ public final class Constants {
 	public static final int COLLISION_VERTEX_LIMIT = 100;
 	public static final float COLLISION_POLYGON_CREATION_EPSILON = 10.0f;
 	public static final String COLLISION_POLYGON_METADATA_PATTERN = "((((\\d+\\.\\d+);(\\d+\\.\\d+);){2,}(\\d+\\.\\d+);(\\d+\\.\\d+))\\|)*((\\d+\\.\\d+);(\\d+\\.\\d+);){2,}(\\d+\\.\\d+);(\\d+\\.\\d+)";
+
+	// background sprite is always on index 0
+	public static final int Z_INDEX_BACKGROUND = 0;
+
+	// this offset reflects the offset caused by "virtual" layers (currently only PenActor)
+	// which are sneaked in at the Stage creation when starting the scene.
+	public static final int Z_INDEX_NUMBER_VIRTUAL_LAYERS = 1;
+
+	// the minimum z index a real sprite layer can have
+	public static final int Z_INDEX_FIRST_SPRITE = Z_INDEX_BACKGROUND + Z_INDEX_NUMBER_VIRTUAL_LAYERS + 1;
 
 	public static final String NO_VARIABLE_SELECTED = "No variable set";
 	public static final String PROJECT_UPLOAD_NAME = "projectUploadName";

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -40,6 +40,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.badlogic.gdx.utils.Array;
 
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.DroneVideoLookData;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.utils.TouchUtil;
@@ -287,7 +288,7 @@ public class Look extends Image {
 		this.lookData = lookData;
 		imageChanged = true;
 
-		boolean isBackgroundLook = getZIndex() == 0;
+		boolean isBackgroundLook = getZIndex() == Constants.Z_INDEX_BACKGROUND;
 		if (isBackgroundLook) {
 			BackgroundWaitHandler.fireBackgroundChangedEvent(lookData);
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/ComeToFrontAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/ComeToFrontAction.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.content.actions;
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.content.Sprite;
 
 import java.util.List;
@@ -41,10 +42,11 @@ public class ComeToFrontAction extends TemporalAction {
 
 		for (int i = 0; i < spriteList.size(); i++) {
 			if (spriteList.get(i).look.getZIndex() > actualSpriteZIndex) {
-				spriteList.get(i).look.setZIndex(spriteList.get(i).look.getZIndex() - 1);
+				spriteList.get(i).look.setZIndex(spriteList.get(i).look.getZIndex()
+						+ Constants.Z_INDEX_NUMBER_VIRTUAL_LAYERS - 1);
 			}
 		}
-		sprite.look.setZIndex(spriteList.size() - 1);
+		sprite.look.setZIndex(spriteList.size() + Constants.Z_INDEX_NUMBER_VIRTUAL_LAYERS - 1);
 	}
 
 	public void setSprite(Sprite sprite) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/GoNStepsBackAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/GoNStepsBackAction.java
@@ -27,6 +27,7 @@ import android.util.Log;
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
@@ -49,8 +50,8 @@ public class GoNStepsBackAction extends TemporalAction {
 		}
 
 		int zPosition = sprite.look.getZIndex();
-		if (stepsValue.intValue() > 0 && (zPosition - stepsValue.intValue()) < 1) {
-			sprite.look.setZIndex(1);
+		if (stepsValue.intValue() > 0 && (zPosition - stepsValue.intValue()) < Constants.Z_INDEX_FIRST_SPRITE) {
+			sprite.look.setZIndex(Constants.Z_INDEX_FIRST_SPRITE);
 		} else if (stepsValue.intValue() < 0 && (zPosition - stepsValue.intValue()) < zPosition) {
 			toFront();
 		} else {
@@ -73,12 +74,7 @@ public class GoNStepsBackAction extends TemporalAction {
 
 	private void goNStepsBack(int steps) {
 		int zPosition = sprite.look.getZIndex();
-		int newSpriteZIndex = zPosition - steps;
-
-		if (newSpriteZIndex < 1) {
-
-			newSpriteZIndex = 1;
-		}
+		int newSpriteZIndex = Math.max(zPosition - steps, Constants.Z_INDEX_FIRST_SPRITE);
 
 		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones();
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -30,6 +30,7 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.bluetooth.base.BluetoothDevice;
 import org.catrobat.catroid.common.CatroidService;
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.ServiceProvider;
 import org.catrobat.catroid.content.Look;
@@ -816,7 +817,7 @@ public class FormulaElement implements Serializable {
 				returnValue = (double) sprite.look.getTransparencyInUserInterfaceDimensionUnit();
 				break;
 			case OBJECT_LAYER:
-				returnValue = (double) sprite.look.getZIndex();
+				returnValue = (double) sprite.look.getZIndex() - Constants.Z_INDEX_NUMBER_VIRTUAL_LAYERS;
 				break;
 			case OBJECT_ROTATION:
 				returnValue = (double) sprite.look.getDirectionInUserInterfaceDimensionUnit();


### PR DESCRIPTION
This is more like a quick fix, with the current implementation it works.

The StageListener sneaks in a PenActor on top of the background layer which caused the offset.
Other bricks which adds actors (display text, etc) put the actor over the Passepartout, which does not cause further Problems.

If we want to have this fix in the release, this is the easiest solution and the way to go.

I'd work on my first approach right after the release to provide a clean solution for that problem.

Since Actor is a LibGDX class and we are using that directly in Z order readout, a refactoring of all types of actors with introduction of an intermediate layer would be needed for a clean solution.

~~//EDIT:~~
~~please put label "Under Discussion" as i still have to adapt the Layer Unit Tests~~