### PR TITLE
CAT-2151 Fixed crash when whatsapp not installed

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -118,7 +118,6 @@ public class StageListener implements ApplicationListener {
 	private boolean reloadProject = false;
 	public boolean firstFrameDrawn = false;
 
-	private static boolean checkIfAutomaticScreenshotShouldBeTaken = true;
 	private boolean makeAutomaticScreenshot = false;
 	private boolean makeScreenshot = false;
 	private String pathForSceneScreenshot;
@@ -244,10 +243,9 @@ public class StageListener implements ApplicationListener {
 		}
 		axes = new Texture(Gdx.files.internal("stage/red_pixel.bmp"));
 		skipFirstFrameForAutomaticScreenshot = true;
-		if (checkIfAutomaticScreenshotShouldBeTaken) {
-			makeAutomaticScreenshot = project.manualScreenshotExists(SCREENSHOT_MANUAL_FILE_NAME) || scene
-					.screenshotExists(SCREENSHOT_AUTOMATIC_FILE_NAME) || scene.screenshotExists(SCREENSHOT_MANUAL_FILE_NAME);
-		}
+		makeAutomaticScreenshot = project.manualScreenshotExists(SCREENSHOT_MANUAL_FILE_NAME) && scene
+				.screenshotExists(SCREENSHOT_AUTOMATIC_FILE_NAME) && scene.screenshotExists
+				(SCREENSHOT_MANUAL_FILE_NAME);
 		if (drawDebugCollisionPolygons) {
 			collisionPolygonDebugRenderer.setProjectionMatrix(camera.combined);
 			collisionPolygonDebugRenderer.setAutoShapeType(true);
@@ -704,7 +702,20 @@ public class StageListener implements ApplicationListener {
 		while (makeScreenshot) {
 			Thread.yield();
 		}
-		return saveScreenshot(this.screenshot, SCREENSHOT_MANUAL_FILE_NAME);
+
+		if(saveScreenshot(this.screenshot, SCREENSHOT_MANUAL_FILE_NAME)) {
+			deleteAutomaticScreenshot();
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	private void deleteAutomaticScreenshot() {
+		FileHandle automaticScreenshot = Gdx.files.absolute(pathForSceneScreenshot + SCREENSHOT_AUTOMATIC_FILE_NAME);
+		if(automaticScreenshot.exists()) {
+				automaticScreenshot.delete();
+		}
 	}
 
 	private boolean saveScreenshot(byte[] screenshot, String fileName) {
@@ -773,10 +784,7 @@ public class StageListener implements ApplicationListener {
 		}
 
 		initScreenMode();
-
-		if (checkIfAutomaticScreenshotShouldBeTaken) {
-			makeAutomaticScreenshot = project.manualScreenshotExists(SCREENSHOT_MANUAL_FILE_NAME);
-		}
+		makeAutomaticScreenshot = project.manualScreenshotExists(SCREENSHOT_MANUAL_FILE_NAME);
 	}
 
 	public void clearBackground() {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
@@ -342,8 +342,7 @@ public class WebViewActivity extends BaseActivity {
 		try {
 			packageManager.getPackageInfo(PACKAGE_NAME_WHATSAPP, PackageManager.GET_ACTIVITIES);
 			return true;
-		}
-		catch (PackageManager.NameNotFoundException e) {
+		} catch (PackageManager.NameNotFoundException e) {
 			return false;
 		}
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
@@ -30,6 +30,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -71,6 +72,7 @@ public class WebViewActivity extends BaseActivity {
 	private String callingActivity;
 	private ProgressDialog progressDialog;
 	private Intent resultIntent = new Intent();
+	private final String PACKAGE_NAME_WHATSAPP = "com.whatsapp";
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -205,10 +207,14 @@ public class WebViewActivity extends BaseActivity {
 		@Override
 		public boolean shouldOverrideUrlLoading(WebView view, String url) {
 			if (url != null && url.startsWith(Constants.WHATSAPP_URI)) {
-				Uri uri = Uri.parse(url);
-				Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-				intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-				startActivity(intent);
+				if (isWhatsappInstalled()) {
+					Uri uri = Uri.parse(url);
+					Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+					intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+					startActivity(intent);
+				} else {
+					ToastUtil.showError(getApplicationContext(), R.string.error_no_whatsapp);
+				}
 				return true;
 			} else if (checkIfWebViewVisitExternalWebsite(url)) {
 				Uri uri = Uri.parse(url);
@@ -328,6 +334,17 @@ public class WebViewActivity extends BaseActivity {
 		} else {
 			CookieManager.getInstance().removeAllCookies(null);
 			CookieManager.getInstance().flush();
+		}
+	}
+
+	private boolean isWhatsappInstalled() {
+		PackageManager packageManager = getPackageManager();
+		try {
+			packageManager.getPackageInfo(PACKAGE_NAME_WHATSAPP, PackageManager.GET_ACTIVITIES);
+			return true;
+		}
+		catch (PackageManager.NameNotFoundException e) {
+			return false;
 		}
 	}
 }

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -496,7 +496,6 @@
         issues!</string>
     <!--  -->
 
-
     <!-- Brick context dialog -->
     <string name="brick_context_dialog_move_brick">Move Brick</string>
     <string name="brick_context_dialog_show_source">Show Source Brick</string>
@@ -827,7 +826,7 @@
     <string name="brick_note_default_value">"add comment here…"</string>
     <string name="brick_think_bubble_default_value">"Hmmmm!"</string>
     <string name="brick_say_bubble_default_value">"Hello!"</string>
-    <string name="brick_broadcast_default_value">"new message"</string>
+    <string name="brick_broadcast_default_value">"message 1"</string>
     <string name="brick_add_item_to_userlist_add">Add</string>
     <string name="brick_add_item_to_userlist">to list</string>
     <string name="brick_delete_item_from_userlist_delete">Delete item from list</string>
@@ -987,6 +986,7 @@
     <string name="error_no_network_one_brick">Following brick will use the network:</string>
     <string name="error_no_network_multiple_bricks">Following bricks will use the network:</string>
     <string name="error_no_network_title">No network</string>
+    <string name="error_no_whatsapp">WhatsApp not installed</string>
     <!--  -->
 
 

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -496,6 +496,7 @@
         issues!</string>
     <!--  -->
 
+
     <!-- Brick context dialog -->
     <string name="brick_context_dialog_move_brick">Move Brick</string>
     <string name="brick_context_dialog_show_source">Show Source Brick</string>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -826,7 +826,7 @@
     <string name="brick_note_default_value">"add comment here…"</string>
     <string name="brick_think_bubble_default_value">"Hmmmm!"</string>
     <string name="brick_say_bubble_default_value">"Hello!"</string>
-    <string name="brick_broadcast_default_value">"message 1"</string>
+    <string name="brick_broadcast_default_value">"new message"</string>
     <string name="brick_add_item_to_userlist_add">Add</string>
     <string name="brick_add_item_to_userlist">to list</string>
     <string name="brick_delete_item_from_userlist_delete">Delete item from list</string>


### PR DESCRIPTION
Social sharing via the WhatsApp button on a details page in the webview crashes Pocket Code when the WhatsApp app is not installed on one's phone.

Added code to check WhatsApp installation before starting the share intent.