### PR TITLE
CAT-2207 Fix Formula Editor history

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -562,7 +562,14 @@ public class FormulaEditorFragment extends Fragment implements OnKeyListener,
 			case android.R.id.home:
 				exitFormulaEditorFragment();
 				return true;
+			case R.id.menu_undo:
+				formulaEditorEditText.undo();
+				break;
+			case R.id.menu_redo:
+				formulaEditorEditText.redo();
+				break;
 		}
+		updateButtonsOnKeyboardAndInvalidateOptionsMenu();
 		return super.onOptionsItemSelected(item);
 	}
 


### PR DESCRIPTION
The undo/redo functions just weren't called when the undo or redo button
was pressed.