### PR TITLE
CAT-2355 Removing Hard-Coding String

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,6 +3,30 @@
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
+  <component name="NullableNotNullManager">
+    <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
+    <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
+    <option name="myNullables">
+      <value>
+        <list size="4">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+        </list>
+      </value>
+    </option>
+    <option name="myNotNulls">
+      <value>
+        <list size="4">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
+          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+        </list>
+      </value>
+    </option>
+  </component>
   <component name="ProjectLevelVcsManager" settingsEditedManually="false">
     <OptionsSetting value="true" id="Add" />
     <OptionsSetting value="true" id="Remove" />
@@ -16,31 +40,4 @@
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
-  <component name="TaskProjectConfiguration">
-    <server type="JIRA" url="https://jira.catrob.at" />
-  </component>
-  <component name="ProjectRunConfigurationManager">
-    <configuration default="true" name="Android Tests" type="AndroidTestRunConfigurationType" factoryName="Android Tests">
-      <module name="Catroid" />
-      <option name="TESTING_TYPE" value="3" />
-      <option name="INSTRUMENTATION_RUNNER_CLASS" value="pl.polidea.instrumentation.PolideaInstrumentationTestRunner" />
-      <option name="METHOD_NAME" value="" />
-      <option name="CLASS_NAME" value="" />
-      <option name="PACKAGE_NAME" value="" />
-      <option name="TARGET_SELECTION_MODE" value="SHOW_DIALOG" />
-      <option name="USE_LAST_SELECTED_DEVICE" value="false" />
-      <option name="PREFERRED_AVD" value="" />
-      <option name="USE_COMMAND_LINE" value="true" />
-      <option name="COMMAND_LINE" value="" />
-      <option name="WIPE_USER_DATA" value="false" />
-      <option name="DISABLE_BOOT_ANIMATION" value="false" />
-      <option name="NETWORK_SPEED" value="full" />
-      <option name="NETWORK_LATENCY" value="none" />
-      <option name="CLEAR_LOGCAT" value="false" />
-      <option name="SHOW_LOGCAT_AUTOMATICALLY" value="true" />
-      <option name="FILTER_LOGCAT_AUTOMATICALLY" value="true" />
-      <method />
-    </configuration>
-  </component>
 </project>
-

--- a/Catroid.iml
+++ b/Catroid.iml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
 </module>
-

