### PR TITLE
CAT-2169 Added nullcheck so StopAllScriptsAction won't run into nullpointer exception

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/RepeatAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/RepeatAction.java
@@ -67,7 +67,7 @@ public class RepeatAction extends com.badlogic.gdx.scenes.scene2d.actions.Repeat
 		if (executedCount >= repeatCountValue && !isForeverRepeat) {
 			return true;
 		}
-		if (action.act(delta) && currentTime >= LOOP_DELAY) {
+		if (action != null && action.act(delta) && currentTime >= LOOP_DELAY) {
 
 			executedCount++;
 			if (executedCount >= repeatCountValue && !isForeverRepeat) {


### PR DESCRIPTION
When reset() method is called on a RepeatAction, the Action member is set to null, but is not checked for null the next time it is called - this null check stops the RepeatAction in case action member is null.