### PR TITLE
CAT-2250 Don't display a think/say bubble when the text equals ""

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -151,7 +151,7 @@ dependencies {
     compile fileTree(include: '*.jar', dir: 'src/main/libs-natives')
     androidTestCompile fileTree(include: '*.jar', dir: 'src/androidTest/libs')
     androidTestCompile 'com.jayway.android.robotium:robotium-solo:5.2.1'
-    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
+    androidTestCompile 'com.linkedin.dexmaker:dexmaker-mockito:1.5.1'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
 
     androidTestCompile ('com.android.support.test:runner:0.5') {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ThinkSayBubbleActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ThinkSayBubbleActionTest.java
@@ -1,0 +1,112 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.actions;
+
+import android.test.AndroidTestCase;
+
+import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.content.ActionFactory;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.actions.ThinkSayBubbleAction;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.InterpretationException;
+import org.catrobat.catroid.stage.ShowBubbleActor;
+import org.catrobat.catroid.stage.StageActivity;
+import org.catrobat.catroid.stage.StageListener;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+public class ThinkSayBubbleActionTest extends AndroidTestCase {
+
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		StageActivity.stageListener = Mockito.mock(StageListener.class);
+	}
+
+	@Override
+	public void tearDown() throws Exception {
+		super.tearDown();
+		StageActivity.stageListener = null;
+	}
+
+	public void testCreateBubbleActor() throws InterpretationException {
+		Formula emptyText = Mockito.mock(Formula.class);
+		Formula normalText = Mockito.mock(Formula.class);
+		Mockito.doReturn("").when(emptyText).interpretString(Mockito.any(Sprite.class));
+		Mockito.doReturn("test").when(normalText).interpretString(Mockito.any(Sprite.class));
+		ActionFactory factory = new ActionFactory();
+
+		ThinkSayBubbleAction thinkActionEmptyText = (ThinkSayBubbleAction) factory.createThinkSayBubbleAction(Mockito
+				.mock(Sprite.class), emptyText, Constants.THINK_BRICK);
+		ThinkSayBubbleAction thinkActionNormalText = (ThinkSayBubbleAction) factory.createThinkSayBubbleAction(Mockito
+				.mock(Sprite.class), emptyText, Constants.THINK_BRICK);
+
+		assert (thinkActionEmptyText.createBubbleActor() == null);
+		assert (thinkActionNormalText.createBubbleActor() != null);
+	}
+
+	public void testBasicThinkSayBubble() throws InterpretationException {
+		Mockito.when(StageActivity.stageListener.getBubbleActorForSprite(Mockito.any(Sprite.class))).thenReturn(null);
+
+		Sprite sprite = Mockito.mock(Sprite.class);
+		Formula text = Mockito.mock(Formula.class);
+		ShowBubbleActor actor = Mockito.mock(ShowBubbleActor.class);
+		ActionFactory factory = new ActionFactory();
+		ThinkSayBubbleAction thinkAction = (ThinkSayBubbleAction) factory.createThinkSayBubbleAction(sprite, text, Constants.THINK_BRICK);
+		thinkAction = Mockito.spy(thinkAction);
+		Mockito.doReturn(actor).when(thinkAction).createBubbleActor();
+
+		thinkAction.act(1f);
+
+		Mockito.verify(StageActivity.stageListener, Mockito.times(1)).setBubbleActorForSprite(sprite, actor);
+		Mockito.verify(StageActivity.stageListener, Mockito.never()).removeBubbleActorForSprite(sprite);
+	}
+
+	public void testRemoveThinkSayBubble() throws InterpretationException {
+		Mockito.when(StageActivity.stageListener.getBubbleActorForSprite(Mockito.any(Sprite.class))).thenReturn(null);
+		Sprite sprite = Mockito.mock(Sprite.class);
+		Formula text = Mockito.mock(Formula.class);
+		ShowBubbleActor actor = Mockito.mock(ShowBubbleActor.class);
+
+		ActionFactory factory = new ActionFactory();
+		ThinkSayBubbleAction thinkAction = (ThinkSayBubbleAction) factory.createThinkSayBubbleAction(sprite, text,
+				Constants.THINK_BRICK);
+		ThinkSayBubbleAction thinkActionWithoutText = (ThinkSayBubbleAction) factory.createThinkSayBubbleAction(sprite,
+				text, Constants.THINK_BRICK);
+		thinkAction = Mockito.spy(thinkAction);
+		thinkActionWithoutText = Mockito.spy(thinkActionWithoutText);
+		Mockito.doReturn(actor).when(thinkAction).createBubbleActor();
+		Mockito.doReturn(null).when(thinkActionWithoutText).createBubbleActor();
+
+		// Act
+		thinkAction.act(1f);
+		Mockito.when(StageActivity.stageListener.getBubbleActorForSprite(Mockito.any(Sprite.class))).thenReturn(actor);
+		thinkActionWithoutText.act(1f);
+
+		InOrder inOrder = Mockito.inOrder(StageActivity.stageListener);
+		inOrder.verify(StageActivity.stageListener, Mockito.times(1)).setBubbleActorForSprite(sprite, actor);
+		inOrder.verify(StageActivity.stageListener, Mockito.times(1)).removeBubbleActorForSprite(sprite);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/content/ActionFactory.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/ActionFactory.java
@@ -30,7 +30,6 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.camera.CameraManager;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.SoundInfo;
 import org.catrobat.catroid.content.BroadcastEvent.BroadcastType;
@@ -507,8 +506,7 @@ public class ActionFactory extends Actions {
 	}
 
 	public Action createClearBackgroundAction() {
-		ClearBackgroundAction action = Actions.action(ClearBackgroundAction.class);
-		return action;
+		return Actions.action(ClearBackgroundAction.class);
 	}
 
 	public Action createStampAction(Sprite sprite) {
@@ -718,35 +716,19 @@ public class ActionFactory extends Actions {
 		return action;
 	}
 
-	public Action createThinkBubbleAction(Sprite sprite, Formula text) {
+	public Action createThinkSayBubbleAction(Sprite sprite, Formula text, int type) {
 		ThinkSayBubbleAction action = action(ThinkSayBubbleAction.class);
 		action.setText(text);
 		action.setSprite(sprite);
-		action.setType(Constants.THINK_BRICK);
+		action.setType(type);
 		return action;
 	}
 
-	public Action createSayBubbleAction(Sprite sprite, Formula text) {
+	public Action createThinkSayForBubbleAction(Sprite sprite, Formula text, int type) {
 		ThinkSayBubbleAction action = action(ThinkSayBubbleAction.class);
 		action.setText(text);
 		action.setSprite(sprite);
-		action.setType(Constants.SAY_BRICK);
-		return action;
-	}
-
-	public Action createThinkForBubbleAction(Sprite sprite, Formula text) {
-		ThinkSayBubbleAction action = action(ThinkSayBubbleAction.class);
-		action.setText(text);
-		action.setSprite(sprite);
-		action.setType(Constants.THINK_BRICK);
-		return action;
-	}
-
-	public Action createSayForBubbleAction(Sprite sprite, Formula text) {
-		ThinkSayBubbleAction action = action(ThinkSayBubbleAction.class);
-		action.setText(text);
-		action.setSprite(sprite);
-		action.setType(Constants.SAY_BRICK);
+		action.setType(type);
 		return action;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/ThinkSayBubbleAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/ThinkSayBubbleAction.java
@@ -22,8 +22,6 @@
  */
 package org.catrobat.catroid.content.actions;
 
-import android.util.Log;
-
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 
 import org.catrobat.catroid.content.Sprite;
@@ -40,21 +38,28 @@ public class ThinkSayBubbleAction extends TemporalAction {
 
 	@Override
 	protected void update(float delta) {
-		String textToDisplay;
+		ShowBubbleActor showBubbleActor;
 		try {
-			textToDisplay = text == null ? "" : text.interpretString(sprite);
-		} catch (InterpretationException interpretationException) {
-			Log.d(getClass().getSimpleName(), "Formula interpretation for this specific Brick failed.", interpretationException);
+			showBubbleActor = createBubbleActor();
+		} catch (InterpretationException e) {
+			e.printStackTrace();
 			return;
 		}
-		ShowBubbleActor showBubbleActor = new ShowBubbleActor(textToDisplay, sprite, type);
 
 		if (StageActivity.stageListener.getBubbleActorForSprite(sprite) != null) {
-			StageActivity.stageListener.getStage().getActors().removeValue(StageActivity.stageListener.getBubbleActorForSprite(sprite), true);
 			StageActivity.stageListener.removeBubbleActorForSprite(sprite);
 		}
-		StageActivity.stageListener.addActor(showBubbleActor);
-		StageActivity.stageListener.putBubbleActor(sprite, showBubbleActor);
+		if (showBubbleActor != null) {
+			StageActivity.stageListener.setBubbleActorForSprite(sprite, showBubbleActor);
+		}
+	}
+
+	public ShowBubbleActor createBubbleActor() throws InterpretationException {
+		String textToDisplay = text == null ? "" : text.interpretString(sprite);
+		if (textToDisplay.isEmpty()) {
+			return null;
+		}
+		return new ShowBubbleActor(textToDisplay, sprite, type);
 	}
 
 	public void setSprite(Sprite sprite) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/WaitForBubbleBrickAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/WaitForBubbleBrickAction.java
@@ -22,7 +22,6 @@
  */
 package org.catrobat.catroid.content.actions;
 
-import org.catrobat.catroid.stage.ShowBubbleActor;
 import org.catrobat.catroid.stage.StageActivity;
 
 public class WaitForBubbleBrickAction extends WaitAction {
@@ -32,9 +31,7 @@ public class WaitForBubbleBrickAction extends WaitAction {
 
 	@Override
 	protected void end() {
-		ShowBubbleActor actor = StageActivity.stageListener.getBubbleActorForSprite(sprite);
-		if (actor != null) {
-			StageActivity.stageListener.getStage().getActors().removeValue(actor, true);
+		if (StageActivity.stageListener.getBubbleActorForSprite(sprite) != null) {
 			StageActivity.stageListener.removeBubbleActorForSprite(sprite);
 		}
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/Brick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/Brick.java
@@ -63,7 +63,20 @@ public interface Brick extends Serializable, Cloneable {
 
 		ARDUINO_ANALOG_PIN_VALUE, ARDUINO_ANALOG_PIN_NUMBER, ARDUINO_DIGITAL_PIN_VALUE, ARDUINO_DIGITAL_PIN_NUMBER,
 
-		RASPI_DIGITAL_PIN_VALUE, RASPI_DIGITAL_PIN_NUMBER, RASPI_PWM_PERCENTAGE, RASPI_PWM_FREQUENCY
+		RASPI_DIGITAL_PIN_VALUE, RASPI_DIGITAL_PIN_NUMBER, RASPI_PWM_PERCENTAGE, RASPI_PWM_FREQUENCY;
+
+		public static final BrickField[] EXPECTS_STRING_VALUE = { VARIABLE, NOTE, SPEAK, STRING, ASK_QUESTION,
+				NFC_NDEF_MESSAGE, ASK_SPEECH_QUESTION, LIST_ADD_ITEM, INSERT_ITEM_INTO_USERLIST_VALUE,
+				REPLACE_ITEM_IN_USERLIST_VALUE };
+
+		public static boolean isExpectingStringValue(BrickField field) {
+			for (BrickField bf : EXPECTS_STRING_VALUE) {
+				if (bf.equals(field)) {
+					return true;
+				}
+			}
+			return false;
+		}
 	}
 
 	//use bitwise | for using multiple resources in a brick

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkBubbleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkBubbleBrick.java
@@ -96,13 +96,8 @@ public class ThinkBubbleBrick extends FormulaBrick implements OnClickListener {
 
 	@Override
 	public List<SequenceAction> addActionToSequence(Sprite sprite, SequenceAction sequence) {
-		if (type == Constants.SAY_BRICK) {
-			sequence.addAction(sprite.getActionFactory().createSayBubbleAction(sprite,
-					getFormulaWithBrickField(BrickField.STRING)));
-		} else {
-			sequence.addAction(sprite.getActionFactory().createThinkBubbleAction(sprite,
-					getFormulaWithBrickField(BrickField.STRING)));
-		}
+		sequence.addAction(sprite.getActionFactory().createThinkSayBubbleAction(sprite, getFormulaWithBrickField(BrickField
+				.STRING), type));
 		return null;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkForBubbleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkForBubbleBrick.java
@@ -156,13 +156,9 @@ public class ThinkForBubbleBrick extends FormulaBrick {
 
 	@Override
 	public List<SequenceAction> addActionToSequence(Sprite sprite, SequenceAction sequence) {
-		if (type == Constants.SAY_BRICK) {
-			sequence.addAction(sprite.getActionFactory().createSayForBubbleAction(sprite, getFormulaWithBrickField(BrickField.STRING)));
-			sequence.addAction(sprite.getActionFactory().createWaitForBubbleBrickAction(sprite, getFormulaWithBrickField(BrickField.DURATION_IN_SECONDS)));
-		} else {
-			sequence.addAction(sprite.getActionFactory().createThinkForBubbleAction(sprite, getFormulaWithBrickField(BrickField.STRING)));
-			sequence.addAction(sprite.getActionFactory().createWaitForBubbleBrickAction(sprite, getFormulaWithBrickField(BrickField.DURATION_IN_SECONDS)));
-		}
+		sequence.addAction(sprite.getActionFactory().createThinkSayForBubbleAction(sprite, getFormulaWithBrickField(BrickField
+				.STRING), type));
+		sequence.addAction(sprite.getActionFactory().createWaitForBubbleBrickAction(sprite, getFormulaWithBrickField(BrickField.DURATION_IN_SECONDS)));
 		return null;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaParser.java
@@ -45,6 +45,7 @@ public class InternFormulaParser {
 
 	public static final int PARSER_OK = -1;
 	public static final int PARSER_STACK_OVERFLOW = -2;
+	public static final int PARSER_INPUT_SYNTAX_ERROR = -3;
 	public static final int PARSER_NO_INPUT = -4;
 	private static final int MAXIMUM_TOKENS_TO_PARSE = 1000;
 	private static final String TAG = InternFormulaParser.class.getSimpleName();
@@ -143,7 +144,7 @@ public class InternFormulaParser {
 		}
 
 		try {
-			List<InternToken> copyIternTokensToParse = new ArrayList<InternToken>(internTokensToParse);
+			List<InternToken> copyIternTokensToParse = new ArrayList<>(internTokensToParse);
 			if (InternFormulaUtils.applyBracketCorrection(copyIternTokensToParse)) {
 				internTokensToParse.clear();
 				internTokensToParse.addAll(copyIternTokensToParse);

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageActivity.java
@@ -90,7 +90,7 @@ public class StageActivity extends AndroidApplication {
 	private StageAudioFocus stageAudioFocus;
 	private PendingIntent pendingIntent;
 	private NfcAdapter nfcAdapter;
-	private static BlockingDeque<NdefMessage> ndefMessageBlockingDeque = new LinkedBlockingDeque<NdefMessage>();
+	private static BlockingDeque<NdefMessage> ndefMessageBlockingDeque = new LinkedBlockingDeque<>();
 	private StageDialog stageDialog;
 	private boolean resizePossible;
 	private boolean askDialogUnanswered = false;

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -171,7 +171,7 @@ public class StageListener implements ApplicationListener {
 	public boolean axesOn = false;
 
 	private byte[] thumbnail;
-	private Map<String, StageBackup> stageBackupMap = new HashMap();
+	private Map<String, StageBackup> stageBackupMap = new HashMap<>();
 
 	private InputListener inputListener = null;
 
@@ -718,7 +718,7 @@ public class StageListener implements ApplicationListener {
 		}
 
 		for (int i = 0; i < length; i += 4) {
-			colors[i / 4] = android.graphics.Color.argb(255, screenshot[i + 0] & 0xFF, screenshot[i + 1] & 0xFF,
+			colors[i / 4] = android.graphics.Color.argb(255, screenshot[i] & 0xFF, screenshot[i + 1] & 0xFF,
 					screenshot[i + 2] & 0xFF);
 		}
 		fullScreenBitmap = Bitmap.createBitmap(colors, 0, screenshotWidth, screenshotWidth, screenshotHeight,
@@ -840,11 +840,13 @@ public class StageListener implements ApplicationListener {
 		look.remove();
 	}
 
-	public void putBubbleActor(Sprite sprite, ShowBubbleActor actor) {
-		bubbleActorMap.put(sprite, actor);
+	public void setBubbleActorForSprite(Sprite sprite, ShowBubbleActor showBubbleActor) {
+		addActor(showBubbleActor);
+		bubbleActorMap.put(sprite, showBubbleActor);
 	}
 
 	public void removeBubbleActorForSprite(Sprite sprite) {
+		getStage().getActors().removeValue(getBubbleActorForSprite(sprite), true);
 		bubbleActorMap.remove(sprite);
 	}
 


### PR DESCRIPTION
This is the second pull request for this issue, as I could not reopen the other one (https://github.com/Catrobat/Catroid/pull/2256) after force pushing.
I had to make quite a few changes to the code to make it testable, so please bear with me ;)

Added **ThinkSayBubbleActionTest** testing new behaviour (bubble disappears if ThinkSayBubble with text "" is created)
**ThinkSayBubbleAction**: moved BubbleActor creation to seperate method (for better testability); moved some code concerning adding/removing BubbleActors to StageListener
**WaitForBubbleBrickAction**:  moved some code concerning adding/removing BubbleActors to StageListener
**Brick**: added a new array that contains all BrickFields that expect a string value & a method that returns a boolean value if a field expects a string value
**ThinkBubbleBrick** & **ThinkForBubbleBrick**: adjusted the call to the ActionFactory method for creating a ThinkSayBubbleAction
**ActionFactory**: merged think & say methods into one
InternFormulaParser: added a constant; minor refactoring
**StageListener**: moved some code concerning adding/removing BubbleActors to StageListener from ThinkSayBubbleAction and WaitForBubbleBrickAction, minor refactoring
**FormulaEditorFragment**: used constants from InternFormulaParser instead of its own ones; now saves a formula with no input, if the BrickField expects a string
**build.gradle**: upped the version of com.google.dexmaker:dexmaker-mockito in order for Mockito.spy to work (needed for my test)
