### PR TITLE
CAT-2408 Bidirectional Localization Testing

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/BricksCategoriesTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/BricksCategoriesTest.java
@@ -1,0 +1,176 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uiespresso.localization;
+
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.espresso.action.ViewActions;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.ui.ProgramMenuActivity;
+import org.catrobat.catroid.uiespresso.util.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.assertion.LayoutAssertions.noEllipsizedText;
+import static android.support.test.espresso.assertion.LayoutAssertions.noOverlaps;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.catrobat.catroid.uiespresso.localization.assertions.LayoutDirectionAssertions.isLayoutDirectionRTL;
+import static org.catrobat.catroid.uiespresso.localization.assertions.TextDirectionAssertions.isTextDirectionRTL;
+import static org.catrobat.catroid.uiespresso.localization.assertions.VisibilityAssertions.isVisible;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+@RunWith(AndroidJUnit4.class)
+
+public class BricksCategoriesTest {
+	private ViewInteraction brickCategoryEvent;
+	private ViewInteraction brickCategoryControl;
+	private ViewInteraction brickCategorySound;
+	private ViewInteraction brickCategoryMotion;
+	private ViewInteraction brickCategoryLooks;
+	private ViewInteraction brickCategoryData;
+	private ViewInteraction brickCategoryPen;
+
+	@Rule
+	public BaseActivityInstrumentationRule<ProgramMenuActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(ProgramMenuActivity.class, true, false);
+
+	@Before
+	public void setUp() throws Exception {
+		UiTestUtils.createProject("BricksCategoriesTest");
+		baseActivityTestRule.launchActivity(null);
+		Espresso.onView(withId(R.id.program_menu_button_scripts)).perform(ViewActions.click());
+		Espresso.onView(withId(R.id.button_add)).perform(ViewActions.click());
+		brickCategoryEvent = Espresso.onView(withText(R.string.category_event));
+		brickCategoryControl = Espresso.onView(withText(R.string.category_control));
+		brickCategorySound = Espresso.onView(withText(R.string.category_sound));
+		brickCategoryMotion = Espresso.onView(withText(R.string.category_motion));
+		brickCategoryLooks = Espresso.onView(withText(R.string.category_looks));
+		brickCategoryData = Espresso.onView(withText(R.string.category_data));
+		brickCategoryPen = Espresso.onView(withText(R.string.category_pen));
+	}
+
+	@Test
+	public void assertCompletelyDisplayed() {
+		brickCategoryEvent.check(matches(isCompletelyDisplayed()));
+		brickCategoryControl.check(matches(isCompletelyDisplayed()));
+		brickCategorySound.check(matches(isCompletelyDisplayed()));
+		brickCategoryMotion.check(matches(isCompletelyDisplayed()));
+		brickCategoryLooks.check(matches(isCompletelyDisplayed()));
+		Espresso.onView(isRoot()).perform(ViewActions.swipeUp());
+		brickCategoryData.check(matches(isCompletelyDisplayed()));
+		brickCategoryPen.check(matches(isCompletelyDisplayed()));
+	}
+
+	@Test
+	public void assertNoEllipsizedTextInRTLMode() {
+		brickCategoryEvent.check(noEllipsizedText());
+		brickCategoryControl.check(noEllipsizedText());
+		brickCategorySound.check(noEllipsizedText());
+		brickCategoryMotion.check(noEllipsizedText());
+		brickCategoryLooks.check(noEllipsizedText());
+		brickCategoryData.check(noEllipsizedText());
+		brickCategoryPen.check(noEllipsizedText());
+	}
+
+	@Test
+	public void assertNotNullValueInRTLMode() {
+		brickCategoryEvent.check(matches(notNullValue()));
+		brickCategoryControl.check(matches(notNullValue()));
+		brickCategorySound.check(matches(notNullValue()));
+		brickCategoryMotion.check(matches(notNullValue()));
+		brickCategoryLooks.check(matches(notNullValue()));
+		brickCategoryData.check(matches(notNullValue()));
+		brickCategoryPen.check(matches(notNullValue()));
+	}
+
+	@Test
+	public void assertNoOverLappingBricksInRTLMode() {
+		brickCategoryEvent.check(noOverlaps());
+		brickCategoryControl.check(noOverlaps());
+		brickCategorySound.check(noOverlaps());
+		brickCategoryMotion.check(noOverlaps());
+		brickCategoryLooks.check(noOverlaps());
+		brickCategoryData.check(noOverlaps());
+		brickCategoryPen.check(noOverlaps());
+	}
+
+	@Test
+	public void assertLayoutDirectionIsRTL() {
+		brickCategoryEvent.check(isLayoutDirectionRTL());
+		brickCategoryControl.check(isLayoutDirectionRTL());
+		brickCategorySound.check(isLayoutDirectionRTL());
+		brickCategoryMotion.check(isLayoutDirectionRTL());
+		brickCategoryLooks.check(isLayoutDirectionRTL());
+		brickCategoryData.check(isLayoutDirectionRTL());
+		brickCategoryPen.check(isLayoutDirectionRTL());
+	}
+
+	@Test
+	public void assertTextDirectionIsRTL() {
+		brickCategoryEvent.check(isTextDirectionRTL());
+		brickCategoryControl.check(isTextDirectionRTL());
+		brickCategorySound.check(isTextDirectionRTL());
+		brickCategoryMotion.check(isTextDirectionRTL());
+		brickCategoryLooks.check(isTextDirectionRTL());
+		brickCategoryData.check(isTextDirectionRTL());
+		brickCategoryPen.check(isTextDirectionRTL());
+	}
+
+	@Test
+	public void assertIsVisibleBrickInRTL() {
+		brickCategoryEvent.check(isVisible());
+		brickCategoryControl.check(isVisible());
+		brickCategorySound.check(isVisible());
+		brickCategoryMotion.check(isVisible());
+		brickCategoryLooks.check(isVisible());
+		brickCategoryData.check(isVisible());
+		brickCategoryPen.check(isVisible());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	public Project createProject(String projectName) {
+		Project project = new Project(null, projectName);
+		Sprite sprite = new Sprite("testSprite");
+		project.getDefaultScene().addSprite(sprite);
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+		return project;
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/MainMenuActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/MainMenuActivityTest.java
@@ -1,0 +1,148 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uiespresso.localization;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.ActivityInstrumentationTestCase2;
+
+import org.catrobat.catroid.R;
+
+import org.catrobat.catroid.ui.MainMenuActivity;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.assertion.LayoutAssertions.noEllipsizedText;
+import static android.support.test.espresso.assertion.LayoutAssertions.noOverlaps;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+import static org.catrobat.catroid.uiespresso.localization.assertions.LayoutDirectionAssertions.isLayoutDirectionRTL;
+import static org.catrobat.catroid.uiespresso.localization.assertions.TextDirectionAssertions.isTextDirectionRTL;
+import static org.catrobat.catroid.uiespresso.localization.assertions.VisibilityAssertions.isVisible;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+@RunWith(AndroidJUnit4.class)
+
+public class MainMenuActivityTest extends ActivityInstrumentationTestCase2<MainMenuActivity> {
+	private MainMenuActivity mainMenuActivity;
+	private ViewInteraction mainMenuContinue;
+	private ViewInteraction mainMenuNew;
+	private ViewInteraction mainMenuPrograms;
+	private ViewInteraction mainMenuHelp;
+	private ViewInteraction mainMenuWeb;
+	private ViewInteraction mainMenuUpload;
+
+	public MainMenuActivityTest() {
+		super(MainMenuActivity.class);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		injectInstrumentation(InstrumentationRegistry.getInstrumentation());
+		mainMenuActivity = getActivity();
+		mainMenuContinue = Espresso.onView(withId(R.id.main_menu_button_continue));
+		mainMenuNew = Espresso.onView(withId(R.id.main_menu_button_new));
+		mainMenuPrograms = Espresso.onView(withId(R.id.main_menu_button_programs));
+		mainMenuHelp = Espresso.onView(withId(R.id.main_menu_button_help));
+		mainMenuWeb = Espresso.onView(withId(R.id.main_menu_button_web));
+		mainMenuUpload = Espresso.onView(withId(R.id.main_menu_button_upload));
+	}
+
+	@Test
+	public void assertNoEllipsizedTextInRTLMode() {
+		mainMenuContinue.check(noEllipsizedText());
+		mainMenuNew.check(noEllipsizedText());
+		mainMenuPrograms.check(noEllipsizedText());
+		mainMenuHelp.check(noEllipsizedText());
+		mainMenuWeb.check(noEllipsizedText());
+		mainMenuUpload.check(noEllipsizedText());
+	}
+
+	@Test
+	public void assertCompletelyDisplayed() {
+		mainMenuContinue.check(matches(isCompletelyDisplayed()));
+		mainMenuNew.check(matches(isCompletelyDisplayed()));
+		mainMenuPrograms.check(matches(isCompletelyDisplayed()));
+		mainMenuHelp.check(matches(isCompletelyDisplayed()));
+		mainMenuWeb.check(matches(isCompletelyDisplayed()));
+		mainMenuUpload.check(matches(isCompletelyDisplayed()));
+	}
+
+	@Test
+	public void assertNotNullValueInRTLMode() {
+		mainMenuContinue.check(matches(notNullValue()));
+		mainMenuNew.check(matches(notNullValue()));
+		mainMenuPrograms.check(matches(notNullValue()));
+		mainMenuHelp.check(matches(notNullValue()));
+		mainMenuWeb.check(matches(notNullValue()));
+		mainMenuUpload.check(matches(notNullValue()));
+	}
+
+	@Test
+	public void assertNoOverLappingBricksInRTLMode() {
+		mainMenuContinue.check(noOverlaps());
+		mainMenuNew.check(noOverlaps());
+		mainMenuPrograms.check(noOverlaps());
+		mainMenuHelp.check(noOverlaps());
+		mainMenuWeb.check(noOverlaps());
+		mainMenuUpload.check(noOverlaps());
+	}
+
+	@Test
+	public void assertLayoutDirectionIsRTL() {
+		mainMenuContinue.check(isLayoutDirectionRTL());
+		mainMenuNew.check(isLayoutDirectionRTL());
+		mainMenuPrograms.check(isLayoutDirectionRTL());
+		mainMenuHelp.check(isLayoutDirectionRTL());
+		mainMenuWeb.check(isLayoutDirectionRTL());
+		mainMenuUpload.check(isLayoutDirectionRTL());
+	}
+
+	@Test
+	public void assertTextDirectionIsRTL() {
+		mainMenuContinue.check(isTextDirectionRTL());
+		mainMenuNew.check(isTextDirectionRTL());
+		mainMenuPrograms.check(isTextDirectionRTL());
+		mainMenuHelp.check(isTextDirectionRTL());
+		mainMenuWeb.check(isTextDirectionRTL());
+		mainMenuUpload.check(isTextDirectionRTL());
+	}
+
+	@Test
+	public void assertIsVisibleBrickInRTL() {
+		mainMenuContinue.check(isVisible());
+		mainMenuNew.check(isVisible());
+		mainMenuPrograms.check(isVisible());
+		mainMenuHelp.check(isVisible());
+		mainMenuWeb.check(isVisible());
+		mainMenuUpload.check(isVisible());
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/ProgramMenuActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/ProgramMenuActivityTest.java
@@ -1,0 +1,133 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uiespresso.localization;
+
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.ui.ProgramMenuActivity;
+import org.catrobat.catroid.uiespresso.util.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.assertion.LayoutAssertions.noEllipsizedText;
+import static android.support.test.espresso.assertion.LayoutAssertions.noOverlaps;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+import static org.catrobat.catroid.uiespresso.localization.assertions.LayoutDirectionAssertions.isLayoutDirectionRTL;
+import static org.catrobat.catroid.uiespresso.localization.assertions.TextDirectionAssertions.isTextDirectionRTL;
+import static org.catrobat.catroid.uiespresso.localization.assertions.VisibilityAssertions.isVisible;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+@RunWith(AndroidJUnit4.class)
+public class ProgramMenuActivityTest {
+	private ViewInteraction programMenuScripts;
+	private ViewInteraction programMenuLooks;
+	private ViewInteraction programMenuSound;
+
+	@Rule
+	public BaseActivityInstrumentationRule<ProgramMenuActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(ProgramMenuActivity.class, true, false);
+
+	@Before
+	public void setUp() throws Exception {
+		UiTestUtils.createProject("ProgramMenuActivityTest");
+		baseActivityTestRule.launchActivity(null);
+		programMenuScripts = Espresso.onView(withId(R.id.program_menu_button_scripts));
+		programMenuLooks = Espresso.onView(withId(R.id.program_menu_button_looks));
+		programMenuSound = Espresso.onView(withId(R.id.program_menu_button_sounds));
+	}
+
+	@Test
+	public void assertCompletelyDisplayed() {
+		programMenuScripts.check(matches(isCompletelyDisplayed()));
+		programMenuLooks.check(matches(isCompletelyDisplayed()));
+		programMenuSound.check(matches(isCompletelyDisplayed()));
+	}
+
+	@Test
+	public void assertNoEllipsizedTextInRTLMode() {
+		programMenuScripts.check(noEllipsizedText());
+		programMenuLooks.check(noEllipsizedText());
+		programMenuSound.check(noEllipsizedText());
+	}
+
+	@Test
+	public void assertNotNullValueInRTLMode() {
+		programMenuScripts.check(matches(notNullValue()));
+		programMenuLooks.check(matches(notNullValue()));
+		programMenuSound.check(matches(notNullValue()));
+	}
+
+	@Test
+	public void assertNoOverLappingBricksInRTLMode() {
+		programMenuScripts.check(noOverlaps());
+		programMenuLooks.check(noOverlaps());
+		programMenuSound.check(noOverlaps());
+	}
+
+	@Test
+	public void assertLayoutDirectionIsRTL() {
+		programMenuScripts.check(isLayoutDirectionRTL());
+		programMenuLooks.check(isLayoutDirectionRTL());
+		programMenuSound.check(isLayoutDirectionRTL());
+	}
+
+	@Test
+	public void assertTextDirectionIsRTL() {
+		programMenuScripts.check(isTextDirectionRTL());
+		programMenuLooks.check(isTextDirectionRTL());
+		programMenuSound.check(isTextDirectionRTL());
+	}
+
+	@Test
+	public void assertIsVisibleBrickInRTLMode() {
+		programMenuScripts.check(isVisible());
+		programMenuLooks.check(isVisible());
+		programMenuSound.check(isVisible());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	public Project createProject(String projectName) {
+		Project project = new Project(null, projectName);
+		Sprite sprite = new Sprite("testSprite");
+		project.getDefaultScene().addSprite(sprite);
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+		return project;
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/assertions/LayoutDirectionAssertions.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/assertions/LayoutDirectionAssertions.java
@@ -1,0 +1,79 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uiespresso.localization.assertions;
+
+import android.support.test.espresso.NoMatchingViewException;
+import android.support.test.espresso.ViewAssertion;
+import android.view.View;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class LayoutDirectionAssertions {
+	public static ViewAssertion isLayoutDirectionRTL() {
+		return new ViewAssertion() {
+			public void check(View view, NoMatchingViewException noView) {
+				assertThat(view, new LayoutDirectionMatcher(View.LAYOUT_DIRECTION_RTL));
+			}
+		};
+	}
+
+	private static class LayoutDirectionMatcher extends BaseMatcher<View> {
+		private int layoutDirection;
+
+		private LayoutDirectionMatcher(int layoutDirection) {
+			this.layoutDirection = layoutDirection;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			String layoutDirectionStr;
+			if (layoutDirection == View.LAYOUT_DIRECTION_RTL) {
+				layoutDirectionStr = "Right to Left";
+			} else {
+				layoutDirectionStr = "Left to Right";
+			}
+			description.appendText("View LayoutDirection must has equals " + layoutDirectionStr);
+		}
+
+		@Override
+		public boolean matches(Object object) {
+			if (object == null) {
+				if (layoutDirection == View.LAYOUT_DIRECTION_RTL) {
+					return true;
+				} else if (layoutDirection == View.LAYOUT_DIRECTION_LTR) {
+					return false;
+				}
+			}
+
+			if (!(object instanceof View)) {
+				throw new IllegalArgumentException("Object must be instance of View. Object is instance of " + object);
+			}
+			return ((View) object).getLayoutDirection() == layoutDirection;
+		}
+	}
+}
+
+

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/assertions/TextDirectionAssertions.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/assertions/TextDirectionAssertions.java
@@ -1,0 +1,76 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uiespresso.localization.assertions;
+
+import android.support.test.espresso.NoMatchingViewException;
+import android.support.test.espresso.ViewAssertion;
+import android.view.View;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class TextDirectionAssertions {
+	public static ViewAssertion isTextDirectionRTL() {
+		return new ViewAssertion() {
+			public void check(View view, NoMatchingViewException noView) {
+				assertThat(view, new TextDirectionMatcher(View.TEXT_DIRECTION_FIRST_STRONG));
+			}
+		};
+	}
+
+	private static class TextDirectionMatcher extends BaseMatcher<View> {
+		private int textDirection;
+
+		private TextDirectionMatcher(int textDirection) {
+			this.textDirection = textDirection;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			String textDirectionStr;
+			if (textDirection == View.TEXT_DIRECTION_FIRST_STRONG) {
+				textDirectionStr = "Right to Left";
+			} else {
+				textDirectionStr = "Left to Right";
+			}
+			description.appendText("View TextDirection must has equals " + textDirectionStr);
+		}
+
+		@Override
+		public boolean matches(Object o) {
+			if (o == null) {
+				if (textDirection == View.TEXT_DIRECTION_FIRST_STRONG) {
+					return true;
+				} else if (textDirection == View.TEXT_DIRECTION_LTR) {
+					return false;
+				}
+			}
+			if (!(o instanceof View)) {
+				throw new IllegalArgumentException("Object must be instance of View. Object is instance of " + o);
+			}
+			return ((View) o).getTextDirection() == textDirection;
+		}
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/assertions/VisibilityAssertions.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/localization/assertions/VisibilityAssertions.java
@@ -1,0 +1,97 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uiespresso.localization.assertions;
+
+import android.support.test.espresso.NoMatchingViewException;
+import android.support.test.espresso.ViewAssertion;
+import android.view.View;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class VisibilityAssertions {
+	public static ViewAssertion isVisible() {
+		return new ViewAssertion() {
+			public void check(View view, NoMatchingViewException noView) {
+				assertThat(view, new VisibilityMatcher(View.VISIBLE));
+			}
+		};
+	}
+
+	public static ViewAssertion isGone() {
+		return new ViewAssertion() {
+			public void check(View view, NoMatchingViewException noView) {
+				assertThat(view, new VisibilityMatcher(View.GONE));
+			}
+		};
+	}
+
+	public static ViewAssertion isInvisible() {
+		return new ViewAssertion() {
+			public void check(View view, NoMatchingViewException noView) {
+				assertThat(view, new VisibilityMatcher(View.INVISIBLE));
+			}
+		};
+	}
+
+	private static class VisibilityMatcher extends BaseMatcher<View> {
+
+		private int visibility;
+
+		private VisibilityMatcher(int visibility) {
+			this.visibility = visibility;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			String visibilityName;
+			if (visibility == View.GONE) {
+				visibilityName = "GONE";
+			} else if (visibility == View.VISIBLE) {
+				visibilityName = "VISIBLE";
+			} else {
+				visibilityName = "INVISIBLE";
+			}
+			description.appendText("View visibility must has equals " + visibilityName);
+		}
+
+		@Override
+		public boolean matches(Object o) {
+
+			if (o == null) {
+				if (visibility == View.GONE || visibility == View.INVISIBLE) {
+					return true;
+				} else if (visibility == View.VISIBLE) {
+					return false;
+				}
+			}
+
+			if (!(o instanceof View)) {
+				throw new IllegalArgumentException("Object must be instance of View. Object is instance of " + o);
+			}
+			return ((View) o).getVisibility() == visibility;
+		}
+	}
+}


### PR DESCRIPTION
The Bidirectional localization testing checks the following screens:
Main Menu 
Program Menu 
Bricks Categories
For bi-directional testing, we need to use the following:
LAYOUT_DIRECTION_RTL`
getLayoutDirection
The warnings appear because of using the LAYOUT_DIRECTION_RTL and getLayoutDirection.