### PR TITLE
CAT-FIX Set Crashlytics flag to True in debug mode

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -86,7 +86,7 @@ android {
             buildConfigField "boolean", "FEATURE_RASPI_ENABLED", "true"
             buildConfigField "boolean", "FEATURE_POCKETMUSIC_ENABLED", "true"
             buildConfigField "boolean", "FEATURE_CAST_ENABLED", "true"
-            buildConfigField "boolean", "CRASHLYTICS_CRASH_REPORT_ENABLED", "false"
+            buildConfigField "boolean", "CRASHLYTICS_CRASH_REPORT_ENABLED", "true"
             resValue "string", "SNACKBAR_HINTS_ENABLED", "false"
             ext.enableCrashlytics = false
         }


### PR DESCRIPTION
Earlier the flag CRASHLYTICS_CRASH_REPORT_ENABLED was set to false in
debug mode. In SettingsActivity the checkbox button (which
enables/disables the Crashlytics crash reporting) is either visible or
hidden depending upon the flag value (visible if true and hidden if
false).

As the checkbox was hidden (hidden for false), it resulted in failure of
different espresso test cases where checkbox was required to perform the
UI test. Moreover, espresso testrun is green because the auto-generated
AllEspressoTestsSuite.java file isn't up-to-date and doesn't contain the
SettingsActivityTest.