### PR TITLE
Fix PointToAction special cases

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PointToActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PointToActionTest.java
@@ -98,6 +98,24 @@ public class PointToActionTest extends AndroidTestCase {
 		assertEquals("Wrong direction", 90f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
 	}
 
+	public void testPointedSpriteNull() {
+		sprite.look.setDirectionInUserInterfaceDimensionUnit(33);
+		final float previousDirection = sprite.look.getDirectionInUserInterfaceDimensionUnit();
+
+		createPointToAction(sprite, null).act(1.0f);
+
+		assertEquals("Wrong direction", previousDirection, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
+	}
+
+	public void testSpriteNotInScene() {
+		sprite.look.setDirectionInUserInterfaceDimensionUnit(33);
+		final float previousDirection = sprite.look.getDirectionInUserInterfaceDimensionUnit();
+
+		createPointToAction(sprite, new Sprite("Sprite not in Scene")).act(1.0f);
+
+		assertEquals("Wrong direction", previousDirection, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
+	}
+
 	private Action createPointToAction(Sprite sprite, Sprite pointedSprite) {
 		return sprite.getActionFactory().createPointToAction(sprite, pointedSprite);
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PointToActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PointToActionTest.java
@@ -88,6 +88,16 @@ public class PointToActionTest extends AndroidTestCase {
 		assertEquals("Wrong direction", 135f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
 	}
 
+	public void testPointToBothSpritesOnSamePosition() {
+		pointedSprite.look.setPositionInUserInterfaceDimensionUnit(0, 0);
+		sprite.look.setPositionInUserInterfaceDimensionUnit(0, 0);
+		sprite.look.setDirectionInUserInterfaceDimensionUnit(45);
+
+		createPointToAction(sprite, pointedSprite).act(1.0f);
+
+		assertEquals("Wrong direction", 90f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
+	}
+
 	private Action createPointToAction(Sprite sprite, Sprite pointedSprite) {
 		return sprite.getActionFactory().createPointToAction(sprite, pointedSprite);
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PointToActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PointToActionTest.java
@@ -27,7 +27,6 @@ import android.test.AndroidTestCase;
 import com.badlogic.gdx.scenes.scene2d.Action;
 
 import org.catrobat.catroid.ProjectManager;
-import org.catrobat.catroid.content.ActionFactory;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.SingleSprite;
@@ -35,58 +34,72 @@ import org.catrobat.catroid.content.Sprite;
 
 public class PointToActionTest extends AndroidTestCase {
 
-	private final float delta = 1e-7f;
+	private static final float DELTA = 1e-7f;
+
+	private Sprite sprite;
+	private Sprite pointedSprite;
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		createProject();
+	}
 
 	public void testPointTo() {
-		Sprite sprite = new SingleSprite("sprite");
-		Sprite pointedSprite = new SingleSprite("pointedSprite");
+		Action pointToAction = createPointToAction(sprite, pointedSprite);
+
+		pointedSprite.look.setPosition(200f, 0f);
+		pointToAction.act(1.0f);
+		assertEquals("Wrong direction", 90f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
+
+		pointedSprite.look.setPosition(200f, 200f);
+		pointToAction.restart();
+		pointToAction.act(1.0f);
+		assertEquals("Wrong direction", 45f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
+
+		pointedSprite.look.setPosition(0f, 200f);
+		pointToAction.restart();
+		pointToAction.act(1.0f);
+		assertEquals("Wrong direction", 0f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
+
+		pointedSprite.look.setPosition(-200f, 200f);
+		pointToAction.restart();
+		pointToAction.act(1.0f);
+		assertEquals("Wrong direction", -45f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
+
+		pointedSprite.look.setPosition(-200f, 0f);
+		pointToAction.restart();
+		pointToAction.act(1.0f);
+		assertEquals("Wrong direction", -90f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
+
+		pointedSprite.look.setPosition(-200f, -200f);
+		pointToAction.restart();
+		pointToAction.act(1.0f);
+		assertEquals("Wrong direction", -135f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
+
+		pointedSprite.look.setPosition(0f, -200f);
+		pointToAction.restart();
+		pointToAction.act(1.0f);
+		assertEquals("Wrong direction", 180f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
+
+		pointedSprite.look.setPosition(200f, -200f);
+		pointToAction.restart();
+		pointToAction.act(1.0f);
+		assertEquals("Wrong direction", 135f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), DELTA);
+	}
+
+	private Action createPointToAction(Sprite sprite, Sprite pointedSprite) {
+		return sprite.getActionFactory().createPointToAction(sprite, pointedSprite);
+	}
+
+	private void createProject() {
+		sprite = new SingleSprite("sprite");
+		pointedSprite = new SingleSprite("pointedSprite");
 		Project project = new Project();
 		Scene scene = new Scene();
 		project.addScene(scene);
 		project.getDefaultScene().addSprite(sprite);
 		project.getDefaultScene().addSprite(pointedSprite);
 		ProjectManager.getInstance().setProject(project);
-
-		ActionFactory factory = sprite.getActionFactory();
-		Action pointToAction = factory.createPointToAction(sprite, pointedSprite);
-
-		pointedSprite.look.setPosition(200f, 0f);
-		pointToAction.act(1.0f);
-		assertEquals("Wrong direction", 90f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), delta);
-
-		pointedSprite.look.setPosition(200f, 200f);
-		pointToAction.restart();
-		pointToAction.act(1.0f);
-		assertEquals("Wrong direction", 45f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), delta);
-
-		pointedSprite.look.setPosition(0f, 200f);
-		pointToAction.restart();
-		pointToAction.act(1.0f);
-		assertEquals("Wrong direction", 0f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), delta);
-
-		pointedSprite.look.setPosition(-200f, 200f);
-		pointToAction.restart();
-		pointToAction.act(1.0f);
-		assertEquals("Wrong direction", -45f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), delta);
-
-		pointedSprite.look.setPosition(-200f, 0f);
-		pointToAction.restart();
-		pointToAction.act(1.0f);
-		assertEquals("Wrong direction", -90f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), delta);
-
-		pointedSprite.look.setPosition(-200f, -200f);
-		pointToAction.restart();
-		pointToAction.act(1.0f);
-		assertEquals("Wrong direction", -135f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), delta);
-
-		pointedSprite.look.setPosition(0f, -200f);
-		pointToAction.restart();
-		pointToAction.act(1.0f);
-		assertEquals("Wrong direction", 180f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), delta);
-
-		pointedSprite.look.setPosition(200f, -200f);
-		pointToAction.restart();
-		pointToAction.act(1.0f);
-		assertEquals("Wrong direction", 135f, sprite.look.getDirectionInUserInterfaceDimensionUnit(), delta);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/PointToAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/PointToAction.java
@@ -49,7 +49,7 @@ public class PointToAction extends TemporalAction {
 
 		double rotationDegrees;
 		if (spriteXPosition == pointedSpriteXPosition && spriteYPosition == pointedSpriteYPosition) {
-			rotationDegrees = 0;
+			rotationDegrees = 90;
 		} else if (spriteXPosition == pointedSpriteXPosition) {
 			if (spriteYPosition < pointedSpriteYPosition) {
 				rotationDegrees = 0;

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/PointToAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/PointToAction.java
@@ -34,12 +34,9 @@ public class PointToAction extends TemporalAction {
 
 	@Override
 	protected void update(float percent) {
-		if (!ProjectManager.getInstance().getSceneToPlay().getSpriteList().contains(pointedSprite)) {
-			pointedSprite = null;
-		}
-
-		if (pointedSprite == null) {
-			pointedSprite = this.sprite;
+		if (pointedSprite == null
+				|| !ProjectManager.getInstance().getSceneToPlay().getSpriteList().contains(pointedSprite)) {
+			return;
 		}
 
 		float spriteXPosition = sprite.look.getXInUserInterfaceDimensionUnit();

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/PointToAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/PointToAction.java
@@ -27,8 +27,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Sprite;
 
-import java.util.ArrayList;
-
 public class PointToAction extends TemporalAction {
 
 	private Sprite sprite;
@@ -36,9 +34,7 @@ public class PointToAction extends TemporalAction {
 
 	@Override
 	protected void update(float percent) {
-		final ArrayList<Sprite> spriteList = (ArrayList<Sprite>) ProjectManager.getInstance().getSceneToPlay()
-				.getSpriteList();
-		if (!spriteList.contains(pointedSprite)) {
+		if (!ProjectManager.getInstance().getSceneToPlay().getSpriteList().contains(pointedSprite)) {
 			pointedSprite = null;
 		}
 
@@ -54,23 +50,21 @@ public class PointToAction extends TemporalAction {
 		double rotationDegrees;
 		if (spriteXPosition == pointedSpriteXPosition && spriteYPosition == pointedSpriteYPosition) {
 			rotationDegrees = 0;
-		} else if (spriteXPosition == pointedSpriteXPosition || spriteYPosition == pointedSpriteYPosition) {
-			if (spriteXPosition == pointedSpriteXPosition) {
-				if (spriteYPosition < pointedSpriteYPosition) {
-					rotationDegrees = 0;
-				} else {
-					rotationDegrees = 180;
-				}
+		} else if (spriteXPosition == pointedSpriteXPosition) {
+			if (spriteYPosition < pointedSpriteYPosition) {
+				rotationDegrees = 0;
 			} else {
-				if (spriteXPosition < pointedSpriteXPosition) {
-					rotationDegrees = 90;
-				} else {
-					rotationDegrees = -90;
-				}
+				rotationDegrees = 180;
+			}
+		} else if (spriteYPosition == pointedSpriteYPosition) {
+			if (spriteXPosition < pointedSpriteXPosition) {
+				rotationDegrees = 90;
+			} else {
+				rotationDegrees = -90;
 			}
 		} else {
-			rotationDegrees = (90f - Math.toDegrees(Math.atan2(pointedSpriteYPosition - spriteYPosition,
-					pointedSpriteXPosition - spriteXPosition)));
+			rotationDegrees = 90f - Math.toDegrees(Math.atan2(pointedSpriteYPosition - spriteYPosition,
+					pointedSpriteXPosition - spriteXPosition));
 		}
 		sprite.look.setDirectionInUserInterfaceDimensionUnit((float) rotationDegrees);
 	}


### PR DESCRIPTION
This PR contains two fixes:
* Both Sprite on same position → direction = 90 (previously direction = 0)
* pointedSprite is invalid (e.g. doesn't exist) → don't change direction (previously direction = 0)

Base can also be changed to `release-0.9.28`