### PR TITLE
JENKINS-89 Added androidTest sourceSet

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -228,6 +228,14 @@ android {
         xmlOutput file("build/reports/lint.xml")
         htmlOutput file("build/reports/lint.html")
     }
+
+    sourceSets {
+        androidTest {
+            if (file('../testexclusions.txt').exists()) {
+                java.exclude file('../testexclusions.txt').readLines()
+            }
+        }
+    }
 }
 
 task copyAndroidNatives() {


### PR DESCRIPTION
JENKINS-89 Added androidTest sourceSet to provide excluded testcases to the gradle build.

This sourceSet is used to provide a list with excluded testcases on the Jenkins-System.