### PR TITLE
CAT-2400 Automatize the creation of standalone APKs.

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -45,6 +45,20 @@ apply from: 'gradle/standalone_apk_tasks.gradle'
 check.dependsOn 'checkstyle'
 check.dependsOn 'pmd'
 
+def appId = 'org.catrobat.catroid'
+def appName = '@string/app_name'
+
+// When -Pindependent was provided on the gradle command the APP name is changed.
+// This allows to have multiple Catroid versions installed in parallel for testing purposes.
+// Furthermore these installations do not interfere with the actual Catroid app.
+if (project.hasProperty('independent')) {
+    def today = new Date()
+    appId += '.independent_' + today.format('YYYYMMdd_HHmm')
+    appName = property('independent') ?: 'Code ' + today.format('MMdd HH:mm')
+}
+ant.copy(file: 'google-services-template.json', tofile: 'google-services.json', overwrite: true)
+ant.replace(file: 'google-services.json', token: '@appId@', value: appId)
+
 android {
     dexOptions {
         javaMaxHeapSize "4g"
@@ -86,7 +100,7 @@ android {
     }
     productFlavors {
         catroid {
-            applicationId 'org.catrobat.catroid'
+            applicationId appId
             buildConfigField "String", "START_PROJECT", "\"No Starting Project\""
             buildConfigField "String", "PROJECT_NAME", "\"No Standalone Project\""
             buildConfigField "boolean", "FEATURE_APK_GENERATOR_ENABLED", "false"
@@ -94,7 +108,7 @@ android {
         }
 
         standalone {
-            applicationId 'org.catrobat.catroid.' + getPackageNameSuffix()
+            applicationId appId + '.' + getPackageNameSuffix()
             versionCode 1
             versionName '1.0'
 
@@ -192,8 +206,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 22
-        applicationId 'org.catrobat.catroid'
-        testApplicationId "org.catrobat.catroid.test"
+        applicationId appId
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         versionCode 35
         println "VersionCode is " + versionCode
@@ -202,6 +215,7 @@ android {
         buildConfigField "String", "GIT_DESCRIBE", "\"${versionName}\""
         buildConfigField "String", "GIT_CURRENT_BRANCH", "\"${getCurrentGitBranch()}\""
         multiDexEnabled true
+        manifestPlaceholders += [appName: appName]
     }
 
     packagingOptions {

--- a/catroid/google-services-template.json
+++ b/catroid/google-services-template.json
@@ -10,7 +10,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:713919797763:android:d9d5e2274e070833",
         "android_client_info": {
-          "package_name": "org.catrobat.catroid"
+          "package_name": "@appId@"
         }
       },
       "oauth_client": [
@@ -41,7 +41,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:713919797763:android:c03d22e27263cfca",
         "android_client_info": {
-          "package_name": "org.catrobat.catroid.gnoID"
+          "package_name": "@appId@.gnoID"
         }
       },
       "oauth_client": [

--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -84,7 +84,7 @@
         android:name=".CatroidApplication"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name"
+        android:label="${appName}"
         android:theme="@style/Theme.Catroid"
         android:supportsRtl="true">
 
@@ -95,7 +95,7 @@
         <activity
             android:name="com.facebook.FacebookActivity"
             android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-            android:label="@string/app_name"
+            android:label="${appName}"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
         <activity


### PR DESCRIPTION
Standalone APKs are allowed to be installed without affecting the
current Pocket Code installation.
This is useful for testers to have different versions installed in parallel.
Automating this process (https://confluence.catrob.at/x/KoGT) makes it more
accessible and allows Jenkins to provide such standalone APKs.

# Usage
./gradlew -Pindependent assembleDebug

The created catroid-catroid-debug.apk file has an internal application name
that depends on the current date and time.
The user displayed label is of the form "Code MMdd HH:mm" in UTC.

Alternatively you can provide an application name yourself:
./gradlew -Pindependent="Code Design Nr 2" assembleDebug

# Implementation
The application name and the package name are stored as placeholders in
android manifest and also in the google-services-template.json.
Moreover the test application id is not set manually anymore, since it
is created automatically by the android gradle plugin.