### PR TITLE
CAT-REF Add catroid/catroid.iml to gradle task gitSkipWorktreeForIntellijConfigFiles

### DIFF
--- a/catroid/gradle/intellij_config_tasks.gradle
+++ b/catroid/gradle/intellij_config_tasks.gradle
@@ -27,6 +27,7 @@ task gitSkipWorktreeForIntellijConfigFiles << {
         'git update-index --skip-worktree .idea/encodings.xml'.execute().text.trim()
         'git update-index --skip-worktree .idea/vcs.xml'.execute().text.trim()
         'git update-index --skip-worktree Catroid.iml'.execute().text.trim()
+        'git update-index --skip-worktree catroid/catroid.iml'.execute().text.trim()
         'git update-index --skip-worktree catroid/src/test/catroidSourceTest.iml'.execute().text.trim()
         'git update-index --skip-worktree .idea/codeStyleSettings.xml'.execute().text.trim()
     } catch (IOException exception) {


### PR DESCRIPTION
With the new folder structure, a new IntelliJ config file has been added
which now will also be ignored when running the gradle task
gitSkipWorktreeForIntellijConfigFiles.