### PR TITLE
CAT-2468 Testing that the CrashReporter is initialized when enabled through settings

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/CrashReporterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/CrashReporterTest.java
@@ -27,19 +27,35 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.test.InstrumentationRegistry;
-import android.test.AndroidTestCase;
 
 import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.utils.CrashReporter;
+import org.catrobat.catroid.utils.CrashReporterInterface;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
-public class CrashReporterTest extends AndroidTestCase {
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CrashReporterTest {
 
 	private Context context;
 	private SharedPreferences sharedPreferences;
 	private SharedPreferences.Editor editor;
 	private Exception exception;
 
-	@Override
+	@Mock
+	CrashReporterInterface reporter;
+
+	@Before
 	public void setUp() {
 		context = InstrumentationRegistry.getTargetContext();
 		sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
@@ -49,37 +65,47 @@ public class CrashReporterTest extends AndroidTestCase {
 		editor.commit();
 		exception = new RuntimeException("Error");
 		CrashReporter.setIsCrashReportEnabled(true);
-		CrashReporter.initialize(context);
+		CrashReporter.setCrashReporterInterface(reporter);
 	}
 
-	@Override
+	@After
 	public void tearDown() {
 		CrashReporter.setIsCrashReportEnabled(false);
 	}
 
+	@Test
 	public void testCrashlyticsUninitializedOnAnonymousReportDisabled() {
 		editor.putBoolean(SettingsActivity.SETTINGS_CRASH_REPORTS, false);
 		editor.commit();
 
-		assertFalse(CrashReporter.initialize(context));
+		CrashReporter.initialize(context);
+
+		verify(reporter, times(0)).initialize(context);
 	}
 
+	@Test
 	public void testCrashlyticsInitializedOnAnonymousReportEnabled() {
-		assertTrue(CrashReporter.initialize(context));
+		CrashReporter.initialize(context);
+		verify(reporter, times(1)).initialize(context);
 	}
 
+	@Test
 	public void testCrashlyticsUninitializedOnCrashReportDisabled() {
 		CrashReporter.setIsCrashReportEnabled(false);
 
-		assertFalse(CrashReporter.initialize(context));
+		CrashReporter.initialize(context);
+
+		verify(reporter, times(0)).initialize(context);
 	}
 
+	@Test
 	public void testUnhandledExceptionStoredOnCrashReportEnabled() {
 		CrashReporter.storeUnhandledException(exception);
 
 		assertFalse(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").isEmpty());
 	}
 
+	@Test
 	public void testUnhandledExceptionNotStoredOnCrashReportDisabled() {
 		CrashReporter.setIsCrashReportEnabled(false);
 		CrashReporter.storeUnhandledException(exception);
@@ -87,6 +113,7 @@ public class CrashReporterTest extends AndroidTestCase {
 		assertTrue(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").isEmpty());
 	}
 
+	@Test
 	public void testUnhandledExceptionStoredOnNoPreviousExceptionStored() {
 		assertTrue(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").isEmpty());
 
@@ -95,6 +122,7 @@ public class CrashReporterTest extends AndroidTestCase {
 		assertFalse(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").isEmpty());
 	}
 
+	@Test
 	public void testUnhandledExceptionNotStoredOnPreviousExceptionStored() {
 		assertTrue(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").isEmpty());
 
@@ -111,6 +139,7 @@ public class CrashReporterTest extends AndroidTestCase {
 		assertTrue(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").equals(error1Data));
 	}
 
+	@Test
 	public void testSharedPreferencesClearedAfterLoggingException() {
 		CrashReporter.storeUnhandledException(exception);
 
@@ -121,6 +150,7 @@ public class CrashReporterTest extends AndroidTestCase {
 		assertTrue(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").isEmpty());
 	}
 
+	@Test
 	public void testSharedPreferencesClearedOnLoggingFailed() {
 		CrashReporter.storeUnhandledException(exception);
 
@@ -131,19 +161,21 @@ public class CrashReporterTest extends AndroidTestCase {
 		assertTrue(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").isEmpty());
 	}
 
+	@Test
 	public void testLogExceptionGenerateLogsOnReportsEnabled() {
-		CrashReporter.initialize(context);
+		CrashReporter.logException(exception);
 
-		assertTrue(CrashReporter.logException(exception));
+		verify(reporter, times(1)).logException(exception);
 	}
 
+	@Test
 	public void testLogExceptionGenerateNoLogsOnReportsDisabled() {
 		editor.putBoolean(SettingsActivity.SETTINGS_CRASH_REPORTS, false);
 		editor.commit();
 
 		CrashReporter.setIsCrashReportEnabled(false);
-		CrashReporter.initialize(context);
+		CrashReporter.logException(exception);
 
-		assertFalse(CrashReporter.logException(exception));
+		verify(reporter, times(0)).logException(exception);
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/SettingsActivityCrashReporterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/SettingsActivityCrashReporterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.utils;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+
+import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.utils.CrashReporter;
+import org.catrobat.catroid.utils.CrashReporterInterface;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SettingsActivityCrashReporterTest {
+
+	@Mock
+	CrashReporterInterface reporter;
+
+	@Before
+	public void setUp() throws Exception {
+		CrashReporter.setIsCrashReportEnabled(true);
+		CrashReporter.setCrashReporterInterface(reporter);
+	}
+
+	@Test
+	public void testAutoCrashReportEnabling() {
+		Context context = InstrumentationRegistry.getTargetContext();
+		SettingsActivity.setAutoCrashReportingEnabled(context, false);
+
+		verify(reporter, times(0)).initialize(context);
+
+		SettingsActivity.setAutoCrashReportingEnabled(context, true);
+
+		verify(reporter, times(1)).initialize(context);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		CrashReporter.setIsCrashReportEnabled(false);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
@@ -401,7 +401,6 @@ public class SettingsActivity extends PreferenceActivity {
 		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
 		editor.putBoolean(SETTINGS_CRASH_REPORTS, isEnabled);
 		editor.commit();
-
 		if (isEnabled) {
 			CrashReporter.initialize(context);
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/utils/CrashReporter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/CrashReporter.java
@@ -29,40 +29,22 @@ import android.preference.PreferenceManager;
 import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 
-import com.crashlytics.android.Crashlytics;
-import com.crashlytics.android.core.CrashlyticsCore;
 import com.google.gson.Gson;
 
 import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.ui.SettingsActivity;
 
-import io.fabric.sdk.android.Fabric;
-
 public final class CrashReporter {
 
 	private static final String TAG = CrashReporter.class.getSimpleName();
 
-	private static SharedPreferences preferences;
 	public static final String EXCEPTION_FOR_REPORT = "EXCEPTION_FOR_REPORT";
+
+	protected static SharedPreferences preferences;
 	private static boolean isCrashReportEnabled = BuildConfig.CRASHLYTICS_CRASH_REPORT_ENABLED;
+	private static CrashReporterInterface reporter = new CrashlyticsCrashReporter();
 
 	private CrashReporter() {
-	}
-
-	public static boolean initialize(Context context) {
-
-		preferences = PreferenceManager.getDefaultSharedPreferences(context);
-
-		if (isReportingEnabled()) {
-			Crashlytics crashlyticsKit = new Crashlytics.Builder()
-					.core(new CrashlyticsCore.Builder().disabled(BuildConfig.DEBUG).build())
-					.build();
-			Fabric.with(context, crashlyticsKit);
-			Log.d(TAG, "INITIALIZED!");
-			return true;
-		}
-		Log.d(TAG, "INITIALIZATION FAILED! [ Report : " + isReportingEnabled() + "]");
-		return false;
 	}
 
 	private static boolean isReportingEnabled() {
@@ -70,18 +52,36 @@ public final class CrashReporter {
 	}
 
 	@VisibleForTesting
-	public static void setIsCrashReportEnabled(boolean isEnabled) {
-		isCrashReportEnabled = isEnabled;
+	public static void setCrashReporterInterface(CrashReporterInterface crashReporterInterface) {
+		reporter = crashReporterInterface;
 	}
 
-	public static boolean logException(Throwable t) {
+	public static boolean initialize(Context context) {
+
+		preferences = PreferenceManager.getDefaultSharedPreferences(context);
 
 		if (isReportingEnabled()) {
-			Crashlytics.logException(t);
+			reporter.initialize(context);
+			Log.d(TAG, "INITIALIZED!");
 			return true;
 		}
 
+		Log.d(TAG, "INITIALIZATION FAILED! [ Report : " + isReportingEnabled() + "]");
 		return false;
+	}
+
+	public static boolean logException(Throwable exception) {
+
+		if (isReportingEnabled()) {
+			reporter.logException(exception);
+			return true;
+		}
+		return false;
+	}
+
+	@VisibleForTesting
+	public static void setIsCrashReportEnabled(boolean isEnabled) {
+		isCrashReportEnabled = isEnabled;
 	}
 
 	public static void sendUnhandledCaughtException() {

--- a/catroid/src/main/java/org/catrobat/catroid/utils/CrashReporterInterface.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/CrashReporterInterface.java
@@ -1,0 +1,31 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.utils;
+
+import android.content.Context;
+
+public interface CrashReporterInterface {
+	void initialize(Context context);
+	void logException(Throwable exception);
+}

--- a/catroid/src/main/java/org/catrobat/catroid/utils/CrashlyticsCrashReporter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/CrashlyticsCrashReporter.java
@@ -1,0 +1,48 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.utils;
+
+import android.content.Context;
+
+import com.crashlytics.android.Crashlytics;
+import com.crashlytics.android.core.CrashlyticsCore;
+
+import org.catrobat.catroid.BuildConfig;
+
+import io.fabric.sdk.android.Fabric;
+
+class CrashlyticsCrashReporter implements CrashReporterInterface {
+
+	public void initialize(Context context) {
+
+		Crashlytics crashlyticsKit = new Crashlytics.Builder()
+				.core(new CrashlyticsCore.Builder().disabled(BuildConfig.DEBUG).build())
+				.build();
+		Fabric.with(context, crashlyticsKit);
+	}
+
+	public void logException(Throwable exception) {
+		Crashlytics.logException(exception);
+	}
+}


### PR DESCRIPTION
This pull request includes the test file for settings activity which tests the enable and disable functionality of Crash Report system.