### PR TITLE
CAT-2169 Stop All Scripts Bugs

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -43,10 +43,14 @@ import com.badlogic.gdx.utils.Array;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.DroneVideoLookData;
 import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.stage.StageActivity;
 import org.catrobat.catroid.utils.TouchUtil;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 public class Look extends Image {
 	private static final float DEGREE_UI_OFFSET = 90.0f;
@@ -639,6 +643,13 @@ public class Look extends Image {
 			setUniformf(HUE_STRING_IN_SHADER, hue);
 			end();
 		}
+	}
+
+	public Map<String, List<String>> createScriptActions() {
+		this.setWhenParallelAction(null);
+		Map<String, List<String>> scriptActions = new HashMap<>();
+		sprite.createStartScriptActionSequenceAndPutToMap(scriptActions, false);
+		return scriptActions;
 	}
 
 	public Polygon[] getCurrentCollisionPolygon() {

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -232,10 +232,11 @@ public class Sprite implements Serializable, Cloneable {
 		return matchingUserBricks;
 	}
 
-	public void createStartScriptActionSequenceAndPutToMap(Map<String, List<String>> scriptActions) {
+	public void createStartScriptActionSequenceAndPutToMap(Map<String, List<String>> scriptActions,
+			boolean includeStartScripts) {
 		for (int scriptCounter = 0; scriptCounter < scriptList.size(); scriptCounter++) {
 			Script script = scriptList.get(scriptCounter);
-			if (script instanceof StartScript && !isClone) {
+			if (script instanceof StartScript && !isClone && includeStartScripts) {
 				Action sequenceAction = createActionSequence(script);
 				look.addAction(sequenceAction);
 				BroadcastHandler.getActionScriptMap().put(sequenceAction, script);
@@ -270,6 +271,10 @@ public class Sprite implements Serializable, Cloneable {
 				createWhenConditionBecomesTrueAction((WhenConditionScript) script);
 			}
 		}
+	}
+
+	public void createStartScriptActionSequenceAndPutToMap(Map<String, List<String>> scriptActions) {
+		createStartScriptActionSequenceAndPutToMap(scriptActions, true);
 	}
 
 	private void createWhenConditionBecomesTrueAction(WhenConditionScript script) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/RepeatAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/RepeatAction.java
@@ -67,7 +67,7 @@ public class RepeatAction extends com.badlogic.gdx.scenes.scene2d.actions.Repeat
 		if (executedCount >= repeatCountValue && !isForeverRepeat) {
 			return true;
 		}
-		if (action.act(delta) && currentTime >= LOOP_DELAY) {
+		if (action != null && action.act(delta) && currentTime >= LOOP_DELAY) {
 
 			executedCount++;
 			if (executedCount >= repeatCountValue && !isForeverRepeat) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/StopAllScriptsAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/StopAllScriptsAction.java
@@ -28,7 +28,11 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 import com.badlogic.gdx.utils.Array;
 
+import org.catrobat.catroid.content.Look;
 import org.catrobat.catroid.stage.StageActivity;
+
+import java.util.List;
+import java.util.Map;
 
 public class StopAllScriptsAction extends TemporalAction {
 
@@ -38,6 +42,11 @@ public class StopAllScriptsAction extends TemporalAction {
 		for (Actor actor : stageActors) {
 			for (Action action : actor.getActions()) {
 				action.reset();
+			}
+			if (actor instanceof Look) {
+				Look look = (Look) actor;
+				Map<String, List<String>> scriptActions = look.createScriptActions();
+				StageActivity.stageListener.precomputeActionsForBroadcastEvents(scriptActions);
 			}
 		}
 	}


### PR DESCRIPTION
Added a nullcheck to RepeatAction (because it would run into null pointer when an action is reset).

Added a method to Look, that resets all broadcast- and when-scripts to what they were before running the "stop all scripts" block. Before that, stop all scripts would result in none of the scripts working anymore.