### PR TITLE
CAT-2355 Removing Hard-Coding String

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilFileTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilFileTest.java
@@ -95,7 +95,7 @@ public class UtilFileTest extends InstrumentationTestCase {
 
 		double expectedSizeInKilobytes = 84.2;
 		assertEquals("Unexpected file size String", String.format(Locale.getDefault(), "%.1f KB", expectedSizeInKilobytes),
-				UtilFile.getSizeAsString(testDirectory));
+				UtilFile.getSizeAsString(testDirectory, getInstrumentation().getTargetContext()));
 
 		for (int i = 2; i < 48; i++) {
 			UtilFile.saveFileToProject("testDirectory", "testScene", i + "testsound.mp3",
@@ -104,7 +104,8 @@ public class UtilFileTest extends InstrumentationTestCase {
 		}
 		DecimalFormat decimalFormat = new DecimalFormat("#.0");
 		String expected = decimalFormat.format(2.0) + " MB";
-		assertEquals("Unexpected file size String", expected, UtilFile.getSizeAsString(testDirectory));
+		assertEquals("Unexpected file size String", expected, UtilFile.getSizeAsString(testDirectory,
+				getInstrumentation().getTargetContext()));
 
 		PrintWriter printWriter = null;
 
@@ -123,7 +124,8 @@ public class UtilFileTest extends InstrumentationTestCase {
 			}
 		}
 
-		assertEquals("Unexpected Filesize!", "7 Byte", UtilFile.getSizeAsString(testFile));
+		assertEquals("Unexpected Filesize!", "7 B", UtilFile.getSizeAsString(testFile, getInstrumentation()
+				.getTargetContext()));
 
 		UtilFile.deleteDirectory(testDirectory);
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/testsuites/AllEspressoTestsSuite.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/testsuites/AllEspressoTestsSuite.java
@@ -131,6 +131,9 @@ import org.catrobat.catroid.uiespresso.stage.StagePausedTest;
 import org.catrobat.catroid.uiespresso.stage.StageSimpleTest;
 import org.catrobat.catroid.uiespresso.ui.activity.ProjectActivityNumberOfBricksRegressionTest;
 import org.catrobat.catroid.uiespresso.ui.activity.SettingsActivityTest;
+import org.catrobat.catroid.uiespresso.ui.activity.rtl.ArabicStringAsSizeUnitLooksTest;
+import org.catrobat.catroid.uiespresso.ui.activity.rtl.ArabicStringAsSizeUnitSoundsTest;
+import org.catrobat.catroid.uiespresso.ui.activity.rtl.ArabicTextAsSizeUnitMyProjectActivityTest;
 import org.catrobat.catroid.uiespresso.ui.activity.rtl.HindiNumberAtShowDetailsAtProjectActivityTest;
 import org.catrobat.catroid.uiespresso.ui.activity.rtl.LanguageSwitchMainMenuTest;
 import org.catrobat.catroid.uiespresso.ui.dialog.AboutDialogTest;
@@ -247,6 +250,9 @@ import org.junit.runners.Suite;
 		StagePausedTest.class,
 		BroadcastForClonesRegressionTest.class,
 		StageSimpleTest.class,
+		ArabicStringAsSizeUnitLooksTest.class,
+		ArabicStringAsSizeUnitSoundsTest.class,
+		ArabicTextAsSizeUnitMyProjectActivityTest.class,
 		ObjectVariableTest.class,
 		MultipleBroadcastsTest.class,
 		BroadcastReceiverRegressionTest.class,

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/ArabicStringAsSizeUnitLooksTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/ArabicStringAsSizeUnitLooksTest.java
@@ -1,0 +1,166 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.activity.rtl;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.SingleSprite;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.PlaceAtBrick;
+import org.catrobat.catroid.content.bricks.SetSizeToBrick;
+import org.catrobat.catroid.io.StorageHandler;
+import org.catrobat.catroid.ui.ScriptActivity;
+import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uiespresso.util.FileTestUtils;
+import org.catrobat.catroid.utils.UtilUi;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.Locale;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static android.support.test.InstrumentationRegistry.getTargetContext;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import static org.catrobat.catroid.common.Constants.LANGUAGE_TAG_KEY;
+import static org.catrobat.catroid.uiespresso.ui.activity.rtl.RtlUiTestUtils.checkTextDirection;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.getResourcesString;
+import static org.hamcrest.Matchers.containsString;
+
+@RunWith(AndroidJUnit4.class)
+public class ArabicStringAsSizeUnitLooksTest {
+	private Locale arLocale = new Locale("ar");
+	private Locale defaultLocale = Locale.getDefault();
+	private String arabicKb = "كيلوبايت";
+	private String expectedSize = "٢٫٦";
+	private Intent intent = new Intent();
+
+	@Rule
+	public BaseActivityInstrumentationRule<ScriptActivity> activityTestRule = new
+			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+
+	@Before
+	public void setUp() throws Exception {
+		createProjectWithBlueSprite("blue");
+		SettingsActivity.updateLocale(getTargetContext(), "ar", "");
+		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_LOOKS);
+		activityTestRule.launchActivity(intent);
+		getInstrumentation().runOnMainSync(new Runnable() {
+			public void run() {
+				activityTestRule.getActivity().getFragment(ScriptActivity.FRAGMENT_LOOKS).setShowDetails(true);
+			}
+		});
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		getInstrumentation().runOnMainSync(new Runnable() {
+			public void run() {
+				activityTestRule.getActivity().getFragment(ScriptActivity.FRAGMENT_LOOKS).setShowDetails(false);
+			}
+		});
+		resetToDefaultLanguage();
+	}
+
+	@Category({Cat.AppUi.class, Level.Functional.class})
+	@Test
+	public void name() throws Exception {
+		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertTrue(checkTextDirection(Locale.getDefault().getDisplayName()));
+
+		onView(withId(R.id.fragment_look_item_size_text_view))
+				.check(matches(withText(containsString(arabicKb))));
+		onView(withId(R.id.fragment_look_item_size_text_view))
+				.check(matches(withText(expectedSize + " " + getResourcesString(R.string
+						.KiloByte_short))));
+	}
+
+	public Project createProjectWithBlueSprite(String projectName) {
+		Project project = new Project(null, projectName);
+
+		// blue Sprite
+		Sprite blueSprite = new SingleSprite("blueSprite");
+		StartScript blueStartScript = new StartScript();
+		LookData blueLookData = new LookData();
+		String blueImageName = "blue_image.bmp";
+
+		blueLookData.setLookName(blueImageName);
+
+		blueSprite.getLookDataList().add(blueLookData);
+
+		blueStartScript.addBrick(new PlaceAtBrick(0, 0));
+		blueStartScript.addBrick(new SetSizeToBrick(5000));
+		blueSprite.addScript(blueStartScript);
+
+		project.getDefaultScene().addSprite(blueSprite);
+
+		StorageHandler.getInstance().saveProject(project);
+		File blueImageFile = FileTestUtils.saveFileToProject(project.getName(), project.getDefaultScene().getName(),
+				blueImageName,
+				org.catrobat.catroid.test.R.raw.blue_image, InstrumentationRegistry.getContext(),
+				FileTestUtils.FileTypes.IMAGE);
+
+		blueLookData.setLookFilename(blueImageFile.getName());
+
+		StorageHandler.getInstance().saveProject(project);
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(blueSprite);
+		UtilUi.updateScreenWidthAndHeight(InstrumentationRegistry.getContext());
+
+		return project;
+	}
+
+	private void resetToDefaultLanguage() {
+		SharedPreferences.Editor editor = PreferenceManager
+				.getDefaultSharedPreferences(getTargetContext())
+				.edit();
+		editor.putString(LANGUAGE_TAG_KEY, defaultLocale.getLanguage());
+		editor.commit();
+		SettingsActivity.updateLocale(getTargetContext(), defaultLocale.getLanguage(),
+				defaultLocale.getCountry());
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/ArabicStringAsSizeUnitSoundsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/ArabicStringAsSizeUnitSoundsTest.java
@@ -1,0 +1,156 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.activity.rtl;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.SoundInfo;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.bricks.PlaySoundAndWaitBrick;
+import org.catrobat.catroid.content.bricks.PlaySoundBrick;
+import org.catrobat.catroid.io.SoundManager;
+import org.catrobat.catroid.ui.ScriptActivity;
+import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uiespresso.util.FileTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.List;
+import java.util.Locale;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static android.support.test.InstrumentationRegistry.getTargetContext;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import static org.catrobat.catroid.common.Constants.LANGUAGE_TAG_KEY;
+import static org.catrobat.catroid.uiespresso.ui.activity.rtl.RtlUiTestUtils.checkTextDirection;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.getResourcesString;
+import static org.hamcrest.Matchers.containsString;
+
+@RunWith(AndroidJUnit4.class)
+public class ArabicStringAsSizeUnitSoundsTest {
+	private static final int RESOURCE_SOUND = org.catrobat.catroid.test.R.raw.longsound;
+	private Locale arLocale = new Locale("ar");
+	private Locale defaultLocale = Locale.getDefault();
+	private String arabicKb = "كيلوبايت";
+	private String expectedSize = "٣٫٧";
+	private String soundName = "testSound1";
+	private File soundFile;
+	private List<SoundInfo> soundInfoList;
+	private Intent intent = new Intent();
+
+	@Rule
+	public BaseActivityInstrumentationRule<ScriptActivity> activityTestRule = new
+			BaseActivityInstrumentationRule<>(ScriptActivity.class, true, false);
+
+	@Before
+	public void setUp() throws Exception {
+		createProject();
+		SettingsActivity.updateLocale(getTargetContext(), "ar", "");
+		intent.putExtra(ScriptActivity.EXTRA_FRAGMENT_POSITION, ScriptActivity.FRAGMENT_SOUNDS);
+		activityTestRule.launchActivity(intent);
+		getInstrumentation().runOnMainSync(new Runnable() {
+			public void run() {
+				activityTestRule.getActivity().getFragment(ScriptActivity.FRAGMENT_SOUNDS).setShowDetails(true);
+			}
+		});
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		getInstrumentation().runOnMainSync(new Runnable() {
+			public void run() {
+				activityTestRule.getActivity().getFragment(ScriptActivity.FRAGMENT_SOUNDS).setShowDetails(false);
+			}
+		});
+		resetToDefaultLanguage();
+	}
+
+	@Category({Cat.AppUi.class, Level.Functional.class})
+	@Test
+	public void name() throws Exception {
+		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertTrue(checkTextDirection(Locale.getDefault().getDisplayName()));
+
+		onView(withId(R.id.fragment_sound_item_size_text_view))
+				.check(matches(withText(containsString(arabicKb))));
+		onView(withId(R.id.fragment_sound_item_size_text_view))
+				.check(matches(withText(expectedSize + " " + getResourcesString(R.string
+						.KiloByte_short))));
+	}
+
+	private void createProject() {
+		String projectName = "SoundFileSizeTest";
+		SoundManager.getInstance();
+		Script startScript = BrickTestUtils.createProjectAndGetStartScript(projectName);
+
+		startScript.addBrick(new PlaySoundAndWaitBrick());
+		startScript.addBrick(new PlaySoundBrick());
+
+		soundFile = FileTestUtils.saveFileToProject(projectName, ProjectManager.getInstance().getCurrentScene()
+						.getName(),
+				"longsound.mp3", RESOURCE_SOUND, InstrumentationRegistry.getTargetContext(),
+				FileTestUtils.FileTypes.SOUND);
+		SoundInfo soundInfo = new SoundInfo();
+		soundInfo.setSoundFileName(soundFile.getName());
+		soundInfo.setTitle(soundName);
+
+		soundInfoList = ProjectManager.getInstance().getCurrentSprite().getSoundList();
+		soundInfoList.add(soundInfo);
+
+		ProjectManager.getInstance().getFileChecksumContainer()
+				.addChecksum(soundInfo.getChecksum(), soundInfo.getAbsolutePath());
+	}
+
+	private void resetToDefaultLanguage() {
+		SharedPreferences.Editor editor = PreferenceManager
+				.getDefaultSharedPreferences(getTargetContext())
+				.edit();
+		editor.putString(LANGUAGE_TAG_KEY, defaultLocale.getLanguage());
+		editor.commit();
+		SettingsActivity.updateLocale(getTargetContext(), defaultLocale.getLanguage(),
+				defaultLocale.getCountry());
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/ArabicTextAsSizeUnitMyProjectActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/ArabicTextAsSizeUnitMyProjectActivityTest.java
@@ -1,0 +1,159 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.activity.rtl;
+
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.SingleSprite;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.PlaceAtBrick;
+import org.catrobat.catroid.content.bricks.SetSizeToBrick;
+import org.catrobat.catroid.io.StorageHandler;
+import org.catrobat.catroid.ui.MyProjectsActivity;
+import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.BaseActivityInstrumentationRule;
+import org.catrobat.catroid.uiespresso.util.FileTestUtils;
+import org.catrobat.catroid.utils.UtilUi;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.Locale;
+
+import static android.support.test.InstrumentationRegistry.getTargetContext;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import static org.catrobat.catroid.common.Constants.LANGUAGE_TAG_KEY;
+import static org.catrobat.catroid.uiespresso.ui.activity.rtl.RtlUiTestUtils.checkTextDirection;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.getResourcesString;
+import static org.hamcrest.Matchers.containsString;
+
+@RunWith(AndroidJUnit4.class)
+public class ArabicTextAsSizeUnitMyProjectActivityTest {
+	@Rule
+	public BaseActivityInstrumentationRule<MyProjectsActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(MyProjectsActivity.class);
+	private String expectedSize = "٥٫٤";
+	private String arabicKb = "كيلوبايت";
+	private Locale arLocale = new Locale("ar");
+	private Locale defaultLocale = Locale.getDefault();
+
+	@Before
+	public void setUp() throws Exception {
+		ProjectManager.getInstance().deleteCurrentProject(getTargetContext());
+		createProjectWithBlueSprite("newTest");
+		SettingsActivity.updateLocale(getTargetContext(), "ar", "");
+		baseActivityTestRule.launchActivity(null);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		resetToDefaultLanguage();
+	}
+
+	@Category({Cat.AppUi.class, Level.Functional.class})
+	@Test
+	public void name() throws Exception {
+		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertTrue(checkTextDirection(Locale.getDefault().getDisplayName()));
+
+		openActionBarOverflowOrOptionsMenu(baseActivityTestRule.getActivity());
+
+		onView(withText(R.string.show_details))
+				.perform(click());
+
+		onView(withId(R.id.details_right_bottom))
+				.check(matches(withText(containsString(arabicKb))));
+		onView(withId(R.id.details_right_bottom))
+				.check(matches(withText(expectedSize + " " + getResourcesString(R.string.KiloByte_short))
+				));
+	}
+
+	public Project createProjectWithBlueSprite(String projectName) {
+		Project project = new Project(null, projectName);
+
+		// blue Sprite
+		Sprite blueSprite = new SingleSprite("blueSprite");
+		StartScript blueStartScript = new StartScript();
+		LookData blueLookData = new LookData();
+		String blueImageName = "blue_image.bmp";
+
+		blueLookData.setLookName(blueImageName);
+
+		blueSprite.getLookDataList().add(blueLookData);
+
+		blueStartScript.addBrick(new PlaceAtBrick(0, 0));
+		blueStartScript.addBrick(new SetSizeToBrick(5000));
+		blueSprite.addScript(blueStartScript);
+
+		project.getDefaultScene().addSprite(blueSprite);
+
+		StorageHandler.getInstance().saveProject(project);
+		File blueImageFile = FileTestUtils.saveFileToProject(project.getName(), project.getDefaultScene().getName(),
+				blueImageName,
+				org.catrobat.catroid.test.R.raw.blue_image, InstrumentationRegistry.getContext(),
+				FileTestUtils.FileTypes.IMAGE);
+
+		blueLookData.setLookFilename(blueImageFile.getName());
+
+		StorageHandler.getInstance().saveProject(project);
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(blueSprite);
+		UtilUi.updateScreenWidthAndHeight(InstrumentationRegistry.getContext());
+
+		return project;
+	}
+
+	private void resetToDefaultLanguage() {
+		SharedPreferences.Editor editor = PreferenceManager
+				.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
+				.edit();
+		editor.putString(LANGUAGE_TAG_KEY, defaultLocale.getLanguage());
+		editor.commit();
+		SettingsActivity.updateLocale(InstrumentationRegistry.getTargetContext(), defaultLocale.getLanguage(),
+				defaultLocale.getCountry());
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/LookListAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/LookListAdapter.java
@@ -60,7 +60,8 @@ public class LookListAdapter extends CheckBoxListAdapter<LookData> {
 			listItemViewHolder.rightBottomDetails.setText(measureString);
 
 			listItemViewHolder.leftTopDetails.setText(R.string.size);
-			listItemViewHolder.rightTopDetails.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath())));
+			listItemViewHolder.rightTopDetails.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath()),
+					getContext()));
 		}
 
 		return listItemView;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/ProjectListAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/ProjectListAdapter.java
