### PR TITLE
CAT-FIX update gradle task to ignore changes to catroid/catroid.iml

### DIFF
--- a/catroid/gradle/intellij_config_tasks.gradle
+++ b/catroid/gradle/intellij_config_tasks.gradle
@@ -29,6 +29,7 @@ task gitSkipWorktreeForIntellijConfigFiles << {
         'git update-index --skip-worktree Catroid.iml'.execute().text.trim()
         'git update-index --skip-worktree catroid/src/test/catroidSourceTest.iml'.execute().text.trim()
         'git update-index --skip-worktree .idea/codeStyleSettings.xml'.execute().text.trim()
+        'git update-index --skip-worktree catroid/catroid.iml'.execute().text.trim()
     } catch (IOException exception) {
         throw new UnsupportedOperationException("Could not find git! Maybe it is not in \$PATH variable?", exception)
     }


### PR DESCRIPTION
On an fresh clone of the repository the mentioned file shows changes in AndroidStudio. The according gradle task that ignores changes to certain files has been updated to also add `catroid/catroid.iml` to the ignore list.