### PR TITLE
Revert changes which broke Pocket Paint editing

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/LookAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/LookAdapter.java
@@ -59,6 +59,14 @@ public class LookAdapter extends LookBaseAdapter implements ActionModeActivityAd
 			return INVALID_ID;
 		}
 		LookData item = getItem(position);
+
+		if (!idMap.containsKey(item)) {
+			idMap.clear();
+			for (int i = 0; i < getCount(); i++) {
+				idMap.put(getItem(i), i);
+			}
+		}
+
 		return idMap.get(item);
 	}
 


### PR DESCRIPTION
This section was removed in #2352 
Although it's ugly code, it had the purpose of fixing a crash when returning to Pocket Code after a look was edited in Pocket Paint.

I'd keep this for now, as the Adapters will be refactored anyway.