### PR TITLE
CAT-2169 StopAllScripts block runs into nullpointer

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/RepeatAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/RepeatAction.java
@@ -67,7 +67,7 @@ public class RepeatAction extends com.badlogic.gdx.scenes.scene2d.actions.Repeat
 		if (executedCount >= repeatCountValue && !isForeverRepeat) {
 			return true;
 		}
-		if (action.act(delta) && currentTime >= LOOP_DELAY) {
+		if (action != null && action.act(delta) && currentTime >= LOOP_DELAY) {
 
 			executedCount++;
 			if (executedCount >= repeatCountValue && !isForeverRepeat) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/StopAllScriptsAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/StopAllScriptsAction.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 import com.badlogic.gdx.utils.Array;
 
+import org.catrobat.catroid.content.Look;
 import org.catrobat.catroid.stage.StageActivity;
 
 public class StopAllScriptsAction extends TemporalAction {
@@ -38,6 +39,9 @@ public class StopAllScriptsAction extends TemporalAction {
 		for (Actor actor : stageActors) {
 			for (Action action : actor.getActions()) {
 				action.reset();
+			}
+			if (actor instanceof Look) {
+				((Look)actor).setWhenParallelAction(null);
 			}
 		}
 	}


### PR DESCRIPTION
Added a nullcheck so that the application wouldn't crash when an action is executed that has been reset.

Reset parallelAction member of the Look object to null - else WhenScripts could not be executed again after the StopAllScriptsAction. This way WhenScripts are now simply recreated in Look (with sprite.createWhenScriptActionSequence) like the first time they are executed.