### PR TITLE
CAT-2355 Removing Hard-Coding String

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/RemovingHardCodingStringForObjectSizeUnitTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/RemovingHardCodingStringForObjectSizeUnitTest.java
@@ -1,0 +1,81 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.utils;
+
+import android.test.ActivityInstrumentationTestCase2;
+
+import com.robotium.solo.Solo;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.ui.MainMenuActivity;
+import org.catrobat.catroid.ui.MyProjectsActivity;
+
+import java.util.Locale;
+
+public class RemovingHardCodingStringForObjectSizeUnitTest extends ActivityInstrumentationTestCase2<MainMenuActivity> {
+	public RemovingHardCodingStringForObjectSizeUnitTest() {
+		super(MainMenuActivity.class);
+	}
+
+	private static Solo solo;
+	private static final String BUTTON_NAME_PROGRAMS = "البرامج";
+	private static final String MENU_ITEM_ShowDetails = "إظهار التفاصيل";
+	private static final String KiloByte_Text = "كيلوبايت";
+
+	@Override
+	public void setUp() throws Exception {
+		solo = new Solo(getInstrumentation(), getActivity());
+	}
+
+	@Override
+	public void tearDown() throws Exception {
+		solo.finishOpenedActivities();
+	}
+
+	// Make sure that your PhoneLanguage is Arabic
+	// tested on SAMSUNG GALAXY S5
+	public void testHardCodingStringForKB_MB_GB_B() throws Exception {
+		solo.assertCurrentActivity("MainMenuActivity is not the Current Activity", MainMenuActivity.class);
+		solo.sleep(1000);
+		assertTrue(isRTL());
+		solo.clickOnButton(BUTTON_NAME_PROGRAMS);
+		solo.assertCurrentActivity("MyProjectActivity is not the Current Activity", MyProjectsActivity.class);
+		solo.sleep(1000);
+		solo.sendKey(solo.MENU);
+		solo.clickOnMenuItem(MENU_ITEM_ShowDetails);
+		solo.sleep(500);
+		String kilobyteStr = getActivity().getString(R.string.kiloByte_short);
+		assertEquals(kilobyteStr, KiloByte_Text);
+	}
+
+	private static boolean isRTL() {
+		return isRTL(Locale.getDefault());
+	}
+
+	private static boolean isRTL(Locale locale) {
+		final int directionality = Character.getDirectionality(locale.getDisplayName().charAt(0));
+		return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT ||
+				directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilFileTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilFileTest.java
@@ -95,7 +95,7 @@ public class UtilFileTest extends InstrumentationTestCase {
 
 		double expectedSizeInKilobytes = 84.2;
 		assertEquals("Unexpected file size String", String.format(Locale.getDefault(), "%.1f KB", expectedSizeInKilobytes),
-				UtilFile.getSizeAsString(testDirectory));
+				UtilFile.getSizeAsString(testDirectory,getInstrumentation().getContext()));
 
 		for (int i = 2; i < 48; i++) {
 			UtilFile.saveFileToProject("testDirectory", "testScene", i + "testsound.mp3",
@@ -104,7 +104,8 @@ public class UtilFileTest extends InstrumentationTestCase {
 		}
 		DecimalFormat decimalFormat = new DecimalFormat("#.0");
 		String expected = decimalFormat.format(2.0) + " MB";
-		assertEquals("Unexpected file size String", expected, UtilFile.getSizeAsString(testDirectory));
+		assertEquals("Unexpected file size String", expected, UtilFile.getSizeAsString(testDirectory,
+				getInstrumentation().getContext()));
 
 		PrintWriter printWriter = null;
 
@@ -123,7 +124,7 @@ public class UtilFileTest extends InstrumentationTestCase {
 			}
 		}
 
-		assertEquals("Unexpected Filesize!", "7 Byte", UtilFile.getSizeAsString(testFile));
+		assertEquals("Unexpected Filesize!", "7 Byte", UtilFile.getSizeAsString(testFile,getInstrumentation().getContext()));
 
 		UtilFile.deleteDirectory(testDirectory);
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/LookListAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/LookListAdapter.java
@@ -60,7 +60,8 @@ public class LookListAdapter extends CheckBoxListAdapter<LookData> {
 			listItemViewHolder.rightBottomDetails.setText(measureString);
 
 			listItemViewHolder.leftTopDetails.setText(R.string.size);
-			listItemViewHolder.rightTopDetails.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath())));
+			listItemViewHolder.rightTopDetails.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath()),
+					getContext()));
 		}
 
 		return listItemView;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/ProjectListAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/ProjectListAdapter.java