@@ -71,7 +71,7 @@ public class ProjectListAdapter extends CheckBoxListAdapter<ProjectData> {
 			listItemViewHolder.rightTopDetails.setText(lastAccess);
 
 			listItemViewHolder.leftBottomDetails.setText(getContext().getString(R.string.size));
-			String size = UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName)));
+			String size = UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName)), getContext());
 			listItemViewHolder.rightBottomDetails.setText(size);
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/SoundListAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/SoundListAdapter.java
@@ -60,7 +60,7 @@ public class SoundListAdapter extends CheckBoxListAdapter<SoundInfo> {
 			listItemViewHolder.leftBottomDetails.setVisibility(View.VISIBLE);
 			listItemViewHolder.rightBottomDetails.setVisibility(View.VISIBLE);
 			listItemViewHolder.leftBottomDetails.setText(getContext().getString(R.string.size));
-			listItemViewHolder.rightBottomDetails.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath())));
+			listItemViewHolder.rightBottomDetails.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath()), getContext()));
 		} else {
 			listItemViewHolder.leftBottomDetails.setVisibility(View.GONE);
 			listItemViewHolder.rightBottomDetails.setVisibility(View.GONE);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/LookController.java
@@ -150,7 +150,8 @@ public final class LookController {
 	private void handleDetails(LookData lookData, LookViewHolder holder, LookBaseAdapter lookAdapter) {
 		if (lookAdapter.getShowDetails()) {
 			if (lookData.getAbsolutePath() != null) {
-				holder.lookFileSizeTextView.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath())));
+				holder.lookFileSizeTextView.setText(UtilFile.getSizeAsString(new File(lookData.getAbsolutePath()),
+						lookAdapter.getContext()));
 			}
 			int[] measure = lookData.getMeasure();
 			int width = measure[0];

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/SoundController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/SoundController.java
@@ -280,7 +280,8 @@ public final class SoundController {
 
 	private void handleDetails(SoundBaseAdapter soundAdapter, SoundViewHolder holder, SoundInfo soundInfo) {
 		if (soundAdapter.getShowDetails()) {
-			holder.soundFileSizeTextView.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath())));
+			holder.soundFileSizeTextView.setText(UtilFile.getSizeAsString(new File(soundInfo.getAbsolutePath()),
+					soundAdapter.getContext()));
 			holder.soundFileSizeTextView.setVisibility(TextView.VISIBLE);
 			holder.soundFileSizePrefixTextView.setVisibility(TextView.VISIBLE);
 		} else {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UploadProjectDialog.java
@@ -114,7 +114,8 @@ public class UploadProjectDialog extends DialogFragment {
 	private void initControls() {
 		currentProjectName = ProjectManager.getInstance().getCurrentProject().getName();
 		currentProjectDescription = ProjectManager.getInstance().getCurrentProject().getDescription();
-		sizeOfProject.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(currentProjectName))));
+		sizeOfProject.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(currentProjectName)),
+				getActivity().getBaseContext()));
 		projectRename.setVisibility(View.GONE);
 		projectUploadName.setText(currentProjectName);
 		projectDescriptionField.setText(currentProjectDescription);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ShowDetailsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ShowDetailsFragment.java