--- a/catroid/catroid.iml
+++ b/catroid/catroid.iml
@@ -9,7 +9,6 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="catroidDebug" />
-        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleCatroidDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileCatroidDebugSources" />
         <afterSyncTasks>

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/RemovingHardCodingStringForObjectSizeUnit.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/RemovingHardCodingStringForObjectSizeUnit.java
@@ -1,0 +1,121 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.utils;
+
+import android.test.ActivityInstrumentationTestCase2;
+
+import com.robotium.solo.Solo;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.ui.MainMenuActivity;
+import org.catrobat.catroid.ui.Multilingual;
+import org.catrobat.catroid.ui.MyProjectsActivity;
+
+/**
+ * Created by Null on 3/28/2017.
+ */
+
+public class RemovingHardCodingStringForObjectSizeUnit extends ActivityInstrumentationTestCase2<MainMenuActivity> {
+
+	public RemovingHardCodingStringForObjectSizeUnit() {
+		super(MainMenuActivity.class);
+	}
+
+	private static Solo solo;
+	private static String ArabicLanguage = "العربية";
+	private static String BUTTON_NAME_PROGRAMS = "البرامج";
+	private static String MENU_ITEM_ShowDetails = "إظهار التفاصيل";
+	private static String Byte_Text = "بايت";
+	private static String KiloByte_Text = "كيلوبايت";
+	private static String MegaByte_Text = "ميغابايت";
+	private static String GigaByte_Text = "غيغابايت";
+
+	@Override
+	protected void setUp() throws Exception {
+		solo = new Solo(getInstrumentation(), getActivity());
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		solo.finishOpenedActivities();
+	}
+
+	@Override
+	protected void runTest() throws Throwable {
+		super.runTest();
+	}
+
+	public void testHardCodingStringForKB_MB_GB_B() throws Exception {
+		solo.assertCurrentActivity("MainMenu", MainMenuActivity.class);
+		solo.sendKey(solo.MENU);
+		solo.clickInList(5);
+		solo.clickInList(1);
+		solo.sleep(3000);
+		solo.assertCurrentActivity("Language", Multilingual.class);
+		solo.scrollDown();
+		solo.clickInList(4);
+		solo.sleep(3000);
+		solo.assertCurrentActivity("MainMenu", MainMenuActivity.class);
+		solo.sleep(2000);
+		solo.clickOnButton("Programs");
+		solo.assertCurrentActivity("Programs", MyProjectsActivity.class);
+		solo.sleep(2000);
+		solo.sendKey(solo.MENU);
+		solo.sleep(1000);
+		solo.clickOnMenuItem("Show details");
+		solo.sleep(5000);
+		assertTrue(solo.searchText("KB", 1, true));
+		//
+		solo.goBack();
+		solo.assertCurrentActivity("MainMenu", MainMenuActivity.class);
+		solo.sendKey(solo.MENU);
+		solo.clickInList(5);
+		solo.clickInList(1);
+		solo.sleep(3000);
+		solo.assertCurrentActivity("Language", Multilingual.class);
+		solo.searchText(ArabicLanguage);
+		solo.clickOnText(ArabicLanguage);
+		//
+		solo.assertCurrentActivity("MainMenu", MainMenuActivity.class);
+		solo.sleep(2000);
+		solo.clickOnButton(BUTTON_NAME_PROGRAMS);
+		solo.assertCurrentActivity("Programs", MyProjectsActivity.class);
+		solo.sleep(2000);
+		solo.sendKey(solo.MENU);
+		solo.sleep(1000);
+		solo.clickOnMenuItem(MENU_ITEM_ShowDetails);
+		solo.sleep(5000);
+		assertTrue(solo.searchText("كيلوبايت", 1, true));
+		String byteStr = getActivity().getString(R.string.Byte_short);
+		String kilobyteStr = getActivity().getString(R.string.kiloByte_short);
+		String megabyteStr = getActivity().getString(R.string.MegaByte_short);
+		String gigabyteStr = getActivity().getString(R.string.GigaByte_short);
+		assertEquals(byteStr, Byte_Text);
+		assertEquals(kilobyteStr, KiloByte_Text);
+		assertEquals(megabyteStr, MegaByte_Text);
+		assertEquals(gigabyteStr, GigaByte_Text);
+	}
+}
+
+

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilFileTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilFileTest.java
@@ -95,7 +95,7 @@ public class UtilFileTest extends InstrumentationTestCase {
 
 		double expectedSizeInKilobytes = 84.2;
 		assertEquals("Unexpected file size String", String.format(Locale.getDefault(), "%.1f KB", expectedSizeInKilobytes),
-				UtilFile.getSizeAsString(testDirectory));
+				UtilFile.getSizeAsString(testDirectory,getInstrumentation().getContext()));
 
 		for (int i = 2; i < 48; i++) {
 			UtilFile.saveFileToProject("testDirectory", "testScene", i + "testsound.mp3",
@@ -104,7 +104,8 @@ public class UtilFileTest extends InstrumentationTestCase {
 		}
 		DecimalFormat decimalFormat = new DecimalFormat("#.0");
 		String expected = decimalFormat.format(2.0) + " MB";
-		assertEquals("Unexpected file size String", expected, UtilFile.getSizeAsString(testDirectory));
+		assertEquals("Unexpected file size String", expected, UtilFile.getSizeAsString(testDirectory,
+				getInstrumentation().getContext()));
 
 		PrintWriter printWriter = null;
 
@@ -123,7 +124,7 @@ public class UtilFileTest extends InstrumentationTestCase {
 			}
 		}
 
-		assertEquals("Unexpected Filesize!", "7 Byte", UtilFile.getSizeAsString(testFile));
+		assertEquals("Unexpected Filesize!", "7 Byte", UtilFile.getSizeAsString(testFile,getInstrumentation().getContext()));
 
 		UtilFile.deleteDirectory(testDirectory);
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/Multilingual.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/Multilingual.java
@@ -1,0 +1,433 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.ui;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.util.DisplayMetrics;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+
+import org.catrobat.catroid.R;
+
+import java.util.Locale;
+
+import static org.catrobat.catroid.CatroidApplication.defaultSystemLanguage;
+import static org.catrobat.catroid.CatroidApplication.languageSharedPreferences;
+
+/**
+ * Created by Null on 3/15/2017.
+ */
+
+public class Multilingual extends Activity {
+	@Override
+	protected void onCreate(@Nullable Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		setContentView(R.layout.activity_multilingual);
+		ListView listview = (ListView) findViewById(R.id.list_Languages);
+		String[] Languages = getResources().getStringArray(R.array.Languages_items);
+		ArrayAdapter<String> adapter = new ArrayAdapter<String>(this,
+				R.layout.multilingual_name_text, R.id.lang_text, Languages);
+		listview.setAdapter(adapter);
+		listview.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+			@Override
+			public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+				if (position == 0) {
+					setLocale(defaultSystemLanguage);
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.commit();
+				}
+				if (position == 1) {
+					setLocale("az-rAZ");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur","az-rAZ");
+					editor.commit();
+
+				}
+				if (position == 2) {
+					setLocale("bs");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur","bs");
+					editor.commit();
+				}
+				if (position == 3) {
+					setLocale("ca-rES");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur","ca-rES");
+					editor.commit();
+				}
+				if (position == 4) {
+					setLocale("cs-rCZ");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur","cs-rCZ");
+					editor.commit();
+				}
+				if (position == 5) {
+					setLocale("sr-rCS");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "sr-rCS");
+					editor.commit();
+				}
+				if (position == 6) {
+					setLocale("sr-rSP");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "sr-rSP");
+					editor.commit();
+				}
+				if (position == 7) {
+					setLocale("da");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "da");
+					editor.commit();
+				}
+				if (position == 8) {
+					setLocale("de");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "de");
+					editor.commit();
+				}
+				if (position == 9) {
+					setLocale("en-rAU");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "en-rAU");
+					editor.commit();
+				}
+				if (position == 10) {
+					setLocale("en-rCA");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "en-rCA");
+					editor.commit();
+				}
+				if (position == 11) {
+					setLocale("en-rGB");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "en-rGB");
+					editor.commit();
+				}
+				if (position == 12) {
+					setLocale("es");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "es");
+					editor.commit();
+				}
+				if (position == 13) {
+					setLocale("fr");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "fr");
+					editor.commit();
+				}
+				if (position == 14) {
+					setLocale("gl-rES");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "gl-rES");
+					editor.commit();
+				}
+				if (position == 15) {
+					setLocale("hr");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "hr");
+					editor.commit();
+				}
+				if (position == 16) {
+					setLocale("id");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "id");
+					editor.commit();
+				}
+				if (position == 17) {
+					setLocale("it");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "it");
+					editor.commit();
+				}
+				if (position == 18) {
+					setLocale("hu");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "hu");
+					editor.commit();
+				}
+				if (position == 19) {
+					setLocale("mk");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "mk");
+					editor.commit();
+				}
+				if (position == 20) {
+					setLocale("ms");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "ms");
+					editor.commit();
+				}
+				if (position == 21) {
+					setLocale("nl");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "nl");
+					editor.commit();
+				}
+				if (position == 22) {
+					setLocale("no");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "no");
+					editor.commit();
+				}
+				if (position == 23) {
+					setLocale("pl");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "pl");
+					editor.commit();
+				}
+				if (position == 24) {
+					setLocale("pt-rBR");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "pt-rBR");
+					editor.commit();
+				}
+				if (position == 25) {
+					setLocale("pt");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "pt");
+					editor.commit();
+				}
+				if (position == 26) {
+					setLocale("ru");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "ru");
+					editor.commit();
+				}
+				if (position == 27) {
+					setLocale("ro");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "ro");
+					editor.commit();
+				}
+				if (position == 28) {
+					setLocale("sq");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "sq");
+					editor.commit();
+				}
+				if (position == 29) {
+					setLocale("sl");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "sl");
+					editor.commit();
+				}
+				if (position == 30) {
+					setLocale("sv");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "sv");
+					editor.commit();
+				}
+				if (position == 31) {
+					setLocale("vi");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "vi");
+					editor.commit();
+				}
+				if (position == 32) {
+					setLocale("tr");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "tr");
+					editor.commit();
+				}
+				if (position == 33) {
+					setLocale("ml");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "ml");
+					editor.commit();
+				}
+				if (position == 34) {
+					setLocale("ta");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "ta");
+					editor.commit();
+				}
+				if (position == 35) {
+					setLocale("te");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "te");
+					editor.commit();
+				}
+				if (position == 36) {
+					setLocale("th");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "th");
+					editor.commit();
+				}
+				if (position == 37) {
+					setLocale("gu");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "gu");
+					editor.commit();
+				}
+				if (position == 38) {
+					setLocale("hi");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "hi");
+					editor.commit();
+				}
+				if (position == 39) {
+					setLocale("ja");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "ja");
+					editor.commit();
+				}
+				if (position == 40) {
+					setLocale("ko");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "ko");
+					editor.commit();
+				}
+				if (position == 41) {
+					setLocale("zh-rCN");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "zh-rCN");
+					editor.commit();
+				}
+				if (position == 42) {
+					setLocale("zh-rTW");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "zh-rTW");
+					editor.commit();
+				}
+				if (position == 43) {
+					setLocale("ar");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "ar");
+					editor.commit();
+
+				}
+				if (position == 44) {
+					setLocale("ur");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "ur");
+					editor.commit();
+				}
+				if (position == 45) {
+					setLocale("fa");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "fa");
+					editor.commit();
+				}
+				if (position == 46) {
+					setLocale("ps");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "ps");
+					editor.commit();
+				}
+				if (position == 47) {
+					setLocale("sd");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "sd");
+					editor.commit();
+				}
+				if (position == 48) {
+					setLocale("he");
+					SharedPreferences.Editor editor = languageSharedPreferences.edit();
+					editor.clear().apply();
+					editor.putString("Nur", "he");
+					editor.commit();
+				}
+			}
+		});
+	}
+	@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+	static public void setContextLocale(Context context, String lang) {
+		Locale Language = new Locale(lang);
+		Resources resources = context.getResources();
+		DisplayMetrics displayMetrics = resources.getDisplayMetrics();
+		Configuration conf = resources.getConfiguration();
+		conf.locale= Language;
+		Language.setDefault(Language);
+		conf.setLayoutDirection(Language);
+		resources.updateConfiguration(conf, displayMetrics);
+
+	}
+	public void setLocale(String lang) {
+		setContextLocale(this, lang);
+		Intent intent = new Intent(Multilingual.this, MainMenuActivity.class);
+		startActivity(intent);
+		finishAffinity();
+	}
+
+
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/LookListAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/LookListAdapter.java
@@ -60,7 +60,8 @@ public class LookListAdapter extends CheckBoxListAdapter<LookData> {
 			listItemViewHolder.rightBottomDetails.setText(measureString);
 
 			listItemViewHolder.leftTopDetails.setText(R.string.size);
-			listItemViewHolder.rightTopDetails.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath())));
+			listItemViewHolder.rightTopDetails.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath()),
+					getContext()));
 		}
 
 		return listItemView;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/ProjectListAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/ProjectListAdapter.java
