### PR TITLE
Fix for CAT-2301 Writing a PWM pin doesn't set its pin mode

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/devices/arduino/ArduinoImpl.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/arduino/ArduinoImpl.java
@@ -286,6 +286,7 @@ public class ArduinoImpl implements Arduino {
 	}
 
 	private void sendAnalogFirmataMessage(int pin, int value) {
+		sendFirmataMessage(new SetPinModeMessage(pin, SetPinModeMessage.PIN_MODE.PWM.getMode()));
 		sendFirmataMessage(new AnalogMessage(pin, castValue(value)));
 	}
 


### PR DESCRIPTION
This PR contains a fix for CAT-2301, based off PRs 2120 and 2121