@@ -91,7 +91,8 @@ public class ShowDetailsFragment extends Fragment implements SetDescriptionDialo
 		screenshotLoader.loadAndShowScreenshot(projectData.projectName, sceneName, false, projectImage);
 		name.setText(projectData.projectName);
 		author.setText(getUserHandle());
-		size.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName))));
+		size.setText(UtilFile.getSizeAsString(new File(Utils.buildProjectPath(projectData.projectName)), getActivity()
+				.getBaseContext()));
 		lastAccess.setText(getLastAccess());
 		screenSize.setText(screen);
 		mode.setText(modeText);

--- a/catroid/src/main/java/org/catrobat/catroid/utils/UtilFile.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/UtilFile.java
@@ -26,6 +26,7 @@ import android.content.Context;
 import android.util.Log;
 
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.soundrecorder.SoundRecorder;
 
@@ -79,22 +80,30 @@ public final class UtilFile {
 		return progress * 100 / fileByteSize;
 	}
 
-	public static String getSizeAsString(File fileOrDirectory) {
-		final int unit = 1024;
+	public static String getSizeAsString(File fileOrDirectory, Context context) {
 		long bytes = UtilFile.getSizeOfFileOrDirectoryInByte(fileOrDirectory);
+		return formatFileSize(bytes, context);
+	}
 
+	private static String formatFileSize(long bytes, Context context) {
+		final double unit = 1024;
+		String[] fileSizeExtension = new String[] {
+				context.getString(R.string.Byte_short),
+				context.getString(R.string.KiloByte_short),
+				context.getString(R.string.MegaByte_short),
+				context.getString(R.string.GigaByte_short),
+				context.getString(R.string.TeraByte_short),
+				context.getString(R.string.PetaByte_short),
+				context.getString(R.string.ExaByte_short)
+		};
 		if (bytes < unit) {
-			return bytes + " Byte";
+			return bytes + " " + fileSizeExtension[0];
 		}
-
-		/*
-		 * Logarithm of "bytes" to base "unit"
-		 * log(a) / log(b) == logarithm of a to the base of b
-		 */
 		int exponent = (int) (Math.log(bytes) / Math.log(unit));
-		char prefix = "KMGTPE".charAt(exponent - 1);
-
-		return String.format(Locale.getDefault(), "%.1f %sB", bytes / Math.pow(unit, exponent), prefix);
+		exponent = Math.min(exponent, fileSizeExtension.length - 1);
+		String prefix = fileSizeExtension[exponent];
+		return String.format(Locale.getDefault(), "%.1f %s", bytes / Math.pow(unit, exponent),
+				prefix);
 	}
 
 	public static boolean deleteDirectory(File fileOrDirectory) {

--- a/catroid/src/main/res/values-ar/strings.xml
+++ b/catroid/src/main/res/values-ar/strings.xml
@@ -1509,4 +1509,15 @@
   <string name="crash_dialog_always_send">دائماً أرسل</string>
   <string name="crash_dialog_send">أرسل</string>
   <!--  -->
+
+  <!-- UtilFile SizeUnits String -->
+  <string name="Byte_short">بايت</string>
+  <string name="KiloByte_short">كيلوبايت</string>
+  <string name="MegaByte_short">ميغابايت</string>
+  <string name="GigaByte_short">غيغابايت</string>
+  <string name="TeraByte_short">تيرابايت</string>
+  <string name="PetaByte_short">بيتابايت</string>
+  <string name="ExaByte_short">إكسابايت</string>
+  <!--  -->
+
 </resources>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1655,5 +1655,16 @@
     <!-- Multilingual List -->
     <string name="device_language">Device Language</string>
 
+
+    <!-- UtilFile SizeUnits String -->
+     <string name="Byte_short">B</string>
+     <string name="KiloByte_short">KB</string>
+     <string name="MegaByte_short">MB</string>
+     <string name="GigaByte_short">GB</string>
+     <string name="TeraByte_short">TB</string>
+     <string name="PetaByte_short">PB</string>
+     <string name="ExaByte_short">EB</string>
+    <!--  -->
+
 </resources>
 


### PR DESCRIPTION
In the course of localizing software, all strings should be declared as resources and separated from the source code. In Pocket Code, program size is expressed in units of measurement (KB, MB, GB, etc.), these units are implemented as a hard-coded string.