### PR TITLE
Revert "CAT-2489 Hiding CrashReporter Setting on flag disabled"

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
@@ -145,12 +145,6 @@ public class SettingsActivity extends PreferenceActivity {
 			nfcPreference.setEnabled(false);
 			screen.removePreference(nfcPreference);
 		}
-
-		if (!BuildConfig.CRASHLYTICS_CRASH_REPORT_ENABLED) {
-			CheckBoxPreference crashlyticsPreference = (CheckBoxPreference) findPreference(SETTINGS_CRASH_REPORTS);
-			crashlyticsPreference.setEnabled(false);
-			screen.removePreference(crashlyticsPreference);
-		}
 	}
 
 	@SuppressWarnings("deprecation")


### PR DESCRIPTION
Reverts Catrobat/Catroid#2392

The Espresso testrun was "green" (excluding three failing but unrelated tests) just because the whole SettingsActivityTest hasn't been added to the test suite previously.
thanks to @nishantt95