### PR TITLE
CAT-FIX Fix infinite loop when app crashes

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/ui/BaseExceptionHandlerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/ui/BaseExceptionHandlerTest.java
@@ -34,17 +34,19 @@ import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.utils.CrashReporter;
 import org.junit.Before;
 
+import static org.catrobat.catroid.ui.BaseActivity.RECOVERED_FROM_CRASH;
 import static org.catrobat.catroid.utils.CrashReporter.EXCEPTION_FOR_REPORT;
 
 public class BaseExceptionHandlerTest extends AndroidTestCase {
 
+	private Context context;
 	private SharedPreferences sharedPreferences;
 	private SharedPreferences.Editor editor;
 
 	@Before
 	public void setUp() throws Exception {
 		super.setUp();
-		Context context = InstrumentationRegistry.getTargetContext();
+		context = InstrumentationRegistry.getTargetContext();
 		sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
 		editor = sharedPreferences.edit();
 		editor.clear();
@@ -65,7 +67,7 @@ public class BaseExceptionHandlerTest extends AndroidTestCase {
 	public void testExceptionStoredOnCallingUncaughtException() {
 		assertTrue(sharedPreferences.getString(EXCEPTION_FOR_REPORT, "").isEmpty());
 
-		BaseExceptionHandler baseExceptionHandler = new BaseExceptionHandler() {
+		BaseExceptionHandler baseExceptionHandler = new BaseExceptionHandler(context) {
 			@Override
 			protected void exit() {
 			}
@@ -74,5 +76,18 @@ public class BaseExceptionHandlerTest extends AndroidTestCase {
 		baseExceptionHandler.uncaughtException(null, new RuntimeException("Test Error"));
 
 		assertFalse(sharedPreferences.getString(EXCEPTION_FOR_REPORT, "").isEmpty());
+	}
+
+	public void testSetRecoveredFromCrashFlag() {
+		assertFalse(sharedPreferences.getBoolean(RECOVERED_FROM_CRASH, false));
+
+		BaseExceptionHandler baseExceptionHandler = new BaseExceptionHandler(context) {
+			@Override
+			protected void exit() {
+			}
+		};
+		baseExceptionHandler.uncaughtException(null, new RuntimeException("Test Error"));
+
+		assertTrue(sharedPreferences.getBoolean(RECOVERED_FROM_CRASH, false));
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.java
@@ -47,7 +47,7 @@ public abstract class BaseActivity extends Activity {
 	private boolean returnToProjectsList;
 	private String titleActionBar;
 	private boolean returnByPressingBackButton;
-	private static final String RECOVERED_FROM_CRASH = "RECOVERED_FROM_CRASH";
+	public static final String RECOVERED_FROM_CRASH = "RECOVERED_FROM_CRASH";
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -55,7 +55,7 @@ public abstract class BaseActivity extends Activity {
 		titleActionBar = null;
 		returnToProjectsList = false;
 		returnByPressingBackButton = false;
-		Thread.setDefaultUncaughtExceptionHandler(new BaseExceptionHandler());
+		Thread.setDefaultUncaughtExceptionHandler(new BaseExceptionHandler(this));
 		checkIfCrashRecoveryAndFinishActivity(this);
 		getActionBar().setDisplayHomeAsUpEnabled(true);
 		if (SettingsActivity.isCastSharedPreferenceEnabled(this)) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/BaseExceptionHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/BaseExceptionHandler.java
@@ -23,15 +23,28 @@
 
 package org.catrobat.catroid.ui;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
 import org.catrobat.catroid.utils.CrashReporter;
+
+import static org.catrobat.catroid.ui.BaseActivity.RECOVERED_FROM_CRASH;
 
 public class BaseExceptionHandler implements
 		java.lang.Thread.UncaughtExceptionHandler {
 
 	private static final int EXIT_CODE = 10;
 
+	private final SharedPreferences preferences;
+
+	public BaseExceptionHandler(Context context) {
+		preferences = PreferenceManager.getDefaultSharedPreferences(context);
+	}
+
 	public void uncaughtException(Thread thread, Throwable exception) {
 		CrashReporter.storeUnhandledException(exception);
+		preferences.edit().putBoolean(RECOVERED_FROM_CRASH, true).commit();
 		exit();
 	}
 


### PR DESCRIPTION
When the app crashes, the RECOVERED_FROM_CRASH flag has to be set to
true and then every Activity is finished until the app is back in the
MainMenuActivity. If the RECOVERED_FROM_CRASH flag is not set, the app
will go into an infinite loop, where it tries to start an activity over
and over again because the activity crashes but never finises. The
problem was only reproducible in specific activities, e.g. when throwing
an exception in ScriptActivity.create.

Setting the RECOVERED_FROM_CRASH flag to true when the app crashes fixes
the infinite loop. It has been unintentionally removed during improving
the Crash Reporter[1].

[1] https://github.com/Catrobat/Catroid/pull/2366/files#diff-d61e5ef6cdb376657aae60af754655d0L136