### PR TITLE
CAT-2353 Broadcast messages are only removed if they don't exist in any scene of a project

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -457,4 +457,12 @@ public class Project implements Serializable {
 			}
 		}
 	}
+
+	public synchronized void removeUnusedMessages() {
+		List<String> usedMessages = new ArrayList<>();
+		for (Scene scene : getSceneList()) {
+			scene.addUsedMessagesToList(usedMessages);
+		}
+		MessageContainer.removeUnusedMessages(usedMessages);
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
@@ -30,7 +30,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.common.MessageContainer;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
 import org.catrobat.catroid.content.bricks.PointToBrick;
@@ -341,8 +340,7 @@ public class Scene implements Serializable {
 		return dataContainer;
 	}
 
-	public synchronized void removeUnusedBroadcastMessages() {
-		List<String> usedMessages = new ArrayList<>();
+	public synchronized void addUsedMessagesToList(List<String> usedMessages) {
 		for (Sprite currentSprite : spriteList) {
 			for (int scriptIndex = 0; scriptIndex < currentSprite.getNumberOfScripts(); scriptIndex++) {
 				Script currentScript = currentSprite.getScript(scriptIndex);
@@ -366,7 +364,6 @@ public class Scene implements Serializable {
 				}
 			}
 		}
-		MessageContainer.removeUnusedMessages(usedMessages);
 	}
 
 	private void addBroadcastMessage(String broadcastMessageToAdd, List<String> broadcastMessages) {

--- a/catroid/src/main/java/org/catrobat/catroid/merge/MergeTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/merge/MergeTask.java
@@ -178,6 +178,7 @@ public class MergeTask {
 		}
 
 		mergedProject.addScene(mergeResult);
+		mergedProject.removeUnusedMessages();
 		try {
 			StorageHandler.getInstance().copyImageFiles(mergeResult.getName(), mergeResult.getProject().getName(), firstScene.getName(), firstScene.getProject().getName());
 			StorageHandler.getInstance().copySoundFiles(mergeResult.getName(), mergeResult.getProject().getName(), firstScene.getName(), firstScene.getProject().getName());
@@ -305,7 +306,6 @@ public class MergeTask {
 		copySpriteScripts(firstScene);
 		current = secondScene;
 		copySpriteScripts(secondScene);
-		mergeResult.removeUnusedBroadcastMessages();
 	}
 
 	private void copySpriteScripts(Scene scene) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ScriptFragment.java
@@ -349,7 +349,7 @@ public class ScriptFragment extends ScriptActivityFragment implements OnCategory
 		}
 		if (projectManager.getCurrentScene() != null) {
 			projectManager.saveProject(getActivity().getApplicationContext());
-			projectManager.getCurrentScene().removeUnusedBroadcastMessages(); // TODO: Find better place
+			projectManager.getCurrentProject().removeUnusedMessages(); // TODO: Find better place
 		}
 	}
 


### PR DESCRIPTION
### Issue
Before this change there were issues with broadcast messages that were used in one scene, but not in the other. The reason for this was that all broadcast messages not used in scene 1 were simply removed (when pausing scene 1's ScriptFragment) leaving scene 2 with invalid broadcast messages used in its scripts. (for further consequences see the ticket)

### Changes
Added removeUnusedBroadcastMessages() to **Project** to remove all broadcast messages that are not used in any of the scenes.

Added addUsedMessagesToList(...) to **Scene** to add all used messages to a given list and removed removeUnusedBroadcastMessages().

Replaced call to scene.removeUnusedBroadcastMessages() with call to project.removeUnusedBroadcastMessages() in **MergeTask** and moved the new call to a different position (where the merged project already has all of its scenes).

Replaced call to scene.removeUnusedBroadcastMessages() with call to project.removeUnusedBroadcastMessages() in **ScriptFragment**.