### PR TITLE
CAT-2258 Clean up gradle task for IntelliJ files

### DIFF
--- a/catroid/gradle/intellij_config_tasks.gradle
+++ b/catroid/gradle/intellij_config_tasks.gradle
@@ -21,50 +21,37 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-task gitSkipWorktreeForIntellijConfigFiles << {
-    try {
-        'git update-index --skip-worktree .idea/misc.xml'.execute().text.trim()
-        'git update-index --skip-worktree .idea/encodings.xml'.execute().text.trim()
-        'git update-index --skip-worktree .idea/vcs.xml'.execute().text.trim()
-        'git update-index --skip-worktree Catroid.iml'.execute().text.trim()
-        'git update-index --skip-worktree catroid/src/test/catroidSourceTest.iml'.execute().text.trim()
-        'git update-index --skip-worktree .idea/codeStyleSettings.xml'.execute().text.trim()
-    } catch (IOException exception) {
-        throw new UnsupportedOperationException("Could not find git! Maybe it is not in \$PATH variable?", exception)
+def skipList = ['.idea/misc.xml',
+                '.idea/encodings.xml',
+                '.idea/vcs.xml',
+                'Catroid.iml',
+                'catroid/src/test/catroidSourceTest.iml',
+                '.idea/codeStyleSettings.xml',
+                'catroid/catroid.iml'
+                ]
+
+task gitSkipWorktreeForIntellijConfigFiles {
+    doLast {
+        try {
+            for (int i = 0; i < skipList.size(); i++) {
+                String gitCmd = 'git update-index --skip-worktree ' + skipList[i]
+                gitCmd.execute().text.trim()
+            }
+        } catch (IOException exception) {
+            throw new UnsupportedOperationException("Could not find git! Maybe it is not in \$PATH variable?", exception)
+        }
     }
 }
 
-task gitNoSkipWorktreeForIntellijConfigFiles << {
-    try {
-        'git update-index --no-skip-worktree .idea/misc.xml'.execute().text.trim()
-        'git update-index --no-skip-worktree Catroid.iml'.execute().text.trim()
-        'git update-index --no-skip-worktree catroid/src/test/catroidSourceTest.iml'.execute().text.trim()
-        'git update-index --no-skip-worktree .idea/codeStyleSettings.xml'.execute().text.trim()
-    } catch (IOException exception) {
-        throw new UnsupportedOperationException("Could not find git! Maybe it is not in \$PATH variable?", exception)
-    }
-}
-
-task gitSaveStashSwitchingToOldBranch << {
-    try {
-        'git update-index --no-skip-worktree .idea/misc.xml'.execute().text.trim()
-        'git update-index --no-skip-worktree Catroid.iml'.execute().text.trim()
-        'git update-index --no-skip-worktree catroid/src/test/catroidSourceTest.iml'.execute().text.trim()
-        'git update-index --no-skip-worktree .idea/codeStyleSettings.xml'.execute().text.trim()
-        'git stash save "IntelliJConfig"'.execute().text.trim()
-    } catch (IOException exception) {
-        throw new UnsupportedOperationException("Could not find git! Maybe it is not in \$PATH variable?", exception)
-    }
-}
-
-task gitApplyStashSwitchingToOldBranch << {
-    try {
-        'git stash apply "IntelliJConfig"'.execute().text.trim()
-        'git update-index --skip-worktree .idea/misc.xml'.execute().text.trim()
-        'git update-index --skip-worktree Catroid.iml'.execute().text.trim()
-        'git update-index --skip-worktree catroid/src/test/catroidSourceTest.iml'.execute().text.trim()
-        'git update-index --skip-worktree .idea/codeStyleSettings.xml'.execute().text.trim()
-    } catch (IOException exception) {
-        throw new UnsupportedOperationException("Could not find git! Maybe it is not in \$PATH variable?", exception)
+task gitNoSkipWorktreeForIntellijConfigFiles {
+    doLast {
+        try {
+            for (int i = 0; i < skipList.size(); i++) {
+                String gitCmd = 'git update-index --no-skip-worktree ' + skipList[i]
+                gitCmd.execute().text.trim()
+            }
+        } catch (IOException exception) {
+            throw new UnsupportedOperationException("Could not find git! Maybe it is not in \$PATH variable?", exception)
+        }
     }
 }


### PR DESCRIPTION
The gradle tasks `gitSkipWorktreeForIntellijConfigFiles` and
`gitNoSkipWorktreeForIntellijConfigFiles` use a list now to update the
affected files. Furthermore the tasks use the _Task.doLast(Action)_ rather
than _Task.leftShift(Closure)_ as the latter is deprecated and will be
removed in Gradle 5.0, see [gradle doc](https://docs.gradle.org/current/userguide/tutorial_using_tasks.html#sec:build_scripts_are_code)

Furthermore the tasks `gitSaveStashSwitchingToOldBranch ` and `gitApplyStashSwitchingToOldBranch ` have been removed due to reasons explained in [CAT-2258](https://jira.catrob.at/browse/CAT-2258?focusedCommentId=19986&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-19986)