### PR TITLE
CAT-2175 use right url if new background will be added to downloaded programm

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/LookFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/LookFragment.java
@@ -577,7 +577,8 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 	public void addLookMediaLibrary() {
 		Intent intent = new Intent(activity, WebViewActivity.class);
 		String url;
-		if (ProjectManager.getInstance().getCurrentSprite().getName().equals(getString(R.string.background))) {
+
+		if (ProjectManager.getInstance().getCurrentSpritePosition() == 0) {
 			url = ProjectManager.getInstance().isCurrentProjectLandscapeMode()
 					? Constants.LIBRARY_BACKGROUNDS_URL_LANDSCAPE
 					: Constants.LIBRARY_BACKGROUNDS_URL_PORTRAIT;


### PR DESCRIPTION
The problem was that the condition in the if clause checked the name (string) of the currentSprite. The string name change regarding to the application language (every language has different string.xml) the creator of the programm uses. So if we download a programm written with an english string.xml on the application that uses a german string.xml we have a comparison between e.g. "Background" and "Hintergrund".
So I changed the condition and now we check if the index of the currentSprite is 0. Due to the fact, that the Background sprite is every time in the first place of a programm.