### PR TITLE
CAT-2249: fixes selection of sprites in when physical collision with brick

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/CollisionReceiverBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/CollisionReceiverBrick.java
@@ -139,7 +139,7 @@ public class CollisionReceiverBrick extends BrickBaseType implements ScriptBrick
 		messageAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 		messageAdapter.add(getDisplayedAnythingString(context));
 		int resources = Brick.NO_RESOURCES;
-		for (Sprite sprite : ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones()) {
+		for (Sprite sprite : ProjectManager.getInstance().getCurrentScene().getSpriteList()) {
 			if (!spriteName.equals(sprite.getName())) {
 				resources |= sprite.getRequiredResources();
 				if ((resources & Brick.PHYSICS) > 0 && messageAdapter.getPosition(sprite.getName()) < 0) {


### PR DESCRIPTION
The sprites were taken from the current stage instead of the current scene