### PR TITLE
CAT-1152 Reduce size of screenshots

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/ImageEditingTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/ImageEditingTest.java
@@ -104,6 +104,12 @@ public class ImageEditingTest extends TestCase {
 		Bitmap loadedBitmap = ImageEditing.getScaledBitmapFromPath(testImageFile.getAbsolutePath(), maxBitmapWidth,
 				maxBitmapHeight, ImageEditing.ResizeType.STAY_IN_RECTANGLE_WITH_SAME_ASPECT_RATIO, true);
 
+		assertEquals("Loaded bitmap has incorrect height", 200, loadedBitmap.getHeight());
+		assertEquals("Loaded bitmap has incorrect width", 100, loadedBitmap.getWidth());
+
+		loadedBitmap = ImageEditing.getScaledBitmapFromPath(testImageFile.getAbsolutePath(), maxBitmapWidth,
+				maxBitmapHeight, ImageEditing.ResizeType.STAY_IN_RECTANGLE_WITH_SAME_ASPECT_RATIO, false);
+
 		assertEquals("Loaded bitmap has incorrect height", 500, loadedBitmap.getHeight());
 		assertEquals("Loaded bitmap has incorrect width", 250, loadedBitmap.getWidth());
 

--- a/catroid/src/main/java/org/catrobat/catroid/io/ProjectAndSceneScreenshotLoader.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/ProjectAndSceneScreenshotLoader.java
@@ -105,6 +105,12 @@ public class ProjectAndSceneScreenshotLoader {
 		}
 	}
 
+	public File getScreenshotFile(String projectName, String sceneName, boolean isBackpackScene) {
+		ScreenshotData screenshotData = new ScreenshotData(projectName, sceneName, isBackpackScene, null);
+		ScreenshotLoader screenshotLoader = new ScreenshotLoader(screenshotData);
+		return screenshotLoader.getScreenshotFile();
+	}
+
 	class ScreenshotLoader implements Runnable {
 		ScreenshotData projectAndSceneScreenshotData;
 
@@ -119,40 +125,9 @@ public class ProjectAndSceneScreenshotLoader {
 			}
 
 			Activity uiActivity = (Activity) projectAndSceneScreenshotData.imageView.getContext();
-			String pathOfScreenshot;
-			if (projectAndSceneScreenshotData.sceneName != null) {
-				if (projectAndSceneScreenshotData.isBackpackScene) {
-					pathOfScreenshot = Utils.buildPath(Utils.buildBackpackScenePath(projectAndSceneScreenshotData.sceneName),
-							StageListener.SCREENSHOT_MANUAL_FILE_NAME);
-				} else {
-					pathOfScreenshot = Utils.buildPath(Utils.buildScenePath(projectAndSceneScreenshotData
-									.projectName, projectAndSceneScreenshotData.sceneName),
-							StageListener.SCREENSHOT_MANUAL_FILE_NAME);
-				}
-			} else {
-				pathOfScreenshot = Utils.buildPath(Utils.buildProjectPath(projectAndSceneScreenshotData.projectName),
-						StageListener.SCREENSHOT_MANUAL_FILE_NAME);
-			}
 
-			File projectAndSceneImageFile = new File(pathOfScreenshot);
-
-			if (!(projectAndSceneImageFile.exists() && projectAndSceneImageFile.length() > 0)) {
-				projectAndSceneImageFile.delete();
-				if (projectAndSceneScreenshotData.sceneName != null) {
-					if (projectAndSceneScreenshotData.isBackpackScene) {
-						pathOfScreenshot = Utils.buildPath(Utils.buildBackpackScenePath(projectAndSceneScreenshotData.sceneName),
-								StageListener.SCREENSHOT_AUTOMATIC_FILE_NAME);
-					} else {
-						pathOfScreenshot = Utils.buildPath(Utils.buildScenePath(projectAndSceneScreenshotData
-										.projectName, projectAndSceneScreenshotData.sceneName),
-								StageListener.SCREENSHOT_AUTOMATIC_FILE_NAME);
-					}
-				} else {
-					pathOfScreenshot = Utils.buildPath(Utils.buildProjectPath(projectAndSceneScreenshotData.projectName),
-							StageListener.SCREENSHOT_AUTOMATIC_FILE_NAME);
-				}
-				projectAndSceneImageFile = new File(pathOfScreenshot);
-			}
+			File projectAndSceneImageFile = getScreenshotFile();
+			String pathOfScreenshot = projectAndSceneImageFile.getAbsolutePath();
 
 			final Bitmap projectAndSceneImage;
 			if (!projectAndSceneImageFile.exists() || ImageEditing.getImageDimensions(pathOfScreenshot)[0] < 0) {
@@ -192,6 +167,36 @@ public class ProjectAndSceneScreenshotLoader {
 				}
 			});
 		}
