### PR TITLE
CAT-2345 Multilingual Feature on Application Level

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/testsuites/AllEspressoTestsSuite.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/testsuites/AllEspressoTestsSuite.java
@@ -107,6 +107,7 @@ import org.catrobat.catroid.uiespresso.stage.MultipleBroadcastsTest;
 import org.catrobat.catroid.uiespresso.stage.ObjectVariableTest;
 import org.catrobat.catroid.uiespresso.stage.StagePausedTest;
 import org.catrobat.catroid.uiespresso.stage.StageSimpleTest;
+import org.catrobat.catroid.uiespresso.ui.activity.LanguageSwitchMainMenuTest;
 import org.catrobat.catroid.uiespresso.ui.activity.SettingsActivityTest;
 import org.catrobat.catroid.uiespresso.ui.dialog.AboutDialogTest;
 import org.catrobat.catroid.uiespresso.ui.dialog.DeleteLookDialogTest;
@@ -211,7 +212,8 @@ import org.junit.runners.Suite;
 		DeleteSoundDialogTest.class,
 		TermsOfUseDialogTest.class,
 		DeleteLookDialogTest.class,
-		AboutDialogTest.class
+		AboutDialogTest.class,
+		LanguageSwitchMainMenuTest.class
 })
 public class AllEspressoTestsSuite {
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/LanguageSwitchMainMenuTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/LanguageSwitchMainMenuTest.java
@@ -1,0 +1,142 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.activity;
+
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.preference.PreferenceManager;
+import android.support.annotation.RequiresApi;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingResource;
+import android.support.test.espresso.matcher.PreferenceMatchers;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.ui.MainMenuActivity;
+import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Locale;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import static org.catrobat.catroid.common.Constants.DEVICE_LANGUAGE;
+import static org.catrobat.catroid.common.Constants.LANGUAGE_TAG_KEY;
+import static org.catrobat.catroid.uiespresso.ui.activity.RtlUiTestUtils.checkTextDirection;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.getResources;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.getResourcesString;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+
+@RunWith(AndroidJUnit4.class)
+public class LanguageSwitchMainMenuTest {
+	private IdlingResource idlingResource;
+	private static final Locale ARABICLOCALE = new Locale("ar");
+	private static final Locale DEUTSCHLOCALE = Locale.GERMAN;
+	private Configuration conf = getResources().getConfiguration();
+
+	@Rule
+	public BaseActivityInstrumentationRule<SettingsActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(SettingsActivity.class);
+
+	@Before
+	public void setUp() throws Exception {
+		baseActivityTestRule.launchActivity(null);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		SharedPreferences.Editor shared = PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry
+				.getTargetContext()).edit();
+		shared.putString(LANGUAGE_TAG_KEY, DEVICE_LANGUAGE);
+		shared.commit();
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+	@Test
+	public void testChangeLanguageToArabic() {
+		onData(PreferenceMatchers.withTitle(R.string.preference_title_language))
+				.perform(click());
+		onData(hasToString(startsWith(ARABICLOCALE.getDisplayName(ARABICLOCALE))))
+				.perform(click());
+		MainMenuActivity mainMenuActivity = (MainMenuActivity) UiTestUtils.getCurrentActivity();
+		idlingResource = mainMenuActivity.getIdlingResource();
+		Espresso.registerIdlingResources(idlingResource);
+
+		assertEquals(Locale.getDefault().getDisplayLanguage(), ARABICLOCALE.getDisplayLanguage());
+		assertTrue(checkTextDirection(Locale.getDefault().getDisplayName()));
+		assertEquals(View.LAYOUT_DIRECTION_RTL, conf.getLayoutDirection());
+		String buttonContinueName = getResourcesString(R.string.main_menu_continue);
+		onView(withId(R.id.main_menu_button_continue))
+				.check(matches(withText(containsString(buttonContinueName))));
+		onView(withId(R.id.main_menu_button_new))
+				.check(matches(withText(R.string.main_menu_new)));
+		onView(withId(R.id.main_menu_button_programs))
+				.check(matches(withText(R.string.main_menu_programs)));
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testChangeLanguageToDeutsch() {
+		onData(PreferenceMatchers.withTitle(R.string.preference_title_language))
+				.perform(click());
+		onData(hasToString(startsWith(DEUTSCHLOCALE.getDisplayName(DEUTSCHLOCALE))))
+				.perform(click());
+		MainMenuActivity mainMenuActivity = (MainMenuActivity) UiTestUtils.getCurrentActivity();
+		idlingResource = mainMenuActivity.getIdlingResource();
+		Espresso.registerIdlingResources(idlingResource);
+
+		assertEquals(Locale.getDefault().getDisplayLanguage(), DEUTSCHLOCALE
+				.getDisplayLanguage());
+		String buttonContinueName = getResourcesString(R.string.main_menu_continue);
+		onView(withId(R.id.main_menu_button_continue))
+				.check(matches(withText(containsString(buttonContinueName))));
+		onView(withId(R.id.main_menu_button_new))
+				.check(matches(withText(R.string.main_menu_new)));
+		onView(withId(R.id.main_menu_button_programs))
+				.check(matches(withText(R.string.main_menu_programs)));
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/RtlUiTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/RtlUiTestUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.activity;
+
+public final class RtlUiTestUtils {
+	private RtlUiTestUtils() {
+		throw new AssertionError();
+	}
+
+	public static boolean checkTextDirection(String string) {
+		return Character.getDirectionality(string.charAt(0)) == Character.DIRECTIONALITY_RIGHT_TO_LEFT
+				||
+				Character.getDirectionality(string.charAt(0)) == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsActivityTest.java
@@ -31,25 +31,35 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
 import org.catrobat.catroid.uiespresso.util.BaseActivityInstrumentationRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
+import static org.catrobat.catroid.common.Constants.LANGUAGE_CODE;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_CAST_GLOBALLY_ENABLED;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_CRASH_REPORTS;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED;
@@ -62,6 +72,9 @@ import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_NFC_BRICKS;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_PHIRO_BRICKS;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_RASPI_BRICKS;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.core.Is.is;
 
 @RunWith(AndroidJUnit4.class)
 public class SettingsActivityTest {
@@ -112,6 +125,7 @@ public class SettingsActivityTest {
 		initialSettings.clear();
 	}
 
+	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void basicSettingsTest() {
 		checkPreference(R.string.preference_title_enable_arduino_bricks, SETTINGS_SHOW_ARDUINO_BRICKS);
@@ -122,6 +136,7 @@ public class SettingsActivityTest {
 		checkPreference(R.string.preference_title_cast_feature_globally_enabled, SETTINGS_CAST_GLOBALLY_ENABLED);
 	}
 
+	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Gadgets.class})
 	@Test
 	public void legoNxtSettingsTest() {
 		onData(PreferenceMatchers.withTitle(R.string.preference_title_enable_mindstorms_nxt_bricks))
@@ -131,6 +146,7 @@ public class SettingsActivityTest {
 		checkPreference(R.string.preference_disable_nxt_info_dialog, SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED);
 	}
 
+	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Gadgets.class})
 	@Test
 	public void legoEv3SettingsTest() {
 		onData(PreferenceMatchers.withTitle(R.string.preference_title_enable_mindstorms_ev3_bricks))
@@ -141,6 +157,7 @@ public class SettingsActivityTest {
 				SETTINGS_MINDSTORMS_EV3_SHOW_SENSOR_INFO_BOX_DISABLED);
 	}
 
+	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Gadgets.class})
 	@Test
 	public void parrotArSettingsTest() {
 		onData(PreferenceMatchers.withTitle(R.string.preference_title_enable_quadcopter_bricks))
@@ -149,12 +166,43 @@ public class SettingsActivityTest {
 		checkPreference(R.string.preference_title_enable_quadcopter_bricks, SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS);
 	}
 
+	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Gadgets.class})
 	@Test
 	public void rasPiSettingsTest() {
 		onData(PreferenceMatchers.withTitle(R.string.preference_title_enable_raspi_bricks))
 				.perform(click());
 
 		checkPreference(R.string.preference_title_enable_raspi_bricks, SETTINGS_SHOW_RASPI_BRICKS);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void languageSettingTest() {
+		onData(PreferenceMatchers.withTitle(R.string.preference_title_language))
+				.perform(click());
+		onView(withText(R.string.preference_title_language))
+				.check(matches(isDisplayed()));
+		onData(is(instanceOf(String.class))).atPosition(0)
+				.check(matches(withText(R.string.device_language)));
+		for (String rtlLanguage : LANGUAGE_CODE) {
+
+			if (rtlLanguage.equals("sd")) {
+				onData(hasToString("سنڌي"))
+						.check(matches(isDisplayed()));
+			} else if (rtlLanguage.length() == 2) {
+				Locale rtlLocale = new Locale(rtlLanguage);
+				onData(hasToString(rtlLocale.getDisplayName(rtlLocale)))
+						.check(matches(isDisplayed()));
+			} else if (rtlLanguage.length() == 6) {
+				String language = rtlLanguage.substring(0, 2);
+				String country = rtlLanguage.substring(4);
+				Locale rtlLocale = new Locale(language, country);
+				onData(hasToString(rtlLocale.getDisplayName(rtlLocale)))
+						.check(matches(isDisplayed()));
+			}
+		}
+		onView(withId(android.R.id.button2))
+				.check(matches(isDisplayed()));
 	}
 
 	private void checkPreference(int displayedTitleResourceString, String sharedPreferenceTag) {

--- a/catroid/src/main/java/org/catrobat/catroid/CatroidApplication.java
+++ b/catroid/src/main/java/org/catrobat/catroid/CatroidApplication.java
@@ -23,13 +23,23 @@
 package org.catrobat.catroid;
 
 import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.support.multidex.MultiDex;
 import android.support.multidex.MultiDexApplication;
 import android.util.Log;
 
 import com.parrot.freeflight.settings.ApplicationSettings;
 
+import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.utils.CrashReporter;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import static org.catrobat.catroid.common.Constants.DEVICE_LANGUAGE;
+import static org.catrobat.catroid.common.Constants.LANGUAGE_CODE;
+import static org.catrobat.catroid.common.Constants.LANGUAGE_TAG_KEY;
 
 public class CatroidApplication extends MultiDexApplication {
 
@@ -39,8 +49,8 @@ public class CatroidApplication extends MultiDexApplication {
 	private static Context context;
 
 	public static final String OS_ARCH = System.getProperty("os.arch");
-
 	public static boolean parrotLibrariesLoaded = false;
+	public static String defaultSystemLanguage;
 
 	@Override
 	public void onCreate() {
@@ -49,6 +59,7 @@ public class CatroidApplication extends MultiDexApplication {
 		Log.d(TAG, "CatroidApplication onCreate");
 		settings = new ApplicationSettings(this);
 		CatroidApplication.context = getApplicationContext();
+		setAppLanguage();
 	}
 
 	@Override
@@ -80,6 +91,22 @@ public class CatroidApplication extends MultiDexApplication {
 			parrotLibrariesLoaded = false;
 		}
 		return parrotLibrariesLoaded;
+	}
+
+	private void setAppLanguage() {
+		defaultSystemLanguage = Locale.getDefault().getLanguage();
+		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+		String languageTag = sharedPreferences.getString(LANGUAGE_TAG_KEY, "");
+
+		if (languageTag.equals(DEVICE_LANGUAGE)) {
+			SettingsActivity.updateLocale(getAppContext(), defaultSystemLanguage, "");
+		} else if (Arrays.asList(LANGUAGE_CODE).contains(languageTag) && languageTag.length() == 2) {
+			SettingsActivity.updateLocale(getAppContext(), languageTag, "");
+		} else if (Arrays.asList(LANGUAGE_CODE).contains(languageTag) && languageTag.length() == 6) {
+			String language = languageTag.substring(0, 2);
+			String country = languageTag.substring(4);
+			SettingsActivity.updateLocale(getAppContext(), language, country);
+		}
 	}
 
 	public static Context getAppContext() {

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -260,6 +260,14 @@ public final class Constants {
 	public static final int STATUS_CODE_UPLOAD_OLD_CATROBAT_LANGUAGE = 518;
 	public static final int STATUS_CODE_UPLOAD_OLD_CATROBAT_VERSION = 519;
 
+	//Multilingual feature
+	public static final String LANGUAGE_TAG_KEY = "applicationLanguage";
+	public static final String DEVICE_LANGUAGE = "deviceLanguage";
+	public static final String[] LANGUAGE_CODE = {DEVICE_LANGUAGE, "az", "bs", "ca", "cs", "sr-rCS", "sr-rSP", "da",
+			"de", "en-rAU", "en-rCA", "en-rGB", "en", "es", "fr", "gl", "hr", "in", "it", "sw-rKE", "hu", "mk", "ms",
+			"nl", "no", "pl", "pt-rBR", "pt", "ru", "ro", "sq", "sl", "sk", "sv", "vi", "tr", "ml", "ta", "te", "th",
+			"gu", "hi", "ja", "ko", "zh-rCN", "zh-rTW", "ar", "ur", "fa", "ps", "sd", "iw"};
+
 	// Suppress default constructor for noninstantiability
 	private Constants() {
 		throw new AssertionError();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
@@ -22,9 +22,13 @@
  */
 package org.catrobat.catroid.ui;
 
+import android.annotation.TargetApi;
 import android.app.ActionBar;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
@@ -35,6 +39,7 @@ import android.preference.PreferenceActivity;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
+import android.util.DisplayMetrics;
 import android.view.MenuItem;
 
 import org.catrobat.catroid.BuildConfig;
@@ -44,6 +49,15 @@ import org.catrobat.catroid.devices.mindstorms.ev3.sensors.EV3Sensor;
 import org.catrobat.catroid.devices.mindstorms.nxt.sensors.NXTSensor;
 import org.catrobat.catroid.utils.CrashReporter;
 import org.catrobat.catroid.utils.SnackbarUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.catrobat.catroid.CatroidApplication.defaultSystemLanguage;
+import static org.catrobat.catroid.common.Constants.DEVICE_LANGUAGE;
+import static org.catrobat.catroid.common.Constants.LANGUAGE_CODE;
+import static org.catrobat.catroid.common.Constants.LANGUAGE_TAG_KEY;
 
 public class SettingsActivity extends PreferenceActivity {
 
@@ -60,6 +74,7 @@ public class SettingsActivity extends PreferenceActivity {
 	public static final String SETTINGS_PARROT_AR_DRONE_CATROBAT_TERMS_OF_SERVICE_ACCEPTED_PERMANENTLY = "setting_parrot_ar_drone_catrobat_terms_of_service_accepted_permanently";
 	public static final String SETTINGS_CAST_GLOBALLY_ENABLED = "setting_cast_globally_enabled";
 	public static final String SETTINGS_SHOW_HINTS = "setting_enable_hints";
+	public static final String SETTINGS_MULTILINGUAL = "setting_multilingual";
 	PreferenceScreen screen = null;
 
 	public static final String NXT_SENSOR_1 = "setting_mindstorms_nxt_sensor_1";
@@ -101,6 +116,7 @@ public class SettingsActivity extends PreferenceActivity {
 		setDronePreferences();
 		setHintPreferences();
 		updateActionBar();
+		setLanguage();
 
 		screen = getPreferenceScreen();
 
@@ -613,5 +629,74 @@ public class SettingsActivity extends PreferenceActivity {
 				return true;
 		}
 		return super.onOptionsItemSelected(item);
+	}
+
+	private void setLanguage() {
+		final List<String> languagesNames = new ArrayList<>();
+		for (String aLanguageCode : LANGUAGE_CODE) {
+			switch (aLanguageCode) {
+				case "sd":
+					languagesNames.add("سنڌي");
+					break;
+				case DEVICE_LANGUAGE:
+					languagesNames.add(getResources().getString(R.string.device_language));
+					break;
+				default:
+					if (aLanguageCode.length() == 2) {
+						languagesNames.add(new Locale(aLanguageCode).getDisplayName(new Locale(aLanguageCode)));
+					} else {
+						String language = aLanguageCode.substring(0, 2);
+						String country = aLanguageCode.substring(4);
+						languagesNames.add(new Locale(language, country).getDisplayName(new Locale(language, country)));
+					}
+			}
+		}
+
+		String[] languages = new String[languagesNames.size()];
+		languagesNames.toArray(languages);
+
+		final ListPreference listPreference = (ListPreference) findPreference(SETTINGS_MULTILINGUAL);
+		listPreference.setEntries(languages);
+		listPreference.setEntryValues(LANGUAGE_CODE);
+		listPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+			@Override
+			public boolean onPreferenceChange(Preference preference, Object newValue) {
+				String selectedLanguageCode = newValue.toString();
+				if (selectedLanguageCode.equals(DEVICE_LANGUAGE)) {
+					updateLocale(getBaseContext(), defaultSystemLanguage, "");
+					setLanguageSharedPreference(defaultSystemLanguage);
+				} else if (selectedLanguageCode.length() == 2) {
+					updateLocale(getBaseContext(), selectedLanguageCode, "");
+					setLanguageSharedPreference(selectedLanguageCode);
+				} else if (selectedLanguageCode.length() == 6) {
+					String language = selectedLanguageCode.substring(0, 2);
+					String country = selectedLanguageCode.substring(4);
+					updateLocale(getBaseContext(), language, country);
+					setLanguageSharedPreference(selectedLanguageCode);
+				}
+				startActivity(new Intent(getBaseContext(), MainMenuActivity.class));
+				finishAffinity();
+				return true;
+			}
+		});
+	}
+
+	@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+	public static void updateLocale(Context context, String languageTag, String countryTag) {
+		Locale mLocale;
+		mLocale = new Locale(languageTag, countryTag);
+		Resources resources = context.getResources();
+		DisplayMetrics displayMetrics = resources.getDisplayMetrics();
+		Configuration conf = resources.getConfiguration();
+		conf.locale = mLocale;
+		Locale.setDefault(mLocale);
+		conf.setLayoutDirection(mLocale);
+		resources.updateConfiguration(conf, displayMetrics);
+	}
+
+	private void setLanguageSharedPreference(String value) {
+		SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();
+		editor.putString(LANGUAGE_TAG_KEY, value);
+		editor.commit();
 	}
 }

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -112,6 +112,8 @@
 
     <!-- Settings activity -->
     <string name="preference_title">Settings</string>
+    <string name="preference_title_language">Language</string>
+    <string name="preference_description_language">Allow to change PocketCode Language</string>
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone bricks</string>
     <string name="preference_description_quadcopter_bricks">Allow to control AR.Drone 2.0 quadcopters</string>
     <string name="preference_title_enable_mindstorms_nxt_bricks">Lego Mindstorms NXT bricks</string>
@@ -1629,5 +1631,9 @@
     <string name="crash_dialog_send">Send</string>
     <string name="plus" translatable="false">+</string>
     <!--  -->
+
+    <!-- Multilingual List -->
+    <string name="device_language">Device Language</string>
+
 </resources>
 

--- a/catroid/src/main/res/xml/preferences.xml
+++ b/catroid/src/main/res/xml/preferences.xml
@@ -22,51 +22,63 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.catrobat.catroid">
+<PreferenceScreen package="org.catrobat.catroid"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <ListPreference
+        android:defaultValue="false"
+        android:key="setting_multilingual"
+        android:summary="@string/preference_description_language"
+        android:title="@string/preference_title_language" />
 
     <PreferenceScreen
         android:key="setting_mindstorms_nxt_bricks"
         android:summary="@string/preference_description_mindstorms_nxt_bricks"
-        android:title="@string/preference_title_enable_mindstorms_nxt_bricks" >
+        android:title="@string/preference_title_enable_mindstorms_nxt_bricks">
 
-        <CheckBoxPreference android:key="settings_mindstorms_nxt_bricks_enabled"
+        <CheckBoxPreference
             android:defaultValue="false"
+            android:key="settings_mindstorms_nxt_bricks_enabled"
             android:summary="@string/preference_description_mindstorms_nxt_bricks"
             android:title="@string/preference_title_enable_mindstorms_nxt_bricks" />
 
-        <CheckBoxPreference android:key="settings_mindstorms_nxt_show_sensor_info_box_disabled"
+        <CheckBoxPreference
             android:defaultValue="false"
-            android:title="@string/preference_disable_nxt_info_dialog"
-            android:summary="@string/preference_disable_nxt_info_dialog_description"/>
+            android:key="settings_mindstorms_nxt_show_sensor_info_box_disabled"
+            android:summary="@string/preference_disable_nxt_info_dialog_description"
+            android:title="@string/preference_disable_nxt_info_dialog" />
 
         <PreferenceCategory android:title="@string/preference_title_mindstorms_nxt_sensors">
             <Preference android:summary="@string/preference_title_mindstorms_nxt_sensors_description" />
 
-            <ListPreference android:key="setting_mindstorms_nxt_sensor_1"
-                android:title="@string/nxt_choose_sensor_1"
-                android:entryValues="@array/nxt_sensor_chooser"
-                android:entries="@array/nxt_sensor_chooser"
+            <ListPreference
                 android:defaultValue="@string/nxt_sensor_touch"
-                android:summary="%s"/>
-            <ListPreference android:key="setting_mindstorms_nxt_sensor_2"
-                android:title="@string/nxt_choose_sensor_2"
-                android:entryValues="@array/nxt_sensor_chooser"
                 android:entries="@array/nxt_sensor_chooser"
+                android:entryValues="@array/nxt_sensor_chooser"
+                android:key="setting_mindstorms_nxt_sensor_1"
+                android:summary="%s"
+                android:title="@string/nxt_choose_sensor_1" />
+            <ListPreference
                 android:defaultValue="@string/nxt_sensor_sound"
-                android:summary="%s"/>
-            <ListPreference android:key="setting_mindstorms_nxt_sensor_3"
-                android:title="@string/nxt_choose_sensor_3"
-                android:entryValues="@array/nxt_sensor_chooser"
                 android:entries="@array/nxt_sensor_chooser"
+                android:entryValues="@array/nxt_sensor_chooser"
+                android:key="setting_mindstorms_nxt_sensor_2"
+                android:summary="%s"
+                android:title="@string/nxt_choose_sensor_2" />
+            <ListPreference
                 android:defaultValue="@string/nxt_sensor_light"
-                android:summary="%s"/>
-            <ListPreference android:key="setting_mindstorms_nxt_sensor_4"
-                android:title="@string/nxt_choose_sensor_4"
-                android:entryValues="@array/nxt_sensor_chooser"
                 android:entries="@array/nxt_sensor_chooser"
+                android:entryValues="@array/nxt_sensor_chooser"
+                android:key="setting_mindstorms_nxt_sensor_3"
+                android:summary="%s"
+                android:title="@string/nxt_choose_sensor_3" />
+            <ListPreference
                 android:defaultValue="@string/nxt_sensor_ultrasonic"
-                android:summary="%s"/>
+                android:entries="@array/nxt_sensor_chooser"
+                android:entryValues="@array/nxt_sensor_chooser"
+                android:key="setting_mindstorms_nxt_sensor_4"
+                android:summary="%s"
+                android:title="@string/nxt_choose_sensor_4" />
         </PreferenceCategory>
 
     </PreferenceScreen>
@@ -74,52 +86,58 @@
     <PreferenceScreen
         android:key="setting_mindstorms_ev3_bricks"
         android:summary="@string/preference_description_mindstorms_ev3_bricks"
-        android:title="@string/preference_title_enable_mindstorms_ev3_bricks" >
+        android:title="@string/preference_title_enable_mindstorms_ev3_bricks">
 
-         <CheckBoxPreference android:key="settings_mindstorms_ev3_bricks_enabled"
+         <CheckBoxPreference
              android:defaultValue="false"
+             android:key="settings_mindstorms_ev3_bricks_enabled"
              android:summary="@string/preference_description_mindstorms_ev3_bricks"
              android:title="@string/preference_title_enable_mindstorms_ev3_bricks" />
 
-        <CheckBoxPreference android:key="settings_mindstorms_ev3_show_sensor_info_box_disabled"
+        <CheckBoxPreference
             android:defaultValue="false"
-            android:title="@string/preference_disable_nxt_info_dialog"
-            android:summary="@string/preference_disable_ev3_info_dialog_description"/>
+            android:key="settings_mindstorms_ev3_show_sensor_info_box_disabled"
+            android:summary="@string/preference_disable_ev3_info_dialog_description"
+            android:title="@string/preference_disable_nxt_info_dialog" />
 
         <PreferenceCategory android:title="@string/preference_title_mindstorms_ev3_sensors">
             <Preference android:summary="@string/preference_title_mindstorms_ev3_sensors_description" />
 
-            <ListPreference android:key="setting_mindstorms_ev3_sensor_1"
-                android:title="@string/ev3_choose_sensor_1"
-                android:entryValues="@array/ev3_sensor_chooser"
-                android:entries="@array/ev3_sensor_chooser"
+            <ListPreference
                 android:defaultValue="@string/ev3_sensor_touch"
-                android:summary="%s"/>
-            <ListPreference android:key="setting_mindstorms_ev3_sensor_2"
-                android:title="@string/ev3_choose_sensor_2"
-                android:entryValues="@array/ev3_sensor_chooser"
                 android:entries="@array/ev3_sensor_chooser"
+                android:entryValues="@array/ev3_sensor_chooser"
+                android:key="setting_mindstorms_ev3_sensor_1"
+                android:summary="%s"
+                android:title="@string/ev3_choose_sensor_1" />
+            <ListPreference
                 android:defaultValue="@string/ev3_sensor_color"
-                android:summary="%s"/>
-            <ListPreference android:key="setting_mindstorms_ev3_sensor_3"
-                android:title="@string/ev3_choose_sensor_3"
-                android:entryValues="@array/ev3_sensor_chooser"
                 android:entries="@array/ev3_sensor_chooser"
+                android:entryValues="@array/ev3_sensor_chooser"
+                android:key="setting_mindstorms_ev3_sensor_2"
+                android:summary="%s"
+                android:title="@string/ev3_choose_sensor_2" />
+            <ListPreference
                 android:defaultValue="@string/ev3_sensor_infrared"
-                android:summary="%s"/>
-            <ListPreference android:key="setting_mindstorms_ev3_sensor_4"
-                android:title="@string/ev3_choose_sensor_4"
-                android:entryValues="@array/ev3_sensor_chooser"
                 android:entries="@array/ev3_sensor_chooser"
+                android:entryValues="@array/ev3_sensor_chooser"
+                android:key="setting_mindstorms_ev3_sensor_3"
+                android:summary="%s"
+                android:title="@string/ev3_choose_sensor_3" />
+            <ListPreference
                 android:defaultValue="@string/ev3_no_sensor"
-                android:summary="%s"/>
+                android:entries="@array/ev3_sensor_chooser"
+                android:entryValues="@array/ev3_sensor_chooser"
+                android:key="setting_mindstorms_ev3_sensor_4"
+                android:summary="%s"
+                android:title="@string/ev3_choose_sensor_4" />
         </PreferenceCategory>
     </PreferenceScreen>
 
     <PreferenceScreen
         android:key="setting_parrot_ar_drone_bricks"
         android:summary="@string/preference_description_quadcopter_bricks"
-        android:title="@string/preference_title_enable_quadcopter_bricks" >
+        android:title="@string/preference_title_enable_quadcopter_bricks">
 
         <CheckBoxPreference
             android:defaultValue="false"
@@ -131,35 +149,40 @@
         <PreferenceCategory android:title="@string/preference_title_drone_config_properties">
             <Preference android:summary="@string/preference_title_drone_properties_setting_description" />
 
-            <ListPreference android:key="setting_drone_basic_configs"
-                android:title="@string/brick_drone_set_config"
+            <ListPreference
                 android:defaultValue="SECOND"
-                android:summary="%s"/>
-            <ListPreference android:key="setting_drone_altitude_limit"
-                android:title="@string/brick_drone_set_altitude"
+                android:key="setting_drone_basic_configs"
+                android:summary="%s"
+                android:title="@string/brick_drone_set_config" />
+            <ListPreference
                 android:defaultValue="SECOND"
-                android:summary="%s"/>
-            <ListPreference android:key="setting_drone_vertical_speed"
-                android:title="@string/brick_drone_set_vertical_speed"
+                android:key="setting_drone_altitude_limit"
+                android:summary="%s"
+                android:title="@string/brick_drone_set_altitude" />
+            <ListPreference
                 android:defaultValue="SECOND"
-                android:summary="%s"/>
-            <ListPreference android:key="setting_drone_rotation_speed"
-                android:title="@string/brick_drone_set_rotation_speed"
+                android:key="setting_drone_vertical_speed"
+                android:summary="%s"
+                android:title="@string/brick_drone_set_vertical_speed" />
+            <ListPreference
                 android:defaultValue="SECOND"
-                android:summary="%s"/>
-            <ListPreference android:key="setting_drone_tilt_angle"
-                android:title="@string/brick_drone_set_tilt_limit"
+                android:key="setting_drone_rotation_speed"
+                android:summary="%s"
+                android:title="@string/brick_drone_set_rotation_speed" />
+            <ListPreference
                 android:defaultValue="SECOND"
-                android:summary="%s"/>
+                android:key="setting_drone_tilt_angle"
+                android:summary="%s"
+                android:title="@string/brick_drone_set_tilt_limit" />
         </PreferenceCategory>
 
     </PreferenceScreen>
 
      <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="setting_arduino_bricks"
-        android:summary="@string/preference_description_arduino_bricks"
-        android:title="@string/preference_title_enable_arduino_bricks" />
+         android:defaultValue="false"
+         android:key="setting_arduino_bricks"
+         android:summary="@string/preference_description_arduino_bricks"
+         android:title="@string/preference_title_enable_arduino_bricks" />
 
     <CheckBoxPreference
         android:defaultValue="false"
@@ -171,7 +194,7 @@
     <PreferenceScreen
         android:key="settings_raspberry_screen"
         android:summary="@string/preference_description_raspi_bricks"
-        android:title="@string/preference_title_enable_raspi_bricks" >
+        android:title="@string/preference_title_enable_raspi_bricks">
 
         <CheckBoxPreference
             android:defaultValue="false"
@@ -180,32 +203,34 @@
             android:title="@string/preference_title_enable_raspi_bricks" />
 
         <PreferenceCategory
-            android:title="@string/raspi_settings_title_name"
-            android:key="setting_raspi_connection_settings_category">
+            android:key="setting_raspi_connection_settings_category"
+            android:title="@string/raspi_settings_title_name">
             <PreferenceScreen
-                android:title="@string/preference_raspi_help"
-                android:summary="@string/preference_raspi_help_summary">
+                android:summary="@string/preference_raspi_help_summary"
+                android:title="@string/preference_raspi_help">
                 <intent
                     android:action="android.intent.action.VIEW"
-                    android:data="@string/preference_raspi_help_link"
-                    />
+                    android:data="@string/preference_raspi_help_link" />
             </PreferenceScreen>
 
-            <EditTextPreference android:key="setting_raspi_host_preference"
-                android:title="@string/preference_raspi_host"
-                android:defaultValue="192.168.0.1" />
+            <EditTextPreference
+                android:defaultValue="192.168.0.1"
+                android:key="setting_raspi_host_preference"
+                android:title="@string/preference_raspi_host" />
 
-            <EditTextPreference android:key="setting_raspi_port_preference"
-                android:title="@string/preference_raspi_port"
+            <EditTextPreference
+                android:defaultValue="10000"
                 android:inputType="number"
-                android:defaultValue="10000" />
+                android:key="setting_raspi_port_preference"
+                android:title="@string/preference_raspi_port" />
 
-            <ListPreference android:key="setting_raspi_version_preference"
-                android:title="@string/raspi_settings_gpio_version"
-                android:summary="%s"
+            <ListPreference
+                android:defaultValue="a01041"
                 android:entries="@array/raspi_version_spinner_names"
                 android:entryValues="@array/raspi_version_spinner_revisions"
-                android:defaultValue="a01041"/>
+                android:key="setting_raspi_version_preference"
+                android:summary="%s"
+                android:title="@string/raspi_settings_gpio_version" />
         </PreferenceCategory>
 
     </PreferenceScreen>


### PR DESCRIPTION
The app must provide an interface that handles user input to switch languages independent of the smartphone’s global settings. This feature should list all languages supported by the app including languages not yet supported by the operating system.