### PR TITLE
CAT-2270 Correcting the negative zero(-0) and positive zero(0) evaluation

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestOperators.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestOperators.java
@@ -27,6 +27,7 @@ import android.test.AndroidTestCase;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
 import org.catrobat.catroid.formulaeditor.Functions;
 import org.catrobat.catroid.formulaeditor.InternFormulaParser;
 import org.catrobat.catroid.formulaeditor.InternToken;
@@ -161,6 +162,21 @@ public class ParserTestOperators extends AndroidTestCase {
 				InternTokenType.STRING, "!`\"§$%&/()=????", FALSE, testSprite);
 		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "555.555", Operators.EQUAL,
 				InternTokenType.STRING, "055.77.77", FALSE, testSprite);
+	}
+
+	public void testNegativeZeroEqualsZero() {
+
+		FormulaElement formulaElement = new FormulaElement(ElementType.OPERATOR, Operators.EQUAL.name(), null,
+				new FormulaElement(ElementType.NUMBER, "-0", null),
+				new FormulaElement(ElementType.NUMBER, "0", null));
+
+		assertEquals("interpretOperatorEqual: -0 should be equal to 0", 1d, formulaElement.interpretRecursive(null));
+
+		formulaElement = new FormulaElement(ElementType.OPERATOR, Operators.EQUAL.name(), null,
+				new FormulaElement(ElementType.NUMBER, "0", null),
+				new FormulaElement(ElementType.NUMBER, "-0", null));
+
+		assertEquals("interpretOperatorEqual: 0 should be equal to -0", 1d, formulaElement.interpretRecursive(null));
 	}
 
 	public void testNotEqual() {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -891,41 +891,31 @@ public class FormulaElement implements Serializable {
 	}
 
 	private Double interpretOperatorEqual(Object left, Object right) {
+		try {
+			Double tempLeft = Double.valueOf(String.valueOf(left));
+			Double tempRight = Double.valueOf(String.valueOf(right));
+			int compareResult = getCompareResult(tempLeft, tempRight);
+			if (compareResult == 0) {
+				return 1d;
+			}
+			return 0d;
+		} catch (NumberFormatException numberFormatException) {
+			int compareResult = String.valueOf(left).compareTo(String.valueOf(right));
+			if (compareResult == 0) {
+				return 1d;
+			}
+			return 0d;
+		}
+	}
 
-		if (left instanceof String && right instanceof String) {
-			try {
-				return (Double.valueOf((String) left).compareTo(Double.valueOf((String) right))) == 0 ? 1d : 0;
-			} catch (NumberFormatException numberFormatException) {
-				int compareResult = ((String) left).compareTo((String) right);
-				if (compareResult == 0) {
-					return 1d;
-				}
-			}
+	private int getCompareResult(Double left, Double right) {
+		int compareResult;
+		if (left == 0 || right == 0) {
+			compareResult = ((Double) Math.abs(left)).compareTo(Math.abs(right));
+		} else {
+			compareResult = left.compareTo(right);
 		}
-		if (left instanceof Double && right instanceof String) {
-			try {
-				int compareResult = ((Double) left).compareTo(Double.valueOf((String) right));
-				if (compareResult == 0) {
-					return 1d;
-				}
-			} catch (NumberFormatException numberFormatException) {
-				return 0d;
-			}
-		}
-		if (left instanceof String && right instanceof Double) {
-			try {
-				int compareResult = Double.valueOf((String) left).compareTo((Double) right);
-				if (compareResult == 0) {
-					return 1d;
-				}
-			} catch (NumberFormatException numberFormatException) {
-				return 0d;
-			}
-		}
-		if (left instanceof Double && right instanceof Double) {
-			return (((Double) left).compareTo((Double) right) == 0) ? 1d : 0d;
-		}
-		return 0d;
+		return compareResult;
 	}
 
 	private Double interpretOperator(Object object) {


### PR DESCRIPTION
CAT-2270 Evaluating -0 = 0 to True 

Earlier -0 and 0 evaluates to False (-0 = 0 is False) and now after the correction -0 and 0 evaluates to True (-0 = 0 is True).

Note: This pull request also includes test file.