@@ -71,7 +71,7 @@ public class ProjectListAdapter extends CheckBoxListAdapter<ProjectData> {
 			listItemViewHolder.rightTopDetails.setText(lastAccess);
 
 			listItemViewHolder.leftBottomDetails.setText(getContext().getString(R.string.size));
-			String size = UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName)));
+			String size = UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName)), getContext());
 			listItemViewHolder.rightBottomDetails.setText(size);
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/SoundListAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/SoundListAdapter.java
@@ -60,7 +60,8 @@ public class SoundListAdapter extends CheckBoxListAdapter<SoundInfo> {
 			listItemViewHolder.leftBottomDetails.setVisibility(View.VISIBLE);
 			listItemViewHolder.rightBottomDetails.setVisibility(View.VISIBLE);
 			listItemViewHolder.leftBottomDetails.setText(getContext().getString(R.string.size));
-			listItemViewHolder.rightBottomDetails.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath())));
+			listItemViewHolder.rightBottomDetails.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath
+					()), getContext()));
 		} else {
 			listItemViewHolder.leftBottomDetails.setVisibility(View.GONE);
 			listItemViewHolder.rightBottomDetails.setVisibility(View.GONE);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
@@ -151,8 +151,7 @@ public final class LookController {
 	private void handleDetails(LookData lookData, LookViewHolder holder, LookBaseAdapter lookAdapter) {
 		if (lookAdapter.getShowDetails()) {
 			if (lookData.getAbsolutePath() != null) {
-				holder.lookFileSizeTextView.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath()),
-						lookAdapter.getContext()));
+				holder.lookFileSizeTextView.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath()),lookAdapter.getContext()));
 			}
 			int[] measure = lookData.getMeasure();
 			String measureString = measure[0] + " x " + measure[1];

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
@@ -151,7 +151,8 @@ public final class LookController {
 	private void handleDetails(LookData lookData, LookViewHolder holder, LookBaseAdapter lookAdapter) {
 		if (lookAdapter.getShowDetails()) {
 			if (lookData.getAbsolutePath() != null) {
-				holder.lookFileSizeTextView.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath())));
+				holder.lookFileSizeTextView.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath()),
+						lookAdapter.getContext()));
 			}
 			int[] measure = lookData.getMeasure();
 			String measureString = measure[0] + " x " + measure[1];
@@ -486,11 +487,11 @@ public final class LookController {
 							activity.startActivity(downloadPocketPaintIntent);
 						}
 					}).setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
-						@Override
-						public void onClick(DialogInterface dialog, int id) {
-							dialog.cancel();
-						}
-					});
+				@Override
+				public void onClick(DialogInterface dialog, int id) {
+					dialog.cancel();
+				}
+			});
 			AlertDialog alert = builder.create();
 			alert.show();
 			return false;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/SoundController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/SoundController.java
@@ -280,7 +280,8 @@ public final class SoundController {
 
 	private void handleDetails(SoundBaseAdapter soundAdapter, SoundViewHolder holder, SoundInfo soundInfo) {
 		if (soundAdapter.getShowDetails()) {
-			holder.soundFileSizeTextView.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath())));
+			holder.soundFileSizeTextView.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath()),
+					soundAdapter.getContext()));
 			holder.soundFileSizeTextView.setVisibility(TextView.VISIBLE);
 			holder.soundFileSizePrefixTextView.setVisibility(TextView.VISIBLE);
 		} else {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
@@ -114,7 +114,8 @@ public class UploadProjectDialog extends DialogFragment {
 	private void initControls() {
 		currentProjectName = ProjectManager.getInstance().getCurrentProject().getName();
 		currentProjectDescription = ProjectManager.getInstance().getCurrentProject().getDescription();
-		sizeOfProject.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(currentProjectName))));
+		sizeOfProject.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(currentProjectName)),
+				getActivity().getApplicationContext()));
 		projectRename.setVisibility(View.GONE);
 		projectUploadName.setText(currentProjectName);
 		projectDescriptionField.setText(currentProjectDescription);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ShowDetailsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ShowDetailsFragment.java