@@ -71,7 +71,7 @@ public class ProjectListAdapter extends CheckBoxListAdapter<ProjectData> {
 			listItemViewHolder.rightTopDetails.setText(lastAccess);
 
 			listItemViewHolder.leftBottomDetails.setText(getContext().getString(R.string.size));
-			String size = UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName)));
+			String size = UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName)),getContext());
 			listItemViewHolder.rightBottomDetails.setText(size);
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/SoundListAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/SoundListAdapter.java
@@ -60,7 +60,8 @@ public class SoundListAdapter extends CheckBoxListAdapter<SoundInfo> {
 			listItemViewHolder.leftBottomDetails.setVisibility(View.VISIBLE);
 			listItemViewHolder.rightBottomDetails.setVisibility(View.VISIBLE);
 			listItemViewHolder.leftBottomDetails.setText(getContext().getString(R.string.size));
-			listItemViewHolder.rightBottomDetails.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath())));
+			listItemViewHolder.rightBottomDetails.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath
+					()),getContext()));
 		} else {
 			listItemViewHolder.leftBottomDetails.setVisibility(View.GONE);
 			listItemViewHolder.rightBottomDetails.setVisibility(View.GONE);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
@@ -151,7 +151,8 @@ public final class LookController {
 	private void handleDetails(LookData lookData, LookViewHolder holder, LookBaseAdapter lookAdapter) {
 		if (lookAdapter.getShowDetails()) {
 			if (lookData.getAbsolutePath() != null) {
-				holder.lookFileSizeTextView.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath())));
+				holder.lookFileSizeTextView.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath()),
+						lookAdapter.getContext()));
 			}
 			int[] measure = lookData.getMeasure();
 			String measureString = measure[0] + " x " + measure[1];

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/SoundController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/SoundController.java
@@ -280,7 +280,8 @@ public final class SoundController {
 
 	private void handleDetails(SoundBaseAdapter soundAdapter, SoundViewHolder holder, SoundInfo soundInfo) {
 		if (soundAdapter.getShowDetails()) {
-			holder.soundFileSizeTextView.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath())));
+			holder.soundFileSizeTextView.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath()),
+					soundAdapter.getContext()));
 			holder.soundFileSizeTextView.setVisibility(TextView.VISIBLE);
 			holder.soundFileSizePrefixTextView.setVisibility(TextView.VISIBLE);
 		} else {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
@@ -114,7 +114,8 @@ public class UploadProjectDialog extends DialogFragment {
 	private void initControls() {
 		currentProjectName = ProjectManager.getInstance().getCurrentProject().getName();
 		currentProjectDescription = ProjectManager.getInstance().getCurrentProject().getDescription();
-		sizeOfProject.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(currentProjectName))));
+		sizeOfProject.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(currentProjectName)),
+				getActivity().getApplicationContext()));
 		projectRename.setVisibility(View.GONE);
 		projectUploadName.setText(currentProjectName);
 		projectDescriptionField.setText(currentProjectDescription);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ShowDetailsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ShowDetailsFragment.java
