### PR TITLE
CAT-2466 Test for BaseExceptionHandler.uncaughtException

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/ui/BaseExceptionHandlerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/ui/BaseExceptionHandlerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.ui;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
+import android.test.AndroidTestCase;
+
+import org.catrobat.catroid.ui.BaseExceptionHandler;
+import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.utils.CrashReporter;
+import org.junit.Before;
+
+import static org.catrobat.catroid.utils.CrashReporter.EXCEPTION_FOR_REPORT;
+
+public class BaseExceptionHandlerTest extends AndroidTestCase {
+
+	private SharedPreferences sharedPreferences;
+	private SharedPreferences.Editor editor;
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		Context context = InstrumentationRegistry.getTargetContext();
+		sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+		editor = sharedPreferences.edit();
+		editor.clear();
+		editor.putBoolean(SettingsActivity.SETTINGS_CRASH_REPORTS, true);
+		editor.commit();
+		CrashReporter.setIsCrashReportEnabled(true);
+		CrashReporter.initialize(context);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		CrashReporter.setIsCrashReportEnabled(false);
+		editor.clear();
+		editor.commit();
+		super.tearDown();
+	}
+
+	public void testExceptionStoredOnCallingUncaughtException() {
+		assertTrue(sharedPreferences.getString(EXCEPTION_FOR_REPORT, "").isEmpty());
+
+		BaseExceptionHandler baseExceptionHandler = new BaseExceptionHandler() {
+			@Override
+			protected void exit() {
+			}
+		};
+
+		baseExceptionHandler.uncaughtException(null, new RuntimeException("Test Error"));
+
+		assertFalse(sharedPreferences.getString(EXCEPTION_FOR_REPORT, "").isEmpty());
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/BaseExceptionHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/BaseExceptionHandler.java
@@ -23,20 +23,19 @@
 
 package org.catrobat.catroid.ui;
 
-import android.util.Log;
-
 import org.catrobat.catroid.utils.CrashReporter;
 
 public class BaseExceptionHandler implements
 		java.lang.Thread.UncaughtExceptionHandler {
 
-	private static final String TAG = BaseExceptionHandler.class.getSimpleName();
-
 	private static final int EXIT_CODE = 10;
 
 	public void uncaughtException(Thread thread, Throwable exception) {
-		Log.e(TAG, "unhandled exception", exception);
 		CrashReporter.storeUnhandledException(exception);
+		exit();
+	}
+
+	protected void exit() {
 		System.exit(EXIT_CODE);
 		android.os.Process.killProcess(android.os.Process.myPid());
 	}


### PR DESCRIPTION
This pull request includes the implementation of test to check if an exception is stored in CrashReporter after uncaughtException.