### PR TITLE
CAT-2163 Enable reading Arduino pin 7

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/devices/arduino/ArduinoListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/arduino/ArduinoListener.java
@@ -80,7 +80,7 @@ public class ArduinoListener implements IFirmata.Listener {
 
 	@Override
 	public void onDigitalMessageReceived(DigitalMessage message) {
-		if (message.getValue() > 64 || message.getValue() < 0) {
+		if (message.getValue() > 0xFF || message.getValue() < 0) {
 			return;
 		}
 


### PR DESCRIPTION
Firmata sends a value containg the aggregate status of all pins
of a given port that are configured as input pins. Thus that value
can be in the range of 0-255.
This fixes the problem of always reading low for pin 7 and
additionally fixes problems if multiple pins are set to inputs and
read HIGH (which might result in a value > 64, even without pin 7).