### PR TITLE
CAT-2207 Fix Formula Editor history

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -557,7 +557,14 @@ public class FormulaEditorFragment extends Fragment implements OnKeyListener,
 			case android.R.id.home:
 				exitFormulaEditorFragment();
 				return true;
+			case R.id.menu_undo:
+				formulaEditorEditText.undo();
+				break;
+			case R.id.menu_redo:
+				formulaEditorEditText.redo();
+				break;
 		}
+		updateButtonsOnKeyboardAndInvalidateOptionsMenu();
 		return super.onOptionsItemSelected(item);
 	}
 


### PR DESCRIPTION
The undo/redo functions just weren't called when the undo or redo button
was pressed.

To speed up the reviewing process: The changes were just restored from https://github.com/Catrobat/Catroid/commit/22186ad0c#diff-d5336e4f047445d9085f6c015edeb69eL699