### PR TITLE
fixed receiving the same broadcast multiple times

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/BroadcastReceiverRegressionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/BroadcastReceiverRegressionTest.java
@@ -221,4 +221,21 @@ public class BroadcastReceiverRegressionTest {
 
 		Assert.assertTrue(StageTestUtils.userVariableEqualsWithinTimeout(userVariable, 20, 1000));
 	}
+
+	@Test
+	public void testBroadcastReceiverWithMoreThanOneReceiverScript() {
+		DataContainer dataContainer = project.getDefaultScene().getDataContainer();
+		UserVariable userVariable2 = dataContainer.addProjectUserVariable(VARIABLE_NAME + "2");
+
+		sprite1StartScript.addBrick(new SetVariableBrick(new Formula(1.0), userVariable));
+		sprite1StartScript.addBrick(new SetVariableBrick(new Formula(1.0), userVariable2));
+		sprite1StartScript.addBrick(new BroadcastBrick(BROADCAST_MESSAGE_1));
+		StageTestUtils.addBroadcastScriptSettingUserVariableToSprite(sprite1, BROADCAST_MESSAGE_1, userVariable, 3.0);
+		StageTestUtils.addBroadcastScriptSettingUserVariableToSprite(sprite1, BROADCAST_MESSAGE_1, userVariable2, 4.0);
+
+		baseActivityTestRule.launchActivity(null);
+
+		Assert.assertTrue(StageTestUtils.userVariableEqualsWithinTimeout(userVariable, 3, 2000));
+		Assert.assertTrue(StageTestUtils.userVariableEqualsWithinTimeout(userVariable2, 4, 2000));
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/common/BroadcastSequenceMap.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/BroadcastSequenceMap.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.common;
 
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +50,15 @@ public class BroadcastSequenceMap {
 			map = new HashMap<>();
 			broadcastSequenceMap.put(sceneName, map);
 		}
-		return map.put(key, values);
+		List<SequenceAction> actions = map.get(key);
+		if (actions == null) {
+			actions = new ArrayList<>();
+			map.put(key, actions);
+		}
+		for (SequenceAction value : values) {
+			actions.add(value);
+		}
+		return actions;
 	}
 
 	public void remove(String key, String sceneName) {


### PR DESCRIPTION
The bug appeared when there were multiple receive broadcast bricks with the same broadcast message in the same sprite.
The list of actions was overriden, instead of of being extended, so only the script of the last added receive brick was executed.