### PR TITLE
Upgrade Checkstyle to 7.6

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -89,7 +89,6 @@
           <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
           <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
           <option name="ALIGN_MULTILINE_FOR" value="false" />
-          <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
           <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
           <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
           <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -175,7 +175,7 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.10.19'
 
     pmd 'net.sourceforge.pmd:pmd:5.1.1'
-    checkstyle 'com.puppycrawl.tools:checkstyle:6.7'
+    checkstyle 'com.puppycrawl.tools:checkstyle:7.6'
 }
 
 def getCurrentGitBranch() {

--- a/catroid/catroidBluetoothTestServer/src/org/catrobat/catroid/bluetoothtestserver/BTServer.java
+++ b/catroid/catroidBluetoothTestServer/src/org/catrobat/catroid/bluetoothtestserver/BTServer.java
@@ -132,7 +132,7 @@ public final class BTServer {
 
 		private Client client;
 
-		public InputConnectionHandler(Client client) {
+		InputConnectionHandler(Client client) {
 			this.client = client;
 		}
 

--- a/catroid/catroidBluetoothTestServer/src/org/catrobat/catroid/bluetoothtestserver/GUI.java
+++ b/catroid/catroidBluetoothTestServer/src/org/catrobat/catroid/bluetoothtestserver/GUI.java
@@ -80,7 +80,7 @@ public class GUI extends javax.swing.JFrame {
 	}
 
 	/**
-	 *  Standard constructor
+	 * Standard constructor
 	 */
 	public GUI() {
 		super();

--- a/catroid/catroidBluetoothTestServer/src/org/catrobat/catroid/bluetoothtestserver/clienthandlers/CommonBluetoothTestClientHandler.java
+++ b/catroid/catroidBluetoothTestServer/src/org/catrobat/catroid/bluetoothtestserver/clienthandlers/CommonBluetoothTestClientHandler.java
@@ -54,7 +54,7 @@ public class CommonBluetoothTestClientHandler extends BTClientHandler {
 		byte[] testResult = payload;
 
 		BTServer.writeMessage("<-- Sending reply message \n");
-		outStream.write(new byte[] {(byte) (0xFF & testResult.length)});
+		outStream.write(new byte[] { (byte) (0xFF & testResult.length) });
 		outStream.write(testResult);
 		outStream.flush();
 	}

--- a/catroid/catroidBluetoothTestServer/src/org/catrobat/catroid/bluetoothtestserver/clienthandlers/CommonBluetoothTestClientHandler.java
+++ b/catroid/catroidBluetoothTestServer/src/org/catrobat/catroid/bluetoothtestserver/clienthandlers/CommonBluetoothTestClientHandler.java
@@ -54,7 +54,7 @@ public class CommonBluetoothTestClientHandler extends BTClientHandler {
 		byte[] testResult = payload;
 
 		BTServer.writeMessage("<-- Sending reply message \n");
-		outStream.write(new byte[] { (byte) (0xFF & testResult.length) });
+		outStream.write(new byte[] {(byte) (0xFF & testResult.length)});
 		outStream.write(testResult);
 		outStream.flush();
 	}

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -49,14 +49,15 @@
       <property name="commentFormat" value="This is expected" />
       <property name="exceptionVariableName" value="expected|ignore|ok" />
     </module>
-    <module name="LeftCurly">
-      <property name="maxLineLength" value="9999" />
-    </module>
+    <module name="LeftCurly" />
     <module name="NeedBraces" />
-    <module name="RightCurly" />
+    <module name="RightCurly">
+      <property name="option" value="same" />
+      <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+    </module>
     <module name="RightCurly">
       <property name="option" value="alone" />
-      <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT" />
+      <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT" />
     </module>
 
     <!-- Coding -->

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -159,9 +159,7 @@
     </module>
 
     <!-- Package and Imports -->
-    <module name="AvoidStarImport">
-      <property name="excludes" value="junit.framework.Assert" />
-    </module>
+    <module name="AvoidStarImport" />
     <module name="ImportOrder">
       <property name="option" value="bottom" />
       <property name="groups" value="android,com,cucumber,edu,junit,net,org,java,javax" />

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -196,9 +196,7 @@
     <module name="GenericWhitespace" />
     <module name="MethodParamPad" />
     <module name="NoLineWrap" />
-    <module name="NoWhitespaceAfter">
-      <property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS, UNARY_PLUS, ARRAY_DECLARATOR" />
-    </module>
+    <module name="NoWhitespaceAfter" />
     <module name="NoWhitespaceBefore">
       <property name="allowLineBreaks" value="true"/>
       <property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, DOT, GENERIC_END, ELLIPSIS"/>
@@ -223,7 +221,9 @@
     <module name="SingleSpaceSeparator" />
     <module name="TypecastParenPad" />
     <module name="WhitespaceAfter" />
-    <module name="WhitespaceAround" />
+    <module name="WhitespaceAround">
+      <property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND" />
+    </module>
     
     <module name="RegexpSinglelineJava">
       <property name="format" value="^\t* " />

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -128,6 +128,7 @@
       <message key="name.invalidPattern" value="Package name not following naming convention - Name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="ParameterName">
+      <property name="ignoreOverridden" value="true"/>
       <message key="name.invalidPattern" value="Parameter name not following naming convention - Name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="StaticVariableName">

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -220,6 +220,7 @@
       <property name="tokens" value="COMMA, ELLIPSIS, ARRAY_DECLARATOR, RBRACK" />
       <property name="option" value="EOL" />
     </module>
+    <module name="SingleSpaceSeparator" />
     <module name="TypecastParenPad" />
     <module name="WhitespaceAfter" />
     <module name="WhitespaceAround" />

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -185,7 +185,14 @@
       <property name="allowLineBreaks" value="true"/>
       <property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, DOT, GENERIC_END, ELLIPSIS"/>
     </module>
-    <module name="OperatorWrap" />
+    <module name="OperatorWrap">
+      <property name="option" value="nl"/>
+      <property name="tokens" value="QUESTION, COLON, EQUAL, NOT_EQUAL, DIV, PLUS, MINUS, STAR, MOD, SR, BSR, GE, GT, SL, LE, LT, BXOR, BOR, LOR, BAND, LAND, LITERAL_INSTANCEOF, TYPE_EXTENSION_AND, METHOD_REF"/>
+    </module>
+    <module name="OperatorWrap">
+      <property name="option" value="eol"/>
+      <property name="tokens" value="ASSIGN, DIV_ASSIGN, PLUS_ASSIGN, MINUS_ASSIGN, STAR_ASSIGN, MOD_ASSIGN, SR_ASSIGN, BSR_ASSIGN, SL_ASSIGN, BXOR_ASSIGN, BOR_ASSIGN, BAND_ASSIGN"/>
+    </module>
     <module name="ParenPad" />
     <module name="SeparatorWrap">
       <property name="tokens" value="DOT, AT" />

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -108,9 +108,7 @@
     <module name="UpperEll" />
 
     <!-- Modifiers -->
-    <module name="ModifierOrder">
-      <message key="mod.order" value="{0}'' modifier out of order with the JLS suggestions" />
-    </module>
+    <module name="ModifierOrder" />
     <module name="RedundantModifier" />
 
     <!-- Naming -->

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -42,6 +42,7 @@
     <module name="AnnotationUseStyle">
       <property name="elementStyle" value="compact"/>
     </module>
+    <module name="MissingDeprecated" />
     <module name="MissingOverride" />
     <module name="SuppressWarnings" />
 

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -179,6 +179,9 @@
     <module name="PackageDeclaration" />
     <module name="UnusedImports" />
 
+    <!-- Size -->
+    <module name="OuterTypeNumber" />
+
     <!-- Whitespace -->
     <module name="EmptyForInitializerPad" />
     <module name="EmptyForIteratorPad">

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -182,6 +182,12 @@
     <module name="EmptyForIteratorPad">
       <property name="option" value="space" />
     </module>
+    <module name="EmptyLineSeparator">
+      <property name="tokens" value="IMPORT, CLASS_DEF, INTERFACE_DEF"/>
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+      <property name="allowMultipleEmptyLines" value="false"/>
+      <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+    </module>
     <module name="GenericWhitespace" />
     <module name="MethodParamPad" />
     <module name="NoLineWrap" />

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -96,6 +96,9 @@
     <module name="MutableException" />
     <module name="OneTopLevelClass" />
 
+    <!-- Javadoc -->
+    <module name="AtclauseOrder" />
+
     <!-- Miscellaneous -->
     <module name="ArrayTypeStyle" />
     <module name="AvoidEscapedUnicodeCharacters" />

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -185,11 +185,11 @@
     <module name="OperatorWrap" />
     <module name="ParenPad" />
     <module name="SeparatorWrap">
-      <property name="tokens" value="DOT" />
+      <property name="tokens" value="DOT, AT" />
       <property name="option" value="nl" />
     </module>
     <module name="SeparatorWrap">
-      <property name="tokens" value="COMMA" />
+      <property name="tokens" value="COMMA, ELLIPSIS, ARRAY_DECLARATOR, RBRACK" />
       <property name="option" value="EOL" />
     </module>
     <module name="TypecastParenPad" />

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -160,6 +160,7 @@
     <module name="ConstantName">
       <message key="name.invalidPattern" value="Constant name not following naming convention - Name ''{0}'' must match pattern ''{1}''." />
     </module>
+    <module name="CatchParameterName" />
     <module name="AbbreviationAsWordInName">
       <property name="allowedAbbreviations" value="UUID" />
     </module>

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -39,6 +39,9 @@
       <property name="allowSamelineSingleParameterlessAnnotation" value="false" />
       <property name="allowSamelineParameterizedAnnotation" value="false" />
     </module>
+    <module name="AnnotationUseStyle">
+      <property name="elementStyle" value="compact"/>
+    </module>
     <module name="MissingOverride" />
     <module name="SuppressWarnings" />
 

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -161,6 +161,7 @@
       <message key="name.invalidPattern" value="Constant name not following naming convention - Name ''{0}'' must match pattern ''{1}''." />
     </module>
     <module name="CatchParameterName" />
+    <module name="InterfaceTypeParameterName" />
     <module name="AbbreviationAsWordInName">
       <property name="allowedAbbreviations" value="UUID" />
     </module>

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -28,7 +28,7 @@
   <property name="severity" value="warning" />
 
   <module name="TreeWalker">
-    <property name="tabWidth" value="1" />
+    <property name="tabWidth" value="4" />
 
     <!-- To enable SuppressWithNearbyCommentFilter -->
     <module name="FileContentsHolder" />
@@ -97,12 +97,12 @@
     <module name="ArrayTypeStyle" />
     <module name="AvoidEscapedUnicodeCharacters" />
     <module name="Indentation">
-      <property name="basicOffset" value="1" />
+      <property name="basicOffset" value="4" />
       <property name="braceAdjustment" value="0" />
-      <property name="caseIndent" value="1" />
-      <property name="throwsIndent" value="2" />
-      <property name="lineWrappingIndentation" value="2" />
-      <property name="arrayInitIndent" value="1" />
+      <property name="caseIndent" value="4" />
+      <property name="throwsIndent" value="8" />
+      <property name="lineWrappingIndentation" value="8" />
+      <property name="arrayInitIndent" value="4" />
     </module>
     <module name="OuterTypeFilename" />
     <module name="UpperEll" />

--- a/catroid/config/checkstyle.xml
+++ b/catroid/config/checkstyle.xml
@@ -181,7 +181,10 @@
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS, UNARY_PLUS, ARRAY_DECLARATOR" />
     </module>
-    <module name="NoWhitespaceBefore" />
+    <module name="NoWhitespaceBefore">
+      <property name="allowLineBreaks" value="true"/>
+      <property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, DOT, GENERIC_END, ELLIPSIS"/>
+    </module>
     <module name="OperatorWrap" />
     <module name="ParenPad" />
     <module name="SeparatorWrap">

--- a/catroid/src/androidTest/java/org/catrobat/catroid/common/bluetooth/models/MindstormsEV3TestModel.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/common/bluetooth/models/MindstormsEV3TestModel.java
@@ -43,17 +43,17 @@ public class MindstormsEV3TestModel implements DeviceModel {
 	private boolean isRunning = true;
 	private boolean replyRequired;
 
-	private EV3Sensor.Sensor[] sensors = { EV3Sensor.Sensor.NO_SENSOR, EV3Sensor.Sensor.NO_SENSOR,
-			EV3Sensor.Sensor.NO_SENSOR, EV3Sensor.Sensor.NO_SENSOR };
-	private byte[] portSensorMode = { 0, 0, 0, 0 };
-	private int[] portSensorValue = { 255, 255, 255, 255 };
-	private boolean[] portSensorActive = { false, false, false, false };
+	private EV3Sensor.Sensor[] sensors = {EV3Sensor.Sensor.NO_SENSOR, EV3Sensor.Sensor.NO_SENSOR,
+			EV3Sensor.Sensor.NO_SENSOR, EV3Sensor.Sensor.NO_SENSOR};
+	private byte[] portSensorMode = {0, 0, 0, 0};
+	private int[] portSensorValue = {255, 255, 255, 255};
+	private boolean[] portSensorActive = {false, false, false, false};
 	private int keepAliveTime = 0;
 	private boolean keepAliveSet = false;
 
 	protected byte[] createResponseFromClientRequest(byte[] message) {
 
-		byte[] msgNumber = { 0, 0 };
+		byte[] msgNumber = {0, 0};
 		msgNumber[0] = message[0];
 		msgNumber[1] = message[1];
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/common/bluetooth/models/MindstormsNXTTestModel.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/common/bluetooth/models/MindstormsNXTTestModel.java
@@ -38,13 +38,13 @@ public class MindstormsNXTTestModel implements DeviceModel {
 	private static final byte SHOULD_REPLY = 0x0;
 	private static final byte NO_ERROR = 0x0;
 	private Random random = new Random(System.currentTimeMillis());
-	private byte[] batteryValue = { getRandomByte(256), getRandomByte(256) };
-	private byte[] keepAliveTime = { getRandomByte(256), getRandomByte(256), getRandomByte(256), getRandomByte(256) };
+	private byte[] batteryValue = {getRandomByte(256), getRandomByte(256)};
+	private byte[] keepAliveTime = {getRandomByte(256), getRandomByte(256), getRandomByte(256), getRandomByte(256)};
 
-	private byte[] portSensorType = { 0, 0, 0, 0 };
-	private byte[] portSensorMode = { 0, 0, 0, 0 };
+	private byte[] portSensorType = {0, 0, 0, 0};
+	private byte[] portSensorMode = {0, 0, 0, 0};
 
-	private byte[] sensorValue = { getRandomByte(256), getRandomByte(256) };
+	private byte[] sensorValue = {getRandomByte(256), getRandomByte(256)};
 
 	private byte ultrasonicSensorBytesReady = 0;
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/OnUtteranceCompletedListenerContainerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/OnUtteranceCompletedListenerContainerTest.java
@@ -115,7 +115,7 @@ public class OnUtteranceCompletedListenerContainerTest extends AndroidTestCase {
 		private static final long serialVersionUID = 1L;
 		private boolean exists;
 
-		public FileMock(boolean exists) {
+		FileMock(boolean exists) {
 			super("");
 			this.exists = exists;
 		}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/XMLValidatingTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/XMLValidatingTest.java
@@ -93,10 +93,10 @@ public class XMLValidatingTest extends AndroidTestCase {
 		ProjectManager.getInstance().setCurrentScript(startScript);
 
 		Context context = getContext();
-		String[] categories = { context.getString(R.string.category_control),
+		String[] categories = {context.getString(R.string.category_control),
 				context.getString(R.string.category_motion), context.getString(R.string.category_sound),
 				context.getString(R.string.category_looks), context.getString(R.string.category_data),
-				context.getString(R.string.category_lego_nxt) };
+				context.getString(R.string.category_lego_nxt)};
 
 		CategoryBricksFactory brickFactory = new CategoryBricksFactory();
 		List<Brick> bricks = new ArrayList<Brick>();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/LookTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/LookTest.java
@@ -138,11 +138,11 @@ public class LookTest extends InstrumentationTestCase {
 	public void testBreakDownCatroidAngle() {
 		Look look = new Look(new SingleSprite("testsprite"));
 
-		float[] posigiveInputAngles = { 0.0f, 45.0f, 90.0f, 135.0f, 180.0f, 225.0f, 270.0f, 315.0f, 360.0f };
-		float[] posigiveHighInputAngles = { 360.0f, 405.0f, 450.0f, 495.0f, 540.0f, 585.0f, 630.0f, 675.0f, 720.0f };
-		float[] posigiveHigherInputAngles = { 720.0f, 765.0f, 810.0f, 855.0f, 900.0f, 945.0f, 990.0f, 1035.0f, 1080.0f };
+		float[] posigiveInputAngles = {0.0f, 45.0f, 90.0f, 135.0f, 180.0f, 225.0f, 270.0f, 315.0f, 360.0f};
+		float[] posigiveHighInputAngles = {360.0f, 405.0f, 450.0f, 495.0f, 540.0f, 585.0f, 630.0f, 675.0f, 720.0f};
+		float[] posigiveHigherInputAngles = {720.0f, 765.0f, 810.0f, 855.0f, 900.0f, 945.0f, 990.0f, 1035.0f, 1080.0f};
 
-		float[] expectedPosigiveCatroidAngles = { 0.0f, 45.0f, 90.0f, 135.0f, 180.0f, -135.0f, -90.0f, -45.0f, 0.0f };
+		float[] expectedPosigiveCatroidAngles = {0.0f, 45.0f, 90.0f, 135.0f, 180.0f, -135.0f, -90.0f, -45.0f, 0.0f};
 
 		for (int index = 0; index < posigiveInputAngles.length; index++) {
 			ParameterList params = new ParameterList(posigiveInputAngles[index]);
@@ -163,13 +163,13 @@ public class LookTest extends InstrumentationTestCase {
 					convertNegativeZeroToPosigiveZero(catroidAngle));
 		}
 
-		float[] negativeInputAngles = { -0.0f, -45.0f, -90.0f, -135.0f, -180.0f, -225.0f, -270.0f, -315.0f, -360.0f };
-		float[] negativeHighInputAngles = { -360.0f, -405.0f, -450.0f, -495.0f, -540.0f, -585.0f, -630.0f, -675.0f,
-				-720.0f };
-		float[] negativeHigherInputAngles = { -720.0f, -765.0f, -810.0f, -855.0f, -900.0f, -945.0f, -990.0f, -1035.0f,
-				-1080.0f };
+		float[] negativeInputAngles = {-0.0f, -45.0f, -90.0f, -135.0f, -180.0f, -225.0f, -270.0f, -315.0f, -360.0f};
+		float[] negativeHighInputAngles = {-360.0f, -405.0f, -450.0f, -495.0f, -540.0f, -585.0f, -630.0f, -675.0f,
+				-720.0f};
+		float[] negativeHigherInputAngles = {-720.0f, -765.0f, -810.0f, -855.0f, -900.0f, -945.0f, -990.0f, -1035.0f,
+				-1080.0f};
 
-		float[] expectedNegativeCatroidAngles = { 0.0f, -45.0f, -90.0f, -135.0f, 180.0f, 135.0f, 90.0f, 45.0f, 0.0f };
+		float[] expectedNegativeCatroidAngles = {0.0f, -45.0f, -90.0f, -135.0f, 180.0f, 135.0f, 90.0f, 45.0f, 0.0f};
 
 		for (int index = 0; index < negativeInputAngles.length; index++) {
 			ParameterList params = new ParameterList(negativeInputAngles[index]);
@@ -194,10 +194,10 @@ public class LookTest extends InstrumentationTestCase {
 	}
 
 	public void testCatroidAngleToStageAngle() {
-		float[] posigiveCatroidAngles = { 0.0f, 45.0f, 90.0f, 135.0f, 180.0f, 225.0f, 270.0f, 315.0f, 360.0f };
-		float[] posigiveHighCatroidAngles = { 360.0f, 405.0f, 450.0f, 495.0f, 540.0f, 585.0f, 630.0f, 675.0f, 720.0f };
+		float[] posigiveCatroidAngles = {0.0f, 45.0f, 90.0f, 135.0f, 180.0f, 225.0f, 270.0f, 315.0f, 360.0f};
+		float[] posigiveHighCatroidAngles = {360.0f, 405.0f, 450.0f, 495.0f, 540.0f, 585.0f, 630.0f, 675.0f, 720.0f};
 		//float[] expectedPosigiveStageAngles = { 90.0f, 45.0f, 0.0f, 315.0f, 270.0f, 225.0f, 180.0f, 135.0f, 90.0f };
-		float[] expectedPosigiveStageAngles = { 90.0f, 45.0f, 0.0f, -45.0f, -90.0f, 225.0f, 180.0f, 135.0f, 90.0f };
+		float[] expectedPosigiveStageAngles = {90.0f, 45.0f, 0.0f, -45.0f, -90.0f, 225.0f, 180.0f, 135.0f, 90.0f};
 
 		for (int index = 0; index < posigiveCatroidAngles.length; index++) {
 			ParameterList params = new ParameterList(posigiveCatroidAngles[index]);
@@ -213,11 +213,11 @@ public class LookTest extends InstrumentationTestCase {
 					expectedPosigiveStageAngles[index], convertNegativeZeroToPosigiveZero(stageAngle));
 		}
 
-		float[] negativeCatroidAngles = { -0.0f, -45.0f, -90.0f, -135.0f, -180.0f, -225.0f, -270.0f, -315.0f, -360.0f };
-		float[] negativeHighCatroidAngles = { -360.0f, -405.0f, -450.0f, -495.0f, -540.0f, -585.0f, -630.0f, -675.0f,
-				-720.0f };
+		float[] negativeCatroidAngles = {-0.0f, -45.0f, -90.0f, -135.0f, -180.0f, -225.0f, -270.0f, -315.0f, -360.0f};
+		float[] negativeHighCatroidAngles = {-360.0f, -405.0f, -450.0f, -495.0f, -540.0f, -585.0f, -630.0f, -675.0f,
+				-720.0f};
 		//float[] expectedNegativeStageAngles = { 90.0f, 135.0f, 180.0f, 225.0f, 270.0f, 315.0f, 0.0f, 45.0f, 90.0f };
-		float[] expectedNegativeStageAngles = { 90.0f, 135.0f, 180.0f, 225.0f, -90.0f, -45.0f, 0.0f, 45.0f, 90.0f };
+		float[] expectedNegativeStageAngles = {90.0f, 135.0f, 180.0f, 225.0f, -90.0f, -45.0f, 0.0f, 45.0f, 90.0f};
 
 		for (int index = 0; index < negativeCatroidAngles.length; index++) {
 			ParameterList params = new ParameterList(negativeCatroidAngles[index]);
@@ -235,10 +235,10 @@ public class LookTest extends InstrumentationTestCase {
 	}
 
 	public void testStageAngleToCatroidAngle() {
-		float[] posigiveStageAngles = { 0.0f, 45.0f, 90.0f, 135.0f, 180.0f, 225.0f, 270.0f, 315.0f, 360.0f };
-		float[] posigiveHighCatroiStagedAngles = { 360.0f, 405.0f, 450.0f, 495.0f, 540.0f, 585.0f, 630.0f, 675.0f,
-				720.0f };
-		float[] expectedPosigiveCatroidAngles = { 90.0f, 45.0f, 0.0f, -45.0f, -90.0f, -135.0f, 180.0f, 135.0f, 90.0f };
+		float[] posigiveStageAngles = {0.0f, 45.0f, 90.0f, 135.0f, 180.0f, 225.0f, 270.0f, 315.0f, 360.0f};
+		float[] posigiveHighCatroiStagedAngles = {360.0f, 405.0f, 450.0f, 495.0f, 540.0f, 585.0f, 630.0f, 675.0f,
+				720.0f};
+		float[] expectedPosigiveCatroidAngles = {90.0f, 45.0f, 0.0f, -45.0f, -90.0f, -135.0f, 180.0f, 135.0f, 90.0f};
 
 		for (int index = 0; index < posigiveStageAngles.length; index++) {
 			ParameterList params = new ParameterList(posigiveStageAngles[index]);
@@ -254,10 +254,10 @@ public class LookTest extends InstrumentationTestCase {
 					expectedPosigiveCatroidAngles[index], convertNegativeZeroToPosigiveZero(stageAngle));
 		}
 
-		float[] negativeStageAngles = { -0.0f, -45.0f, -90.0f, -135.0f, -180.0f, -225.0f, -270.0f, -315.0f, -360.0f };
-		float[] negativeHighStageAngles = { -360.0f, -405.0f, -450.0f, -495.0f, -540.0f, -585.0f, -630.0f, -675.0f,
-				-720.0f };
-		float[] expectedNegativeCatroidAngles = { 90.0f, 135.0f, 180.0f, -135.0f, -90.0f, -45.0f, 0.0f, 45.0f, 90.0f };
+		float[] negativeStageAngles = {-0.0f, -45.0f, -90.0f, -135.0f, -180.0f, -225.0f, -270.0f, -315.0f, -360.0f};
+		float[] negativeHighStageAngles = {-360.0f, -405.0f, -450.0f, -495.0f, -540.0f, -585.0f, -630.0f, -675.0f,
+				-720.0f};
+		float[] expectedNegativeCatroidAngles = {90.0f, 135.0f, 180.0f, -135.0f, -90.0f, -45.0f, 0.0f, 45.0f, 90.0f};
 
 		for (int index = 0; index < negativeStageAngles.length; index++) {
 			ParameterList params = new ParameterList(negativeStageAngles[index]);
@@ -275,9 +275,9 @@ public class LookTest extends InstrumentationTestCase {
 	}
 
 	public void testDirection() {
-		float[] degreesInUserInterfaceDimensionUnit = { 90f, 60f, 30f, 0f, -30f, -60f, -90f, -120f, -150f, 180f, 150f,
-				120f };
-		float[] degrees = { 0f, 30f, 60f, 90f, 120f, 150f, 180f, 210f, 240f, -90f, -60f, -30f };
+		float[] degreesInUserInterfaceDimensionUnit = {90f, 60f, 30f, 0f, -30f, -60f, -90f, -120f, -150f, 180f, 150f,
+				120f};
+		float[] degrees = {0f, 30f, 60f, 90f, 120f, 150f, 180f, 210f, 240f, -90f, -60f, -30f};
 
 		assertEquals("Wrong Array length", degrees.length, degreesInUserInterfaceDimensionUnit.length);
 		for (int index = 0; index < degrees.length; index++) {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/mindstorms/nxt/LegoNXTImplTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/mindstorms/nxt/LegoNXTImplTest.java
@@ -67,8 +67,8 @@ public class LegoNXTImplTest extends AndroidTestCase {
 	public void testSensorAssignment() throws InterruptedException {
 
 		SettingsActivity.setLegoMindstormsNXTSensorMapping(applicationContext,
-				new NXTSensor.Sensor[] { NXTSensor.Sensor.LIGHT_INACTIVE, NXTSensor.Sensor.SOUND,
-						NXTSensor.Sensor.TOUCH, NXTSensor.Sensor.ULTRASONIC });
+				new NXTSensor.Sensor[] {NXTSensor.Sensor.LIGHT_INACTIVE, NXTSensor.Sensor.SOUND,
+						NXTSensor.Sensor.TOUCH, NXTSensor.Sensor.ULTRASONIC});
 
 		nxt.initialise();
 
@@ -95,8 +95,8 @@ public class LegoNXTImplTest extends AndroidTestCase {
 
 	private void resetSensorMappingToDefault() throws InterruptedException {
 		SettingsActivity.setLegoMindstormsNXTSensorMapping(this.getContext(),
-				new NXTSensor.Sensor[] { NXTSensor.Sensor.TOUCH, NXTSensor.Sensor.SOUND,
-						NXTSensor.Sensor.LIGHT_INACTIVE, NXTSensor.Sensor.ULTRASONIC });
+				new NXTSensor.Sensor[] {NXTSensor.Sensor.TOUCH, NXTSensor.Sensor.SOUND,
+						NXTSensor.Sensor.LIGHT_INACTIVE, NXTSensor.Sensor.ULTRASONIC});
 	}
 
 	public void testSensorAssignmentChange() throws InterruptedException {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/mindstorms/nxt/MindstormsConnectionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/mindstorms/nxt/MindstormsConnectionTest.java
@@ -68,7 +68,7 @@ public class MindstormsConnectionTest extends AndroidTestCase {
 
 	public void testSendAndReceive() {
 
-		byte[] inputBuffer = new byte[] { 4, 0, 3, 4, 5, 7 };
+		byte[] inputBuffer = new byte[] {4, 0, 3, 4, 5, 7};
 		ByteArrayInputStream inStream = new ByteArrayInputStream(inputBuffer);
 		ByteArrayOutputStream outStream = new ByteArrayOutputStream();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/io/CatroidFieldKeySorterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/io/CatroidFieldKeySorterTest.java
@@ -83,14 +83,14 @@ public class CatroidFieldKeySorterTest extends AndroidTestCase {
 		xstream.toXML(new BaseClass());
 
 		MoreAsserts.assertEquals("Sorted fields differ",
-				new String[] { "a", "x" }, fieldKeySorter.getFieldNames(BaseClass.class));
+				new String[] {"a", "x"}, fieldKeySorter.getFieldNames(BaseClass.class));
 	}
 
 	public void testSortTagsAlphabeticallyByClassHierarchy() {
 		xstream.toXML(new SubClass());
 
 		MoreAsserts.assertEquals("Sorted fields differ",
-				new String[] { "a", "x", "b", "y", "z" }, fieldKeySorter.getFieldNames(SubClass.class));
+				new String[] {"a", "x", "b", "y", "z"}, fieldKeySorter.getFieldNames(SubClass.class));
 	}
 
 	@SuppressWarnings("PMD.UnusedPrivateField")
@@ -125,7 +125,7 @@ public class CatroidFieldKeySorterTest extends AndroidTestCase {
 		xstream.toXML(new SortAlphabeticallyWithAliases());
 
 		MoreAsserts.assertEquals("Sorted fields differ",
-				new String[] { "b", "x", "y" }, fieldKeySorter.getFieldNames(SortAlphabeticallyWithAliases.class));
+				new String[] {"b", "x", "y"}, fieldKeySorter.getFieldNames(SortAlphabeticallyWithAliases.class));
 	}
 
 	@SuppressWarnings("PMD.UnusedPrivateField")
@@ -140,7 +140,7 @@ public class CatroidFieldKeySorterTest extends AndroidTestCase {
 		xstream.toXML(new SortByAnnotation());
 
 		MoreAsserts.assertEquals("Sorted fields differ",
-				new String[] { "c", "a", "d", "b" }, fieldKeySorter.getFieldNames(SortByAnnotation.class));
+				new String[] {"c", "a", "d", "b"}, fieldKeySorter.getFieldNames(SortByAnnotation.class));
 	}
 
 	// Remove checkstyle disable when https://github.com/checkstyle/checkstyle/issues/1349 is fixed
@@ -163,7 +163,7 @@ public class CatroidFieldKeySorterTest extends AndroidTestCase {
 		xstream.toXML(new SortByAnnotationWithAliases());
 
 		MoreAsserts.assertEquals("Sorted fields differ",
-				new String[] { "x", "b" }, fieldKeySorter.getFieldNames(SortByAnnotationWithAliases.class));
+				new String[] {"x", "b"}, fieldKeySorter.getFieldNames(SortByAnnotationWithAliases.class));
 	}
 
 	// Remove checkstyle disable when https://github.com/checkstyle/checkstyle/issues/1349 is fixed
@@ -202,7 +202,7 @@ public class CatroidFieldKeySorterTest extends AndroidTestCase {
 		xstream.toXML(new SubClassWithoutAnnotation());
 
 		MoreAsserts.assertEquals("Sorted fields differ",
-				new String[] { "b", "a" }, fieldKeySorter.getFieldNames(SubClassWithoutAnnotation.class));
+				new String[] {"b", "a"}, fieldKeySorter.getFieldNames(SubClassWithoutAnnotation.class));
 	}
 
 	public void testMissingFieldInSubClassWithoutAnnotationThrowsException() {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionBetweenTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionBetweenTest.java
@@ -59,7 +59,7 @@ public class PhysicsCollisionBetweenTest extends PhysicsCollisionBaseTest {
 					(Map<Integer, PhysicsCollisionBroadcast>) Reflection.getPrivateField(PhysicsCollision.class,
 							physicsCollisionTestListener, "physicsCollisionBroadcasts");
 			assertTrue("Map must contain one element", physicsCollisionBroadcasts.size() == 2);
-			Object[] parameters = { sprite, sprite2 };
+			Object[] parameters = {sprite, sprite2};
 			Reflection.ParameterList paramList = new Reflection.ParameterList(parameters);
 			String key = (String) Reflection.invokeMethod(PhysicsCollision.class, physicsCollisionTestListener,
 					"generateKey", paramList);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionBetweenTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionBetweenTest.java
@@ -55,9 +55,9 @@ public class PhysicsCollisionBetweenTest extends PhysicsCollisionBaseTest {
 	public void beginContactCallback(Contact contact) {
 		try {
 			super.beginContactCallback(contact);
-			Map<Integer, PhysicsCollisionBroadcast> physicsCollisionBroadcasts = (Map<Integer,
-					PhysicsCollisionBroadcast>) Reflection.getPrivateField(PhysicsCollision.class,
-					physicsCollisionTestListener, "physicsCollisionBroadcasts");
+			Map<Integer, PhysicsCollisionBroadcast> physicsCollisionBroadcasts =
+					(Map<Integer, PhysicsCollisionBroadcast>) Reflection.getPrivateField(PhysicsCollision.class,
+							physicsCollisionTestListener, "physicsCollisionBroadcasts");
 			assertTrue("Map must contain one element", physicsCollisionBroadcasts.size() == 2);
 			Object[] parameters = { sprite, sprite2 };
 			Reflection.ParameterList paramList = new Reflection.ParameterList(parameters);
@@ -76,8 +76,8 @@ public class PhysicsCollisionBetweenTest extends PhysicsCollisionBaseTest {
 	public void endContactCallback(Contact contact) {
 		try {
 			super.endContactCallback(contact);
-			Map<Integer, PhysicsCollisionBroadcast> physicsCollisionBroadcasts = (Map<Integer,
-					PhysicsCollisionBroadcast>) Reflection.getPrivateField(PhysicsCollision.class,
+			Map<Integer, PhysicsCollisionBroadcast> physicsCollisionBroadcasts =
+					(Map<Integer, PhysicsCollisionBroadcast>) Reflection.getPrivateField(PhysicsCollision.class,
 					physicsCollisionTestListener, "physicsCollisionBroadcasts");
 			if (getContactDifference() == 0) {
 				assertTrue("Map must contain zero elements", physicsCollisionBroadcasts.size() == 0);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionBetweenTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionBetweenTest.java
@@ -78,7 +78,7 @@ public class PhysicsCollisionBetweenTest extends PhysicsCollisionBaseTest {
 			super.endContactCallback(contact);
 			Map<Integer, PhysicsCollisionBroadcast> physicsCollisionBroadcasts =
 					(Map<Integer, PhysicsCollisionBroadcast>) Reflection.getPrivateField(PhysicsCollision.class,
-					physicsCollisionTestListener, "physicsCollisionBroadcasts");
+							physicsCollisionTestListener, "physicsCollisionBroadcasts");
 			if (getContactDifference() == 0) {
 				assertTrue("Map must contain zero elements", physicsCollisionBroadcasts.size() == 0);
 			} else {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionScriptInteractionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionScriptInteractionTest.java
@@ -134,7 +134,7 @@ public class PhysicsCollisionScriptInteractionTest extends InstrumentationTestCa
 				secondSpriteCollisionScript.getBroadcastMessage());
 
 		try {
-			Object[] values = { FIRST_SPRITE_NAME_NEW };
+			Object[] values = {FIRST_SPRITE_NAME_NEW};
 			Reflection.ParameterList paramList = new Reflection.ParameterList(values);
 			Reflection.invokeMethod(Sprite.class, firstSprite, SPRITE_RENAME_METHOD_NAME, paramList);
 
@@ -147,7 +147,7 @@ public class PhysicsCollisionScriptInteractionTest extends InstrumentationTestCa
 					secondSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgSecondFirstNew,
 					secondSpriteCollisionScript.getBroadcastMessage());
 
-			values = new Object[] { SECOND_SPRITE_NAME_NEW };
+			values = new Object[] {SECOND_SPRITE_NAME_NEW};
 			paramList = new Reflection.ParameterList(values);
 			Reflection.invokeMethod(Sprite.class, secondSprite, SPRITE_RENAME_METHOD_NAME, paramList);
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionScriptInteractionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionScriptInteractionTest.java
@@ -103,8 +103,8 @@ public class PhysicsCollisionScriptInteractionTest extends InstrumentationTestCa
 
 	public void testCollisionBroadcastMessageGeneration() {
 		Assert.assertEquals(String.format("The generated collision broadcast message is incorrect (%s != %s)",
-						COLLISION_BROADCAST_MESSAGE,
-						PhysicsCollision.generateBroadcastMessage(FIRST_SPRITE_NAME, SECOND_SPRITE_NAME)),
+				COLLISION_BROADCAST_MESSAGE,
+				PhysicsCollision.generateBroadcastMessage(FIRST_SPRITE_NAME, SECOND_SPRITE_NAME)),
 				COLLISION_BROADCAST_MESSAGE,
 				PhysicsCollision.generateBroadcastMessage(FIRST_SPRITE_NAME, SECOND_SPRITE_NAME));
 	}
@@ -125,12 +125,12 @@ public class PhysicsCollisionScriptInteractionTest extends InstrumentationTestCa
 				FIRST_SPRITE_NAME_NEW);
 
 		Assert.assertEquals(String.format("collision broadcast message of first collision script is wrong before "
-								+ "renaming (%s != %s)", colBroadcastMsgFirstSecond,
-						firstSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgFirstSecond,
+						+ "renaming (%s != %s)", colBroadcastMsgFirstSecond,
+				firstSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgFirstSecond,
 				firstSpriteCollisionScript.getBroadcastMessage());
 		Assert.assertEquals(String.format("collision broadcast message of second collision script is wrong before "
-								+ "renaming (%s != %s)", colBroadcastMsgSecondFirst,
-						secondSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgSecondFirst,
+						+ "renaming (%s != %s)", colBroadcastMsgSecondFirst,
+				secondSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgSecondFirst,
 				secondSpriteCollisionScript.getBroadcastMessage());
 
 		try {
@@ -139,12 +139,12 @@ public class PhysicsCollisionScriptInteractionTest extends InstrumentationTestCa
 			Reflection.invokeMethod(Sprite.class, firstSprite, SPRITE_RENAME_METHOD_NAME, paramList);
 
 			Assert.assertEquals(String.format("collision broadcast message of first collision script is wrong after "
-									+ "renaming first sprite (%s != %s)", colBroadcastMsgFirstNewSecond,
-							firstSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgFirstNewSecond,
+							+ "renaming first sprite (%s != %s)", colBroadcastMsgFirstNewSecond,
+					firstSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgFirstNewSecond,
 					firstSpriteCollisionScript.getBroadcastMessage());
 			Assert.assertEquals(String.format("collision broadcast message of second collision script is wrong after"
-									+ "renaming first sprite (%s != %s)", colBroadcastMsgSecondFirstNew,
-							secondSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgSecondFirstNew,
+							+ "renaming first sprite (%s != %s)", colBroadcastMsgSecondFirstNew,
+					secondSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgSecondFirstNew,
 					secondSpriteCollisionScript.getBroadcastMessage());
 
 			values = new Object[] { SECOND_SPRITE_NAME_NEW };
@@ -152,12 +152,12 @@ public class PhysicsCollisionScriptInteractionTest extends InstrumentationTestCa
 			Reflection.invokeMethod(Sprite.class, secondSprite, SPRITE_RENAME_METHOD_NAME, paramList);
 
 			Assert.assertEquals(String.format("collision broadcast message of first collision script is wrong after "
-									+ "renaming second sprite (%s != %s)", colBroadcastMsgFirstNewSecondNew,
-							firstSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgFirstNewSecondNew,
+							+ "renaming second sprite (%s != %s)", colBroadcastMsgFirstNewSecondNew,
+					firstSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgFirstNewSecondNew,
 					firstSpriteCollisionScript.getBroadcastMessage());
 			Assert.assertEquals(String.format("collision broadcast message of second collision script is wrong after "
-									+ "renaming second sprite (%s != %s)", colBroadcastMsgSecondNewFirstNew,
-							secondSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgSecondNewFirstNew,
+							+ "renaming second sprite (%s != %s)", colBroadcastMsgSecondNewFirstNew,
+					secondSpriteCollisionScript.getBroadcastMessage()), colBroadcastMsgSecondNewFirstNew,
 					secondSpriteCollisionScript.getBroadcastMessage());
 		} catch (Exception e) {
 			Log.e(TAG, e.getMessage(), e);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionTest.java
@@ -36,11 +36,11 @@ public class PhysicsCollisionTest extends InstrumentationTestCase {
 		Sprite sprite1 = new Sprite("testsprite_1234()77//Njasd%&klf");
 		Sprite sprite2 = new Sprite("spritetest_9087124356iguaöwdzf() //OGZLUSDüKJGFLHKsd");
 
-		Object[] values1 = { sprite1, sprite2 };
+		Object[] values1 = {sprite1, sprite2};
 		Reflection.ParameterList paramList = new Reflection.ParameterList(values1);
 		String key1 = (String) Reflection.invokeMethod(PhysicsCollision.class, physicsCollision, "generateKey", paramList);
 
-		Object[] values2 = { sprite2, sprite1 };
+		Object[] values2 = {sprite2, sprite1};
 		paramList = new Reflection.ParameterList(values2);
 		String key2 = (String) Reflection.invokeMethod(PhysicsCollision.class, physicsCollision, "generateKey", paramList);
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsLookTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsLookTest.java
@@ -226,12 +226,12 @@ public class PhysicsLookTest extends InstrumentationTestCase {
 						Vector2 vertex = new Vector2();
 						((PolygonShape) shape).getVertex(idx, vertex);
 
-						Object[] objectsX = { vertexXQueue.poll(), testScaleFactor };
+						Object[] objectsX = {vertexXQueue.poll(), testScaleFactor};
 						Reflection.ParameterList parameterListX = new Reflection.ParameterList(objectsX);
 						float scaledX = (float) Reflection.invokeMethod(PhysicsShapeScaleUtils.class, "scaleCoordinate",
 								parameterListX);
 
-						Object[] objectsY = { vertexYQueue.poll(), testScaleFactor };
+						Object[] objectsY = {vertexYQueue.poll(), testScaleFactor};
 						Reflection.ParameterList parameterListY = new Reflection.ParameterList(objectsY);
 						float scaledY = (float) Reflection.invokeMethod(PhysicsShapeScaleUtils.class, "scaleCoordinate",
 								parameterListY);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsObjectTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsObjectTest.java
@@ -111,7 +111,7 @@ public class PhysicsObjectTest extends AndroidTestCase {
 
 	public void testSetShape() {
 		PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld);
-		PolygonShape[] rectangle = new PolygonShape[] { PhysicsTestUtils.createRectanglePolygonShape(5.0f, 5.0f) };
+		PolygonShape[] rectangle = new PolygonShape[] {PhysicsTestUtils.createRectanglePolygonShape(5.0f, 5.0f)};
 		physicsObject.setShape(rectangle);
 
 		checkIfShapesAreTheSameAsInPhysicsObject(rectangle, PhysicsTestUtils.getBody(physicsObject));
@@ -119,11 +119,11 @@ public class PhysicsObjectTest extends AndroidTestCase {
 
 	public void testSetNewShape() {
 		PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld);
-		Shape[] shape = new PolygonShape[] { PhysicsTestUtils.createRectanglePolygonShape(5.0f, 5.0f) };
+		Shape[] shape = new PolygonShape[] {PhysicsTestUtils.createRectanglePolygonShape(5.0f, 5.0f)};
 		physicsObject.setShape(shape);
 
 		Body body = PhysicsTestUtils.getBody(physicsObject);
-		PolygonShape[] newShape = new PolygonShape[] { PhysicsTestUtils.createRectanglePolygonShape(2.0f, 3.0f) };
+		PolygonShape[] newShape = new PolygonShape[] {PhysicsTestUtils.createRectanglePolygonShape(2.0f, 3.0f)};
 		physicsObject.setShape(newShape);
 
 		assertNotSame("The new shape hasn't been set", shape, PhysicsTestUtils.getShapes(physicsObject));
@@ -134,7 +134,7 @@ public class PhysicsObjectTest extends AndroidTestCase {
 		PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld);
 		Body body = PhysicsTestUtils.getBody(physicsObject);
 
-		Shape[] rectangle = new Shape[] { PhysicsTestUtils.createRectanglePolygonShape(5.0f, 5.0f) };
+		Shape[] rectangle = new Shape[] {PhysicsTestUtils.createRectanglePolygonShape(5.0f, 5.0f)};
 		physicsObject.setShape(rectangle);
 		assertFalse("No shape has been set", body.getFixtureList().size == 0);
 
@@ -149,7 +149,7 @@ public class PhysicsObjectTest extends AndroidTestCase {
 		PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld);
 		Body body = PhysicsTestUtils.getBody(physicsObject);
 
-		physicsObject.setShape(new Shape[] { PhysicsTestUtils.createRectanglePolygonShape(5.0f, 5.0f) });
+		physicsObject.setShape(new Shape[] {PhysicsTestUtils.createRectanglePolygonShape(5.0f, 5.0f)});
 		assertFalse("No shape has been set", body.getFixtureList().size == 0);
 
 		physicsObject.setShape(null);
@@ -159,13 +159,13 @@ public class PhysicsObjectTest extends AndroidTestCase {
 
 	public void testSetShapeUpdatesDensityButNotMass() {
 		PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld);
-		physicsObject.setShape(new Shape[] { PhysicsTestUtils.createRectanglePolygonShape(5.0f, 5.0f) });
+		physicsObject.setShape(new Shape[] {PhysicsTestUtils.createRectanglePolygonShape(5.0f, 5.0f)});
 		Body body = PhysicsTestUtils.getBody(physicsObject);
 
 		float oldDensity = PhysicsTestUtils.getFixtureDef(physicsObject).density;
 		float oldMass = body.getMass();
 
-		physicsObject.setShape(new Shape[] { PhysicsTestUtils.createRectanglePolygonShape(111.0f, 111.0f) });
+		physicsObject.setShape(new Shape[] {PhysicsTestUtils.createRectanglePolygonShape(111.0f, 111.0f)});
 
 		assertNotSame("Density hasn't changed", oldDensity, PhysicsTestUtils.getFixtureDef(physicsObject).density);
 		assertEquals("Mass has changed", oldMass, body.getMass());
@@ -209,7 +209,7 @@ public class PhysicsObjectTest extends AndroidTestCase {
 
 		float rectangleSize = 10.0f;
 		physicsObject
-				.setShape(new Shape[] { PhysicsTestUtils.createRectanglePolygonShape(rectangleSize, rectangleSize) });
+				.setShape(new Shape[] {PhysicsTestUtils.createRectanglePolygonShape(rectangleSize, rectangleSize)});
 
 		float mass = 128.0f;
 		physicsObject.setMass(mass);
@@ -224,7 +224,7 @@ public class PhysicsObjectTest extends AndroidTestCase {
 			PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld, type);
 			assertEquals("Wrong initialization", 0.0f, PhysicsTestUtils.getBody(physicsObject).getAngle());
 
-			float[] angles = { 45.0f, 1.0f, 131.4f, -10.0f, -180.0f };
+			float[] angles = {45.0f, 1.0f, 131.4f, -10.0f, -180.0f};
 			for (float angle : angles) {
 				physicsObject.setDirection(angle);
 				assertEquals("Wrong angle returned from physics object", angle, physicsObject.getDirection(), TestUtils.DELTA);
@@ -237,7 +237,7 @@ public class PhysicsObjectTest extends AndroidTestCase {
 			PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld, type);
 			assertEquals("Wrong initialization", new Vector2(), PhysicsTestUtils.getBody(physicsObject).getPosition());
 
-			Vector2[] positions = { new Vector2(12.34f, 56.78f), new Vector2(-87.65f, -43.21f) };
+			Vector2[] positions = {new Vector2(12.34f, 56.78f), new Vector2(-87.65f, -43.21f)};
 			for (Vector2 position : positions) {
 				physicsObject.setPosition(position.x, position.y);
 
@@ -283,14 +283,14 @@ public class PhysicsObjectTest extends AndroidTestCase {
 	public void testSetDensity() {
 		for (PhysicsObject.Type type : PhysicsObject.Type.values()) {
 			PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld, type);
-			physicsObject.setShape(new Shape[] { new PolygonShape(), new PolygonShape() });
+			physicsObject.setShape(new Shape[] {new PolygonShape(), new PolygonShape()});
 
-			float[] densityValues = { 0.123f, -0.765f, 24.32f };
+			float[] densityValues = {0.123f, -0.765f, 24.32f};
 			assertFalse("Without any fixtures the correctness won't be tested.", PhysicsTestUtils
 					.getBody(physicsObject).getFixtureList().size == 0);
 
 			for (float density : densityValues) {
-				Object[] values = { density };
+				Object[] values = {density};
 				String methodName = "setDensity";
 				ParameterList paramList = new ParameterList(values);
 				Reflection.invokeMethod(physicsObject, methodName, paramList);
@@ -320,7 +320,7 @@ public class PhysicsObjectTest extends AndroidTestCase {
 		float density = 12.0f;
 		assertNotSame("Densities are the same", density, PhysicsTestUtils.getFixtureDef(physicsObject).density);
 
-		Object[] values = { density };
+		Object[] values = {density};
 		String methodName = "setDensity";
 		ParameterList paramList = new ParameterList(values);
 		Reflection.invokeMethod(physicsObject, methodName, paramList);
@@ -332,10 +332,10 @@ public class PhysicsObjectTest extends AndroidTestCase {
 		Body body = PhysicsTestUtils.getBody(physicsObject);
 
 		float rectangleSize = 24.0f;
-		float[] masses = { PhysicsObject.MIN_MASS, 1.0f, 24.0f };
+		float[] masses = {PhysicsObject.MIN_MASS, 1.0f, 24.0f};
 
 		physicsObject
-				.setShape(new Shape[] { PhysicsTestUtils.createRectanglePolygonShape(rectangleSize, rectangleSize) });
+				.setShape(new Shape[] {PhysicsTestUtils.createRectanglePolygonShape(rectangleSize, rectangleSize)});
 		for (float mass : masses) {
 			physicsObject.setMass(mass);
 			float actualDensity = body.getMass() / (rectangleSize * rectangleSize);
@@ -347,8 +347,8 @@ public class PhysicsObjectTest extends AndroidTestCase {
 	public void testSetFriction() {
 		for (PhysicsObject.Type type : PhysicsObject.Type.values()) {
 			PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld, type);
-			physicsObject.setShape(new Shape[] { new PolygonShape(), new PolygonShape() });
-			float[] frictionValues = { 0.123f, -0.765f, 0.32f };
+			physicsObject.setShape(new Shape[] {new PolygonShape(), new PolygonShape()});
+			float[] frictionValues = {0.123f, -0.765f, 0.32f};
 
 			assertFalse("Without any fixtures the correctness won't be tested.", PhysicsTestUtils
 					.getBody(physicsObject).getFixtureList().size == 0);
@@ -375,8 +375,8 @@ public class PhysicsObjectTest extends AndroidTestCase {
 	public void testSetBounceFactor() {
 		for (PhysicsObject.Type type : PhysicsObject.Type.values()) {
 			PhysicsObject physicsObject = PhysicsTestUtils.createPhysicsObject(physicsWorld, type);
-			physicsObject.setShape(new Shape[] { new PolygonShape(), new PolygonShape() });
-			float[] bounceFactors = { 0.123f, -0.765f, 0.32f };
+			physicsObject.setShape(new Shape[] {new PolygonShape(), new PolygonShape()});
+			float[] bounceFactors = {0.123f, -0.765f, 0.32f};
 
 			assertFalse("Without any fixtures the correctness won't be tested.", PhysicsTestUtils
 					.getBody(physicsObject).getFixtureList().size == 0);
@@ -408,7 +408,7 @@ public class PhysicsObjectTest extends AndroidTestCase {
 			checkBodyMassDependingOnType(type, body, PhysicsObject.DEFAULT_MASS);
 			assertEquals("Wrong initialization", PhysicsObject.DEFAULT_MASS, PhysicsTestUtils.getMass(physicsObject));
 
-			float[] masses = { PhysicsObject.MIN_MASS, 0.01f, 1.0f, 12345.0f };
+			float[] masses = {PhysicsObject.MIN_MASS, 0.01f, 1.0f, 12345.0f};
 			for (float mass : masses) {
 				physicsObject.setMass(mass);
 				checkBodyMassDependingOnType(type, body, mass);
@@ -442,7 +442,7 @@ public class PhysicsObjectTest extends AndroidTestCase {
 	public void testMassWithNoShapeArea() {
 		PhysicsObject[] physicsObjects = {
 				PhysicsTestUtils.createPhysicsObject(physicsWorld, PhysicsObject.Type.DYNAMIC),
-				PhysicsTestUtils.createPhysicsObject(physicsWorld, PhysicsObject.Type.DYNAMIC, 0.0f, 0.0f) };
+				PhysicsTestUtils.createPhysicsObject(physicsWorld, PhysicsObject.Type.DYNAMIC, 0.0f, 0.0f)};
 
 		for (PhysicsObject physicsObject : physicsObjects) {
 			Body body = PhysicsTestUtils.getBody(physicsObject);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsShapeBuilderTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsShapeBuilderTest.java
@@ -118,7 +118,7 @@ public class PhysicsShapeBuilderTest extends InstrumentationTestCase {
 				sprite.look.getSizeInUserInterfaceDimensionUnit() / 100f);
 
 		int expectedPolynoms = 1;
-		int[] expectedVertices = { 4 };
+		int[] expectedVertices = {4};
 		checkBuiltShapes(shapes, expectedPolynoms, expectedVertices);
 	}
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsWorldConverterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsWorldConverterTest.java
@@ -60,7 +60,7 @@ public class PhysicsWorldConverterTest extends AndroidTestCase {
 		Assert.assertEquals("180° should be convertBox2dToNormalAngle(PI)", 180.0f,
 				PhysicsWorldConverter.convertBox2dToNormalAngle((float) Math.PI), TestUtils.DELTA);
 
-		float[] angles = { 123.456f, -123.456f, 1024.0f };
+		float[] angles = {123.456f, -123.456f, 1024.0f};
 		for (float currentAngle : angles) {
 			Assert.assertEquals((float) Math.toDegrees(currentAngle),
 					PhysicsWorldConverter.convertBox2dToNormalAngle(currentAngle));
@@ -74,7 +74,7 @@ public class PhysicsWorldConverterTest extends AndroidTestCase {
 		Assert.assertEquals(length, PhysicsWorldConverter.convertBox2dToNormalCoordinate(length));
 		Assert.assertEquals(length, PhysicsWorldConverter.convertNormalToBox2dCoordinate(length));
 
-		float[] lengths = { 123.456f, -654.321f };
+		float[] lengths = {123.456f, -654.321f};
 		for (float currentLength : lengths) {
 			Assert.assertEquals(currentLength * ratio,
 					PhysicsWorldConverter.convertBox2dToNormalCoordinate(currentLength));
@@ -88,8 +88,8 @@ public class PhysicsWorldConverterTest extends AndroidTestCase {
 		Assert.assertEquals(vector, PhysicsWorldConverter.convertBox2dToNormalVector(vector));
 		Assert.assertEquals(vector, PhysicsWorldConverter.convertCatroidToBox2dVector(vector));
 
-		Vector2[] vectors = { new Vector2(123.456f, 123.456f), new Vector2(654.321f, -123.456f),
-				new Vector2(-654.321f, 0.0f), new Vector2(-123.456f, -654.321f) };
+		Vector2[] vectors = {new Vector2(123.456f, 123.456f), new Vector2(654.321f, -123.456f),
+				new Vector2(-654.321f, 0.0f), new Vector2(-123.456f, -654.321f)};
 
 		Vector2 expected;
 		for (Vector2 currentVector : vectors) {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsWorldTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsWorldTest.java
@@ -120,7 +120,7 @@ public class PhysicsWorldTest extends AndroidTestCase {
 	}
 
 	public void testCreatePhysicsObject() {
-		Object[] values = { new Sprite("testsprite") };
+		Object[] values = {new Sprite("testsprite")};
 		ParameterList paramList = new ParameterList(values);
 		PhysicsObject physicsObject = (PhysicsObject) Reflection.invokeMethod(physicsWorld, "createPhysicsObject",
 				paramList);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/pocketmusic/note/NoteNameTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/pocketmusic/note/NoteNameTest.java
@@ -30,8 +30,8 @@ import org.catrobat.catroid.pocketmusic.note.NoteName;
 public class NoteNameTest extends AndroidTestCase {
 
 	public void testMidi() {
-		NoteName[] noteNames = new NoteName[] { NoteName.C1, NoteName.C2, NoteName.C3, NoteName.C4,
-				NoteName.C5, NoteName.C6, NoteName.C7, NoteName.C8, };
+		NoteName[] noteNames = new NoteName[] {NoteName.C1, NoteName.C2, NoteName.C3, NoteName.C4,
+				NoteName.C5, NoteName.C6, NoteName.C7, NoteName.C8};
 
 		int startMidi = 24;
 		int increment = 12;

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/pocketmusic/note/OctaveTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/pocketmusic/note/OctaveTest.java
@@ -36,7 +36,7 @@ public class OctaveTest extends AndroidTestCase {
 				NoteName.C4, NoteName.C4S, NoteName.D4,
 				NoteName.D4S, NoteName.E4, NoteName.F4,
 				NoteName.F4S, NoteName.G4, NoteName.G4S,
-				NoteName.A4, NoteName.A4S, NoteName.B4 };
+				NoteName.A4, NoteName.A4S, NoteName.B4};
 		Octave octave = Octave.ONE_LINE_OCTAVE;
 
 		assertTrue(Arrays.equals(noteNames, octave.getNoteNames()));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/pocketmusic/note/trackgrid/TrackGridTestDataFactory.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/pocketmusic/note/trackgrid/TrackGridTestDataFactory.java
@@ -87,10 +87,10 @@ public final class TrackGridTestDataFactory {
 
 		List<GridRow> gridRows = new ArrayList<GridRow>();
 
-		gridRows.add(new GridRow(NoteName.C4, createGridRowPositionsGridRow(new int[] { 0, 3 })));
-		gridRows.add(new GridRow(NoteName.E4, createGridRowPositionsGridRow(new int[] { 1 })));
-		gridRows.add(new GridRow(NoteName.F4, createGridRowPositionsGridRow(new int[] { 2 })));
-		gridRows.add(new GridRow(NoteName.C5, createGridRowPositionsGridRow(new int[] { 4 })));
+		gridRows.add(new GridRow(NoteName.C4, createGridRowPositionsGridRow(new int[] {0, 3})));
+		gridRows.add(new GridRow(NoteName.E4, createGridRowPositionsGridRow(new int[] {1})));
+		gridRows.add(new GridRow(NoteName.F4, createGridRowPositionsGridRow(new int[] {2})));
+		gridRows.add(new GridRow(NoteName.C5, createGridRowPositionsGridRow(new int[] {4})));
 
 		return new TrackGrid(MusicalKey.VIOLIN, MusicalInstrument.ACOUSTIC_GRAND_PIANO, MusicalBeat
 				.BEAT_4_4, gridRows);
@@ -100,7 +100,7 @@ public final class TrackGridTestDataFactory {
 
 		List<GridRow> gridRows = new ArrayList<GridRow>();
 
-		gridRows.add(new GridRow(NoteName.C4, createGridRowPositionsGridRow(new int[] { 3 })));
+		gridRows.add(new GridRow(NoteName.C4, createGridRowPositionsGridRow(new int[] {3})));
 
 		return new TrackGrid(MusicalKey.VIOLIN, MusicalInstrument.ACOUSTIC_GRAND_PIANO, MusicalBeat
 				.BEAT_4_4, gridRows);
@@ -110,11 +110,11 @@ public final class TrackGridTestDataFactory {
 
 		List<GridRow> gridRows = new ArrayList<GridRow>();
 
-		gridRows.add(new GridRow(NoteName.C5, createGridRowPositionsGridRow(new int[] { 0 })));
-		gridRows.add(new GridRow(NoteName.C4, createGridRowPositionsGridRow(new int[] { 1, 2 })));
-		gridRows.add(new GridRow(NoteName.D4, createGridRowPositionsGridRow(new int[] { 1, 2 })));
-		gridRows.add(new GridRow(NoteName.E4, createGridRowPositionsGridRow(new int[] { 3 })));
-		gridRows.add(new GridRow(NoteName.F4, createGridRowPositionsGridRow(new int[] { 3 })));
+		gridRows.add(new GridRow(NoteName.C5, createGridRowPositionsGridRow(new int[] {0})));
+		gridRows.add(new GridRow(NoteName.C4, createGridRowPositionsGridRow(new int[] {1, 2})));
+		gridRows.add(new GridRow(NoteName.D4, createGridRowPositionsGridRow(new int[] {1, 2})));
+		gridRows.add(new GridRow(NoteName.E4, createGridRowPositionsGridRow(new int[] {3})));
+		gridRows.add(new GridRow(NoteName.F4, createGridRowPositionsGridRow(new int[] {3})));
 
 		return new TrackGrid(MusicalKey.VIOLIN, MusicalInstrument.ACOUSTIC_GRAND_PIANO, MusicalBeat
 				.BEAT_4_4, gridRows);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/scratchconverter/ScratchServerCallsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/scratchconverter/ScratchServerCallsTest.java
@@ -94,7 +94,7 @@ public class ScratchServerCallsTest extends InstrumentationTestCase {
 						+ Constants.SCRATCH_IMAGE_BASE_URL + "' any more: " + Constants.SCRATCH_IMAGE_BASE_URL,
 				urlString.startsWith(Constants.SCRATCH_IMAGE_BASE_URL));
 
-		final int[] imageSize = new int[] { Constants.SCRATCH_IMAGE_DEFAULT_WIDTH, Constants.SCRATCH_IMAGE_DEFAULT_HEIGHT };
+		final int[] imageSize = new int[] {Constants.SCRATCH_IMAGE_DEFAULT_WIDTH, Constants.SCRATCH_IMAGE_DEFAULT_HEIGHT};
 		assertTrue("Invalid width extracated of image URL", programData.getImage().getWidth() == imageSize[0]);
 		assertTrue("Invalid height extracted from image URL", programData.getImage().getHeight() == imageSize[1]);
 		final String imageURLWithoutQuery = programData.getImage().getUrl().toString().split("\\?")[0];

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/scratchconverter/WebSocketClientTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/scratchconverter/WebSocketClientTest.java
@@ -552,7 +552,7 @@ public class WebSocketClientTest extends AndroidTestCase {
 
 		final float expectedCatrobatLanguageVersion = Constants.CURRENT_CATROBAT_LANGUAGE_VERSION;
 
-		final Job[] expectedJobs = new Job[] { expectedUnscheduledJob, expectedFinishedJob };
+		final Job[] expectedJobs = new Job[] {expectedUnscheduledJob, expectedFinishedJob};
 		final InfoMessage infoMessage = new InfoMessage(expectedCatrobatLanguageVersion, expectedJobs);
 
 		final DownloadCallback downloadCallbackMock = Mockito.mock(DownloadCallback.class);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/scratchconverter/protocol/JobHandlerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/scratchconverter/protocol/JobHandlerTest.java
@@ -84,7 +84,7 @@ public class JobHandlerTest extends AndroidTestCase {
 
 	public void testReceivedJobMessageWhenJobIsNotInProgressShouldFail() {
 		// tests all not-in-progress states! -> see: Job.State.isInProgress()
-		for (Job.State givenState : new Job.State[] { Job.State.UNSCHEDULED, Job.State.FINISHED, Job.State.FAILED }) {
+		for (Job.State givenState : new Job.State[] {Job.State.UNSCHEDULED, Job.State.FINISHED, Job.State.FAILED}) {
 			expectedJob.setState(givenState);
 			try {
 				jobHandler.onJobMessage(new JobReadyMessage(WRONG_JOB_ID));
@@ -120,7 +120,7 @@ public class JobHandlerTest extends AndroidTestCase {
 	}
 
 	public void testReceivedJobReadyMessageWhenHandlerIsNotInScheduledStateButInProgressShouldBeIgnored() {
-		for (Job.State givenState : new Job.State[] { Job.State.READY, Job.State.RUNNING }) {
+		for (Job.State givenState : new Job.State[] {Job.State.READY, Job.State.RUNNING}) {
 			expectedJob.setState(givenState);
 			jobHandler.onJobMessage(new JobReadyMessage(JOB_ID_OF_JOB_HANDLER));
 			assertEquals("State of expectedJob changed unexpectedly", givenState, expectedJob.getState());
@@ -155,7 +155,7 @@ public class JobHandlerTest extends AndroidTestCase {
 	}
 
 	public void testReceivedJobAlreadyRunningMessageWhenHandlerIsNotInScheduledStateButInProgressShouldBeIgnored() {
-		for (Job.State givenState : new Job.State[] { Job.State.READY, Job.State.RUNNING }) {
+		for (Job.State givenState : new Job.State[] {Job.State.READY, Job.State.RUNNING}) {
 			expectedJob.setState(givenState);
 			final String expectedProgramImageURL = "https://cdn2.scratch.mit.edu/get_image/project/11656680_480x360.png";
 			jobHandler.onJobMessage(new JobAlreadyRunningMessage(JOB_ID_OF_JOB_HANDLER, expectedJob.getTitle(),
@@ -198,7 +198,7 @@ public class JobHandlerTest extends AndroidTestCase {
 	}
 
 	public void testReceivedJobProgressMessageWhenHandlerIsNotInRunningStateButInProgressShouldBeIgnored() {
-		for (Job.State givenState : new Job.State[] { Job.State.SCHEDULED, Job.State.READY }) {
+		for (Job.State givenState : new Job.State[] {Job.State.SCHEDULED, Job.State.READY}) {
 			final short expectedProgress = 31;
 			expectedJob.setState(givenState);
 			jobHandler.onJobMessage(new JobProgressMessage(JOB_ID_OF_JOB_HANDLER, expectedProgress));
@@ -210,7 +210,7 @@ public class JobHandlerTest extends AndroidTestCase {
 	}
 
 	public void testReceivedJobOutputMessageWhenHandlerIsInRunningStateShouldWork() {
-		final String[] expectedLines = new String[] { "line1", "line2" };
+		final String[] expectedLines = new String[] {"line1", "line2"};
 
 		doAnswer(new Answer<Void>() {
 			@Override
@@ -241,8 +241,8 @@ public class JobHandlerTest extends AndroidTestCase {
 	}
 
 	public void testReceivedJobOutputMessageWhenHandlerIsNotInRunningStateButInProgressShouldBeIgnored() {
-		for (Job.State givenState : new Job.State[] { Job.State.SCHEDULED, Job.State.READY }) {
-			final String[] expectedLines = new String[] { "line1", "line2" };
+		for (Job.State givenState : new Job.State[] {Job.State.SCHEDULED, Job.State.READY}) {
+			final String[] expectedLines = new String[] {"line1", "line2"};
 
 			expectedJob.setState(givenState);
 			jobHandler.onJobMessage(new JobOutputMessage(JOB_ID_OF_JOB_HANDLER, expectedLines));
@@ -288,7 +288,7 @@ public class JobHandlerTest extends AndroidTestCase {
 		}).when(convertCallbackMock).onConversionFinished(any(Job.class), any(Client.DownloadCallback.class),
 				any(String.class), any(Date.class));
 
-		for (Job.State givenState : new Job.State[] { Job.State.SCHEDULED, Job.State.RUNNING }) {
+		for (Job.State givenState : new Job.State[] {Job.State.SCHEDULED, Job.State.RUNNING}) {
 			expectedJob.setState(givenState);
 			jobHandler.onJobMessage(new JobFinishedMessage(JOB_ID_OF_JOB_HANDLER, expectedDownloadURL,
 					expectedCacheDate));
@@ -338,7 +338,7 @@ public class JobHandlerTest extends AndroidTestCase {
 			}
 		}).when(convertCallbackMock).onConversionFailure(any(Job.class), any(ClientException.class));
 
-		for (Job.State givenState : new Job.State[] { Job.State.SCHEDULED, Job.State.RUNNING }) {
+		for (Job.State givenState : new Job.State[] {Job.State.SCHEDULED, Job.State.RUNNING}) {
 			expectedJob.setState(givenState);
 			jobHandler.onJobMessage(new JobFailedMessage(JOB_ID_OF_JOB_HANDLER, expectedErrorMessage));
 			assertEquals("Expecting state to be FAILED after processed JobFailedMessage",
@@ -383,7 +383,7 @@ public class JobHandlerTest extends AndroidTestCase {
 	}
 
 	public void testReceivedJobRunningMessageWhenHandlerIsNotInReadyStateButInProgressShouldBeIgnored() {
-		for (Job.State givenState : new Job.State[] { Job.State.SCHEDULED, Job.State.RUNNING }) {
+		for (Job.State givenState : new Job.State[] {Job.State.SCHEDULED, Job.State.RUNNING}) {
 			expectedJob.setState(givenState);
 			final String programImageURL = "https://cdn2.scratch.mit.edu/get_image/project/11656680_480x360.png";
 			jobHandler.onJobMessage(new JobRunningMessage(JOB_ID_OF_JOB_HANDLER, expectedJob.getTitle(),

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/scratchconverter/protocol/WebSocketMessageListenerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/scratchconverter/protocol/WebSocketMessageListenerTest.java
@@ -326,7 +326,7 @@ public class WebSocketMessageListenerTest extends AndroidTestCase {
 	}
 
 	public void testReceivingJobOutputMessage() {
-		final String[] expectedLines = new String[] { "line1", "line2" };
+		final String[] expectedLines = new String[] {"line1", "line2"};
 
 		doAnswer(new Answer<Void>() {
 			@Override

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/CollisionDetectionBasicTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/CollisionDetectionBasicTest.java
@@ -32,61 +32,61 @@ import org.catrobat.catroid.sensing.CollisionDetection;
 public class CollisionDetectionBasicTest extends AndroidTestCase {
 
 	public void testIntersectPolygons() {
-		Polygon[] p1 = { new Polygon(new float[] { 0, 2, 2, 2, 1, 0 }) };
-		Polygon[] p2 = { new Polygon(new float[] { 0, 0, 1, 2, 2, 0 }) };
+		Polygon[] p1 = {new Polygon(new float[] {0, 2, 2, 2, 1, 0})};
+		Polygon[] p2 = {new Polygon(new float[] {0, 0, 1, 2, 2, 0})};
 		assertTrue("Collision of intersecting polygons not detected!",
 				CollisionDetection.checkCollisionBetweenPolygons(p1, p2));
 
-		Polygon[] p3 = { new Polygon(new float[] { 2, 0, 3, 2, 4, 0 }) };
+		Polygon[] p3 = {new Polygon(new float[] {2, 0, 3, 2, 4, 0})};
 		assertFalse("Not colliding polygons falsely detected as intersecting!",
 				CollisionDetection.checkCollisionBetweenPolygons(p1, p3));
 
-		Polygon[] p4 = { new Polygon(new float[] { -5, -1, -5, 1, 5, 1, 5, -1 }) };
-		Polygon[] p5 = { new Polygon(new float[] { -1, 5, 1, 5, 1, -5, -1, -5 }) };
+		Polygon[] p4 = {new Polygon(new float[] {-5, -1, -5, 1, 5, 1, 5, -1})};
+		Polygon[] p5 = {new Polygon(new float[] {-1, 5, 1, 5, 1, -5, -1, -5})};
 		assertTrue("Cross test not detected as intersecting!",
 				CollisionDetection.checkCollisionBetweenPolygons(p4, p5));
 
-		Polygon[] p6 = { new Polygon(new float[] { 0, 2, 2, 2, 1, 0 }) };
-		Polygon[] p7 = { new Polygon(new float[] { 0, 2, 2, 2, 1, 0 }) };
+		Polygon[] p6 = {new Polygon(new float[] {0, 2, 2, 2, 1, 0})};
+		Polygon[] p7 = {new Polygon(new float[] {0, 2, 2, 2, 1, 0})};
 		assertTrue("Same Polygons not detected as collision",
 				CollisionDetection.checkCollisionBetweenPolygons(p6, p7));
 	}
 
 	public void testCollisionForContainedPolygon() {
-		Polygon[] p1 = { new Polygon(new float[] { 0, 0, 0, 4, 4, 4, 4, 0 }) };
-		Polygon[] p2 = { new Polygon(new float[] { 2, 2, 3, 2, 2, 3 }) };
+		Polygon[] p1 = {new Polygon(new float[] {0, 0, 0, 4, 4, 4, 4, 0})};
+		Polygon[] p2 = {new Polygon(new float[] {2, 2, 3, 2, 2, 3})};
 		assertTrue("Polygon in Polygon not detected as intersecting!",
 				CollisionDetection.checkCollisionBetweenPolygons(p1, p2));
 	}
 
 	public void testObjectInDonut() {
-		Polygon[] donut = { new Polygon(new float[] { 0, 0, 0, 5, 5, 5, 5, 0 }),
-				new Polygon(new float[] { 2, 2, 2, 3, 3, 3, 3, 2 }) };
-		Polygon[] p2 = { new Polygon(new float[] { 0.5f, 0.5f, 0.5f, 1.5f, 1.5f, 1.5f, 1.5f, 0.5f }) };
+		Polygon[] donut = {new Polygon(new float[] {0, 0, 0, 5, 5, 5, 5, 0}),
+				new Polygon(new float[] {2, 2, 2, 3, 3, 3, 3, 2})};
+		Polygon[] p2 = {new Polygon(new float[] {0.5f, 0.5f, 0.5f, 1.5f, 1.5f, 1.5f, 1.5f, 0.5f})};
 		assertTrue("Polygon in Donut falsely detected as colliding!",
 				CollisionDetection.checkCollisionBetweenPolygons(donut, p2));
 	}
 
 	public void testDonutInObject() {
-		Polygon[] donut = { new Polygon(new float[] { 1, 1, 1, 5, 5, 5, 5, 1 }),
-				new Polygon(new float[] { 2, 2, 2, 3, 3, 3, 3, 2 }) };
-		Polygon[] p2 = { new Polygon(new float[] { 0, 0, 0, 10, 10, 10, 10, 0 }) };
+		Polygon[] donut = {new Polygon(new float[] {1, 1, 1, 5, 5, 5, 5, 1}),
+				new Polygon(new float[] {2, 2, 2, 3, 3, 3, 3, 2})};
+		Polygon[] p2 = {new Polygon(new float[] {0, 0, 0, 10, 10, 10, 10, 0})};
 		assertTrue("Polygon in Donut falsely detected as colliding!",
 				CollisionDetection.checkCollisionBetweenPolygons(donut, p2));
 	}
 
 	public void testObjectInDonutHole() {
-		Polygon[] donut = { new Polygon(new float[] { 0, 0, 0, 5, 5, 5, 5, 0 }),
-				new Polygon(new float[] { 1, 1, 1, 4, 4, 4, 4, 1 }) };
-		Polygon[] p2 = { new Polygon(new float[] { 2, 2, 2, 3, 3, 3, 3, 2 }) };
+		Polygon[] donut = {new Polygon(new float[] {0, 0, 0, 5, 5, 5, 5, 0}),
+				new Polygon(new float[] {1, 1, 1, 4, 4, 4, 4, 1})};
+		Polygon[] p2 = {new Polygon(new float[] {2, 2, 2, 3, 3, 3, 3, 2})};
 		assertFalse("Polygon in Donut Hole falsely detected as colliding!",
 				CollisionDetection.checkCollisionBetweenPolygons(donut, p2));
 	}
 
 	public void testObjectCollidingWithDonut() {
-		Polygon[] donut = { new Polygon(new float[] { 0, 0, 0, 5, 5, 5, 5, 0 }),
-				new Polygon(new float[] { 1, 1, 1, 4, 4, 4, 4, 1 }) };
-		Polygon[] p2 = { new Polygon(new float[] { 2, 2, 2, 4.5f, 3, 3, 3, 2 }) };
+		Polygon[] donut = {new Polygon(new float[] {0, 0, 0, 5, 5, 5, 5, 0}),
+				new Polygon(new float[] {1, 1, 1, 4, 4, 4, 4, 1})};
+		Polygon[] p2 = {new Polygon(new float[] {2, 2, 2, 4.5f, 3, 3, 3, 2})};
 		assertTrue("Polygon colliding with Donut not detected!",
 				CollisionDetection.checkCollisionBetweenPolygons(donut, p2));
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/CollisionDetectionPolygonCreationTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/CollisionDetectionPolygonCreationTest.java
@@ -98,7 +98,7 @@ public class CollisionDetectionPolygonCreationTest extends InstrumentationTestCa
 		Assert.assertEquals("Wrong amount of collisionPolygons", 1, collisionInformation.collisionPolygons.length);
 		Assert.assertTrue("Wrong Collision Polygon",
 				Arrays.equals(collisionInformation.collisionPolygons[0].getVertices(),
-						new float[] { 0.0f, 0.0f, 0.0f, 125.0f, 125.0f, 125.0f, 125.0f, 0.0f }));
+						new float[] {0.0f, 0.0f, 0.0f, 125.0f, 125.0f, 125.0f, 125.0f, 0.0f}));
 	}
 
 	public void testSimpleConvexPolygon() {
@@ -109,7 +109,7 @@ public class CollisionDetectionPolygonCreationTest extends InstrumentationTestCa
 		Assert.assertEquals("Wrong amount of collisionPolygons", 1, collisionInformation.collisionPolygons.length);
 		Assert.assertTrue("Wrong Collision Polygon",
 				Arrays.equals(collisionInformation.collisionPolygons[0].getVertices(),
-						new float[] { 0.0f, 47.0f, 17.0f, 98.0f, 52.0f, 98.0f, 68.0f, 44.0f, 52.0f, 0.0f, 17.0f, 0.0f }));
+						new float[] {0.0f, 47.0f, 17.0f, 98.0f, 52.0f, 98.0f, 68.0f, 44.0f, 52.0f, 0.0f, 17.0f, 0.0f}));
 	}
 
 	public void testMultipleConcavePolygons() {
@@ -121,11 +121,11 @@ public class CollisionDetectionPolygonCreationTest extends InstrumentationTestCa
 		Assert.assertEquals("Wrong amount of collisionPolygons", 2, collisionInformation.collisionPolygons.length);
 		Assert.assertTrue("Wrong first Collision Polygon",
 				Arrays.equals(collisionInformation.collisionPolygons[0].getVertices(),
-						new float[] { 0.0f, 110.0f, 0.0f, 185.0f, 91.0f, 185.0f, 91.0f, 136.0f, 34.0f, 136.0f, 34.0f, 110.0f }));
+						new float[] {0.0f, 110.0f, 0.0f, 185.0f, 91.0f, 185.0f, 91.0f, 136.0f, 34.0f, 136.0f, 34.0f, 110.0f}));
 		Assert.assertTrue("Wrong second Collision Polygon",
 				Arrays.equals(collisionInformation.collisionPolygons[1].getVertices(),
-						new float[] { 128.0f, 30.0f, 128.0f, 91.0f, 159.0f, 91.0f, 159.0f, 121.0f, 227.0f, 121.0f, 227.0f, 91.0f,
-								257.0f, 91.0f, 257.0f, 30.0f, 227.0f, 30.0f, 227.0f, 0.0f, 159.0f, 0.0f, 159.0f, 30.0f }));
+						new float[] {128.0f, 30.0f, 128.0f, 91.0f, 159.0f, 91.0f, 159.0f, 121.0f, 227.0f, 121.0f, 227.0f, 91.0f,
+								257.0f, 91.0f, 257.0f, 30.0f, 227.0f, 30.0f, 227.0f, 0.0f, 159.0f, 0.0f, 159.0f, 30.0f}));
 	}
 
 	public void testDonutPolygons() {
@@ -137,14 +137,14 @@ public class CollisionDetectionPolygonCreationTest extends InstrumentationTestCa
 		Assert.assertEquals("Wrong amount of collisionPolygons", 2, collisionInformation.collisionPolygons.length);
 		Assert.assertTrue("Wrong first Collision Polygon",
 				Arrays.equals(collisionInformation.collisionPolygons[0].getVertices(),
-						new float[] { 0.0f, 228.0f, 9.0f, 321.0f, 57.0f, 411.0f, 136.0f, 474.0f, 228.0f, 500.0f, 305.0f,
+						new float[] {0.0f, 228.0f, 9.0f, 321.0f, 57.0f, 411.0f, 136.0f, 474.0f, 228.0f, 500.0f, 305.0f,
 								495.0f, 375.0f, 468.0f, 436.0f, 419.0f, 474.0f, 364.0f, 497.0f, 295.0f, 499.0f, 218.0f,
 								481.0f, 151.0f, 443.0f, 89.0f, 385.0f, 38.0f, 321.0f, 9.0f, 179.0f, 9.0f, 115.0f, 38.0f,
-								57.0f, 89.0f, 19.0f, 151.0f }));
+								57.0f, 89.0f, 19.0f, 151.0f}));
 		Assert.assertTrue("Wrong second Collision Polygon",
 				Arrays.equals(collisionInformation.collisionPolygons[1].getVertices(),
-						new float[] { 125.0f, 248.0f, 154.0f, 330.0f, 201.0f, 365.0f, 248.0f, 375.0f, 313.0f, 358.0f,
+						new float[] {125.0f, 248.0f, 154.0f, 330.0f, 201.0f, 365.0f, 248.0f, 375.0f, 313.0f, 358.0f,
 								365.0f, 299.0f, 374.0f, 234.0f, 346.0f, 170.0f, 285.0f, 130.0f, 206.0f, 133.0f, 150.0f,
-								175.0f }));
+								175.0f}));
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/CollisionInformationTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/CollisionInformationTest.java
@@ -78,7 +78,7 @@ public class CollisionInformationTest extends InstrumentationTestCase {
 		Bitmap bitmap = Bitmap.createBitmap(200, 100, Bitmap.Config.ALPHA_8);
 		Polygon[] polygons = CollisionInformation.createCollisionPolygonByHitbox(bitmap);
 		Assert.assertTrue("Wrong vertices calculated", Arrays.equals(polygons[0].getVertices(),
-				new float[] { 0.0f, 0.0f, 200.0f, 0.0f, 200.0f, 100.0f, 0.0f, 100.0f }));
+				new float[] {0.0f, 0.0f, 200.0f, 0.0f, 200.0f, 100.0f, 0.0f, 100.0f}));
 	}
 
 	public void testGetCollisionPolygonFromPNGMeta() {
@@ -107,7 +107,7 @@ public class CollisionInformationTest extends InstrumentationTestCase {
 		Assert.assertEquals("Wrong amount of collisionPolygons", 1, collisionPolygons.length);
 		Assert.assertTrue("Wrong Collision Polygon",
 				Arrays.equals(collisionPolygons[0].getVertices(),
-						new float[] { 0.0f, 47.0f, 17.0f, 98.0f, 52.0f, 98.0f, 68.0f, 44.0f, 52.0f, 0.0f, 17.0f, 0.0f }));
+						new float[] {0.0f, 47.0f, 17.0f, 98.0f, 52.0f, 98.0f, 68.0f, 44.0f, 52.0f, 0.0f, 17.0f, 0.0f}));
 	}
 
 	public void testWriteReadCollisionVerticesToPNGMeta() {
@@ -130,9 +130,9 @@ public class CollisionInformationTest extends InstrumentationTestCase {
 			Assert.fail("Couldn't load file, exception thrown!");
 		}
 
-		float[] firstVertices = new float[] { 0.0f, 0.0f, 111.0f, 0.0f, 111.0f, 222.0f };
-		float[] secondVertices = new float[] { 10.0f, 10.0f, 20.0f, 10.0f, 20.0f, 20.0f, 10.0f, 20.0f };
-		Polygon[] polygons = { new Polygon(firstVertices), new Polygon(secondVertices) };
+		float[] firstVertices = new float[] {0.0f, 0.0f, 111.0f, 0.0f, 111.0f, 222.0f};
+		float[] secondVertices = new float[] {10.0f, 10.0f, 20.0f, 10.0f, 20.0f, 20.0f, 10.0f, 20.0f};
+		Polygon[] polygons = {new Polygon(firstVertices), new Polygon(secondVertices)};
 		CollisionInformation.writeCollisionVerticesToPNGMeta(polygons, file.getAbsolutePath());
 		Polygon[] testPolygons = CollisionInformation.getCollisionPolygonFromPNGMeta(file.getAbsolutePath());
 
@@ -180,25 +180,25 @@ public class CollisionInformationTest extends InstrumentationTestCase {
 	}
 
 	public void testCreateHorizontalAndVerticalVertices() {
-		boolean[][] grid = new boolean[][] { { false, false, true, true, true, false, false },
-				{ false, false, true, false, true, false, false },
-				{ true, true, true, true, true, true, true },
-				{ true, false, true, false, true, false, true },
-				{ true, true, true, true, true, true, true },
-				{ false, false, true, false, true, false, false },
-				{ false, false, true, true, true, false, false } };
+		boolean[][] grid = new boolean[][] {{false, false, true, true, true, false, false},
+				{false, false, true, false, true, false, false},
+				{true, true, true, true, true, true, true},
+				{true, false, true, false, true, false, true},
+				{true, true, true, true, true, true, true},
+				{false, false, true, false, true, false, false},
+				{false, false, true, true, true, false, false}};
 		int width = grid.length;
 		int height = grid[0].length;
-		float[] horizontalCorrect = new float[] { 2.0f, 0.0f, 5.0f, 0.0f, 3.0f, 1.0f, 4.0f, 1.0f, 0.0f, 2.0f, 2.0f, 2.0f,
+		float[] horizontalCorrect = new float[] {2.0f, 0.0f, 5.0f, 0.0f, 3.0f, 1.0f, 4.0f, 1.0f, 0.0f, 2.0f, 2.0f, 2.0f,
 				1.0f, 3.0f, 2.0f, 3.0f, 3.0f, 2.0f, 4.0f, 2.0f, 3.0f, 3.0f, 4.0f, 3.0f, 5.0f, 2.0f, 7.0f, 2.0f, 5.0f,
 				3.0f, 6.0f, 3.0f, 0.0f, 5.0f, 2.0f, 5.0f, 1.0f, 4.0f, 2.0f, 4.0f, 3.0f, 4.0f, 4.0f, 4.0f, 3.0f, 5.0f,
 				4.0f, 5.0f, 5.0f, 4.0f, 6.0f, 4.0f, 5.0f, 5.0f, 7.0f, 5.0f, 2.0f, 7.0f, 5.0f, 7.0f, 3.0f, 6.0f, 4.0f,
-				6.0f };
-		float[] verticalCorrect = new float[] { 0.0f, 2.0f, 0.0f, 5.0f, 1.0f, 3.0f, 1.0f, 4.0f, 2.0f, 0.0f, 2.0f, 2.0f,
+				6.0f};
+		float[] verticalCorrect = new float[] {0.0f, 2.0f, 0.0f, 5.0f, 1.0f, 3.0f, 1.0f, 4.0f, 2.0f, 0.0f, 2.0f, 2.0f,
 				3.0f, 1.0f, 3.0f, 2.0f, 2.0f, 3.0f, 2.0f, 4.0f, 3.0f, 3.0f, 3.0f, 4.0f, 2.0f, 5.0f, 2.0f, 7.0f, 3.0f,
 				5.0f, 3.0f, 6.0f, 5.0f, 0.0f, 5.0f, 2.0f, 4.0f, 1.0f, 4.0f, 2.0f, 4.0f, 3.0f, 4.0f, 4.0f, 5.0f, 3.0f,
 				5.0f, 4.0f, 4.0f, 5.0f, 4.0f, 6.0f, 5.0f, 5.0f, 5.0f, 7.0f, 7.0f, 2.0f, 7.0f, 5.0f, 6.0f, 3.0f, 6.0f,
-				4.0f };
+				4.0f};
 
 		ArrayList<CollisionPolygonVertex> horizontal = CollisionInformation.createHorizontalVertices(grid, width,
 				height);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/ExpiringLruMemoryCacheTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/ExpiringLruMemoryCacheTest.java
@@ -60,7 +60,7 @@ public final class ExpiringLruMemoryCacheTest extends InstrumentationTestCase {
 		int maxNumOfEntries = 2;      // number of entries
 
 		// this bypasses the getInstance() singleton method
-		Class[] constructorArgs = new Class[] { Long.TYPE, LruCache.class, ExpiringLruMemoryCache.ClockInterface.class };
+		Class[] constructorArgs = new Class[] {Long.TYPE, LruCache.class, ExpiringLruMemoryCache.ClockInterface.class};
 		Constructor<ExpiringLruMemoryObjectCache> textCacheConstructor = ExpiringLruMemoryObjectCache.class.getDeclaredConstructor(constructorArgs);
 		textCacheConstructor.setAccessible(true);
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/PhysicsTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/PhysicsTestUtils.java
@@ -61,7 +61,7 @@ public final class PhysicsTestUtils {
 		}
 
 		if (shape != null) {
-			physicsObject.setShape(new Shape[] { shape });
+			physicsObject.setShape(new Shape[] {shape});
 		}
 		return physicsObject;
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/ReflectionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/ReflectionTest.java
@@ -219,8 +219,8 @@ public class ReflectionTest extends AndroidTestCase {
 				Short.valueOf((short) 1));
 
 		Class<?>[] primitiveObjectsClass = (Class<?>[]) Reflection.getPrivateField(parameterList, "types");
-		Class<?>[] expectedPrimitiveObjectsClasses = new Class<?>[] { boolean.class, byte.class, char.class,
-				double.class, float.class, int.class, long.class, short.class };
+		Class<?>[] expectedPrimitiveObjectsClasses = new Class<?>[] {boolean.class, byte.class, char.class,
+				double.class, float.class, int.class, long.class, short.class};
 		assertTrue("Not all object classes are converted into primitve classes",
 				Arrays.deepEquals(expectedPrimitiveObjectsClasses, primitiveObjectsClass));
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/web/ZipTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/web/ZipTest.java
@@ -45,7 +45,7 @@ public class ZipTest extends AndroidTestCase {
 		testfile.getParentFile().mkdirs();
 		testfile.createNewFile();
 
-		String[] paths = { pathToTest };
+		String[] paths = {pathToTest};
 
 		String zipFileName = Constants.TMP_PATH + "/testzip" + Constants.CATROBAT_EXTENSION;
 		File zipFile = new File(zipFileName);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/StageTestSimple.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/StageTestSimple.java
@@ -69,7 +69,7 @@ public class StageTestSimple {
 		createProjectWithBlueSprite("blueProject");
 		baseActivityTestRule.launchActivity(null);
 
-		byte[] blue = { 0, (byte) 162, (byte) 232, (byte) 255 };
+		byte[] blue = {0, (byte) 162, (byte) 232, (byte) 255};
 
 		//color matcher only accepts a GL20View, this can be aquired by getting the only focusable element in the stage
 		onView(isFocusable())

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/SystemAnimations.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/SystemAnimations.java
@@ -74,7 +74,7 @@ public class SystemAnimations {
 			for (int i = 0; i < currentScales.length; i++) {
 				currentScales[i] = animationScale;
 			}
-			setAnimationScales.invoke(windowManagerObj, new Object[] { currentScales });
+			setAnimationScales.invoke(windowManagerObj, new Object[] {currentScales});
 		} catch (Exception e) {
 			Log.e(TAG, "Could not change animation scale to " + animationScale + " :'(");
 		}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/UiTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/UiTestUtils.java
@@ -188,7 +188,7 @@ public final class UiTestUtils {
 		}
 	}
 
-	public static enum FileTypes {
+	public enum FileTypes {
 		IMAGE, SOUND, ROOT, SCREENSHOT
 	}
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/UiTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/UiTestUtils.java
@@ -69,7 +69,7 @@ public final class UiTestUtils {
 
 	@Nullable
 	public static Activity getCurrentActivity() {
-		final Activity[] currentActivity = { null };
+		final Activity[] currentActivity = {null};
 		getInstrumentation().runOnMainSync(new Runnable() {
 			public void run() {
 				Collection<Activity> resumedActivities = ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(RESUMED);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/bluetooth/BluetoothDeviceServiceTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/bluetooth/BluetoothDeviceServiceTest.java
@@ -103,7 +103,7 @@ public class BluetoothDeviceServiceTest extends BaseActivityInstrumentationTestC
 		assertNotNull("Device should be registered now. Bluetooth connection might failed. Is Bluetooth-Server running?", btDevice);
 		btDevice.connect();
 
-		byte[] expectedMessage = new byte[] { 1, 2, 3 };
+		byte[] expectedMessage = new byte[] {1, 2, 3};
 
 		btDevice.sendTestMessage(expectedMessage);
 		solo.sleep(2000); // wait some time till return message arrives
@@ -203,7 +203,7 @@ public class BluetoothDeviceServiceTest extends BaseActivityInstrumentationTestC
 
 		public void sendTestMessage(byte[] message) throws IOException {
 
-			outStream.write(new byte[] { (byte) (0xFF & message.length) });
+			outStream.write(new byte[] {(byte) (0xFF & message.length)});
 			outStream.write(message);
 			outStream.flush();
 		}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/BrickValueParameterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/content/brick/BrickValueParameterTest.java
@@ -281,7 +281,7 @@ public class BrickValueParameterTest extends BaseActivityInstrumentationTestCase
 		TextView setColorTextView = (TextView) solo.getView(R.id.brick_set_color_edit_text);
 		float setColorPrototypeValue = Float.parseFloat(setColorTextView.getText().toString());
 		assertEquals("Value in Brick SetColor is not correct", BrickValues.SET_COLOR_TO,
-					setColorPrototypeValue);
+				setColorPrototypeValue);
 
 		if (!solo.searchText(solo.getString(R.string.brick_change_color))) {
 			solo.scrollDownList(fragmentListView);
@@ -290,7 +290,7 @@ public class BrickValueParameterTest extends BaseActivityInstrumentationTestCase
 		TextView changeColorTextView = (TextView) solo.getView(R.id.brick_change_color_by_edit_text);
 		float changeColorPrototypeValue = Float.parseFloat(changeColorTextView.getText().toString());
 		assertEquals("Value in Brick ChangeColor is not correct", BrickValues.CHANGE_COLOR_BY,
-					changeColorPrototypeValue);
+				changeColorPrototypeValue);
 
 		solo.clickOnText(solo.getString(R.string.brick_change_color));
 		solo.sleep(500);
@@ -299,10 +299,10 @@ public class BrickValueParameterTest extends BaseActivityInstrumentationTestCase
 
 		TextView changeColorEditText = (TextView) solo.getView(R.id.brick_change_color_by_edit_text);
 		float changeColorEditTextValue = Float.parseFloat(changeColorEditText.getText().toString()
-					.replace(',', '.'));
+				.replace(',', '.'));
 
 		assertEquals("Value in Selected Brick ChangeBrightness is not correct",
-					(float) BrickValues.CHANGE_COLOR_BY, changeColorEditTextValue);
+				(float) BrickValues.CHANGE_COLOR_BY, changeColorEditTextValue);
 	}
 
 	public void testSoundBricksDefaultValues() {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/arduino/ArduinoTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/arduino/ArduinoTest.java
@@ -168,12 +168,12 @@ public class ArduinoTest extends BaseActivityInstrumentationTestCase<MainMenuAct
 
 		ArduinoSendPWMValueBrick arduinoArduinoSendPWMValueBrick1 = new ArduinoSendPWMValueBrick(
 				PWM_PIN, PIN_HIGH);
-		commands.add(new int[] { PIN_HIGH, PWM_PIN, PIN_HIGH });
+		commands.add(new int[] {PIN_HIGH, PWM_PIN, PIN_HIGH});
 		WaitBrick firstWaitBrick = new WaitBrick(100);
 
 		ArduinoSendPWMValueBrick arduinoArduinoSendPWMValueBrick2 = new ArduinoSendPWMValueBrick(
 				PWM_PIN, PIN_LOW);
-		commands.add(new int[] { PIN_LOW, PWM_PIN, PIN_LOW });
+		commands.add(new int[] {PIN_LOW, PWM_PIN, PIN_LOW});
 
 		whenScript.addBrick(arduinoArduinoSendPWMValueBrick1);
 		whenScript.addBrick(firstWaitBrick);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/mindstorms/ev3/LegoEV3SensorInfoTests.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/mindstorms/ev3/LegoEV3SensorInfoTests.java
@@ -72,7 +72,7 @@ public class LegoEV3SensorInfoTests extends BaseActivityInstrumentationTestCase<
 
 	private void setSensors(EV3Sensor.Sensor sensor) {
 		SettingsActivity.setLegoMindstormsEV3SensorMapping(this.getInstrumentation().getTargetContext(),
-				new EV3Sensor.Sensor[] { sensor, sensor, sensor, sensor });
+				new EV3Sensor.Sensor[] {sensor, sensor, sensor, sensor});
 	}
 
 	public void testEV3SensorInfoDialog() throws InterruptedException {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/mindstorms/nxt/LegoNXTImplTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/mindstorms/nxt/LegoNXTImplTest.java
@@ -83,7 +83,7 @@ public class LegoNXTImplTest extends BaseActivityInstrumentationTestCase<MainMen
 
 	private void disableSensors() {
 		SettingsActivity.setLegoMindstormsNXTSensorMapping(this.getInstrumentation().getTargetContext(),
-				new NXTSensor.Sensor[] { NXTSensor.Sensor.NO_SENSOR, NXTSensor.Sensor.NO_SENSOR, NXTSensor.Sensor.NO_SENSOR, NXTSensor.Sensor.NO_SENSOR });
+				new NXTSensor.Sensor[] {NXTSensor.Sensor.NO_SENSOR, NXTSensor.Sensor.NO_SENSOR, NXTSensor.Sensor.NO_SENSOR, NXTSensor.Sensor.NO_SENSOR});
 	}
 
 	@Device
@@ -215,24 +215,24 @@ public class LegoNXTImplTest extends BaseActivityInstrumentationTestCase<MainMen
 
 		LegoNxtMotorMoveBrick legoMotorActionBrick = new LegoNxtMotorMoveBrick(
 				LegoNxtMotorMoveBrick.Motor.MOTOR_B_C, 100);
-		commands.add(new int[] { MOTOR_ACTION, 1, 100 });
-		commands.add(new int[] { MOTOR_ACTION, 2, 100 });
+		commands.add(new int[] {MOTOR_ACTION, 1, 100});
+		commands.add(new int[] {MOTOR_ACTION, 2, 100});
 		WaitBrick firstWaitBrick = new WaitBrick(500);
 
 		LegoNxtMotorStopBrick legoMotorStopBrick = new LegoNxtMotorStopBrick(
 				LegoNxtMotorStopBrick.Motor.MOTOR_B_C);
-		commands.add(new int[] { MOTOR_STOP, 1 });
-		commands.add(new int[] { MOTOR_STOP, 2 });
+		commands.add(new int[] {MOTOR_STOP, 1});
+		commands.add(new int[] {MOTOR_STOP, 2});
 		WaitBrick secondWaitBrick = new WaitBrick(500);
 
 		LegoNxtMotorTurnAngleBrick legoMotorTurnAngleBrick = new LegoNxtMotorTurnAngleBrick(
 				LegoNxtMotorTurnAngleBrick.Motor.MOTOR_C, 515);
-		commands.add(new int[] { MOTOR_TURN, 2, 515 });
+		commands.add(new int[] {MOTOR_TURN, 2, 515});
 
 		WaitBrick thirdWaitBrick = new WaitBrick(500);
 		LegoNxtPlayToneBrick legoPlayToneBrick = new LegoNxtPlayToneBrick(50, 1.5f);
 		//Tone does not return a command
-		commands.add(new int[] { PLAY_TONE, 5000, 1500 });
+		commands.add(new int[] {PLAY_TONE, 5000, 1500});
 
 		whenScript.addBrick(legoMotorActionBrick);
 		whenScript.addBrick(firstWaitBrick);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/mindstorms/nxt/LegoNXTPreferencesTests.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/mindstorms/nxt/LegoNXTPreferencesTests.java
@@ -136,7 +136,7 @@ public class LegoNXTPreferencesTests extends BaseActivityInstrumentationTestCase
 
 		solo.clickOnText(projectName);
 
-		NXTSensor.Sensor[] sensorMapping  = new NXTSensor.Sensor[4];
+		NXTSensor.Sensor[] sensorMapping = new NXTSensor.Sensor[4];
 		sensorMapping[0] = NXTSensor.Sensor.SOUND;
 		sensorMapping[1] = NXTSensor.Sensor.SOUND;
 		sensorMapping[2] = NXTSensor.Sensor.SOUND;

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/mindstorms/nxt/LegoNXTSensorInfoTests.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/mindstorms/nxt/LegoNXTSensorInfoTests.java
@@ -67,7 +67,7 @@ public class LegoNXTSensorInfoTests extends BaseActivityInstrumentationTestCase<
 
 	private void setSensors(NXTSensor.Sensor sensor) {
 		SettingsActivity.setLegoMindstormsNXTSensorMapping(this.getInstrumentation().getTargetContext(),
-				new NXTSensor.Sensor[] { sensor, sensor, sensor, sensor });
+				new NXTSensor.Sensor[] {sensor, sensor, sensor, sensor});
 	}
 
 	public void testNXTSensorInfoDialog() throws InterruptedException {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/phiro/PhiroTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/devices/phiro/PhiroTest.java
@@ -173,12 +173,12 @@ public class PhiroTest extends BaseActivityInstrumentationTestCase<MainMenuActiv
 
 		PhiroMotorMoveForwardBrick phiro = new PhiroMotorMoveForwardBrick(
 				PhiroMotorMoveForwardBrick.Motor.MOTOR_LEFT, 100);
-		commands.add(new int[] { MOTOR_MOVE, PIN_LEFT_MOTOR_FORWARD, 100 });
+		commands.add(new int[] {MOTOR_MOVE, PIN_LEFT_MOTOR_FORWARD, 100});
 		WaitBrick firstWaitBrick = new WaitBrick(100);
 
 		PhiroMotorStopBrick phiroMotorStopBrick = new PhiroMotorStopBrick(
 				PhiroMotorStopBrick.Motor.MOTOR_LEFT);
-		commands.add(new int[] { MOTOR_STOP, PIN_LEFT_MOTOR_FORWARD, PIN_LEFT_MOTOR_BACKWARD });
+		commands.add(new int[] {MOTOR_STOP, PIN_LEFT_MOTOR_FORWARD, PIN_LEFT_MOTOR_BACKWARD});
 
 		whenScript.addBrick(phiro);
 		whenScript.addBrick(firstWaitBrick);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/formulaeditor/FormulaEditorListFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/formulaeditor/FormulaEditorListFragmentTest.java
@@ -41,7 +41,7 @@ import java.util.regex.Pattern;
 
 public class FormulaEditorListFragmentTest extends BaseActivityInstrumentationTestCase<MainMenuActivity> {
 
-	private static final int[] FUNCTIONS_ITEMS = { R.string.formula_editor_function_sin,
+	private static final int[] FUNCTIONS_ITEMS = {R.string.formula_editor_function_sin,
 			R.string.formula_editor_function_cos, R.string.formula_editor_function_tan,
 			R.string.formula_editor_function_ln, R.string.formula_editor_function_log,
 			R.string.formula_editor_function_pi, R.string.formula_editor_function_sqrt,
@@ -53,9 +53,9 @@ public class FormulaEditorListFragmentTest extends BaseActivityInstrumentationTe
 			R.string.formula_editor_function_max, R.string.formula_editor_function_min,
 			R.string.formula_editor_function_length, R.string.formula_editor_function_letter,
 			R.string.formula_editor_function_join, R.string.formula_editor_function_number_of_items,
-			R.string.formula_editor_function_list_item, R.string.formula_editor_function_contains };
+			R.string.formula_editor_function_list_item, R.string.formula_editor_function_contains};
 
-	private static final int[] FUNCTIONS_PARAMETERS = { R.string.formula_editor_function_sin_parameter,
+	private static final int[] FUNCTIONS_PARAMETERS = {R.string.formula_editor_function_sin_parameter,
 			R.string.formula_editor_function_cos_parameter, R.string.formula_editor_function_tan_parameter,
 			R.string.formula_editor_function_ln_parameter, R.string.formula_editor_function_log_parameter,
 			R.string.formula_editor_function_pi_parameter, R.string.formula_editor_function_sqrt_parameter,
@@ -67,7 +67,7 @@ public class FormulaEditorListFragmentTest extends BaseActivityInstrumentationTe
 			R.string.formula_editor_function_max_parameter, R.string.formula_editor_function_min_parameter,
 			R.string.formula_editor_function_length_parameter, R.string.formula_editor_function_letter_parameter,
 			R.string.formula_editor_function_join_parameter, R.string.formula_editor_function_number_of_items_parameter,
-			R.string.formula_editor_function_list_item_parameter, R.string.formula_editor_function_contains_parameter };
+			R.string.formula_editor_function_list_item_parameter, R.string.formula_editor_function_contains_parameter};
 
 	public FormulaEditorListFragmentTest() {
 		super(MainMenuActivity.class);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/stage/StageTestComplex.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/stage/StageTestComplex.java
@@ -51,14 +51,14 @@ public class StageTestComplex extends BaseActivityInstrumentationTestCase<MainMe
 	private static final int PROJECT_WIDTH = 480;
 	private static final int PROJECT_HEIGHT = 800;
 
-	private static final byte[] RED_PIXEL = { (byte) 237, 28, 36, (byte) 255 };
-	private static final byte[] RED_BRIGHTNESS_PIXEL = { (byte) 109, 0, 0, (byte) 255 };
-	private static final byte[] GREEN_PIXEL = { 34, (byte) 177, 76, (byte) 255 };
-	private static final byte[] YELLOW_PIXEL = { (byte) 255, (byte) 242, 0, (byte) 255 };
-	private static final byte[] BLUE_PIXEL = { 0, (byte) 162, (byte) 232, (byte) 255 };
-	private static final byte[] WHITE_PIXEL = { (byte) 255, (byte) 255, (byte) 255, (byte) 255 };
-	private static final byte[] BLACK_PIXEL = { (byte) 0, (byte) 0, (byte) 0, (byte) 255 };
-	private static final byte[] BLACK_BRIGHTNESS_PIXEL = { (byte) -124, (byte) -124, (byte) -124, (byte) 255 };
+	private static final byte[] RED_PIXEL = {(byte) 237, 28, 36, (byte) 255};
+	private static final byte[] RED_BRIGHTNESS_PIXEL = {(byte) 109, 0, 0, (byte) 255};
+	private static final byte[] GREEN_PIXEL = {34, (byte) 177, 76, (byte) 255};
+	private static final byte[] YELLOW_PIXEL = {(byte) 255, (byte) 242, 0, (byte) 255};
+	private static final byte[] BLUE_PIXEL = {0, (byte) 162, (byte) 232, (byte) 255};
+	private static final byte[] WHITE_PIXEL = {(byte) 255, (byte) 255, (byte) 255, (byte) 255};
+	private static final byte[] BLACK_PIXEL = {(byte) 0, (byte) 0, (byte) 0, (byte) 255};
+	private static final byte[] BLACK_BRIGHTNESS_PIXEL = {(byte) -124, (byte) -124, (byte) -124, (byte) 255};
 
 	private float screenScaleFactorX = 1.0F;
 	private float screenScaleFactorY = 1.0F;

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/stage/StageTestSimple.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/stage/StageTestSimple.java
@@ -50,7 +50,7 @@ public class StageTestSimple extends BaseActivityInstrumentationTestCase<MainMen
 	}
 
 	public void testSimple() {
-		byte[] whitePixel = { (byte) 255, (byte) 255, (byte) 255, (byte) 255 };
+		byte[] whitePixel = {(byte) 255, (byte) 255, (byte) 255, (byte) 255};
 
 		byte[] result = StageActivity.stageListener.getPixels(0, 0, 1, 1);
 		UiTestUtils.compareByteArrays(whitePixel, result);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/stage/TouchAxisTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/stage/TouchAxisTest.java
@@ -70,7 +70,7 @@ public class TouchAxisTest extends BaseActivityInstrumentationTestCase<MainMenuA
 		solo.clickOnScreen(ScreenValues.SCREEN_WIDTH / 2, 100);
 		solo.sleep(500);
 
-		byte[] blackPixel = { (byte) 0, (byte) 0, (byte) 0, (byte) 255 };
+		byte[] blackPixel = {(byte) 0, (byte) 0, (byte) 0, (byte) 255};
 		byte[] screenPixel = StageActivity.stageListener.getPixels(ScreenValues.SCREEN_WIDTH / 2, 100, 1, 1);
 
 		Log.d(TAG, "width: " + ScreenValues.SCREEN_WIDTH / 2);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/activity/DoubleClickOpensViewOnceTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/activity/DoubleClickOpensViewOnceTest.java
@@ -89,7 +89,7 @@ public class DoubleClickOpensViewOnceTest extends TestSuite {
 			ActivityInstrumentationTestCase2<T> {
 		public Solo solo;
 
-		public ActivityInstrumentationTestBase(Class<T> clazz) {
+		ActivityInstrumentationTestBase(Class<T> clazz) {
 			super(clazz);
 		}
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/activity/MyProjectsActivityTest.java
@@ -318,13 +318,13 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 				int testPixelX = viewBitmap.getWidth() / 2;
 				int testPixelY = viewBitmap.getHeight() / 2;
 
-				byte[] whitePixel = { (byte) 255, (byte) 255, (byte) 255, (byte) 255 };
-				byte[] blackPixel = { 0, 0, 0, (byte) 255 };
+				byte[] whitePixel = {(byte) 255, (byte) 255, (byte) 255, (byte) 255};
+				byte[] blackPixel = {0, 0, 0, (byte) 255};
 				switch (counter) {
 					case 1:
 						pixelColor = viewBitmap.getPixel(testPixelX, testPixelY);
-						byte[] screenPixel = { (byte) Color.red(pixelColor), (byte) Color.green(pixelColor),
-								(byte) Color.blue(pixelColor), (byte) Color.alpha(pixelColor) };
+						byte[] screenPixel = {(byte) Color.red(pixelColor), (byte) Color.green(pixelColor),
+								(byte) Color.blue(pixelColor), (byte) Color.alpha(pixelColor)};
 						assertTrue("Image color should be white",
 								UiTestUtils.comparePixelRgbaArrays(whitePixel, screenPixel));
 
@@ -333,8 +333,8 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 						break;
 					case 2:
 						pixelColor = viewBitmap.getPixel(testPixelX, testPixelY);
-						byte[] screenPixel2 = { (byte) Color.red(pixelColor), (byte) Color.green(pixelColor),
-								(byte) Color.blue(pixelColor), (byte) Color.alpha(pixelColor) };
+						byte[] screenPixel2 = {(byte) Color.red(pixelColor), (byte) Color.green(pixelColor),
+								(byte) Color.blue(pixelColor), (byte) Color.alpha(pixelColor)};
 						assertTrue("Image color should be black",
 								UiTestUtils.comparePixelRgbaArrays(blackPixel, screenPixel2));
 
@@ -1846,8 +1846,8 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 		byte[] greenPixel1 = createScreenshotBitmap();
 
 		//The color values below are those we get on our emulated test device
-		byte[] greenPixel = { 0, (byte) 255, 0, (byte) 255 };
-		byte[] redPixel = { (byte) 255, 0, 0, (byte) 255 };
+		byte[] greenPixel = {0, (byte) 255, 0, (byte) 255};
+		byte[] redPixel = {(byte) 255, 0, 0, (byte) 255};
 
 		assertTrue("The extracted pixel was not green", UiTestUtils.comparePixelRgbaArrays(greenPixel, greenPixel1));
 		UiTestUtils.clickOnTextInList(solo, UiTestUtils.DEFAULT_TEST_PROJECT_NAME);
@@ -2169,8 +2169,8 @@ public class MyProjectsActivityTest extends BaseActivityInstrumentationTestCase<
 					viewBitmap = viewToTest.getDrawingCache();
 					int pixelValue = viewBitmap.getPixel(viewBitmap.getWidth() / 2, viewBitmap.getHeight() / 2);
 					viewToTest.destroyDrawingCache();
-					pixel = new byte[] { (byte) Color.red(pixelValue), (byte) Color.green(pixelValue),
-							(byte) Color.blue(pixelValue), (byte) Color.alpha(pixelValue) };
+					pixel = new byte[] {(byte) Color.red(pixelValue), (byte) Color.green(pixelValue),
+							(byte) Color.blue(pixelValue), (byte) Color.alpha(pixelValue)};
 				}
 			}
 		}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/activity/ProjectActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/activity/ProjectActivityTest.java
@@ -381,8 +381,8 @@ public class ProjectActivityTest extends BaseActivityInstrumentationTestCase<Mai
 				R.string.copy_sprite_name_suffix)), SECOND_TEST_SPRITE_NAME);
 
 		assertEquals(String.format("collision broadcast message of copied collision script is wrong before renaming "
-								+ "second sprite (%s != %s)", expectedMessage,
-						copiedCollisionScript.getBroadcastMessage()), expectedMessage,
+						+ "second sprite (%s != %s)", expectedMessage,
+				copiedCollisionScript.getBroadcastMessage()), expectedMessage,
 				copiedCollisionScript.getBroadcastMessage());
 	}
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/dialog/StageDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/dialog/StageDialogTest.java
@@ -286,7 +286,7 @@ public class StageDialogTest extends BaseActivityInstrumentationTestCase<MainMen
 		solo.clickOnButton(solo.getString(R.string.stage_dialog_axes_on));
 		solo.clickOnButton(solo.getString(R.string.stage_dialog_resume));
 		solo.sleep(100);
-		byte[] redPixel = { (byte) 255, 0, 0, (byte) 255 };
+		byte[] redPixel = {(byte) 255, 0, 0, (byte) 255};
 		byte[] stagePixel = StageActivity.stageListener.getPixels(ScreenValues.SCREEN_WIDTH / 2,
 				ScreenValues.SCREEN_HEIGHT / 2, 1, 1);
 		UiTestUtils.compareByteArrays(redPixel, stagePixel);
@@ -304,7 +304,7 @@ public class StageDialogTest extends BaseActivityInstrumentationTestCase<MainMen
 		solo.clickOnButton(solo.getString(R.string.stage_dialog_axes_off));
 		solo.clickOnButton(solo.getString(R.string.stage_dialog_resume));
 		solo.sleep(100);
-		byte[] whitePixel = { (byte) 255, (byte) 255, (byte) 255, (byte) 255 };
+		byte[] whitePixel = {(byte) 255, (byte) 255, (byte) 255, (byte) 255};
 		stagePixel = StageActivity.stageListener.getPixels(ScreenValues.SCREEN_WIDTH / 2,
 				ScreenValues.SCREEN_HEIGHT / 2, 1, 1);
 		UiTestUtils.compareByteArrays(whitePixel, stagePixel);
@@ -336,7 +336,7 @@ public class StageDialogTest extends BaseActivityInstrumentationTestCase<MainMen
 		UiTestUtils.clickOnBottomBar(solo, R.id.button_play);
 		solo.waitForActivity(StageActivity.class.getSimpleName());
 		assertTrue("Stage not resizeable.", ((StageActivity) solo.getCurrentActivity()).getResizePossible());
-		byte[] whitePixel = { (byte) 255, (byte) 255, (byte) 255, (byte) 255 };
+		byte[] whitePixel = {(byte) 255, (byte) 255, (byte) 255, (byte) 255};
 		byte[] screenPixel = StageActivity.stageListener.getPixels(0, 0, 1, 1);
 		UiTestUtils.compareByteArrays(whitePixel, screenPixel);
 		screenPixel = StageActivity.stageListener.getPixels(ScreenValues.SCREEN_WIDTH - 1,
@@ -350,7 +350,7 @@ public class StageDialogTest extends BaseActivityInstrumentationTestCase<MainMen
 		solo.clickOnView(solo.getView(R.id.stage_dialog_button_maximize));
 		solo.clickOnView(solo.getView(R.id.stage_dialog_button_continue));
 		solo.sleep(100);
-		byte[] blackPixel = { 0, 0, 0, (byte) 255 };
+		byte[] blackPixel = {0, 0, 0, (byte) 255};
 		screenPixel = StageActivity.stageListener.getPixels(0, 0, 1, 1);
 		UiTestUtils.compareByteArrays(blackPixel, screenPixel);
 		screenPixel = StageActivity.stageListener.getPixels(ScreenValues.SCREEN_WIDTH - 1,

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/fragment/LookFragmentTest.java
@@ -1709,7 +1709,7 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		assertTrue("Bottom bar is visible", solo.getView(R.id.bottom_bar).getVisibility() == View.GONE);
 
-		int[] checkboxIndicesToCheck = { solo.getCurrentViews(CheckBox.class).size() - 1, 0, 2 };
+		int[] checkboxIndicesToCheck = {solo.getCurrentViews(CheckBox.class).size() - 1, 0, 2};
 		int expectedNumberOfLooks = currentNumberOfLooks - checkboxIndicesToCheck.length;
 
 		solo.scrollDown();
@@ -1734,7 +1734,7 @@ public class LookFragmentTest extends BaseActivityInstrumentationTestCase<MainMe
 
 		assertTrue("Bottom bar is visible", solo.getView(R.id.bottom_bar).getVisibility() == View.GONE);
 
-		int[] checkboxIndicesToCheck = { solo.getCurrentViews(CheckBox.class).size() - 1, 0, 2 };
+		int[] checkboxIndicesToCheck = {solo.getCurrentViews(CheckBox.class).size() - 1, 0, 2};
 
 		solo.scrollDown();
 		solo.clickOnCheckBox(checkboxIndicesToCheck[0]);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/fragment/NfcTagFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/fragment/NfcTagFragmentTest.java
@@ -614,7 +614,7 @@ public class NfcTagFragmentTest extends BaseActivityInstrumentationTestCase<Main
 
 		assertTrue("Bottom bar is visible", solo.getView(R.id.bottom_bar).getVisibility() == View.GONE);
 
-		int[] checkboxIndicesToCheck = { solo.getCurrentViews(CheckBox.class).size() - 1, 0, 2 };
+		int[] checkboxIndicesToCheck = {solo.getCurrentViews(CheckBox.class).size() - 1, 0, 2};
 		int expectedNumberOfTags = currentNumberOfTags - checkboxIndicesToCheck.length;
 
 		solo.scrollDown();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/ui/fragment/SoundFragmentTest.java
@@ -1425,7 +1425,7 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 		UiTestUtils.openActionMode(solo, delete, R.id.delete);
 		solo.sleep(800);
 
-		int[] checkboxIndicesToCheck = { solo.getCurrentViews(CheckBox.class).size() - 1, 0, 2 };
+		int[] checkboxIndicesToCheck = {solo.getCurrentViews(CheckBox.class).size() - 1, 0, 2};
 		assertTrue("Bottom bar is visible" + solo.getCurrentViews(CheckBox.class).size(), solo.getCurrentViews(CheckBox.class).size() == 5);
 		int expectedNumberOfSounds = currentNumberOfSounds - checkboxIndicesToCheck.length;
 
@@ -1638,7 +1638,7 @@ public class SoundFragmentTest extends BaseActivityInstrumentationTestCase<MainM
 
 		assertTrue("Bottom bar is visible", solo.getView(R.id.bottom_bar).getVisibility() == View.GONE);
 
-		int[] checkboxIndicesToCheck = { solo.getCurrentViews(CheckBox.class).size() - 1, 0, 2 };
+		int[] checkboxIndicesToCheck = {solo.getCurrentViews(CheckBox.class).size() - 1, 0, 2};
 
 		solo.scrollDown();
 		solo.clickOnCheckBox(checkboxIndicesToCheck[0]);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/SystemAnimations.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/SystemAnimations.java
@@ -74,7 +74,7 @@ class SystemAnimations {
 			for (int i = 0; i < currentScales.length; i++) {
 				currentScales[i] = animationScale;
 			}
-			setAnimationScales.invoke(windowManagerObj, new Object[] { currentScales });
+			setAnimationScales.invoke(windowManagerObj, new Object[] {currentScales});
 		} catch (Exception e) {
 			Log.e(TAG, "Could not change animation scale to " + animationScale + " :'(");
 		}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -59,6 +59,7 @@ import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import com.google.common.io.CharStreams;
 import com.robotium.solo.Condition;
 import com.robotium.solo.Solo;
 
@@ -173,6 +174,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
@@ -374,7 +376,7 @@ public final class UiTestUtils {
 		return setVariableBrick;
 	}
 
-	public static enum FileTypes {
+	public enum FileTypes {
 		IMAGE, SOUND, ROOT, SCREENSHOT
 	}
 
@@ -2055,7 +2057,7 @@ public final class UiTestUtils {
 		static final long serialVersionUID = 1L;
 		private final float catrobatLanguageVersion;
 
-		public ProjectWithCatrobatLanguageVersion(String name, float catrobatLanguageVersion) {
+		ProjectWithCatrobatLanguageVersion(String name, float catrobatLanguageVersion) {
 			super(null, name);
 			this.catrobatLanguageVersion = catrobatLanguageVersion;
 		}
@@ -2589,13 +2591,9 @@ public final class UiTestUtils {
 
 	public static Map<String, String> readConfigFile(Context context) {
 		try {
-
-			InputStream stream = context.getAssets().open("oauth_config.xml");
-			int size = stream.available();
-			byte[] buffer = new byte[size];
-			stream.read(buffer);
-			stream.close();
-			String text = new String(buffer);
+			InputStreamReader reader = new InputStreamReader(context.getAssets().open("oauth_config.xml"));
+			String text = CharStreams.toString(reader);
+			reader.close();
 			facebookTestUserName = text.substring(text.indexOf(CONFIG_FACEBOOK_NAME) + CONFIG_FACEBOOK_NAME.length() + 1,
 					text.indexOf("/" + CONFIG_FACEBOOK_NAME) - 1);
 			facebookTestuserMail = text.substring(text.indexOf(CONFIG_FACEBOOK_MAIL) + CONFIG_FACEBOOK_MAIL.length() + 1,

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uitest/util/UiTestUtils.java
@@ -2522,7 +2522,7 @@ public final class UiTestUtils {
 		}
 		intent.putExtra(NfcAdapter.EXTRA_ID, tagId);
 		if (ndefMessage != null) {
-			intent.putExtra(NfcAdapter.EXTRA_NDEF_MESSAGES, new NdefMessage[] { ndefMessage });
+			intent.putExtra(NfcAdapter.EXTRA_NDEF_MESSAGES, new NdefMessage[] {ndefMessage});
 			if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intentAction)) {
 				Uri uri = ndefMessage.getRecords()[0].toUri();
 				String mime = ndefMessage.getRecords()[0].toMimeType();

--- a/catroid/src/main/java/org/catrobat/catroid/bluetooth/BluetoothConnectionImpl.java
+++ b/catroid/src/main/java/org/catrobat/catroid/bluetooth/BluetoothConnectionImpl.java
@@ -115,7 +115,7 @@ public class BluetoothConnectionImpl implements BluetoothConnection {
 				Log.d(TAG, "Try connecting again");
 				// try another method for connection, this should work on the HTC desire, credits to Michael Biermann
 				Method mMethod = bluetoothDevice.getClass()
-						.getMethod(REFLECTION_METHOD_NAME, new Class[] { int.class });
+						.getMethod(REFLECTION_METHOD_NAME, new Class[] {int.class});
 				this.bluetoothSocket = (BluetoothSocket) mMethod.invoke(bluetoothDevice, Integer.valueOf(1));
 				this.bluetoothSocket.connect();
 				return (state = State.CONNECTED);

--- a/catroid/src/main/java/org/catrobat/catroid/bluetooth/base/BluetoothConnection.java
+++ b/catroid/src/main/java/org/catrobat/catroid/bluetooth/base/BluetoothConnection.java
@@ -30,7 +30,7 @@ import java.io.OutputStream;
 
 public interface BluetoothConnection {
 
-	static enum State {
+	enum State {
 		CONNECTED, NOT_CONNECTED, ERROR_BLUETOOTH_NOT_SUPPORTED, ERROR_BLUETOOTH_NOT_ON,
 		ERROR_ADAPTER, ERROR_DEVICE, ERROR_SOCKET, ERROR_STILL_BONDING, ERROR_NOT_BONDED, ERROR_CLOSING
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/camera/CameraManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/camera/CameraManager.java
@@ -297,8 +297,8 @@ public final class CameraManager implements DeviceCameraControl, Camera.PreviewC
 		if (texture != null) {
 			try {
 				setTexture();
-			} catch (IOException iOException) {
-				Log.e(TAG, "Setting preview texture failed!", iOException);
+			} catch (IOException ioException) {
+				Log.e(TAG, "Setting preview texture failed!", ioException);
 				return false;
 			}
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -52,8 +52,8 @@ public final class Constants {
 	public static final char REMIX_URL_REPLACE_SEPARATOR = ';';
 
 	//Extensions:
-	public static final String[] IMAGE_EXTENSIONS = { ".png", ".jpg", ".jpeg", ".png", ".gif" };
-	public static final String[] SOUND_EXTENSIONS = { ".wav", ".mp3", ".mpga", ".wav", ".ogy" };
+	public static final String[] IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".png", ".gif"};
+	public static final String[] SOUND_EXTENSIONS = {".wav", ".mp3", ".mpga", ".wav", ".ogy"};
 
 	public static final String DEFAULT_ROOT = Environment.getExternalStorageDirectory().getAbsolutePath()
 			+ "/Pocket Code";

--- a/catroid/src/main/java/org/catrobat/catroid/common/DroneVideoLookData.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/DroneVideoLookData.java
@@ -42,7 +42,7 @@ public class DroneVideoLookData extends LookData {
 
 	private transient boolean firstStart = true;
 	private transient GLBGVideoSprite videoTexture;
-	private transient int[] videoSize = { 0, 0 };
+	private transient int[] videoSize = {0, 0};
 	private transient int[] defaultVideoTextureSize;
 
 	@Override
@@ -71,7 +71,7 @@ public class DroneVideoLookData extends LookData {
 		// BUG: Height() should be 1280, but it is 1184, so we need an scaling factor of 1.081081
 		int virtualScreenHeight = (int) Math.round(1.081081 * ScreenValues.SCREEN_HEIGHT);
 
-		defaultVideoTextureSize = new int[] { virtualScreenHeight, ScreenValues.SCREEN_WIDTH };
+		defaultVideoTextureSize = new int[] {virtualScreenHeight, ScreenValues.SCREEN_WIDTH};
 
 		if (pixmap == null) {
 			pixmap = new Pixmap(virtualScreenHeight, ScreenValues.SCREEN_WIDTH, Pixmap.Format.RGB888);

--- a/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
@@ -241,7 +241,7 @@ public class LookData implements Serializable, Cloneable {
 		width = options.outWidth;
 		height = options.outHeight;
 
-		return new int[] { width, height };
+		return new int[] {width, height};
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorPhysics.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/defaultprojectcreators/DefaultProjectCreatorPhysics.java
@@ -116,13 +116,13 @@ public class DefaultProjectCreatorPhysics extends DefaultProjectCreator {
 		Sprite leftArm = spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Left arm");
 		Sprite rightArm = spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Right arm");
 
-		Sprite[] upperBouncers = { spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Left cat bouncer"),
+		Sprite[] upperBouncers = {spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Left cat bouncer"),
 				spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Middle cat bouncer"),
-				spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Right cat bouncer") };
+				spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Right cat bouncer")};
 
-		Sprite[] lowerBouncers = { spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Left circle bouncer"),
+		Sprite[] lowerBouncers = {spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Left circle bouncer"),
 				spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Middle circle bouncer"),
-				spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Right circle bouncer") };
+				spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Right circle bouncer")};
 
 		Sprite middleBouncer = spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Cat head bouncer");
 		Sprite leftHardBouncer = spriteFactory.newInstance(SingleSprite.class.getSimpleName(), "Left hard bouncer");
@@ -216,8 +216,8 @@ public class DefaultProjectCreatorPhysics extends DefaultProjectCreator {
 		setPhysicsProperties(rightHardBouncer, rightHardBouncerStartScript, PhysicsObject.Type.FIXED, 10.0f, -1.0f);
 
 		// Lower circle bouncers
-		Vector2[] lowerBouncersPositions = { new Vector2(-100.0f, 0.0f),
-				new Vector2(0.0f, -70.0f), new Vector2(100.0f, 0.0f) };
+		Vector2[] lowerBouncersPositions = {new Vector2(-100.0f, 0.0f),
+				new Vector2(0.0f, -70.0f), new Vector2(100.0f, 0.0f)};
 		for (int index = 0; index < lowerBouncers.length; index++) {
 			Script lowerBouncerStartScript = createElement(context, projectName, sceneName, lowerBouncers[index], "physics_bouncer_100",
 					R.drawable.physics_bouncer_100, lowerBouncersPositions[index], Float.NaN, 60f);
@@ -231,8 +231,8 @@ public class DefaultProjectCreatorPhysics extends DefaultProjectCreator {
 		middleBouncerStartScript.addBrick(new TurnLeftSpeedBrick(100));
 
 		// Upper bouncers
-		Vector2[] upperBouncersPositions = { new Vector2(-150.0f, 200.0f), new Vector2(0.0f, 300.f),
-				new Vector2(150.0f, 200.0f) };
+		Vector2[] upperBouncersPositions = {new Vector2(-150.0f, 200.0f), new Vector2(0.0f, 300.f),
+				new Vector2(150.0f, 200.0f)};
 		for (int index = 0; index < upperBouncers.length; index++) {
 			Script upperBouncersStartScript = createElement(context, projectName, sceneName, upperBouncers[index], "physics_bouncer_200",
 					R.drawable.physics_bouncer_200, upperBouncersPositions[index], Float.NaN, 50f);

--- a/catroid/src/main/java/org/catrobat/catroid/content/BroadcastEvent.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/BroadcastEvent.java
@@ -100,7 +100,7 @@ public class BroadcastEvent extends Event {
 		setRun(true);
 	}
 
-	public static enum BroadcastType {
+	public enum BroadcastType {
 		broadcast, broadcastWait
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -619,7 +619,7 @@ public class Look extends Image {
 		private static final String CONTRAST_STRING_IN_SHADER = "contrast";
 		private static final String HUE_STRING_IN_SHADER = "hue";
 
-		public BrightnessContrastHueShader() {
+		BrightnessContrastHueShader() {
 			super(VERTEX_SHADER, FRAGMENT_SHADER);
 			ShaderProgram.pedantic = false;
 			if (isCompiled()) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/WhenScript.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/WhenScript.java
@@ -35,8 +35,8 @@ public class WhenScript extends Script {
 	private static final String SWIPERIGHT = "Swipe Right";
 	private static final String SWIPEUP = "Swipe Up";
 	private static final String SWIPEDOWN = "Swipe Down";
-	private static final String[] ACTIONS = { TAPPED, DOUBLETAPPED, LONGPRESSED, SWIPEUP, SWIPEDOWN, SWIPELEFT,
-			SWIPERIGHT };
+	private static final String[] ACTIONS = {TAPPED, DOUBLETAPPED, LONGPRESSED, SWIPEUP, SWIPEDOWN, SWIPELEFT,
+			SWIPERIGHT};
 	private String action;
 	private transient int position;
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/ArduinoSendPWMValueAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/ArduinoSendPWMValueAction.java
@@ -55,7 +55,7 @@ public class ArduinoSendPWMValueAction extends TemporalAction {
 			pinNumberInterpretation = pinNumber == null ? Integer.valueOf(0) : pinNumber.interpretInteger(sprite);
 		} catch (InterpretationException interpretationException) {
 			pinNumberInterpretation = 0;
-			Log.d(getClass().getSimpleName(), "Formula interpretation for this specific Brick failed." ,
+			Log.d(getClass().getSimpleName(), "Formula interpretation for this specific Brick failed.",
 					interpretationException);
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/BrickBaseType.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/BrickBaseType.java
@@ -155,5 +155,6 @@ public abstract class BrickBaseType implements Brick {
 	public abstract List<SequenceAction> addActionToSequence(Sprite sprite, SequenceAction sequence);
 
 	@Override
-	public void storeDataForBackPack(Sprite sprite) { }
+	public void storeDataForBackPack(Sprite sprite) {
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorMoveBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorMoveBrick.java
@@ -49,7 +49,7 @@ public class LegoEv3MotorMoveBrick extends FormulaBrick {
 	private transient Motor motorEnum;
 	private transient TextView editSpeed;
 
-	public static enum Motor {
+	public enum Motor {
 		MOTOR_A, MOTOR_B, MOTOR_C, MOTOR_D, MOTOR_B_C
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorStopBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorStopBrick.java
@@ -42,7 +42,7 @@ public class LegoEv3MotorStopBrick extends BrickBaseType implements OnItemSelect
 	private transient Motor motorEnum;
 	private String motor;
 
-	public static enum Motor {
+	public enum Motor {
 		MOTOR_A, MOTOR_B, MOTOR_C, MOTOR_D, MOTOR_B_C, ALL_MOTORS
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorTurnAngleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorTurnAngleBrick.java
@@ -49,7 +49,7 @@ public class LegoEv3MotorTurnAngleBrick extends FormulaBrick {
 	private transient Motor motorEnum;
 	private transient TextView editSpeed;
 
-	public static enum Motor {
+	public enum Motor {
 		MOTOR_A, MOTOR_B, MOTOR_C, MOTOR_D, MOTOR_B_C, MOTOR_ALL
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3SetLedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3SetLedBrick.java
@@ -42,7 +42,7 @@ public class LegoEv3SetLedBrick extends BrickBaseType implements OnItemSelectedL
 	private transient LedStatus ledStatusEnum;
 	private String ledStatus;
 
-	public static enum LedStatus {
+	public enum LedStatus {
 		LED_OFF, LED_GREEN, LED_RED, LED_ORANGE,
 		LED_GREEN_FLASHING, LED_RED_FLASHING, LED_ORANGE_FLASHING,
 		LED_GREEN_PULSE, LED_RED_PULSE, LED_ORANGE_PULSE

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorMoveBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorMoveBrick.java
@@ -51,7 +51,7 @@ public class LegoNxtMotorMoveBrick extends FormulaBrick {
 	private transient Motor motorEnum;
 	private transient TextView editSpeed;
 
-	public static enum Motor {
+	public enum Motor {
 		MOTOR_A, MOTOR_B, MOTOR_C, MOTOR_B_C
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroPlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroPlayToneBrick.java
@@ -51,7 +51,7 @@ public class PhiroPlayToneBrick extends FormulaBrick {
 	private transient Tone toneEnum;
 	private transient TextView editDuration;
 
-	public static enum Tone {
+	public enum Tone {
 		DO, RE, MI, FA, SO, LA, TI
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundAndWaitBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundAndWaitBrick.java
@@ -222,7 +222,7 @@ public class PlaySoundAndWaitBrick extends BrickBaseType implements OnItemSelect
 
 		private boolean isTouchInDropDownView;
 
-		public SpinnerAdapterWrapper(Context context, ArrayAdapter<SoundInfo> spinnerAdapter) {
+		SpinnerAdapterWrapper(Context context, ArrayAdapter<SoundInfo> spinnerAdapter) {
 			this.context = context;
 			this.spinnerAdapter = spinnerAdapter;
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
@@ -200,7 +200,7 @@ public class PlaySoundBrick extends BrickBaseType implements OnItemSelectedListe
 
 		private boolean isTouchInDropDownView;
 
-		public SpinnerAdapterWrapper(Context context, ArrayAdapter<SoundInfo> spinnerAdapter) {
+		SpinnerAdapterWrapper(Context context, ArrayAdapter<SoundInfo> spinnerAdapter) {
 			this.context = context;
 			this.spinnerAdapter = spinnerAdapter;
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PointInDirectionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PointInDirectionBrick.java
@@ -44,12 +44,12 @@ public class PointInDirectionBrick extends FormulaBrick {
 
 	private transient View prototypeView;
 
-	public static enum Direction {
+	public enum Direction {
 		RIGHT(90), LEFT(-90), UP(0), DOWN(180);
 
 		private double directionDegrees;
 
-		private Direction(double degrees) {
+		Direction(double degrees) {
 			directionDegrees = degrees;
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneStartBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneStartBrick.java
@@ -194,7 +194,7 @@ public class SceneStartBrick extends BrickBaseType implements NewSceneDialog.OnN
 
 		private boolean isTouchInDropDownView;
 
-		public SpinnerAdapterWrapper(Context context, ArrayAdapter<String> spinnerAdapter) {
+		SpinnerAdapterWrapper(Context context, ArrayAdapter<String> spinnerAdapter) {
 			this.context = context;
 			this.spinnerAdapter = spinnerAdapter;
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneTransitionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneTransitionBrick.java
@@ -217,7 +217,7 @@ public class SceneTransitionBrick extends BrickBaseType implements NewSceneDialo
 
 		private boolean isTouchInDropDownView;
 
-		public SpinnerAdapterWrapper(Context context, ArrayAdapter<String> spinnerAdapter) {
+		SpinnerAdapterWrapper(Context context, ArrayAdapter<String> spinnerAdapter) {
 			this.context = context;
 			this.spinnerAdapter = spinnerAdapter;
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetLookBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetLookBrick.java
@@ -219,7 +219,7 @@ public class SetLookBrick extends BrickBaseType implements OnLookDataListChanged
 
 		private boolean isTouchInDropDownView;
 
-		public SpinnerAdapterWrapper(Context context, ArrayAdapter<LookData> spinnerAdapter) {
+		SpinnerAdapterWrapper(Context context, ArrayAdapter<LookData> spinnerAdapter) {
 			this.context = context;
 			this.spinnerAdapter = spinnerAdapter;
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetNfcTagBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetNfcTagBrick.java
@@ -171,7 +171,7 @@ public class SetNfcTagBrick extends FormulaBrick {
 		protected Context context;
 		protected ArrayAdapter<String> spinnerAdapter;
 
-		public SpinnerAdapterWrapper(Context context, ArrayAdapter<String> spinnerAdapter) {
+		SpinnerAdapterWrapper(Context context, ArrayAdapter<String> spinnerAdapter) {
 			this.context = context;
 			this.spinnerAdapter = spinnerAdapter;
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetRotationStyleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetRotationStyleBrick.java
@@ -128,7 +128,7 @@ public class SetRotationStyleBrick extends BrickBaseType {
 		protected Context context;
 		protected ArrayAdapter<String> spinnerAdapter;
 
-		public SpinnerAdapterWrapper(Context context, ArrayAdapter<String> spinnerAdapter) {
+		SpinnerAdapterWrapper(Context context, ArrayAdapter<String> spinnerAdapter) {
 			this.context = context;
 			this.spinnerAdapter = spinnerAdapter;
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBackgroundChangesBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBackgroundChangesBrick.java
@@ -213,7 +213,7 @@ public class WhenBackgroundChangesBrick extends BrickBaseType implements
 
 		private boolean isTouchInDropDownView;
 
-		public SpinnerAdapterWrapper(Context context, ArrayAdapter<LookData> spinnerAdapter) {
+		SpinnerAdapterWrapper(Context context, ArrayAdapter<LookData> spinnerAdapter) {
 			this.context = context;
 			this.spinnerAdapter = spinnerAdapter;
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenNfcBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenNfcBrick.java
@@ -236,7 +236,7 @@ public class WhenNfcBrick extends BrickBaseType implements ScriptBrick, NfcTagFr
 
 		private boolean isTouchInDropDownView;
 
-		public SpinnerAdapterWrapper(Context context, ArrayAdapter<NfcTagData> spinnerAdapter) {
+		SpinnerAdapterWrapper(Context context, ArrayAdapter<NfcTagData> spinnerAdapter) {
 			this.context = context;
 			this.spinnerAdapter = spinnerAdapter;
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/arduino/ArduinoImpl.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/arduino/ArduinoImpl.java
@@ -191,7 +191,8 @@ public class ArduinoImpl implements Arduino {
 	}
 
 	@Override
-	public void pause() { }
+	public void pause() {
+	}
 
 	@Override
 	public void destroy() {

--- a/catroid/src/main/java/org/catrobat/catroid/devices/arduino/ArduinoImpl.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/arduino/ArduinoImpl.java
@@ -46,7 +46,7 @@ public class ArduinoImpl implements Arduino {
 
 	public static final int NUMBER_OF_DIGITAL_PINS = 14; // assuming numbered from 0 to NUMBER_OF_DIGITAL_PINS-1
 	public static final int NUMBER_OF_ANALOG_PINS = 6;   // assuming numbered from 0 to NUMBER_OF_ANALOG_PINS-1
-	public static final int[] PWM_PINS = { 3, 5, 6, 9, 10, 11 };
+	public static final int[] PWM_PINS = {3, 5, 6, 9, 10, 11};
 
 	public static final int PINS_IN_A_PORT = 8;
 	public static final int NUMBER_OF_DIGITAL_PORTS = (NUMBER_OF_DIGITAL_PINS + PINS_IN_A_PORT - 1) / PINS_IN_A_PORT;

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/ev3/EV3CommandByte.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/ev3/EV3CommandByte.java
@@ -41,7 +41,7 @@ public class EV3CommandByte {
 
 		private int commandParamByteCode;
 
-		private EV3CommandParamByteCode(int commandParamByteCode) {
+		EV3CommandParamByteCode(int commandParamByteCode) {
 			this.commandParamByteCode = commandParamByteCode;
 		}
 
@@ -55,7 +55,7 @@ public class EV3CommandByte {
 
 		private int variableScope;
 
-		private EV3CommandVariableScope(int variableScope) {
+		EV3CommandVariableScope(int variableScope) {
 			this.variableScope = variableScope;
 		}
 
@@ -69,7 +69,7 @@ public class EV3CommandByte {
 
 		private int commandParamFormat;
 
-		private EV3CommandParamFormat(int commandParamFormat) {
+		EV3CommandParamFormat(int commandParamFormat) {
 			this.commandParamFormat = commandParamFormat;
 		}
 
@@ -90,7 +90,7 @@ public class EV3CommandByte {
 
 		private int commandByteCode;
 
-		private EV3CommandByteCode(int commandByteCode) {
+		EV3CommandByteCode(int commandByteCode) {
 			this.commandByteCode = commandByteCode;
 		}
 
@@ -121,7 +121,7 @@ public class EV3CommandByte {
 				LOOKUP.put(c.commandByteValue, c);
 			}
 		}
-		private EV3CommandOpCode(int commandByteValue) {
+		EV3CommandOpCode(int commandByteValue) {
 			this.commandByteValue = commandByteValue;
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/ev3/EV3CommandType.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/ev3/EV3CommandType.java
@@ -31,7 +31,7 @@ public enum EV3CommandType {
 
 	private int commandTypeValue;
 
-	private EV3CommandType(int commandTypeValue) {
+	EV3CommandType(int commandTypeValue) {
 		this.commandTypeValue = commandTypeValue;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/ev3/EV3MotorOutputByteCode.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/ev3/EV3MotorOutputByteCode.java
@@ -28,7 +28,7 @@ public enum EV3MotorOutputByteCode {
 
 	private int ev3MotorOutputValue;
 
-	private EV3MotorOutputByteCode(int ev3MotorOutputValue) {
+	EV3MotorOutputByteCode(int ev3MotorOutputValue) {
 		this.ev3MotorOutputValue = ev3MotorOutputValue;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/ev3/sensors/EV3SensorService.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/ev3/sensors/EV3SensorService.java
@@ -171,7 +171,7 @@ public class EV3SensorService implements CatroidService, SharedPreferences.OnSha
 	private static class SensorValueUpdater implements Runnable {
 		private EV3Sensor sensor;
 
-		public SensorValueUpdater(EV3Sensor sensor) {
+		SensorValueUpdater(EV3Sensor sensor) {
 			this.sensor = sensor;
 		}
 
@@ -190,7 +190,7 @@ public class EV3SensorService implements CatroidService, SharedPreferences.OnSha
 			public ScheduledFuture scheduledFuture;
 			public EV3Sensor sensor;
 
-			public SensorTuple(ScheduledFuture scheduledFuture, EV3Sensor sensor) {
+			SensorTuple(ScheduledFuture scheduledFuture, EV3Sensor sensor) {
 				this.scheduledFuture = scheduledFuture;
 				this.sensor = sensor;
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/CommandByte.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/CommandByte.java
@@ -43,7 +43,7 @@ public enum CommandByte {
 			LOOKUP.put(c.commandByteValue, c);
 		}
 	}
-	private CommandByte(int commandByteValue) {
+	CommandByte(int commandByteValue) {
 		this.commandByteValue = commandByteValue;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/CommandType.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/CommandType.java
@@ -28,7 +28,7 @@ public enum CommandType {
 
 	private int commandTypeValue;
 
-	private CommandType(int commandTypeValue) {
+	CommandType(int commandTypeValue) {
 		this.commandTypeValue = commandTypeValue;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/NXTError.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/NXTError.java
@@ -62,7 +62,7 @@ public final class NXTError {
 				LOOKUP.put(c.errorCodeValue, c);
 			}
 		}
-		private ErrorCode(int errorCodeValue) {
+		ErrorCode(int errorCodeValue) {
 			this.errorCodeValue = errorCodeValue;
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/NXTMotor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/NXTMotor.java
@@ -139,7 +139,7 @@ public class NXTMotor implements MindstormsMotor {
 
 		private int motorRegulationValue;
 
-		private MotorRegulation(int motorRegulationValue) {
+		MotorRegulation(int motorRegulationValue) {
 			this.motorRegulationValue = motorRegulationValue;
 		}
 
@@ -153,7 +153,7 @@ public class NXTMotor implements MindstormsMotor {
 
 		private int motorRunStateValue;
 
-		private MotorRunState(int motorRunStateValue) {
+		MotorRunState(int motorRunStateValue) {
 			this.motorRunStateValue = motorRunStateValue;
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTI2CSensor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTI2CSensor.java
@@ -63,7 +63,7 @@ public abstract class NXTI2CSensor extends NXTSensor {
 		if (!hasInit) {
 			initialize();
 		}
-		byte[] command = { address, register, data };
+		byte[] command = {address, register, data};
 		write(command, (byte) 0, reply);
 	}
 
@@ -71,7 +71,7 @@ public abstract class NXTI2CSensor extends NXTSensor {
 		if (!hasInit) {
 			initialize();
 		}
-		byte[] command = { address, (byte) register };
+		byte[] command = {address, (byte) register};
 		return writeAndRead(command, (byte) rxLength);
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTI2CUltraSonicSensor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTI2CUltraSonicSensor.java
@@ -45,7 +45,7 @@ public class NXTI2CUltraSonicSensor extends NXTI2CSensor {
 
 		private int register;
 
-		private SensorRegister(int register) {
+		SensorRegister(int register) {
 			this.register = register;
 		}
 
@@ -59,7 +59,7 @@ public class NXTI2CUltraSonicSensor extends NXTI2CSensor {
 
 		private int command;
 
-		private UltrasonicCommand(int command) {
+		UltrasonicCommand(int command) {
 			this.command = command;
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTSensorMode.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTSensorMode.java
@@ -27,7 +27,7 @@ public enum NXTSensorMode {
 
 	private int sensorModeValue;
 
-	private NXTSensorMode(int sensorModeValue) {
+	NXTSensorMode(int sensorModeValue) {
 		this.sensorModeValue = sensorModeValue;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTSensorService.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTSensorService.java
@@ -164,7 +164,7 @@ public class NXTSensorService implements CatroidService, SharedPreferences.OnSha
 	private static class SensorValueUpdater implements Runnable {
 		private NXTSensor sensor;
 
-		public SensorValueUpdater(NXTSensor sensor) {
+		SensorValueUpdater(NXTSensor sensor) {
 			this.sensor = sensor;
 		}
 
@@ -183,7 +183,7 @@ public class NXTSensorService implements CatroidService, SharedPreferences.OnSha
 			public ScheduledFuture scheduledFuture;
 			public NXTSensor sensor;
 
-			public SensorTuple(ScheduledFuture scheduledFuture, NXTSensor sensor) {
+			SensorTuple(ScheduledFuture scheduledFuture, NXTSensor sensor) {
 				this.scheduledFuture = scheduledFuture;
 				this.sensor = sensor;
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTSensorType.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTSensorType.java
@@ -30,7 +30,7 @@ public enum NXTSensorType {
 
 	private int sensorTypeValue;
 
-	private NXTSensorType(int sensorTypeValue) {
+	NXTSensorType(int sensorTypeValue) {
 		this.sensorTypeValue = sensorTypeValue;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/drone/DroneBrickFactory.java
+++ b/catroid/src/main/java/org/catrobat/catroid/drone/DroneBrickFactory.java
@@ -59,7 +59,7 @@ public final class DroneBrickFactory {
 	}
 
 	public static BrickBaseType getInstanceOfDroneBrick(DroneBricks brick, int timeInMilliseconds,
-														int powerInPercent) {
+			int powerInPercent) {
 
 		switch (brick) {
 			case DRONE_TAKE_OFF_LAND_BRICK:

--- a/catroid/src/main/java/org/catrobat/catroid/facedetection/FaceDetector.java
+++ b/catroid/src/main/java/org/catrobat/catroid/facedetection/FaceDetector.java
@@ -67,10 +67,10 @@ public abstract class FaceDetector {
 	}
 
 	protected void onFaceDetected(Point position, int size) {
-		float[] positionXFloatValue = new float[] { position.x };
+		float[] positionXFloatValue = new float[] {position.x};
 		boolean invertY = !CameraManager.getInstance().isCurrentCameraFacingBack();
-		float[] positionYFloatValue = new float[] { invertY ? -position.y : position.y };
-		float[] sizeFloatValue = new float[] { size };
+		float[] positionYFloatValue = new float[] {invertY ? -position.y : position.y};
+		float[] sizeFloatValue = new float[] {size};
 		SensorCustomEvent xPositionEvent = new SensorCustomEvent(Sensors.FACE_X_POSITION, positionXFloatValue);
 		SensorCustomEvent yPositionEvent = new SensorCustomEvent(Sensors.FACE_Y_POSITION, positionYFloatValue);
 		SensorCustomEvent sizeEvent = new SensorCustomEvent(Sensors.FACE_SIZE, sizeFloatValue);
@@ -84,7 +84,7 @@ public abstract class FaceDetector {
 	protected void onFaceDetected(boolean faceDetected) {
 		if (this.faceDetected != faceDetected) {
 			this.faceDetected = faceDetected;
-			float[] detectedFloatValue = new float[] { faceDetected ? 1 : 0 };
+			float[] detectedFloatValue = new float[] {faceDetected ? 1 : 0};
 			SensorCustomEvent event = new SensorCustomEvent(Sensors.FACE_DETECTED, detectedFloatValue);
 			for (SensorCustomEventListener listener : faceDetectionStatusListeners) {
 				listener.onCustomSensorChanged(event);

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -52,7 +52,7 @@ public class FormulaElement implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	public static enum ElementType {
+	public enum ElementType {
 		OPERATOR, FUNCTION, NUMBER, SENSOR, USER_VARIABLE, USER_LIST, BRACKET, STRING, COLLISION_FORMULA
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
@@ -33,15 +33,15 @@ import java.util.List;
 public class InternFormula {
 	private static final String TAG = InternFormula.class.getSimpleName();
 
-	public static enum CursorTokenPosition {
+	public enum CursorTokenPosition {
 		LEFT, MIDDLE, RIGHT
 	}
 
-	public static enum CursorTokenPropertiesAfterModification {
+	public enum CursorTokenPropertiesAfterModification {
 		LEFT, RIGHT, SELECT, DO_NOT_MODIFY
 	}
 
-	public static enum TokenSelectionType {
+	public enum TokenSelectionType {
 		USER_SELECTION, PARSER_ERROR_SELECTION
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
@@ -38,7 +38,7 @@ public class InternFormulaParser {
 
 		private static final long serialVersionUID = 1L;
 
-		public InternFormulaParserException(String errorMessage) {
+		InternFormulaParserException(String errorMessage) {
 			super(errorMessage);
 		}
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaUtils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaUtils.java
@@ -358,7 +358,7 @@ public final class InternFormulaUtils {
 						currentParameterInternTokenList = new LinkedList<InternToken>();
 						break;
 					}
-
+					// fallthrough
 				default:
 					currentParameterInternTokenList.add(tempSearchToken);
 					break;

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/SensorHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/SensorHandler.java
@@ -67,7 +67,7 @@ public final class SensorHandler implements SensorEventListener, SensorCustomEve
 	private float[] rotationVector = new float[3];
 	private float[] accelerationXYZ = new float[3];
 	private float signAccelerationZ = 0f;
-	private float[] gravity = new float[] { 0f, 0f, 0f };
+	private float[] gravity = new float[] {0f, 0f, 0f};
 	private boolean useLinearAccelerationFallback = false;
 	private boolean useRotationVectorFallback = false;
 	private float linearAccelerationX = 0f;

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/SensorLoudness.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/SensorLoudness.java
@@ -80,8 +80,8 @@ public final class SensorLoudness {
 			try {
 				recorder.start();
 				statusChecker.run();
-			} catch (IOException iOException) {
-				Log.d(TAG, "Could not start recorder", iOException);
+			} catch (IOException ioException) {
+				Log.d(TAG, "Could not start recorder", ioException);
 				listenerList.remove(listener);
 				recorder = new SoundRecorder("/dev/null");
 				return false;
@@ -103,9 +103,9 @@ public final class SensorLoudness {
 				if (recorder.isRecording()) {
 					try {
 						recorder.stop();
-					} catch (IOException iOException) {
+					} catch (IOException ioException) {
 						// ignored, nothing we can do
-						Log.d(TAG, "Could not stop recorder", iOException);
+						Log.d(TAG, "Could not stop recorder", ioException);
 					}
 					recorder = new SoundRecorder("/dev/null");
 				}

--- a/catroid/src/main/java/org/catrobat/catroid/io/BackpackScriptSerializerAndDeserializer.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/BackpackScriptSerializerAndDeserializer.java
@@ -64,12 +64,12 @@ public class BackpackScriptSerializerAndDeserializer implements JsonSerializer<S
 
 		try {
 			return context.deserialize(element, Class.forName(PACKAGE_NAME + type));
-		} catch (ClassNotFoundException e) {
+		} catch (ClassNotFoundException classNotFoundException) {
 			try {
 				return context.deserialize(element, Class.forName(PACKAGE_NAME_PHYSICS + type));
-			} catch (ClassNotFoundException e2) {
+			} catch (ClassNotFoundException physicsClassNotFoundException) {
 				Log.e(TAG, "Could not deserialize backpacked script element!");
-				throw new JsonParseException("Unknown element type: " + type, e2);
+				throw new JsonParseException("Unknown element type: " + type, physicsClassNotFoundException);
 			}
 		}
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/io/CatroidFieldKeySorter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/CatroidFieldKeySorter.java
@@ -65,7 +65,7 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 		return null;
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	private Map sortByList(final List<String> fieldOrder, final Map keyedByFieldKey) {
 		checkMissingSerializableField(fieldOrder, keyedByFieldKey.entrySet());
 		final Map map = new TreeMap(new Comparator() {
@@ -100,7 +100,7 @@ public class CatroidFieldKeySorter implements FieldKeySorter {
 		return !Modifier.isStatic(modifiers) && !Modifier.isTransient(modifiers);
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	private Map sortAlphabeticallyByClassHierarchy(final Map keyedByFieldKey) {
 		final Map map = new TreeMap(new Comparator() {
 			@Override

--- a/catroid/src/main/java/org/catrobat/catroid/io/ProjectAndSceneScreenshotLoader.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/ProjectAndSceneScreenshotLoader.java
@@ -48,7 +48,7 @@ public class ProjectAndSceneScreenshotLoader {
 		public boolean isBackpackScene;
 		public ImageView imageView;
 
-		public ScreenshotData(String projectName, String sceneName, boolean isBackpackScene, ImageView imageView) {
+		ScreenshotData(String projectName, String sceneName, boolean isBackpackScene, ImageView imageView) {
 			this.projectName = projectName;
 			this.sceneName = sceneName;
 			this.isBackpackScene = isBackpackScene;

--- a/catroid/src/main/java/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/StorageHandler.java
@@ -406,7 +406,7 @@ public final class StorageHandler {
 		xstream.alias("brick", IfLogicElseBrick.class);
 		xstream.alias("brick", IfLogicEndBrick.class);
 		xstream.alias("brick", IfThenLogicBeginBrick.class);
-		xstream.alias("brick", IfThenLogicEndBrick .class);
+		xstream.alias("brick", IfThenLogicEndBrick.class);
 		xstream.alias("brick", IfOnEdgeBounceBrick.class);
 		xstream.alias("brick", InsertItemIntoUserListBrick.class);
 		xstream.alias("brick", FlashBrick.class);

--- a/catroid/src/main/java/org/catrobat/catroid/io/XStreamBrickConverter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/XStreamBrickConverter.java
@@ -37,8 +37,8 @@ import org.catrobat.catroid.content.bricks.Brick;
 public class XStreamBrickConverter extends ReflectionConverter {
 
 	private static final String TAG = XStreamBrickConverter.class.getSimpleName();
-	private static final String[] BRICKS_PACKAGE_NAMES = { "org.catrobat.catroid.content.bricks",
-			"org.catrobat.catroid.physics.content.bricks" };
+	private static final String[] BRICKS_PACKAGE_NAMES = {"org.catrobat.catroid.content.bricks",
+			"org.catrobat.catroid.physics.content.bricks"};
 	private static final String TYPE = "type";
 
 	public XStreamBrickConverter(Mapper mapper, ReflectionProvider reflectionProvider) {

--- a/catroid/src/main/java/org/catrobat/catroid/nfc/NfcHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/nfc/NfcHandler.java
@@ -242,7 +242,7 @@ public final class NfcHandler {
 			default:
 				ndefRecord = NdefRecord.createUri(message);
 		}
-		return new NdefMessage(new NdefRecord[] { ndefRecord });
+		return new NdefMessage(new NdefRecord[] {ndefRecord});
 	}
 
 	public static String deleteProtocolPrefixIfExist(String url) {

--- a/catroid/src/main/java/org/catrobat/catroid/physics/PhysicsBoundaryBox.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/PhysicsBoundaryBox.java
@@ -36,7 +36,7 @@ public class PhysicsBoundaryBox {
 
 	private final World world;
 
-	public enum BoundaryBoxIdentifier { BBI_HORIZONTAL, BBI_VERTICAL }
+	public enum BoundaryBoxIdentifier {BBI_HORIZONTAL, BBI_VERTICAL}
 
 	public PhysicsBoundaryBox(World world) {
 		this.world = world;

--- a/catroid/src/main/java/org/catrobat/catroid/physics/PhysicsLook.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/PhysicsLook.java
@@ -238,7 +238,7 @@ public class PhysicsLook extends Look {
 		private boolean fixed = false;
 		private boolean nonColliding = false;
 
-		public PhysicsObjectStateHandler() {
+		PhysicsObjectStateHandler() {
 
 			positionCondition = new PhysicsObjectStateCondition() {
 				@Override

--- a/catroid/src/main/java/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilder.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilder.java
@@ -35,7 +35,7 @@ import java.util.Map;
 public final class PhysicsShapeBuilder {
 
 	private static final String TAG = PhysicsShapeBuilder.class.getSimpleName();
-	private static final float[] ACCURACY_LEVELS = { 0.125f, 0.25f, 0.50f, 0.75f, 1.0f };
+	private static final float[] ACCURACY_LEVELS = {0.125f, 0.25f, 0.50f, 0.75f, 1.0f};
 
 	private static PhysicsShapeBuilder instance = null;
 

--- a/catroid/src/main/java/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilder.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilder.java
@@ -115,7 +115,7 @@ public final class PhysicsShapeBuilder {
 		private Pixmap pixmap;
 		private float sizeAdjustmentScaleFactor = 1;
 
-		public ImageShapes(Pixmap pixmap) {
+		ImageShapes(Pixmap pixmap) {
 			if (pixmap == null) {
 				throw new RuntimeException("Pixmap must not null");
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilderStrategyFastHull.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilderStrategyFastHull.java
@@ -138,7 +138,7 @@ public final class PhysicsShapeBuilderStrategyFastHull implements PhysicsShapeBu
 		if (convexpoints.length < 9) {
 			PolygonShape polygon = new PolygonShape();
 			polygon.set(convexpoints);
-			return new Shape[] { polygon };
+			return new Shape[] {polygon};
 		}
 
 		List<Shape> shapes = new ArrayList<Shape>(convexpoints.length / 6 + 1);

--- a/catroid/src/main/java/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilderStrategyRectangle.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/shapebuilder/PhysicsShapeBuilderStrategyRectangle.java
@@ -92,6 +92,6 @@ public class PhysicsShapeBuilderStrategyRectangle implements PhysicsShapeBuilder
 		PolygonShape polygonShape = new PolygonShape();
 		polygonShape.setAsBox(box2dWidth, box2dHeight, center, 0.0f);
 
-		return new Shape[] { polygonShape };
+		return new Shape[] {polygonShape};
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/pocketmusic/PocketMusicActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/pocketmusic/PocketMusicActivity.java
@@ -53,6 +53,7 @@ public class PocketMusicActivity extends BaseActivity {
 
 	private Project project;
 	private TactScrollRecyclerView tactScroller;
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);

--- a/catroid/src/main/java/org/catrobat/catroid/pocketmusic/note/MusicalBeat.java
+++ b/catroid/src/main/java/org/catrobat/catroid/pocketmusic/note/MusicalBeat.java
@@ -29,7 +29,7 @@ public enum MusicalBeat {
 	private final int bottomNumber;
 	private final NoteLength noteLength;
 
-	private MusicalBeat(int topNumnber, int bottomNumber, NoteLength noteLength) {
+	MusicalBeat(int topNumnber, int bottomNumber, NoteLength noteLength) {
 		this.topNumber = topNumnber;
 		this.bottomNumber = bottomNumber;
 		this.noteLength = noteLength;

--- a/catroid/src/main/java/org/catrobat/catroid/pocketmusic/note/MusicalKey.java
+++ b/catroid/src/main/java/org/catrobat/catroid/pocketmusic/note/MusicalKey.java
@@ -27,7 +27,7 @@ public enum MusicalKey {
 
 	private NoteName noteNameOnMiddleLine;
 
-	private MusicalKey(NoteName noteNameOnMiddleLine) {
+	MusicalKey(NoteName noteNameOnMiddleLine) {
 		this.noteNameOnMiddleLine = noteNameOnMiddleLine;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/pocketmusic/note/NoteLength.java
+++ b/catroid/src/main/java/org/catrobat/catroid/pocketmusic/note/NoteLength.java
@@ -28,7 +28,7 @@ public enum NoteLength {
 	WHOLE_DOT(4f + 2f), WHOLE(4f), HALF_DOT(2f + 1f), HALF(2f), QUARTER_DOT(1f + 1 / 2f),
 	QUARTER(1f), EIGHT_DOT(1 / 2f + 1 / 4f), EIGHT(1 / 2f), SIXTEENTH(1 / 4f);
 
-	private static final NoteLength[] SORTED_NOTE_LENGTHS = new NoteLength[] { SIXTEENTH, EIGHT, EIGHT_DOT, QUARTER, QUARTER_DOT, HALF, HALF_DOT, WHOLE, WHOLE_DOT };
+	private static final NoteLength[] SORTED_NOTE_LENGTHS = new NoteLength[] {SIXTEENTH, EIGHT, EIGHT_DOT, QUARTER, QUARTER_DOT, HALF, HALF_DOT, WHOLE, WHOLE_DOT};
 	private static final long DEFAULT_TICK_DURATION_MODIFIER = 8;
 	private static final NoteLength SMALLEST_NOTE_LENGTH = SIXTEENTH;
 

--- a/catroid/src/main/java/org/catrobat/catroid/pocketmusic/note/NoteName.java
+++ b/catroid/src/main/java/org/catrobat/catroid/pocketmusic/note/NoteName.java
@@ -42,7 +42,7 @@ public enum NoteName {
 	private int midi;
 	private boolean signed;
 
-	private NoteName(int midi, boolean signed) {
+	NoteName(int midi, boolean signed) {
 		this.midi = midi;
 		this.signed = signed;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/pocketmusic/note/Octave.java
+++ b/catroid/src/main/java/org/catrobat/catroid/pocketmusic/note/Octave.java
@@ -24,20 +24,20 @@ package org.catrobat.catroid.pocketmusic.note;
 
 public enum Octave {
 
-	CONTRA_OCTAVE(new NoteName[] { NoteName.C1, NoteName.C1S, NoteName.D1, NoteName.D1S, NoteName.E1,
-			NoteName.F1, NoteName.F1S, NoteName.G1, NoteName.G1S, NoteName.A1, NoteName.A1S, NoteName.B1 }),
-	GREAT_OCTAVE(new NoteName[] { NoteName.C2, NoteName.C2S, NoteName.D2, NoteName.D2S, NoteName.E2,
-			NoteName.F2, NoteName.F2S, NoteName.G2, NoteName.G2S, NoteName.A2, NoteName.A2S, NoteName.B2 }),
-	SMALL_OCTAVE(new NoteName[] { NoteName.C3, NoteName.C3S, NoteName.D3, NoteName.D3S, NoteName.E3,
-			NoteName.F3, NoteName.F3S, NoteName.G3, NoteName.G3S, NoteName.A3, NoteName.A3S, NoteName.B3 }),
-	ONE_LINE_OCTAVE(new NoteName[] { NoteName.C4, NoteName.C4S, NoteName.D4, NoteName.D4S, NoteName.E4,
-			NoteName.F4, NoteName.F4S, NoteName.G4, NoteName.G4S, NoteName.A4, NoteName.A4S, NoteName.B4 }),
-	TWO_LINE_OCTAVE(new NoteName[] { NoteName.C5, NoteName.C5S, NoteName.D5, NoteName.D5S, NoteName.E5,
-			NoteName.F5, NoteName.F5S, NoteName.G5, NoteName.G5S, NoteName.A5, NoteName.A5S, NoteName.B5 }),
-	THREE_LINE_OCTAVE(new NoteName[] { NoteName.C6, NoteName.C6S, NoteName.D6, NoteName.D6S, NoteName.E6,
-			NoteName.F6, NoteName.F6S, NoteName.G6, NoteName.G6S, NoteName.A6, NoteName.A6S, NoteName.B6 }),
-	FOUR_LINE_OCTAVE(new NoteName[] { NoteName.C7, NoteName.C7S, NoteName.D7, NoteName.D7S, NoteName.E7,
-			NoteName.F7, NoteName.F7S, NoteName.G7, NoteName.G7S, NoteName.A7, NoteName.A7S, NoteName.B7 });
+	CONTRA_OCTAVE(new NoteName[] {NoteName.C1, NoteName.C1S, NoteName.D1, NoteName.D1S, NoteName.E1,
+			NoteName.F1, NoteName.F1S, NoteName.G1, NoteName.G1S, NoteName.A1, NoteName.A1S, NoteName.B1}),
+	GREAT_OCTAVE(new NoteName[] {NoteName.C2, NoteName.C2S, NoteName.D2, NoteName.D2S, NoteName.E2,
+			NoteName.F2, NoteName.F2S, NoteName.G2, NoteName.G2S, NoteName.A2, NoteName.A2S, NoteName.B2}),
+	SMALL_OCTAVE(new NoteName[] {NoteName.C3, NoteName.C3S, NoteName.D3, NoteName.D3S, NoteName.E3,
+			NoteName.F3, NoteName.F3S, NoteName.G3, NoteName.G3S, NoteName.A3, NoteName.A3S, NoteName.B3}),
+	ONE_LINE_OCTAVE(new NoteName[] {NoteName.C4, NoteName.C4S, NoteName.D4, NoteName.D4S, NoteName.E4,
+			NoteName.F4, NoteName.F4S, NoteName.G4, NoteName.G4S, NoteName.A4, NoteName.A4S, NoteName.B4}),
+	TWO_LINE_OCTAVE(new NoteName[] {NoteName.C5, NoteName.C5S, NoteName.D5, NoteName.D5S, NoteName.E5,
+			NoteName.F5, NoteName.F5S, NoteName.G5, NoteName.G5S, NoteName.A5, NoteName.A5S, NoteName.B5}),
+	THREE_LINE_OCTAVE(new NoteName[] {NoteName.C6, NoteName.C6S, NoteName.D6, NoteName.D6S, NoteName.E6,
+			NoteName.F6, NoteName.F6S, NoteName.G6, NoteName.G6S, NoteName.A6, NoteName.A6S, NoteName.B6}),
+	FOUR_LINE_OCTAVE(new NoteName[] {NoteName.C7, NoteName.C7S, NoteName.D7, NoteName.D7S, NoteName.E7,
+			NoteName.F7, NoteName.F7S, NoteName.G7, NoteName.G7S, NoteName.A7, NoteName.A7S, NoteName.B7});
 
 	public static final Octave DEFAULT_OCTAVE = ONE_LINE_OCTAVE;
 	public static final int NUMBER_OF_UNSIGNED_HALF_TONE_STEPS_PER_OCTAVE = 7;

--- a/catroid/src/main/java/org/catrobat/catroid/scratchconverter/ConversionManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/scratchconverter/ConversionManager.java
@@ -37,7 +37,7 @@ public interface ConversionManager extends ConnectAuthCallback, ConvertCallback,
 	void setCurrentActivity(Activity activity);
 	void connectAndAuthenticate();
 	void shutdown();
-	void convertProgram(final long jobID, final String title, final WebImage image, final boolean force);
+	void convertProgram(long jobID, String title, WebImage image, boolean force);
 	void addBaseInfoViewListener(BaseInfoViewListener baseInfoViewListener);
 	boolean removeBaseInfoViewListener(BaseInfoViewListener baseInfoViewListener);
 	void addGlobalJobViewListener(JobViewListener jobViewListener);

--- a/catroid/src/main/java/org/catrobat/catroid/scratchconverter/protocol/Job.java
+++ b/catroid/src/main/java/org/catrobat/catroid/scratchconverter/protocol/Job.java
@@ -125,7 +125,7 @@ public class Job {
 				: data.getString(JsonJobDataKeys.IMAGE_URL.toString());
 		WebImage image = null;
 		if (imageURL != null) {
-			final int[] imageSize = new int[] { Constants.SCRATCH_IMAGE_DEFAULT_WIDTH, Constants.SCRATCH_IMAGE_DEFAULT_HEIGHT };
+			final int[] imageSize = new int[] {Constants.SCRATCH_IMAGE_DEFAULT_WIDTH, Constants.SCRATCH_IMAGE_DEFAULT_HEIGHT};
 			image = new WebImage(Uri.parse(imageURL), imageSize[0], imageSize[1]);
 		}
 		final short progress = (short) data.getInt(JsonJobDataKeys.PROGRESS.toString());

--- a/catroid/src/main/java/org/catrobat/catroid/scratchconverter/protocol/JobHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/scratchconverter/protocol/JobHandler.java
@@ -182,7 +182,7 @@ public class JobHandler implements Client.DownloadCallback {
 		job.setTitle(jobRunningMessage.getJobTitle());
 		final String jobImageURL = jobRunningMessage.getJobImageURL();
 		if (jobImageURL != null) {
-			final int[] imageSize = new int[] { Constants.SCRATCH_IMAGE_DEFAULT_WIDTH, Constants.SCRATCH_IMAGE_DEFAULT_HEIGHT };
+			final int[] imageSize = new int[] {Constants.SCRATCH_IMAGE_DEFAULT_WIDTH, Constants.SCRATCH_IMAGE_DEFAULT_HEIGHT};
 			job.setImage(new WebImage(Uri.parse(jobImageURL), imageSize[0], imageSize[1]));
 		}
 		job.setState(Job.State.RUNNING);

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
@@ -124,8 +124,7 @@ public class CollisionInformation {
 					collisionPolygons = temporaryCollisionPolygons.toArray(new Polygon[temporaryCollisionPolygons
 							.size()]);
 					epsilon *= 1.2f;
-				}
-				while (getNumberOfVertices() > Constants.COLLISION_VERTEX_LIMIT);
+				} while (getNumberOfVertices() > Constants.COLLISION_VERTEX_LIMIT);
 
 				if (collisionPolygons.length == 0) {
 					Bitmap bitmap = BitmapFactory.decodeFile(path);

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
@@ -440,7 +440,7 @@ public class CollisionInformation {
 	public static Polygon[] createCollisionPolygonByHitbox(Bitmap bitmap) {
 		float width = bitmap.getWidth();
 		float height = bitmap.getHeight();
-		float[] vertices = { 0f, 0f, width, 0f, width, height, 0f, height };
+		float[] vertices = {0f, 0f, width, 0f, width, height, 0f, height};
 		Polygon polygon = new Polygon(vertices);
 		Polygon[] polygons = new Polygon[1];
 		polygons[0] = polygon;

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -875,9 +875,6 @@ public class StageListener implements ApplicationListener {
 		public boolean cameraRunning;
 		public Map<Sprite, ShowBubbleActor> bubbleActorMap;
 		public PenActor penActor;
-
-		public StageBackup() {
-		}
 	}
 
 	private StageBackup saveToBackup() {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/DragNDropBrickLayout.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/DragNDropBrickLayout.java
@@ -581,7 +581,7 @@ public class DragNDropBrickLayout extends BrickLayout {
 		public int width;
 		public int height;
 
-		public WeirdFloatingWindowData(View view, int width, int height) {
+		WeirdFloatingWindowData(View view, int width, int height) {
 			this.view = view;
 			this.width = width;
 			this.height = height;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -323,7 +323,7 @@ public class ProjectActivity extends BaseActivity {
 		if (numberOfItemsInBackpack == 0) {
 			actionListener.startBackPackActionMode();
 		} else {
-			items = new CharSequence[] { getString(R.string.packing), getString(R.string.unpack) };
+			items = new CharSequence[] {getString(R.string.packing), getString(R.string.unpack)};
 			builder.setItems(items, new DialogInterface.OnClickListener() {
 				@Override
 				public void onClick(DialogInterface dialog, int which) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ScriptActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ScriptActivity.java
@@ -445,7 +445,7 @@ public class ScriptActivity extends BaseActivity {
 				currentFragment.startBackPackActionMode();
 			}
 		} else {
-			items = new CharSequence[] { getString(R.string.packing), getString(R.string.unpack) };
+			items = new CharSequence[] {getString(R.string.packing), getString(R.string.unpack)};
 
 			builder.setItems(items, new DialogInterface.OnClickListener() {
 				@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
@@ -63,13 +63,13 @@ public class SettingsActivity extends PreferenceActivity {
 	public static final String NXT_SENSOR_2 = "setting_mindstorms_nxt_sensor_2";
 	public static final String NXT_SENSOR_3 = "setting_mindstorms_nxt_sensor_3";
 	public static final String NXT_SENSOR_4 = "setting_mindstorms_nxt_sensor_4";
-	public static final String[] NXT_SENSORS = { NXT_SENSOR_1, NXT_SENSOR_2, NXT_SENSOR_3, NXT_SENSOR_4 };
+	public static final String[] NXT_SENSORS = {NXT_SENSOR_1, NXT_SENSOR_2, NXT_SENSOR_3, NXT_SENSOR_4};
 
 	public static final String EV3_SENSOR_1 = "setting_mindstorms_ev3_sensor_1";
 	public static final String EV3_SENSOR_2 = "setting_mindstorms_ev3_sensor_2";
 	public static final String EV3_SENSOR_3 = "setting_mindstorms_ev3_sensor_3";
 	public static final String EV3_SENSOR_4 = "setting_mindstorms_ev3_sensor_4";
-	public static final String[] EV3_SENSORS = { EV3_SENSOR_1, EV3_SENSOR_2, EV3_SENSOR_3, EV3_SENSOR_4 };
+	public static final String[] EV3_SENSORS = {EV3_SENSOR_1, EV3_SENSOR_2, EV3_SENSOR_3, EV3_SENSOR_4};
 
 	public static final String DRONE_CONFIGS = "setting_drone_basic_configs";
 	public static final String DRONE_ALTITUDE_LIMIT = "setting_drone_altitude_limit";
@@ -181,7 +181,7 @@ public class SettingsActivity extends PreferenceActivity {
 
 		boolean areChoosersEnabled = getDroneChooserEnabled(this);
 
-		final String[] dronePreferences = new String[] { DRONE_CONFIGS, DRONE_ALTITUDE_LIMIT, DRONE_VERTICAL_SPEED, DRONE_ROTATION_SPEED, DRONE_TILT_ANGLE };
+		final String[] dronePreferences = new String[] {DRONE_CONFIGS, DRONE_ALTITUDE_LIMIT, DRONE_VERTICAL_SPEED, DRONE_ROTATION_SPEED, DRONE_TILT_ANGLE};
 		for (String dronePreference : dronePreferences) {
 			ListPreference listPreference = (ListPreference) findPreference(dronePreference);
 
@@ -260,7 +260,7 @@ public class SettingsActivity extends PreferenceActivity {
 
 		boolean areChoosersEnabled = getMindstormsNXTSensorChooserEnabled(this);
 
-		final String[] sensorPreferences = new String[] { NXT_SENSOR_1, NXT_SENSOR_2, NXT_SENSOR_3, NXT_SENSOR_4 };
+		final String[] sensorPreferences = new String[] {NXT_SENSOR_1, NXT_SENSOR_2, NXT_SENSOR_3, NXT_SENSOR_4};
 		for (int i = 0; i < sensorPreferences.length; ++i) {
 			ListPreference listPreference = (ListPreference) findPreference(sensorPreferences[i]);
 			listPreference.setEntryValues(NXTSensor.Sensor.getSensorCodes());
@@ -273,7 +273,7 @@ public class SettingsActivity extends PreferenceActivity {
 
 		boolean areChoosersEnabled = getMindstormsEV3SensorChooserEnabled(this);
 
-		final String[] sensorPreferences = new String[] { EV3_SENSOR_1, EV3_SENSOR_2, EV3_SENSOR_3, EV3_SENSOR_4 };
+		final String[] sensorPreferences = new String[] {EV3_SENSOR_1, EV3_SENSOR_2, EV3_SENSOR_3, EV3_SENSOR_4};
 		for (int i = 0; i < sensorPreferences.length; i++) {
 			ListPreference listPreference = (ListPreference) findPreference(sensorPreferences[i]);
 			listPreference.setEntryValues(EV3Sensor.Sensor.getSensorCodes());
@@ -385,7 +385,7 @@ public class SettingsActivity extends PreferenceActivity {
 	public static NXTSensor.Sensor[] getLegoMindstormsNXTSensorMapping(Context context) {
 
 		final String[] sensorPreferences =
-				new String[] { NXT_SENSOR_1, NXT_SENSOR_2, NXT_SENSOR_3, NXT_SENSOR_4 };
+				new String[] {NXT_SENSOR_1, NXT_SENSOR_2, NXT_SENSOR_3, NXT_SENSOR_4};
 
 		NXTSensor.Sensor[] sensorMapping = new NXTSensor.Sensor[4];
 		for (int i = 0; i < 4; i++) {
@@ -399,7 +399,7 @@ public class SettingsActivity extends PreferenceActivity {
 	public static EV3Sensor.Sensor[] getLegoMindstormsEV3SensorMapping(Context context) {
 
 		final String[] sensorPreferences =
-				new String[] { EV3_SENSOR_1, EV3_SENSOR_2, EV3_SENSOR_3, EV3_SENSOR_4 };
+				new String[] {EV3_SENSOR_1, EV3_SENSOR_2, EV3_SENSOR_3, EV3_SENSOR_4};
 
 		EV3Sensor.Sensor[] sensorMapping = new EV3Sensor.Sensor[4];
 		for (int i = 0; i < 4; i++) {
@@ -469,7 +469,7 @@ public class SettingsActivity extends PreferenceActivity {
 	public static DroneConfigPreference.Preferences[] getDronePreferenceMapping(Context context) {
 
 		final String[] dronePreferences =
-				new String[] { DRONE_CONFIGS, DRONE_ALTITUDE_LIMIT, DRONE_VERTICAL_SPEED, DRONE_ROTATION_SPEED, DRONE_TILT_ANGLE };
+				new String[] {DRONE_CONFIGS, DRONE_ALTITUDE_LIMIT, DRONE_VERTICAL_SPEED, DRONE_ROTATION_SPEED, DRONE_TILT_ANGLE};
 
 		DroneConfigPreference.Preferences[] preferenceMapping = new DroneConfigPreference.Preferences[5];
 		for (int i = 0; i < 5; i++) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
@@ -485,7 +485,8 @@ public final class LookController {
 									.parse(Constants.POCKET_PAINT_DOWNLOAD_LINK));
 							activity.startActivity(downloadPocketPaintIntent);
 						}
-					}).setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+					})
+					.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
 						@Override
 						public void onClick(DialogInterface dialog, int id) {
 							dialog.cancel();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
@@ -210,7 +210,7 @@ public final class LookController {
 		if (arguments != null) {
 			imageUri = (Uri) arguments.get(LOADER_ARGUMENTS_IMAGE_URI);
 		}
-		String[] projection = { MediaStore.MediaColumns.DATA };
+		String[] projection = {MediaStore.MediaColumns.DATA};
 		return new CursorLoader(activity, imageUri, projection, null, null, null);
 	}
 
@@ -379,7 +379,7 @@ public final class LookController {
 		Uri imageUri = intent.getData();
 		if (imageUri != null) {
 
-			Cursor cursor = activity.getContentResolver().query(imageUri, new String[] { android.provider.MediaStore.Images.ImageColumns.DATA }, null, null, null);
+			Cursor cursor = activity.getContentResolver().query(imageUri, new String[] {android.provider.MediaStore.Images.ImageColumns.DATA}, null, null, null);
 
 			if (cursor != null) {
 				cursor.moveToFirst();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/SoundController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/SoundController.java
@@ -148,7 +148,7 @@ public final class SoundController {
 				}
 
 				final String selection = "_id=?";
-				final String[] selectionArgs = new String[] { split[1] };
+				final String[] selectionArgs = new String[] {split[1]};
 
 				return getDataColumn(context, contentUri, selection, selectionArgs);
 			}
@@ -172,7 +172,7 @@ public final class SoundController {
 
 		Cursor cursor = null;
 		final String column = "_data";
-		final String[] projection = { column };
+		final String[] projection = {column};
 
 		try {
 			cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs, null);
@@ -594,7 +594,7 @@ public final class SoundController {
 		if (arguments != null) {
 			audioUri = (Uri) arguments.get(BUNDLE_ARGUMENTS_SELECTED_SOUND);
 		}
-		String[] projection = { MediaStore.Audio.Media.DATA };
+		String[] projection = {MediaStore.Audio.Media.DATA};
 		return new CursorLoader(activity, audioUri, projection, null, null, null);
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/LegoSensorPortConfigDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/LegoSensorPortConfigDialog.java
@@ -39,7 +39,9 @@ public class LegoSensorPortConfigDialog extends DialogFragment {
 
 	public static final String DIALOG_FRAGMENT_TAG = "dialog_lego_sensor_port_config";
 	public static final String TAG = LegoSensorPortConfigDialog.class.getSimpleName();
-	public enum Lego { NXT, EV3 }
+
+	public enum Lego {NXT, EV3}
+
 	private int clickedItem = 0;
 	private Lego legoType;
 	private String legoTypeString;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/MergeNameDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/MergeNameDialog.java
@@ -139,7 +139,7 @@ public class MergeNameDialog extends DialogFragment {
 		} else {
 			if (task.mergeProjects(mergeName)) {
 				String msg = task.getFirstProject().getName() + " " + getActivity().getString(R.string.merge_info) + " "
-						+ "" + 	task.getSecondProject().getName() + "!";
+						+ "" + task.getSecondProject().getName() + "!";
 				ToastUtil.showSuccess(getActivity(), msg);
 			} else {
 				ToastUtil.showError(getActivity(), R.string.error_merge);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/NewDataDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/NewDataDialog.java
@@ -61,7 +61,7 @@ public class NewDataDialog extends DialogFragment {
 	DialogType dialogType = DialogType.SHOW_LIST_CHECKBOX;
 	private int spinnerPositionIfCancel;
 
-	public static enum DialogType {
+	public enum DialogType {
 		SHOW_LIST_CHECKBOX, USER_LIST, USER_VARIABLE
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/NewSpriteDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/NewSpriteDialog.java
@@ -263,7 +263,7 @@ public class NewSpriteDialog extends DialogFragment {
 	}
 
 	private Uri decodeUri(Uri uri) throws NullPointerException {
-		String[] filePathColumn = { MediaStore.Images.Media.DATA };
+		String[] filePathColumn = {MediaStore.Images.Media.DATA};
 		Cursor cursor = getActivity().getContentResolver().query(uri, filePathColumn, null, null, null);
 		cursor.moveToFirst();
 		int columnIndex = cursor.getColumnIndexOrThrow(filePathColumn[0]);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/RenameVariableDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/RenameVariableDialog.java
@@ -56,7 +56,7 @@ public class RenameVariableDialog extends DialogFragment {
 	private DataAdapter adapter;
 	private DialogType type;
 
-	public static enum DialogType {
+	public enum DialogType {
 		USER_LIST, USER_VARIABLE
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProgressDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProgressDialog.java
@@ -83,10 +83,10 @@ public class UploadProgressDialog extends DialogFragment {
 		progressBarDialog.setCancelable(false);
 		progressBarDialog.setCanceledOnTouchOutside(false);
 
-		progressBarDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.cancel), (DialogInterface
-				.OnClickListener) null);
-		progressBarDialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.progress_upload_dialog_show_program), (DialogInterface
-				.OnClickListener) null);
+		progressBarDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.cancel),
+				(DialogInterface.OnClickListener) null);
+		progressBarDialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.progress_upload_dialog_show_program),
+				(DialogInterface.OnClickListener) null);
 
 		return progressBarDialog;
 	}
@@ -162,7 +162,7 @@ public class UploadProgressDialog extends DialogFragment {
 	@SuppressLint("ParcelCreator")
 	private class UploadReceiver extends ResultReceiver {
 
-		public UploadReceiver(Handler handler) {
+		UploadReceiver(Handler handler) {
 			super(handler);
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorCategoryListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorCategoryListFragment.java
@@ -69,40 +69,40 @@ public class FormulaEditorCategoryListFragment extends ListFragment implements D
 	public static final String ACTION_BAR_TITLE_BUNDLE_ARGUMENT = "actionBarTitle";
 	public static final String FRAGMENT_TAG_BUNDLE_ARGUMENT = "fragmentTag";
 
-	public static final String[] TAGS = { OBJECT_TAG, FUNCTION_TAG, LOGIC_TAG, SENSOR_TAG };
+	public static final String[] TAGS = {OBJECT_TAG, FUNCTION_TAG, LOGIC_TAG, SENSOR_TAG};
 	private String actionBarTitle;
 	private int[] itemsIds;
 	private int[] parameterIds;
 	private CategoryListAdapter adapter;
 
-	private static final int[] OBJECT_GENERAL_PROPERTIES_ITEMS = { R.string.formula_editor_object_transparency,
+	private static final int[] OBJECT_GENERAL_PROPERTIES_ITEMS = {R.string.formula_editor_object_transparency,
 			R.string.formula_editor_object_brightness, R.string.formula_editor_object_color/*,
-			R.string.formula_editor_object_distance_to*/ };
+			R.string.formula_editor_object_distance_to*/};
 
-	private static final int[] OBJECT_PHYSICAL_PROPERTIES_ITEMS = { R.string.formula_editor_object_x,
+	private static final int[] OBJECT_PHYSICAL_PROPERTIES_ITEMS = {R.string.formula_editor_object_x,
 			R.string.formula_editor_object_y, R.string.formula_editor_object_size,
 			R.string.formula_editor_object_rotation, R.string.formula_editor_object_layer,
 			R.string.formula_editor_function_collision,
 			R.string.formula_editor_function_collides_with_edge, R.string.formula_editor_function_touched,
 			R.string.formula_editor_object_x_velocity, R.string.formula_editor_object_y_velocity,
-			R.string.formula_editor_object_angular_velocity };
+			R.string.formula_editor_object_angular_velocity};
 
-	private static final int[] OBJECT_ITEMS_LOOK = { R.string.formula_editor_object_look_number,
-			R.string.formula_editor_object_look_name };
+	private static final int[] OBJECT_ITEMS_LOOK = {R.string.formula_editor_object_look_number,
+			R.string.formula_editor_object_look_name};
 
-	private static final int[] OBJECT_ITEMS_BACKGROUND = { R.string.formula_editor_object_background_number,
-			R.string.formula_editor_object_background_name };
+	private static final int[] OBJECT_ITEMS_BACKGROUND = {R.string.formula_editor_object_background_number,
+			R.string.formula_editor_object_background_name};
 
-	private static final int[] LOGIC_BOOLEAN_OPERATORS_ITEMS = { R.string.formula_editor_logic_and,
+	private static final int[] LOGIC_BOOLEAN_OPERATORS_ITEMS = {R.string.formula_editor_logic_and,
 			R.string.formula_editor_logic_or, R.string.formula_editor_logic_not,
-			R.string.formula_editor_function_true, R.string.formula_editor_function_false };
+			R.string.formula_editor_function_true, R.string.formula_editor_function_false};
 
-	private static final int[] LOGIC_COMPARISON_OPERATORS_ITEMS = { R.string.formula_editor_logic_equal,
+	private static final int[] LOGIC_COMPARISON_OPERATORS_ITEMS = {R.string.formula_editor_logic_equal,
 			R.string.formula_editor_logic_notequal, R.string.formula_editor_logic_lesserthan,
 			R.string.formula_editor_logic_leserequal, R.string.formula_editor_logic_greaterthan,
-			R.string.formula_editor_logic_greaterequal };
+			R.string.formula_editor_logic_greaterequal};
 
-	private static final int[] FUNCTIONS_MATH_ITEMS = { R.string.formula_editor_function_sin,
+	private static final int[] FUNCTIONS_MATH_ITEMS = {R.string.formula_editor_function_sin,
 			R.string.formula_editor_function_cos, R.string.formula_editor_function_tan,
 			R.string.formula_editor_function_ln, R.string.formula_editor_function_log,
 			R.string.formula_editor_function_pi, R.string.formula_editor_function_sqrt,
@@ -112,9 +112,9 @@ public class FormulaEditorCategoryListFragment extends ListFragment implements D
 			R.string.formula_editor_function_arctan, R.string.formula_editor_function_exp,
 			R.string.formula_editor_function_power,
 			R.string.formula_editor_function_floor, R.string.formula_editor_function_ceil,
-			R.string.formula_editor_function_max, R.string.formula_editor_function_min };
+			R.string.formula_editor_function_max, R.string.formula_editor_function_min};
 
-	private static final int[] FUNCTIONS_MATH_PARAMETERS = { R.string.formula_editor_function_sin_parameter,
+	private static final int[] FUNCTIONS_MATH_PARAMETERS = {R.string.formula_editor_function_sin_parameter,
 			R.string.formula_editor_function_cos_parameter, R.string.formula_editor_function_tan_parameter,
 			R.string.formula_editor_function_ln_parameter, R.string.formula_editor_function_log_parameter,
 			R.string.formula_editor_function_pi_parameter, R.string.formula_editor_function_sqrt_parameter,
@@ -124,84 +124,84 @@ public class FormulaEditorCategoryListFragment extends ListFragment implements D
 			R.string.formula_editor_function_arctan_parameter, R.string.formula_editor_function_exp_parameter,
 			R.string.formula_editor_function_power_parameter,
 			R.string.formula_editor_function_floor_parameter, R.string.formula_editor_function_ceil_parameter,
-			R.string.formula_editor_function_max_parameter, R.string.formula_editor_function_min_parameter };
+			R.string.formula_editor_function_max_parameter, R.string.formula_editor_function_min_parameter};
 
-	private static final int[] FUNCTIONS_STRINGS_ITEMS = { R.string.formula_editor_function_length,
-			R.string.formula_editor_function_letter, R.string.formula_editor_function_join };
+	private static final int[] FUNCTIONS_STRINGS_ITEMS = {R.string.formula_editor_function_length,
+			R.string.formula_editor_function_letter, R.string.formula_editor_function_join};
 
-	private static final int[] FUNCTIONS_STRINGS_PARAMETERS = { R.string.formula_editor_function_length_parameter,
-			R.string.formula_editor_function_letter_parameter, R.string.formula_editor_function_join_parameter };
+	private static final int[] FUNCTIONS_STRINGS_PARAMETERS = {R.string.formula_editor_function_length_parameter,
+			R.string.formula_editor_function_letter_parameter, R.string.formula_editor_function_join_parameter};
 
-	private static final int[] FUNCTIONS_LISTS_ITEMS = { R.string.formula_editor_function_number_of_items,
-			R.string.formula_editor_function_list_item, R.string.formula_editor_function_contains };
+	private static final int[] FUNCTIONS_LISTS_ITEMS = {R.string.formula_editor_function_number_of_items,
+			R.string.formula_editor_function_list_item, R.string.formula_editor_function_contains};
 
-	private static final int[] FUNCTIONS_LISTS_PARAMETERS = { R.string.formula_editor_function_number_of_items_parameter,
-			R.string.formula_editor_function_list_item_parameter, R.string.formula_editor_function_contains_parameter };
+	private static final int[] FUNCTIONS_LISTS_PARAMETERS = {R.string.formula_editor_function_number_of_items_parameter,
+			R.string.formula_editor_function_list_item_parameter, R.string.formula_editor_function_contains_parameter};
 
-	private static final int[] DEFAULT_SENSOR_ITEMS = { R.string.formula_editor_sensor_loudness, R.string
-			.formula_editor_function_touched };
+	private static final int[] DEFAULT_SENSOR_ITEMS = {R.string.formula_editor_sensor_loudness, R.string
+			.formula_editor_function_touched};
 
-	private static final int[] DATE_AND_TIME_SENSOR_ITEMS = { R.string.formula_editor_sensor_date_year, R.string.formula_editor_sensor_date_month, R.string.formula_editor_sensor_date_day, R.string.formula_editor_sensor_date_weekday,
-			R.string.formula_editor_sensor_time_hour, R.string.formula_editor_sensor_time_minute, R.string.formula_editor_sensor_time_second };
+	private static final int[] DATE_AND_TIME_SENSOR_ITEMS = {R.string.formula_editor_sensor_date_year, R.string.formula_editor_sensor_date_month, R.string.formula_editor_sensor_date_day, R.string.formula_editor_sensor_date_weekday,
+			R.string.formula_editor_sensor_time_hour, R.string.formula_editor_sensor_time_minute, R.string.formula_editor_sensor_time_second};
 
-	private static final int[] ACCELERATION_SENSOR_ITEMS = { R.string.formula_editor_sensor_x_acceleration,
-			R.string.formula_editor_sensor_y_acceleration, R.string.formula_editor_sensor_z_acceleration };
+	private static final int[] ACCELERATION_SENSOR_ITEMS = {R.string.formula_editor_sensor_x_acceleration,
+			R.string.formula_editor_sensor_y_acceleration, R.string.formula_editor_sensor_z_acceleration};
 
-	private static final int[] INCLINATION_SENSOR_ITEMS = { R.string.formula_editor_sensor_x_inclination,
-			R.string.formula_editor_sensor_y_inclination };
+	private static final int[] INCLINATION_SENSOR_ITEMS = {R.string.formula_editor_sensor_x_inclination,
+			R.string.formula_editor_sensor_y_inclination};
 
-	private static final int[] COMPASS_SENSOR_ITEMS = { R.string.formula_editor_sensor_compass_direction };
+	private static final int[] COMPASS_SENSOR_ITEMS = {R.string.formula_editor_sensor_compass_direction};
 
-	private static final int[] GPS_SENSOR_ITEMS = { R.string.formula_editor_sensor_latitude, R.string
+	private static final int[] GPS_SENSOR_ITEMS = {R.string.formula_editor_sensor_latitude, R.string
 			.formula_editor_sensor_longitude, R.string.formula_editor_sensor_location_accuracy, R.string
-			.formula_editor_sensor_altitude };
+			.formula_editor_sensor_altitude};
 
-	private static final int[] NXT_SENSOR_ITEMS = { R.string.formula_editor_sensor_lego_nxt_touch,
+	private static final int[] NXT_SENSOR_ITEMS = {R.string.formula_editor_sensor_lego_nxt_touch,
 			R.string.formula_editor_sensor_lego_nxt_sound, R.string.formula_editor_sensor_lego_nxt_light,
-			R.string.formula_editor_sensor_lego_nxt_light_active, R.string.formula_editor_sensor_lego_nxt_ultrasonic };
+			R.string.formula_editor_sensor_lego_nxt_light_active, R.string.formula_editor_sensor_lego_nxt_ultrasonic};
 
-	private static final int[] NFC_TAG_ITEMS = { R.string.formula_editor_nfc_tag_id,
-			R.string.formula_editor_nfc_tag_message };
+	private static final int[] NFC_TAG_ITEMS = {R.string.formula_editor_nfc_tag_id,
+			R.string.formula_editor_nfc_tag_message};
 
-	private static final int[] SENSOR_ITEMS_DRONE = { R.string.formula_editor_sensor_drone_battery_status,
+	private static final int[] SENSOR_ITEMS_DRONE = {R.string.formula_editor_sensor_drone_battery_status,
 			R.string.formula_editor_sensor_drone_emergency_state, R.string.formula_editor_sensor_drone_flying,
 			R.string.formula_editor_sensor_drone_initialized, R.string.formula_editor_sensor_drone_usb_active,
 			R.string.formula_editor_sensor_drone_usb_remaining_time, R.string.formula_editor_sensor_drone_camera_ready,
 			R.string.formula_editor_sensor_drone_record_ready, R.string.formula_editor_sensor_drone_recording,
-			R.string.formula_editor_sensor_drone_num_frames };
+			R.string.formula_editor_sensor_drone_num_frames};
 
-	private static final int[] EV3_SENSOR_ITEMS = { R.string.formula_editor_sensor_lego_ev3_sensor_touch,
+	private static final int[] EV3_SENSOR_ITEMS = {R.string.formula_editor_sensor_lego_ev3_sensor_touch,
 			R.string.formula_editor_sensor_lego_ev3_sensor_infrared, R.string.formula_editor_sensor_lego_ev3_sensor_color,
 			R.string.formula_editor_sensor_lego_ev3_sensor_color_ambient, R.string
-			.formula_editor_sensor_lego_ev3_sensor_color_reflected };
+			.formula_editor_sensor_lego_ev3_sensor_color_reflected};
 
-	private static final int[] PHIRO_SENSOR_ITEMS = { R.string.formula_editor_phiro_sensor_front_left,
+	private static final int[] PHIRO_SENSOR_ITEMS = {R.string.formula_editor_phiro_sensor_front_left,
 			R.string.formula_editor_phiro_sensor_front_right, R.string.formula_editor_phiro_sensor_side_left,
 			R.string.formula_editor_phiro_sensor_side_right, R.string.formula_editor_phiro_sensor_bottom_left,
-			R.string.formula_editor_phiro_sensor_bottom_right };
+			R.string.formula_editor_phiro_sensor_bottom_right};
 
-	private static final int[] ARDUINO_SENSOR_ITEMS = { R.string.formula_editor_function_arduino_read_pin_value_analog,
-			R.string.formula_editor_function_arduino_read_pin_value_digital };
+	private static final int[] ARDUINO_SENSOR_ITEMS = {R.string.formula_editor_function_arduino_read_pin_value_analog,
+			R.string.formula_editor_function_arduino_read_pin_value_digital};
 
-	private static final int[] FACE_DETECTION_SENSOR_ITEMS = { R.string.formula_editor_sensor_face_detected,
+	private static final int[] FACE_DETECTION_SENSOR_ITEMS = {R.string.formula_editor_sensor_face_detected,
 			R.string.formula_editor_sensor_face_size, R.string.formula_editor_sensor_face_x_position,
-			R.string.formula_editor_sensor_face_y_position };
+			R.string.formula_editor_sensor_face_y_position};
 
-	private static final int[] TOUCH_DEDECTION_SENSOR_ITEMS = { R.string.formula_editor_function_finger_x, R.string.formula_editor_function_finger_y,
+	private static final int[] TOUCH_DEDECTION_SENSOR_ITEMS = {R.string.formula_editor_function_finger_x, R.string.formula_editor_function_finger_y,
 			R.string.formula_editor_function_is_finger_touching, R.string.formula_editor_function_multi_finger_x,
 			R.string.formula_editor_function_multi_finger_y,
 			R.string.formula_editor_function_is_multi_finger_touching,
-			R.string.formula_editor_function_index_of_last_finger };
+			R.string.formula_editor_function_index_of_last_finger};
 
-	private static final int[] TOUCH_DEDECTION_PARAMETERS = { R.string.formula_editor_function_no_parameter, R.string.formula_editor_function_no_parameter,
+	private static final int[] TOUCH_DEDECTION_PARAMETERS = {R.string.formula_editor_function_no_parameter, R.string.formula_editor_function_no_parameter,
 			R.string.formula_editor_function_no_parameter, R.string.formula_editor_function_touch_parameter,
 			R.string.formula_editor_function_touch_parameter,
 			R.string.formula_editor_function_touch_parameter,
-			R.string.formula_editor_function_no_parameter };
+			R.string.formula_editor_function_no_parameter};
 
-	private static final int[] RASPBERRY_SENSOR_ITEMS = { R.string.formula_editor_function_raspi_read_pin_value_digital };
+	private static final int[] RASPBERRY_SENSOR_ITEMS = {R.string.formula_editor_function_raspi_read_pin_value_digital};
 
-	private static final int[] RASPBERRY_SENSOR_PARAMETERS = { R.string.formula_editor_function_pin_default_parameter };
+	private static final int[] RASPBERRY_SENSOR_PARAMETERS = {R.string.formula_editor_function_pin_default_parameter};
 
 	private int[] concatAll(int[] first, int[]... rest) {
 		int totalLength = first.length;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -107,7 +107,7 @@ public class FormulaEditorFragment extends Fragment implements OnKeyListener,
 	private Menu currentMenu;
 	private FormulaElement formulaElementForComputeDialog;
 
-	private long[] confirmSwitchEditTextTimeStamp = { 0, 0 };
+	private long[] confirmSwitchEditTextTimeStamp = {0, 0};
 	private int confirmSwitchEditTextCounter = 0;
 	private CharSequence previousActionBarTitle;
 	private VariableOrUserListDeletedReceiver variableOrUserListDeletedReceiver;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/LookFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/LookFragment.java
@@ -896,7 +896,6 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 
 					return true;
 				}
-			default:
 				break;
 		}
 		return false;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/NfcTagFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/NfcTagFragment.java
@@ -669,7 +669,6 @@ public class NfcTagFragment extends ScriptActivityFragment implements NfcTagBase
 					BottomBar.showAddButton(getActivity());
 					return true;
 				}
-			default:
 				break;
 		}
 		return false;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SoundFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SoundFragment.java
@@ -905,7 +905,6 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 
 					return true;
 				}
-			default:
 				break;
 		}
 		return false;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/UserBrickElementEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/UserBrickElementEditorFragment.java
@@ -134,7 +134,7 @@ public class UserBrickElementEditorFragment extends Fragment implements OnKeyLis
 			((ScriptActivity) activity).redrawBricks();
 		} else {
 			Log.e(TAG, "UserBrickDataEditor.onUserDismiss() called when the parent activity is not a UserBrickScriptActivity!\n"
-							+ "This should never happen, afaik. I don't know how to correctly reset the action bar...");
+					+ "This should never happen, afaik. I don't know how to correctly reset the action bar...");
 		}
 
 		ActionBar actionBar = activity.getActionBar();

--- a/catroid/src/main/java/org/catrobat/catroid/utils/DownloadUtil.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/DownloadUtil.java
@@ -187,7 +187,7 @@ public final class DownloadUtil {
 
 	@SuppressLint("ParcelCreator")
 	private class DownloadProjectReceiver extends ResultReceiver {
-		public DownloadProjectReceiver(Handler handler) {
+		DownloadProjectReceiver(Handler handler) {
 			super(handler);
 		}
 
@@ -220,7 +220,7 @@ public final class DownloadUtil {
 
 	@SuppressLint("ParcelCreator")
 	private class DownloadMediaReceiver extends ResultReceiver {
-		public DownloadMediaReceiver(Handler handler) {
+		DownloadMediaReceiver(Handler handler) {
 			super(handler);
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/utils/PausableScheduledThreadPoolExecutor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/PausableScheduledThreadPoolExecutor.java
@@ -46,7 +46,7 @@ public class PausableScheduledThreadPoolExecutor extends ScheduledThreadPoolExec
 			while (isPaused) {
 				unpaused.await();
 			}
-		} catch (InterruptedException ie) {
+		} catch (InterruptedException interruptedException) {
 			t.interrupt();
 		} finally {
 			pauseLock.unlock();

--- a/catroid/src/main/java/org/catrobat/catroid/utils/UtilCamera.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/UtilCamera.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 
 public final class UtilCamera {
 	private static final String TAG = UtilCamera.class.getSimpleName();
+
 	// Suppress default constructor for noninstantiability
 	private UtilCamera() {
 		throw new AssertionError();

--- a/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
@@ -855,9 +855,9 @@ public final class Utils {
 		try {
 			GdxNativesLoader.load();
 			pixmap = new Pixmap(new FileHandle(imageFile));
-		} catch (GdxRuntimeException e) {
+		} catch (GdxRuntimeException gdxRuntimeException) {
 			return null;
-		} catch (Exception e1) {
+		} catch (Exception e) {
 			return null;
 		}
 		return pixmap;

--- a/catroid/src/main/java/org/catrobat/catroid/web/ScratchDataFetcher.java
+++ b/catroid/src/main/java/org/catrobat/catroid/web/ScratchDataFetcher.java
@@ -29,9 +29,9 @@ import org.catrobat.catroid.common.ScratchSearchResult;
 import java.io.InterruptedIOException;
 
 public interface ScratchDataFetcher {
-	ScratchProgramData fetchScratchProgramDetails(final long programID)
+	ScratchProgramData fetchScratchProgramDetails(long programID)
 			throws WebconnectionException, WebScratchProgramException, InterruptedIOException;
 	ScratchSearchResult fetchDefaultScratchPrograms() throws WebconnectionException, InterruptedIOException;
-	ScratchSearchResult scratchSearch(final String query, final int numberOfItems, final int pageNumber)
+	ScratchSearchResult scratchSearch(String query, int numberOfItems, int pageNumber)
 			throws WebconnectionException, InterruptedIOException;
 }

--- a/catroid/src/test/java/org/catrobat/catroid/test/code/SystemOutTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/code/SystemOutTest.java
@@ -39,7 +39,7 @@ public class SystemOutTest extends TestCase {
 	private boolean errorFound;
 
 	private static final String[] TOAST_STACK_TRACE_DIRECTORIES = Utils.TOAST_STACK_TRACE_TEST_DIRECTORIES;
-	private static final String[] IGNORED_FILES = { "SystemOutTest.java", "ToastUtil.java", "BTServer.java" };
+	private static final String[] IGNORED_FILES = {"SystemOutTest.java", "ToastUtil.java", "BTServer.java"};
 	private static final String TOAST_STRING = "Toast.makeText";
 	private static final String SUPERTOAST_STRING = "SuperToast";
 
@@ -72,7 +72,7 @@ public class SystemOutTest extends TestCase {
 			assertTrue("Couldn't find directory: " + directoryName, directory.exists() && directory.isDirectory());
 			assertTrue("Couldn't read directory: " + directoryName, directory.canRead());
 
-			List<File> filesToCheck = Utils.getFilesFromDirectoryByExtension(directory, new String[] { ".java", });
+			List<File> filesToCheck = Utils.getFilesFromDirectoryByExtension(directory, new String[] {".java"});
 			if (IGNORED_FILES != null) {
 				for (String ignoredFileString : IGNORED_FILES) {
 					for (ListIterator<File> listIterator = filesToCheck.listIterator(); listIterator.hasNext(); ) {

--- a/catroid/src/test/java/org/catrobat/catroid/test/utils/Utils.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/utils/Utils.java
@@ -39,10 +39,10 @@ public final class Utils {
 	public static final String SRC_TEST = "src/test/java";
 	public static final String BLUETOOTH = "catroidBluetoothTestServer/src";
 
-	public static final String[] TEST_FILE_DIRECTORIES = {ANDROID_TEST_SRC, SRC_TEST};
-	public static final String[] TOAST_STACK_TRACE_TEST_DIRECTORIES = {SRC, SRC_TEST, BLUETOOTH};
-	public static final String[] VERSION_NAME_AND_CODE_TEST_DIRECTORIES = {ANDROID_TEST};
-	public static final String[] SLEEP_TEST_DIRECTORIES = { };
+	public static final String[] TEST_FILE_DIRECTORIES = { ANDROID_TEST_SRC, SRC_TEST };
+	public static final String[] TOAST_STACK_TRACE_TEST_DIRECTORIES = { SRC, SRC_TEST, BLUETOOTH };
+	public static final String[] VERSION_NAME_AND_CODE_TEST_DIRECTORIES = { ANDROID_TEST };
+	public static final String[] SLEEP_TEST_DIRECTORIES = {};
 
 	private Utils() {
 		throw new AssertionError();

--- a/catroid/src/test/java/org/catrobat/catroid/test/utils/Utils.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/utils/Utils.java
@@ -39,9 +39,9 @@ public final class Utils {
 	public static final String SRC_TEST = "src/test/java";
 	public static final String BLUETOOTH = "catroidBluetoothTestServer/src";
 
-	public static final String[] TEST_FILE_DIRECTORIES = { ANDROID_TEST_SRC, SRC_TEST };
-	public static final String[] TOAST_STACK_TRACE_TEST_DIRECTORIES = { SRC, SRC_TEST, BLUETOOTH };
-	public static final String[] VERSION_NAME_AND_CODE_TEST_DIRECTORIES = { ANDROID_TEST };
+	public static final String[] TEST_FILE_DIRECTORIES = {ANDROID_TEST_SRC, SRC_TEST};
+	public static final String[] TOAST_STACK_TRACE_TEST_DIRECTORIES = {SRC, SRC_TEST, BLUETOOTH};
+	public static final String[] VERSION_NAME_AND_CODE_TEST_DIRECTORIES = {ANDROID_TEST};
 	public static final String[] SLEEP_TEST_DIRECTORIES = {};
 
 	private Utils() {
@@ -49,7 +49,7 @@ public final class Utils {
 	}
 
 	public static List<File> getFilesFromDirectoryByExtension(File directory, String extension) {
-		String[] extensions = { extension };
+		String[] extensions = {extension};
 		return getFilesFromDirectoryByExtension(directory, extensions);
 	}
 


### PR DESCRIPTION
Mostly updating checks and adding new ones. I also reformatted the whole project to check for disagreements between Checkstyle and the Android Studio Formatter and I found one. Arrays and enums were definitely a problem. So I had to made a drastically change. No whitespaces within arrays and enums. ~`new int[] { 1, 2 }`~ → `new int[] {1, 2}`. I'd prefer it anyway because it's also the [default setting](https://github.com/Catrobat/Catroid/pull/2206/files#diff-f1045aea3015ed5f80704025e3ee300eL92) in Android Studio. For more details see last commit. I added a `Under discussion` label because of this.

I already closed all according Jira tickets by moving them to `Rejected` :laughing:
For review, I suggest to look at each commit on it's own. It'll be sooo much easier :wink: 