### PR TITLE
[CAT-2099] Fix crash when Sound/Look is renamed

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
@@ -95,7 +95,7 @@ public class LookData implements Serializable, Cloneable {
 
 	@Override
 	public int hashCode() {
-		return name.hashCode() + fileName.hashCode() + super.hashCode();
+		return fileName.hashCode() + super.hashCode();
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/common/SoundInfo.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/SoundInfo.java
@@ -59,15 +59,12 @@ public class SoundInfo implements Serializable, Comparable<SoundInfo>, Cloneable
 		}
 
 		SoundInfo soundInfo = (SoundInfo) obj;
-		if (soundInfo.fileName.equals(this.fileName) && soundInfo.name.equals(this.name)) {
-			return true;
-		}
-		return false;
+		return (soundInfo.fileName.equals(this.fileName) && soundInfo.name.equals(this.name));
 	}
 
 	@Override
 	public int hashCode() {
-		return name.hashCode() + fileName.hashCode() + super.hashCode();
+		return fileName.hashCode() + super.hashCode();
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/LookAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/LookAdapter.java
@@ -58,15 +58,7 @@ public class LookAdapter extends LookBaseAdapter implements ActionModeActivityAd
 		if (position < 0 || position >= idMap.size()) {
 			return INVALID_ID;
 		}
-
 		LookData item = getItem(position);
-		if (!idMap.containsKey(item)) {
-			idMap.clear();
-			for (int i = 0; i < getCount(); i++) {
-				idMap.put(getItem(i), i);
-			}
-		}
-
 		return idMap.get(item);
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/SoundAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/SoundAdapter.java
@@ -45,7 +45,7 @@ public class SoundAdapter extends SoundBaseAdapter implements ActionModeActivity
 
 	private SoundFragment soundFragment;
 
-	private HashMap<SoundInfo, Integer> idMap = new HashMap<SoundInfo, Integer>();
+	private HashMap<SoundInfo, Integer> idMap = new HashMap<>();
 
 	public SoundAdapter(final Context context, int resource, int textViewResourceId, List<SoundInfo> items,
 			boolean showDetails) {


### PR DESCRIPTION
Removes the member 'name/title' from the **hashCode** function of **LookData** and **SoundInfo**.
Reason: LookData & SoundInfo are used as keys in a HashMap. 
If the hash changes when renaming a look or a sound, we will not be able to find the object in the HashMap.
This resulted in a NPE for renaming a sound. There was a workaround in place for renaming a Look - it has now been replaced with a proper solution (not changing the hash value of the object).

This is not an issue for Sprites, Scenes, Project or NfcTags, as their hashcode function is not overridden or does not include their names.

Very minor cosmetic changes.