@@ -91,7 +91,8 @@ public class ShowDetailsFragment extends Fragment implements SetDescriptionDialo
 		screenshotLoader.loadAndShowScreenshot(projectData.projectName, sceneName, false, projectImage);
 		name.setText(projectData.projectName);
 		author.setText(getUserHandle());
-		size.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName))));
+		size.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName)),getActivity()
+				.getApplicationContext()));
 		lastAccess.setText(getLastAccess());
 		screenSize.setText(screen);
 		mode.setText(modeText);

--- a/catroid/src/main/java/org/catrobat/catroid/utils/UtilFile.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/UtilFile.java
@@ -26,6 +26,7 @@ import android.content.Context;
 import android.util.Log;
 
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.soundrecorder.SoundRecorder;
 
@@ -79,22 +80,30 @@ public final class UtilFile {
 		return progress * 100 / fileByteSize;
 	}
 
-	public static String getSizeAsString(File fileOrDirectory) {
-		final int unit = 1024;
+	public static String getSizeAsString(File fileOrDirectory, Context context) {
 		long bytes = UtilFile.getSizeOfFileOrDirectoryInByte(fileOrDirectory);
+		return formatFileSize(bytes, context);
+	}
 
+	public static String formatFileSize(long bytes, Context context) {
+		final double unit = 1024;
+		String fileSizeExtension[] = new String[] {
+				context.getString(R.string.Byte_short),
+				context.getString(R.string.kiloByte_short),
+				context.getString(R.string.MegaByte_short),
+				context.getString(R.string.GigaByte_short),
+				context.getString(R.string.TeraByte_short),
+				context.getString(R.string.PetaByte_short),
+				context.getString(R.string.ExaByte_short)
+		};
 		if (bytes < unit) {
-			return bytes + " Byte";
+			return bytes + " " + fileSizeExtension[0];
 		}
-
-		/*
-		 * Logarithm of "bytes" to base "unit"
-		 * log(a) / log(b) == logarithm of a to the base of b
-		 */
 		int exponent = (int) (Math.log(bytes) / Math.log(unit));
-		char prefix = "KMGTPE".charAt(exponent - 1);
-
-		return String.format(Locale.getDefault(), "%.1f %sB", bytes / Math.pow(unit, exponent), prefix);
+		exponent = Math.min(exponent, fileSizeExtension.length - 1);
+		String prefix = fileSizeExtension[exponent];
+		return String.format(Locale.getDefault(), "%.1f %s", bytes / Math.pow(unit, exponent),
+				prefix);
 	}
 
 	public static boolean deleteDirectory(File fileOrDirectory) {

--- a/catroid/src/main/res/layout/activity_multilingual.xml
+++ b/catroid/src/main/res/layout/activity_multilingual.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <ListView
+        android:id="@+id/list_Languages"
+        android:layout_width="match_parent"
+        android:layout_height="fill_parent"
+        android:isScrollContainer="true"></ListView>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout/multilingual_name_text.xml
+++ b/catroid/src/main/res/layout/multilingual_name_text.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/lang_linearLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="65dp"
+        android:orientation="horizontal">
+
+        <View
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="19"
+            />
+
+        <TextView
+            android:id="@+id/lang_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_weight="2"
+            android:text="Example"
+            android:textColor="@color/white"
+            android:textSize="@dimen/language_name_text"
+            android:textStyle="normal">
+        </TextView>
+        <View
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="19"
+            />
+
+
+
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -110,6 +110,8 @@
 
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
+    <string name="preference_title_language">Language</string>
+    <string name="preference_description_language">Allow to change the language</string>
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone bricks</string>
     <string name="preference_description_quadcopter_bricks">Allow to control ARDrone 2.0 quadcopters</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT bricks</string>
@@ -1542,5 +1544,69 @@
     <string name="crash_dialog_text">Please help to improve Pocket Code by sending us anonymous crash reports!</string>
     <string name="crash_dialog_always_send">Always send</string>
     <string name="crash_dialog_send">Send</string>
+    <!--  -->
+
+    <!--Multilingual activity  -->
+         <string-array name="Languages_items">
+         <item>Device Language</item>
+         <item>Azərbaycan</item>
+         <item>Bosanski</item>
+         <item>Català(Espanya)</item>
+         <item>Čeština</item>
+         <item>Српски(Latin)</item>
+         <item>Cрпски(Ћирилица)</item>
+         <item>Dansk</item>
+         <item>Deutsch</item>
+         <item>English(Australia)</item>
+         <item>English(Canada)</item>
+         <item>English(United Kingdom)</item>
+         <item>Español</item>
+         <item>Français</item>
+         <item>Galego</item>
+         <item>Hrvatski</item>
+         <item>Indonesia</item>
+         <item>Italiano</item>
+         <item>Magyar</item>
+         <item>Македонски</item>
+         <item>Malay</item>
+         <item>Nederlands(Nederland)</item>
+         <item>Norsk</item>
+         <item>Polski</item>
+         <item>Português(Brasil)</item>
+         <item>Português(Portugal)</item>
+         <item>Pусский</item>
+         <item>Română</item>
+         <item>Shqip</item>
+         <item>Slovenščina</item>
+         <item>Svenska</item>
+         <item>Tiếng Việt</item>
+         <item>Türkçe</item>
+         <item>മലയാളം</item>
+         <item>தமிழ்</item>
+         <item>తెలుగు</item>
+         <item>ไทย</item>
+         <item>ગુજરાતી</item>
+         <item>हिंदी</item>
+         <item>日本語 </item>
+         <item>한국어 </item>
+         <item>简体中文</item>
+         <item>中國傳統的</item>
+         <item>العربية</item>
+         <item>اردو</item>
+         <item>فارسی</item>
+         <item>پښتو</item>
+         <item>سنڌي</item>
+         <item>עִברִית</item>
+         </string-array>
+
+    <!--  -->
+    <string name="Byte_short">B</string>
+    <string name="kiloByte_short">KB</string>
+    <string name="MegaByte_short">MB</string>
+    <string name="GigaByte_short">GB</string>
+    <string name="TeraByte_short">TB</string>
+    <string name="PetaByte_short">PB</string>
+    <string name="ExaByte_short">EB</string>
+    <string name="ZERO">0</string>
     <!--  -->
 </resources>


### PR DESCRIPTION
In Pocket Code, program size is expressed in units of measurement (KB, MB, GB, etc.), these units are implemented as hard-coding string. Therefore, this pull request removes these hard_coding string from the app.