### PR TITLE
CAT-2123 Toast Bug fixed.

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenColorBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenColorBrick.java
@@ -81,9 +81,7 @@ public class SetPenColorBrick extends FormulaBrick {
 
 	@Override
 	public int getRequiredResources() {
-		return getFormulaWithBrickField(BrickField.PHIRO_LIGHT_RED).getRequiredResources()
-				| getFormulaWithBrickField(BrickField.PHIRO_LIGHT_GREEN).getRequiredResources()
-				| getFormulaWithBrickField(BrickField.PHIRO_LIGHT_BLUE).getRequiredResources();
+		return NO_RESOURCES;
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -112,6 +112,7 @@ public class FormulaEditorFragment extends Fragment implements OnKeyListener,
 	private CharSequence previousActionBarTitle;
 	private VariableOrUserListDeletedReceiver variableOrUserListDeletedReceiver;
 	private static OnFormulaChangedListener onFormulaChangedListener;
+	private boolean hasFormulaBeenChanged = false;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -619,7 +620,7 @@ public class FormulaEditorFragment extends Fragment implements OnKeyListener,
 					currentFormula.refreshTextField(brickView);
 				}
 				formulaEditorEditText.formulaSaved();
-				showToast(R.string.formula_editor_changes_saved, false);
+				hasFormulaBeenChanged = true;
 				return true;
 			case PARSER_STACK_OVERFLOW:
 				return checkReturnWithoutSaving(PARSER_STACK_OVERFLOW);
@@ -667,6 +668,10 @@ public class FormulaEditorFragment extends Fragment implements OnKeyListener,
 	public boolean onKey(View view, int keyCode, KeyEvent event) {
 		switch (keyCode) {
 			case KeyEvent.KEYCODE_BACK:
+				if (hasFormulaBeenChanged) {
+					showToast(R.string.formula_editor_changes_saved, false);
+					hasFormulaBeenChanged = false;
+				}
 				exitFormulaEditorFragment();
 				return true;
 		}
@@ -693,6 +698,8 @@ public class FormulaEditorFragment extends Fragment implements OnKeyListener,
 						@Override
 						public void onClick(DialogInterface dialog, int which) {
 							if (saveFormulaIfPossible()) {
+								showToast(R.string.formula_editor_changes_saved, false);
+								hasFormulaBeenChanged = false;
 								onUserDismiss();
 							}
 						}
@@ -705,6 +712,8 @@ public class FormulaEditorFragment extends Fragment implements OnKeyListener,
 	private void endFormulaEditor() {
 		if (formulaEditorEditText.hasChanges()) {
 			if (saveFormulaIfPossible()) {
+				showToast(R.string.formula_editor_changes_saved, false);
+				hasFormulaBeenChanged = false;
 				updateUserBricksIfNecessary();
 				onUserDismiss();
 			}


### PR DESCRIPTION
Toast shows up only if something in the formula has been changed and only after the entire change. That means, the Toast does show up only if we press the back or ok button respectively(if something was changed). 
Furthermore the SetPenColorBrick doesn't have the Phiro Label anymore. The getRequiredRessources now returns the NO_RESSOURCE Label.