### PR TITLE
CAT-2489 Hiding CrashReporter Setting on flag disabled

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
@@ -145,6 +145,12 @@ public class SettingsActivity extends PreferenceActivity {
 			nfcPreference.setEnabled(false);
 			screen.removePreference(nfcPreference);
 		}
+
+		if (!BuildConfig.CRASHLYTICS_CRASH_REPORT_ENABLED) {
+			CheckBoxPreference crashlyticsPreference = (CheckBoxPreference) findPreference(SETTINGS_CRASH_REPORTS);
+			crashlyticsPreference.setEnabled(false);
+			screen.removePreference(crashlyticsPreference);
+		}
 	}
 
 	@SuppressWarnings("deprecation")


### PR DESCRIPTION
This pull request includes an updated settings file where the settings option for enabling/disabling CrashReporter will be disabled if flag (CRASHLYTICS_CRASH_REPORT_ENABLED) is disabled.