@@ -91,7 +91,8 @@ public class ShowDetailsFragment extends Fragment implements SetDescriptionDialo
 		screenshotLoader.loadAndShowScreenshot(projectData.projectName, sceneName, false, projectImage);
 		name.setText(projectData.projectName);
 		author.setText(getUserHandle());
-		size.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName))));
+		size.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName)), getActivity()
+				.getApplicationContext()));
 		lastAccess.setText(getLastAccess());
 		screenSize.setText(screen);
 		mode.setText(modeText);

--- a/catroid/src/main/java/org/catrobat/catroid/utils/UtilFile.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/UtilFile.java
@@ -26,6 +26,7 @@ import android.content.Context;
 import android.util.Log;
 
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.soundrecorder.SoundRecorder;
 
@@ -79,22 +80,30 @@ public final class UtilFile {
 		return progress * 100 / fileByteSize;
 	}
 
-	public static String getSizeAsString(File fileOrDirectory) {
-		final int unit = 1024;
+	public static String getSizeAsString(File fileOrDirectory, Context context) {
 		long bytes = UtilFile.getSizeOfFileOrDirectoryInByte(fileOrDirectory);
+		return formatFileSize(bytes, context);
+	}
 
+	public static String formatFileSize(long bytes, Context context) {
+		final double unit = 1024;
+		String fileSizeExtension[] = new String[] {
+				context.getString(R.string.Byte_short),
+				context.getString(R.string.kiloByte_short),
+				context.getString(R.string.MegaByte_short),
+				context.getString(R.string.GigaByte_short),
+				context.getString(R.string.TeraByte_short),
+				context.getString(R.string.PetaByte_short),
+				context.getString(R.string.ExaByte_short)
+		};
 		if (bytes < unit) {
-			return bytes + " Byte";
+			return bytes + " " + fileSizeExtension[0];
 		}
-
-		/*
-		 * Logarithm of "bytes" to base "unit"
-		 * log(a) / log(b) == logarithm of a to the base of b
-		 */
 		int exponent = (int) (Math.log(bytes) / Math.log(unit));
-		char prefix = "KMGTPE".charAt(exponent - 1);
-
-		return String.format(Locale.getDefault(), "%.1f %sB", bytes / Math.pow(unit, exponent), prefix);
+		exponent = Math.min(exponent, fileSizeExtension.length - 1);
+		String prefix = fileSizeExtension[exponent];
+		return String.format(Locale.getDefault(), "%.1f %s", bytes / Math.pow(unit, exponent),
+				prefix);
 	}
 
 	public static boolean deleteDirectory(File fileOrDirectory) {

--- a/catroid/src/main/res/values-ar/strings.xml
+++ b/catroid/src/main/res/values-ar/strings.xml
@@ -1447,4 +1447,14 @@
   <string name="crash_dialog_always_send">دائماً أرسل</string>
   <string name="crash_dialog_send">أرسل</string>
   <!--  -->
+
+  <string name="Byte_short">بايت</string>
+    <string name="kiloByte_short">كيلوبايت</string>
+    <string name="MegaByte_short">ميغابايت</string>
+    <string name="GigaByte_short">غيغابايت</string>
+    <string name="TeraByte_short">تيرابايت</string>
+    <string name="PetaByte_short">بيتابايت</string>
+    <string name="ExaByte_short">إكسابايت</string>
+    <string name="ZERO">0</string>
+  <!--  -->
 </resources>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<!--
+<?xml version="1.0" encoding="utf-8" standalone="no"?><!--
   ~ Catroid: An on-device visual programming system for Android devices
   ~ Copyright (C) 2010-2017 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
@@ -1542,5 +1541,15 @@
     <string name="crash_dialog_text">Please help to improve Pocket Code by sending us anonymous crash reports!</string>
     <string name="crash_dialog_always_send">Always send</string>
     <string name="crash_dialog_send">Send</string>
+    <!--  -->
+
+    <!--  -->
+    <string name="Byte_short">B</string>
+    <string name="kiloByte_short">KB</string>
+    <string name="MegaByte_short">MB</string>
+    <string name="GigaByte_short">GB</string>
+    <string name="TeraByte_short">TB</string>
+    <string name="PetaByte_short">PB</string>
+    <string name="ExaByte_short">EB</string>
     <!--  -->
 </resources>


### PR DESCRIPTION
In the course of localizing software, all strings should be declared as resources and separated from the source code. In Pocket Code, program size is expressed in units of measurement (KB, MB, GB, etc.), these units are implemented as a hard-coded string.