### PR TITLE
CAT-FIX Use getCurrentScene in InternFormulaParser

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
@@ -256,7 +256,7 @@ public class InternFormulaParser {
 	}
 
 	private FormulaElement userVariable() throws InternFormulaParserException {
-		DataContainer dataContainer = ProjectManager.getInstance().getSceneToPlay().getDataContainer();
+		DataContainer dataContainer = ProjectManager.getInstance().getCurrentScene().getDataContainer();
 
 		UserBrick currentBrick = ProjectManager.getInstance().getCurrentUserBrick();
 		Sprite currentSprite = ProjectManager.getInstance().getCurrentSprite();
@@ -279,7 +279,7 @@ public class InternFormulaParser {
 		boolean formulaOk;
 		int spriteCount = 0;
 
-		for (Sprite sprite : ProjectManager.getInstance().getSceneToPlay().getSpriteList()) {
+		for (Sprite sprite : ProjectManager.getInstance().getCurrentScene().getSpriteList()) {
 			if (sprite.getName().compareTo(firstSpriteName) == 0 || sprite.getName().compareTo(secondSpriteName) == 0) {
 				spriteCount++;
 			}
@@ -299,7 +299,7 @@ public class InternFormulaParser {
 	}
 
 	private FormulaElement userList() throws InternFormulaParserException {
-		DataContainer dataContainer = ProjectManager.getInstance().getSceneToPlay().getDataContainer();
+		DataContainer dataContainer = ProjectManager.getInstance().getCurrentScene().getDataContainer();
 		Sprite currentSprite = ProjectManager.getInstance().getCurrentSprite();
 
 		if (dataContainer.getUserList(currentToken.getTokenStringValue(), currentSprite) == null) {


### PR DESCRIPTION
Parsing only happens when editing a Formula through the
FormulaEditorFragment in the UI. So the InternFormulaParser uses
getCurrentScene only for now on.

Normally you can use getCurrentScene or getSceneToPlay in the UI. Both
are always refering to the same Scene Object when in the UI. However,
for correctness getCurrentScene is used because it represents the
currently opened Scene.