+
+		File getScreenshotFile() {
+			String pathOfManualScreenshot;
+			String pathOfAutomaticScreenshot;
+			if (projectAndSceneScreenshotData.sceneName != null) {
+				if (projectAndSceneScreenshotData.isBackpackScene) {
+					String backpackScenePath = Utils.buildBackpackScenePath(projectAndSceneScreenshotData.sceneName);
+					pathOfManualScreenshot = Utils.buildPath(backpackScenePath,
+							StageListener.SCREENSHOT_MANUAL_FILE_NAME);
+					pathOfAutomaticScreenshot = Utils.buildPath(backpackScenePath,
+							StageListener.SCREENSHOT_AUTOMATIC_FILE_NAME);
+				} else {
+					String scenePath = Utils.buildScenePath(projectAndSceneScreenshotData.projectName,
+							projectAndSceneScreenshotData.sceneName);
+					pathOfManualScreenshot = Utils.buildPath(scenePath, StageListener.SCREENSHOT_MANUAL_FILE_NAME);
+					pathOfAutomaticScreenshot = Utils.buildPath(scenePath, StageListener.SCREENSHOT_AUTOMATIC_FILE_NAME);
+				}
+			} else {
+				String projectPath = Utils.buildProjectPath(projectAndSceneScreenshotData.projectName);
+				pathOfManualScreenshot = Utils.buildPath(projectPath, StageListener.SCREENSHOT_MANUAL_FILE_NAME);
+				pathOfAutomaticScreenshot = Utils.buildPath(projectPath, StageListener.SCREENSHOT_AUTOMATIC_FILE_NAME);
+			}
+
+			File projectAndSceneImageFile = new File(pathOfManualScreenshot);
+			if (!(projectAndSceneImageFile.exists() && projectAndSceneImageFile.length() > 0)) {
+				projectAndSceneImageFile.delete();
+				projectAndSceneImageFile = new File(pathOfAutomaticScreenshot);
+			}
+			return projectAndSceneImageFile;
+		}
 	}
 
 	boolean imageViewReused(ScreenshotData projectScreenshotData) {
@@ -203,10 +208,6 @@ public class ProjectAndSceneScreenshotLoader {
 		if (projectScreenshotData.sceneName != null) {
 			screenshotName = screenshotName.concat(projectScreenshotData.sceneName);
 		}
-
-		if (tag == null || !tag.equals(screenshotName)) {
-			return true;
-		}
-		return false;
+		return (tag == null || !tag.equals(screenshotName));
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/ProjectUploadService.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/ProjectUploadService.java
@@ -34,7 +34,9 @@ import android.util.Log;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.io.ProjectAndSceneScreenshotLoader;
 import org.catrobat.catroid.io.StorageHandler;
+import org.catrobat.catroid.utils.ImageEditing;
 import org.catrobat.catroid.utils.StatusBarNotificationManager;
 import org.catrobat.catroid.utils.ToastUtil;
 import org.catrobat.catroid.utils.UtilDeviceInfo;
@@ -44,6 +46,7 @@ import org.catrobat.catroid.web.ServerCalls;
 import org.catrobat.catroid.web.WebconnectionException;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 public class ProjectUploadService extends IntentService {
@@ -54,6 +57,7 @@ public class ProjectUploadService extends IntentService {
 	private String projectPath;
 	private String projectName;
 	private String projectDescription;
+	private String[] sceneNames;
 	private String token;
 	private String provider;
 	private String serverAnswer;
@@ -74,6 +78,7 @@ public class ProjectUploadService extends IntentService {
 		this.projectPath = intent.getStringExtra("projectPath");
 		this.projectName = intent.getStringExtra("uploadName");
 		this.projectDescription = intent.getStringExtra("projectDescription");
+		this.sceneNames = intent.getStringArrayExtra("sceneNames");
 		this.token = intent.getStringExtra("token");
 		this.username = intent.getStringExtra("username");
 		this.provider = intent.getStringExtra("provider");
@@ -106,6 +111,18 @@ public class ProjectUploadService extends IntentService {
 				return;
 			}
 
+			ProjectAndSceneScreenshotLoader screenshotLoader = new ProjectAndSceneScreenshotLoader(getApplicationContext());
+			for (String scene : sceneNames) {
+				File screenshotFile = screenshotLoader.getScreenshotFile(projectName, scene, false);
+				if (screenshotFile.exists() && screenshotFile.length() > 0) {
+					try {
+						ImageEditing.scaleImageFile(screenshotFile, 480, 480);
+					} catch (FileNotFoundException ex) {
+						Log.e(TAG, Log.getStackTraceString(ex));
+					}
+				}
+			}
+
 			for (int i = 0; i < paths.length; i++) {
 				paths[i] = Utils.buildPath(directoryPath.getAbsolutePath(), paths[i]);
 			}
@@ -127,12 +144,16 @@ public class ProjectUploadService extends IntentService {
 			SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
 			String userEmail = sharedPreferences.getString(Constants.EMAIL, Constants.NO_EMAIL);
 
-			if (provider.equals(Constants.FACEBOOK)) {
-				userEmail = sharedPreferences.getString(Constants.FACEBOOK_EMAIL, Constants.NO_FACEBOOK_EMAIL);
-			} else if (provider.equals(Constants.GOOGLE_PLUS)) {
-				userEmail = sharedPreferences.getString(Constants.GOOGLE_EMAIL, Constants.NO_GOOGLE_EMAIL);
-			} else if (provider.equals(Constants.NO_OAUTH_PROVIDER)) {
-				userEmail = sharedPreferences.getString(Constants.EMAIL, Constants.NO_EMAIL);
+			switch (provider) {
+				case Constants.FACEBOOK:
+					userEmail = sharedPreferences.getString(Constants.FACEBOOK_EMAIL, Constants.NO_FACEBOOK_EMAIL);
+					break;
+				case Constants.GOOGLE_PLUS:
+					userEmail = sharedPreferences.getString(Constants.GOOGLE_EMAIL, Constants.NO_GOOGLE_EMAIL);
+					break;
+				case Constants.NO_OAUTH_PROVIDER:
+					userEmail = sharedPreferences.getString(Constants.EMAIL, Constants.NO_EMAIL);
+					break;
 			}
 
 			if (userEmail.equals(Constants.NO_EMAIL)) {
@@ -144,6 +165,7 @@ public class ProjectUploadService extends IntentService {
 			uploadBackupBundle.putString("projectName", projectName);
 			uploadBackupBundle.putString("projectDescription", projectDescription);
 			uploadBackupBundle.putString("projectPath", projectPath);
+			uploadBackupBundle.putStringArray("sceneNames", sceneNames);
 			uploadBackupBundle.putString("userEmail", userEmail);
 			uploadBackupBundle.putString("language", language);
 			uploadBackupBundle.putString("token", token);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProgressDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProgressDialog.java
@@ -44,12 +44,15 @@ import android.widget.ProgressBar;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.transfers.ProjectUploadService;
 import org.catrobat.catroid.ui.WebViewActivity;
 import org.catrobat.catroid.utils.StatusBarNotificationManager;
 import org.catrobat.catroid.utils.UtilFile;
 import org.catrobat.catroid.utils.Utils;
 import org.catrobat.catroid.web.ServerCalls;
+
+import java.util.List;
 
 public class UploadProgressDialog extends DialogFragment {
 	public static final String DIALOG_PROGRESS_FRAGMENT_TAG = "dialog_upload_progress_tags";
@@ -196,6 +199,7 @@ public class UploadProgressDialog extends DialogFragment {
 		String token = sharedPreferences.getString(Constants.TOKEN, Constants.NO_TOKEN);
 		String username = sharedPreferences.getString(Constants.USERNAME, Constants.NO_USERNAME);
 		Intent uploadIntent = new Intent(getActivity(), ProjectUploadService.class);
+		String[] sceneNames = getSceneNamesAsArray(projectManager.getCurrentProject().getSceneList());
 
 		// TODO check this extras - e.g. project description isn't used by web
 		uploadIntent.putExtra("receiver", new UploadReceiver(new Handler()));
@@ -205,6 +209,7 @@ public class UploadProgressDialog extends DialogFragment {
 		uploadIntent.putExtra("username", username);
 		uploadIntent.putExtra("token", token);
 		uploadIntent.putExtra("provider", openAuthProvider);
+		uploadIntent.putExtra("sceneNames", sceneNames);
 
 		int notificationId = StatusBarNotificationManager.getInstance().createUploadNotification(getActivity(),
 				uploadName);
@@ -218,5 +223,13 @@ public class UploadProgressDialog extends DialogFragment {
 			dialog.show(getFragmentManager(), RatingDialog.TAG);
 		}
 		sharedPreferences.edit().putInt(NUMBER_OF_UPLOADED_PROJECTS, numberOfUploadedProjects).commit();
+	}
+
+	private String[] getSceneNamesAsArray(List<Scene> sceneList) {
+		String[] sceneNames = new String[sceneList.size()];
+		for (int i = 0; i < sceneNames.length; i++) {
+			sceneNames[i] = sceneList.get(i).getName();
+		}
+		return sceneNames;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/utils/ImageEditing.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/ImageEditing.java
@@ -26,17 +26,15 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
+import android.util.Log;
 
 import com.badlogic.gdx.math.Vector2;
-import com.google.common.io.Closeables;
 
 import org.catrobat.catroid.common.ScreenValues;
 import org.catrobat.catroid.io.StorageHandler;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.InputStream;
 
 import ar.com.hjg.pngj.IImageLine;
 import ar.com.hjg.pngj.PngReader;
@@ -48,6 +46,8 @@ import ar.com.hjg.pngj.chunks.PngChunk;
 import ar.com.hjg.pngj.chunks.PngChunkTextVar;
 
 public final class ImageEditing {
+
+	private static final String TAG = ImageEditing.class.getSimpleName();
 
 	public enum ResizeType {
 		STRETCH_TO_RECTANGLE, STAY_IN_RECTANGLE_WITH_SAME_ASPECT_RATIO, FILL_RECTANGLE_WITH_SAME_ASPECT_RATIO
@@ -74,8 +74,7 @@ public final class ImageEditing {
 		float scaleWidth = (((float) xSize) / bitmap.getWidth());
 		float scaleHeight = (((float) ySize) / bitmap.getHeight());
 		matrix.postScale(scaleWidth, scaleHeight);
-		Bitmap newBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
-		return newBitmap;
+		return Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
 	}
 
 	public static Bitmap getScaledBitmapFromPath(String imagePath, int outputRectangleWidth, int outputRectangleHeight,
@@ -83,98 +82,24 @@ public final class ImageEditing {
 		if (imagePath == null) {
 			return null;
 		}
-
 		int[] imageDimensions = getImageDimensions(imagePath);
-
 		int originalWidth = imageDimensions[0];
 		int originalHeight = imageDimensions[1];
-		int newWidth = originalHeight;
-		int newHeight = originalWidth;
-		int loadingSampleSize = 1;
 
-		double sampleSizeWidth = ((double) originalWidth) / (double) outputRectangleWidth;
-		double sampleSizeHeight = ((double) originalHeight) / (double) outputRectangleHeight;
-		double sampleSizeMinimum = Math.min(sampleSizeWidth, sampleSizeHeight);
-		double sampleSizeMaximum = Math.max(sampleSizeWidth, sampleSizeHeight);
+		int[] scaledImageDimensions = getScaledImageDimensions(originalWidth, originalHeight, outputRectangleWidth,
+				outputRectangleHeight, resizeType, justScaleDown);
+		int newWidth = scaledImageDimensions[0];
+		int newHeight = scaledImageDimensions[1];
 
-		if (resizeType == ResizeType.STRETCH_TO_RECTANGLE) {
-			newWidth = outputRectangleWidth;
-			newHeight = outputRectangleHeight;
-		} else if (resizeType == ResizeType.STAY_IN_RECTANGLE_WITH_SAME_ASPECT_RATIO) {
-			newWidth = (int) Math.floor(originalWidth / sampleSizeMaximum);
-			newHeight = (int) Math.floor(originalHeight / sampleSizeMaximum);
-		} else if (resizeType == ResizeType.FILL_RECTANGLE_WITH_SAME_ASPECT_RATIO) {
-			newWidth = (int) Math.floor(originalWidth / sampleSizeMinimum);
-			newHeight = (int) Math.floor(originalHeight / sampleSizeMinimum);
-		}
-
-		loadingSampleSize = calculateInSampleSize(originalWidth, originalHeight, outputRectangleWidth, outputRectangleHeight);
+		int loadingSampleSize = calculateInSampleSize(originalWidth, originalHeight, outputRectangleWidth,
+				outputRectangleHeight);
 
 		BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
 		bitmapOptions.inSampleSize = loadingSampleSize;
 		bitmapOptions.inJustDecodeBounds = false;
-
 		Bitmap tempBitmap = BitmapFactory.decodeFile(imagePath, bitmapOptions);
 
 		return scaleBitmap(tempBitmap, newWidth, newHeight);
-	}
-
-	public static Bitmap getScaledBitmapOfLoadedBitmap(byte[] byteArray, int outputRectangleWidth,
-			int outputRectangleHeight, ResizeType resizeType,
-			boolean justScaleDown) {
-		if (byteArray == null) {
-			return null;
-		}
-
-		ByteArrayInputStream inputStream = new ByteArrayInputStream(byteArray);
-		int[] imageDimensions = getImageDimensionsForLoadedImage(inputStream);
-		Closeables.closeQuietly(inputStream);
-
-		int originalWidth = imageDimensions[0];
-		int originalHeight = imageDimensions[1];
-		int newWidth = originalHeight;
-		int newHeight = originalWidth;
-		int loadingSampleSize = 1;
-
-		double sampleSizeWidth = ((double) originalWidth) / (double) outputRectangleWidth;
-		double sampleSizeHeight = ((double) originalHeight) / (double) outputRectangleHeight;
-		double sampleSizeMinimum = Math.min(sampleSizeWidth, sampleSizeHeight);
-		double sampleSizeMaximum = Math.max(sampleSizeWidth, sampleSizeHeight);
-
-		if (resizeType == ResizeType.STRETCH_TO_RECTANGLE) {
-			newWidth = outputRectangleWidth;
-			newHeight = outputRectangleHeight;
-		} else if (resizeType == ResizeType.STAY_IN_RECTANGLE_WITH_SAME_ASPECT_RATIO) {
-			newWidth = (int) Math.floor(originalWidth / sampleSizeMaximum);
-			newHeight = (int) Math.floor(originalHeight / sampleSizeMaximum);
-		} else if (resizeType == ResizeType.FILL_RECTANGLE_WITH_SAME_ASPECT_RATIO) {
-			newWidth = (int) Math.floor(originalWidth / sampleSizeMinimum);
-			newHeight = (int) Math.floor(originalHeight / sampleSizeMinimum);
-		}
-
-		loadingSampleSize = calculateInSampleSize(originalWidth, originalHeight, outputRectangleWidth, outputRectangleHeight);
-
-		BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
-		bitmapOptions.inSampleSize = loadingSampleSize;
-		bitmapOptions.inJustDecodeBounds = false;
-
-		inputStream = new ByteArrayInputStream(byteArray);
-		Bitmap tempBitmap = BitmapFactory.decodeStream(inputStream, null, bitmapOptions);
-		Closeables.closeQuietly(inputStream);
-		return scaleBitmap(tempBitmap, newWidth, newHeight);
-	}
-
-	public static int[] getImageDimensionsForLoadedImage(InputStream inputStream) {
-		int[] imageDimensions = new int[2];
-
-		BitmapFactory.Options options = new BitmapFactory.Options();
-		options.inJustDecodeBounds = true;
-		BitmapFactory.decodeStream(inputStream, null, options);
-
-		imageDimensions[0] = options.outWidth;
-		imageDimensions[1] = options.outHeight;
-
-		return imageDimensions;
 	}
 
 	public static int[] getImageDimensions(String imagePath) {
@@ -188,6 +113,35 @@ public final class ImageEditing {
 		imageDimensions[1] = options.outHeight;
 
 		return imageDimensions;
+	}
+
+	private static int[] getScaledImageDimensions(int originalWidth, int originalHeight, int outputRectangleWidth, int
+			outputRectangleHeight,
+			ResizeType resizeType, boolean justScaleDown) {
+		int newWidth = originalWidth;
+		int newHeight = originalHeight;
+
+		double sampleSizeWidth = ((double) originalWidth) / (double) outputRectangleWidth;
+		double sampleSizeHeight = ((double) originalHeight) / (double) outputRectangleHeight;
+		double sampleSizeMinimum = Math.min(sampleSizeWidth, sampleSizeHeight);
+		double sampleSizeMaximum = Math.max(sampleSizeWidth, sampleSizeHeight);
+
+		if (!justScaleDown || originalHeight >= outputRectangleHeight || originalWidth >= outputRectangleWidth) {
+			if (resizeType == ResizeType.STRETCH_TO_RECTANGLE) {
+				newWidth = outputRectangleWidth;
+				newHeight = outputRectangleHeight;
+			} else if (resizeType == ResizeType.STAY_IN_RECTANGLE_WITH_SAME_ASPECT_RATIO) {
+				newWidth = (int) Math.floor(originalWidth / sampleSizeMaximum);
+				newHeight = (int) Math.floor(originalHeight / sampleSizeMaximum);
+			} else if (resizeType == ResizeType.FILL_RECTANGLE_WITH_SAME_ASPECT_RATIO) {
+				newWidth = (int) Math.floor(originalWidth / sampleSizeMinimum);
+				newHeight = (int) Math.floor(originalHeight / sampleSizeMinimum);
+			}
+		}
+		int[] scaledImageDimensions = new int[2];
+		scaledImageDimensions[0] = newWidth;
+		scaledImageDimensions[1] = newHeight;
+		return scaledImageDimensions;
 	}
 
 	public static void overwriteImageFileWithNewBitmap(File imageFile) throws FileNotFoundException {
@@ -206,17 +160,20 @@ public final class ImageEditing {
 	public static Bitmap rotateBitmap(Bitmap bitmap, int rotationDegree) {
 		Matrix rotateMatrix = new Matrix();
 		rotateMatrix.postRotate(rotationDegree);
-		Bitmap rotatedBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), rotateMatrix,
-				true);
-		return rotatedBitmap;
+		return Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), rotateMatrix, true);
 	}
 
 	public static void scaleImageFile(File file, double scaleFactor) throws FileNotFoundException {
 		String path = file.getAbsolutePath();
 		int[] originalBackgroundImageDimensions = getImageDimensions(path);
-		Bitmap scaledBitmap = ImageEditing.getScaledBitmapFromPath(path,
+		scaleImageFile(file,
 				(int) (originalBackgroundImageDimensions[0] * scaleFactor),
-				(int) (originalBackgroundImageDimensions[1] * scaleFactor),
+				(int) (originalBackgroundImageDimensions[1] * scaleFactor));
+	}
+
+	public static void scaleImageFile(File file, int width, int height) throws FileNotFoundException {
+		String path = file.getAbsolutePath();
+		Bitmap scaledBitmap = ImageEditing.getScaledBitmapFromPath(path, width, height,
 				ImageEditing.ResizeType.FILL_RECTANGLE_WITH_SAME_ASPECT_RATIO, false);
 		StorageHandler.saveBitmapToImageFile(file, scaledBitmap);
 	}
@@ -273,15 +230,11 @@ public final class ImageEditing {
 
 	//method from developer.android.com
 	public static int calculateInSampleSize(int origWidth, int origHeight, int reqWidth, int reqHeight) {
-		// Raw height and width of image
-		final int height = origHeight;
-		final int width = origWidth;
 		int inSampleSize = 1;
 
-		if (height > reqHeight || width > reqWidth) {
-
-			final int halfHeight = height / 2;
-			final int halfWidth = width / 2;
+		if (origHeight > reqHeight || origWidth > reqWidth) {
+			final int halfHeight = origHeight / 2;
+			final int halfWidth = origWidth / 2;
 
 			// Calculate the largest inSampleSize value that is a power of 2 and keeps both
 			// height and width larger than the requested height and width.
@@ -290,7 +243,6 @@ public final class ImageEditing {
 				inSampleSize *= 2;
 			}
 		}
-
 		return inSampleSize;
 	}
 
@@ -331,7 +283,11 @@ public final class ImageEditing {
 		pngr.end();
 		pngw.end();
 
-		oldFile.delete();
-		newFile.renameTo(new File(absolutePath));
+		if (!oldFile.delete()) {
+			Log.e(TAG, "writeMetaDataStringToPNG: Failed to delete old file");
+		}
+		if (!newFile.renameTo(new File(absolutePath))) {
+			Log.e(TAG, "writeMetaDataStringToPNG: Failed to rename new file");
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/utils/StatusBarNotificationManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/StatusBarNotificationManager.java
@@ -310,6 +310,7 @@ public final class StatusBarNotificationManager {
 			String projectName = intent.getBundleExtra("bundle").getString("projectName");
 			String projectDescription = intent.getBundleExtra("bundle").getString("projectDescription");
 			String projectPath = intent.getBundleExtra("bundle").getString("projectPath");
+			String[] sceneNames = intent.getBundleExtra("bundle").getStringArray("sceneNames");
 			String token = intent.getBundleExtra("bundle").getString("token");
 			String username = intent.getBundleExtra("bundle").getString("username");
 			ResultReceiver receiver = intent.getBundleExtra("bundle").getParcelable("receiver");
@@ -321,7 +322,7 @@ public final class StatusBarNotificationManager {
 			reuploadIntent.putExtra("projectPath", projectPath);
 			reuploadIntent.putExtra("username", username);
 			reuploadIntent.putExtra("token", token);
-
+			reuploadIntent.putExtra("sceneNames", sceneNames);
 			return reuploadIntent;
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/utils/UtilFile.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/UtilFile.java
@@ -111,7 +111,7 @@ public final class UtilFile {
 			sb.append('-');
 		}
 
-		boolean success = true;
+		boolean success;
 		if (fileOrDirectory.exists() && fileOrDirectory.isDirectory()) {
 			// Please note: especially with MyProjectsActivityTest.testAddNewProjectMixedCase(), it happens that listFiles
 			// returns null (although fileOrDirectory exists and is a directory). This should definitely not happen
@@ -171,7 +171,7 @@ public final class UtilFile {
 
 			BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file), Constants.BUFFER_8K);
 			byte[] buffer = new byte[Constants.BUFFER_8K];
-			int length = 0;
+			int length;
 			while ((length = in.read(buffer)) > 0) {
 				out.write(buffer, 0, length);
 			}
@@ -189,7 +189,7 @@ public final class UtilFile {
 
 	public static void createStandardProjectIfRootDirectoryIsEmpty(Context context) {
 		File rootDirectory = new File(Constants.DEFAULT_ROOT);
-		if (rootDirectory == null || rootDirectory.listFiles() == null || getProjectNames(rootDirectory).size() == 0) {
+		if (rootDirectory.listFiles() == null || getProjectNames(rootDirectory).size() == 0) {
 			ProjectManager.getInstance().initializeDefaultProject(context);
 		}
 	}
@@ -198,7 +198,7 @@ public final class UtilFile {
 	 * returns a list of strings of all projectnames in the catroid folder
 	 */
 	public static List<String> getProjectNames(File directory) {
-		List<String> projectList = new ArrayList<String>();
+		List<String> projectList = new ArrayList<>();
 		File[] fileList = directory.listFiles();
 		if (fileList != null) {
 			FilenameFilter filenameFilter = new FilenameFilter() {
@@ -228,8 +228,6 @@ public final class UtilFile {
 			outputChannel = outputStream.getChannel();
 			inputChannel.transferTo(0, inputChannel.size(), outputChannel);
 			return destinationFile;
-		} catch (IOException exception) {
-			throw exception;
 		} finally {
 			if (inputChannel != null) {
 				inputChannel.close();
@@ -260,7 +258,7 @@ public final class UtilFile {
 		InputStream in = context.getResources().openRawResource(resourceId);
 		OutputStream out = new BufferedOutputStream(new FileOutputStream(copiedFile), Constants.BUFFER_8K);
 		byte[] buffer = new byte[Constants.BUFFER_8K];
-		int length = 0;
+		int length;
 		while ((length = in.read(buffer)) > 0) {
 			out.write(buffer, 0, length);
 		}
@@ -290,9 +288,7 @@ public final class UtilFile {
 	}
 
 	public static File copyImageFromResourceIntoProject(String projectName, String sceneName, String outputFilename,
-			int
-					resourceId,
-			Context context, boolean prependMd5ToFilename, double scaleFactor) throws IOException {
+			int resourceId, Context context, boolean prependMd5ToFilename, double scaleFactor) throws IOException {
 		if (scaleFactor <= 0) {
 			throw new IllegalArgumentException("scale factor is smaller or equal zero");
 		}


### PR DESCRIPTION
To get all screenshots we need to know which scenes the project has (screenshots are in their scenes' respective folders) - therefore we pass an array of scene names to the ProjectUploadService and scale all images accordingly. The scaling method had to be adjusted, because it didn't provide scaling to a specific width/height. Also the justScaleDown feature of getScaledBitmapFromPath(...) was implemented as the flag was previously passed without doing anything.

**ProjectAndSceneScreenshotLoader**: Made getScreenshotFile(...) method of inner class ScreenshotLoader accessible to public. This method is needed for retrieving the screenshot Files by their project and scene name.

**ProjectUploadService**: Retrieve an array of scene names from the intent, loop through all the scene names and get their screenshots with ProjectAndSceneScreenshotLoader's getScreenshotFile(...) method. Refactored if-chain to a switch statement. Added scene-name-array to the uploadBackupBundle (in case the upload fails).

**UploadProgressDialog**: Put the scene-name-array into the intent for the ProjectUploadService. Added small method for creating an array of scene names from a list of scenes.

**ImageEditing**: Overloaded scaleImageFile(...) method to scale with width and height in addition to a scaling factor. Changed getScaledBitmapFromPath(...) to use the justScaleDown boolean flag (instead of doing nothing with it).

**StatusBarNotificationManager**: Added scene-names-array to the reuploadIntent
