### PR TITLE
UI Test- error correction in BaseActivityInstrumentationTestCase.java

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/BaseActivityInstrumentationTestCase.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/BaseActivityInstrumentationTestCase.java
@@ -79,8 +79,10 @@ public abstract class BaseActivityInstrumentationTestCase<T extends Activity> ex
 
 	@Override
 	protected void setUp() throws Exception {
+		if (createSoloInSetUp) {
+			solo = new Solo(getInstrumentation(), getActivity());
+		}
 		Log.v(TAG, "setUp");
-		super.setUp();
 
 		systemAnimations = new SystemAnimations(getInstrumentation().getTargetContext());
 		systemAnimations.disableAll();
@@ -91,15 +93,12 @@ public abstract class BaseActivityInstrumentationTestCase<T extends Activity> ex
 		if (clazz.getSimpleName().equalsIgnoreCase(MainMenuActivity.class.getSimpleName())) {
 			UiTestUtils.createEmptyProject();
 		}
-		if (createSoloInSetUp) {
-			solo = new Solo(getInstrumentation(), getActivity());
-		}
 		Reflection.setPrivateField(StageListener.class, "checkIfAutomaticScreenshotShouldBeTaken", false);
 
 		if (solo != null) {
 			solo.unlockScreen();
 		}
-
+		super.setUp();
 		Log.v(TAG, "setUp end");
 	}
 


### PR DESCRIPTION
In the file
catrobat/catroid/uitest/util/BaseActivityInstrumentationTestCase.java,
in the setUp() method
creating emptyProject before the initialization of  new Solo(getInstrumentation(), getActivity());
result in error for most of the tests i.e., test runs on old project and not the new one.
