### PR TITLE
CAT-2162 Cloning a sprite should not increase the usage counter (FileChecksumContainer)

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
@@ -90,10 +90,7 @@ public class LookData implements Serializable, Cloneable {
 		}
 
 		LookData lookData = (LookData) obj;
-		if (lookData.fileName.equals(this.fileName) && lookData.name.equals(this.name)) {
-			return true;
-		}
-		return false;
+		return (lookData.fileName.equals(this.fileName) && lookData.name.equals(this.name));
 	}
 
 	@Override
@@ -103,16 +100,21 @@ public class LookData implements Serializable, Cloneable {
 
 	@Override
 	public LookData clone() {
+		return clone(true);
+	}
+
+	public LookData clone(boolean incrementUsage) {
 		LookData cloneLookData = new LookData(this.name, this.fileName);
 
 		String filePath = getPathToImageDirectory() + "/" + fileName;
 		cloneLookData.isBackpackLookData = false;
-		try {
-			ProjectManager.getInstance().getFileChecksumContainer().incrementUsage(filePath);
-		} catch (FileNotFoundException fileNotFoundexception) {
-			Log.e(TAG, Log.getStackTraceString(fileNotFoundexception));
+		if (incrementUsage) {
+			try {
+				ProjectManager.getInstance().getFileChecksumContainer().incrementUsage(filePath);
+			} catch (FileNotFoundException fileNotFoundexception) {
+				Log.e(TAG, Log.getStackTraceString(fileNotFoundexception));
+			}
 		}
-
 		return cloneLookData;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -360,7 +360,7 @@ public class Sprite implements Serializable, Cloneable {
 		Sprite originalSprite = ProjectManager.getInstance().getCurrentSprite();
 		ProjectManager.getInstance().setCurrentSprite(cloneSprite);
 
-		cloneLooks(cloneSprite);
+		cloneLooks(cloneSprite, false);
 		cloneUserBricks(cloneSprite);
 		cloneSpriteVariables(ProjectManager.getInstance().getCurrentScene(), cloneSprite);
 		cloneScripts(cloneSprite);
@@ -498,9 +498,13 @@ public class Sprite implements Serializable, Cloneable {
 	}
 
 	private void cloneLooks(Sprite cloneSprite) {
+		cloneLooks(cloneSprite, true);
+	}
+
+	private void cloneLooks(Sprite cloneSprite, boolean incrementUsage) {
 		List<LookData> cloneLookList = new ArrayList<>();
 		for (LookData element : this.lookList) {
-			cloneLookList.add(element.clone());
+			cloneLookList.add(element.clone(incrementUsage));
 		}
 		cloneSprite.lookList = cloneLookList;
 	}
@@ -549,7 +553,7 @@ public class Sprite implements Serializable, Cloneable {
 	}
 
 	public void createWhenScriptActionSequence(String action) {
-		ParallelAction whenParallelAction = actionFactory.parallel();
+		ParallelAction whenParallelAction = ActionFactory.parallel();
 		for (Script s : scriptList) {
 			if (s instanceof WhenScript && (((WhenScript) s).getAction().equalsIgnoreCase(action))) {
 				SequenceAction sequence = createActionSequence(s);
@@ -952,7 +956,7 @@ public class Sprite implements Serializable, Cloneable {
 	}
 
 	public List<Brick> getBricksRequiringResource(int resource) {
-		List<Brick> resourceBrickList = new ArrayList<Brick>();
+		List<Brick> resourceBrickList = new ArrayList<>();
 
 		for (Script script : scriptList) {
 			resourceBrickList.addAll(script.getBricksRequiringResources(resource));


### PR DESCRIPTION
Overloaded the LookData's clone function and Sprite's cloneLooks function so it would take a boolean flag that specifies if the usage counter should be increased.
Called the overloaded function in cloneForCloneBrick function.

Did some minor refactoring (LookData equals method, Sprite createWhenScriptActionSequence and getBricksRequiringResource method).