### PR TITLE
CAT-2473 Setting for enable disable cloud notifications

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/cloudmessaging/CloudMessagingTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/cloudmessaging/CloudMessagingTest.java
@@ -1,0 +1,91 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.cloudmessaging;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.cloudmessaging.CloudMessaging;
+import org.catrobat.catroid.cloudmessaging.CloudMessagingInterface;
+import org.catrobat.catroid.cloudmessaging.FirebaseCloudMessaging;
+import org.catrobat.catroid.ui.SettingsActivity;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(AndroidJUnit4.class)
+public class CloudMessagingTest {
+
+	private Context context;
+	private SharedPreferences sharedPreferences;
+	private CloudMessagingInterface messagingService;
+
+	@Before
+	public void setUp() {
+		sharedPreferences = mock(SharedPreferences.class);
+		context = mock(Context.class);
+		messagingService = mock(FirebaseCloudMessaging.class);
+		when(PreferenceManager.getDefaultSharedPreferences(context)).thenReturn(sharedPreferences);
+		when(sharedPreferences.getBoolean(SettingsActivity.SETTINGS_CLOUD_NOTIFICATIONS, false)).thenReturn(true);
+		CloudMessaging.setIsCloudNotificationsEnabled(true);
+		CloudMessaging.setCloudMessagingInterface(messagingService);
+	}
+
+	@Test
+	public void testCloudMessagingUninitializedOnNotificationsDisabled() {
+		CloudMessaging.setIsCloudNotificationsEnabled(false);
+
+		assertFalse(CloudMessaging.initialize(context));
+	}
+
+	@Test
+	public void testUserSubscribedToTopicsOnCloudMessagingInitialized() {
+		assertTrue(CloudMessaging.initialize(context));
+		verify(messagingService, times(1)).subscribe();
+	}
+
+	@Test
+	public void testUserUnsubscribedToTopicsOnCloudMessagingInitializationFailed() {
+		when(sharedPreferences.getBoolean(SettingsActivity.SETTINGS_CLOUD_NOTIFICATIONS, false)).thenReturn(false);
+
+		assertFalse(CloudMessaging.initialize(context));
+		verify(messagingService, times(1)).unsubscribe();
+	}
+
+	@After
+	public void tearDown() {
+		CloudMessaging.setIsCloudNotificationsEnabled(false);
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/cloudmessaging/SettingsActivityCloudNotificationTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/cloudmessaging/SettingsActivityCloudNotificationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.cloudmessaging;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.cloudmessaging.CloudMessaging;
+import org.catrobat.catroid.ui.SettingsActivity;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class SettingsActivityCloudNotificationTest {
+	@Before
+	public void setUp() {
+		CloudMessaging.setIsCloudNotificationsEnabled(true);
+	}
+
+	@Test
+	public void testCloudNotificationsEnabling() {
+		Context context = InstrumentationRegistry.getTargetContext();
+		SettingsActivity.setCloudNotificationsEnabled(context, false);
+
+		assertFalse(CloudMessaging.initialize(context));
+
+		SettingsActivity.setCloudNotificationsEnabled(context, true);
+
+		assertTrue(CloudMessaging.initialize(context));
+	}
+
+	@After
+	public void tearDown() {
+		CloudMessaging.setIsCloudNotificationsEnabled(false);
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsActivityTest.java
@@ -51,6 +51,7 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_CAST_GLOBALLY_ENABLED;
+import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_CLOUD_NOTIFICATIONS;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_CRASH_REPORTS;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_MINDSTORMS_EV3_SHOW_SENSOR_INFO_BOX_DISABLED;
@@ -74,7 +75,7 @@ public class SettingsActivityTest {
 			SETTINGS_SHOW_PHIRO_BRICKS, SETTINGS_SHOW_NFC_BRICKS, SETTINGS_SHOW_HINTS, SETTINGS_CRASH_REPORTS,
 			SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED,
 			SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED, SETTINGS_MINDSTORMS_EV3_SHOW_SENSOR_INFO_BOX_DISABLED,
-			SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS,
+			SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS, SETTINGS_CLOUD_NOTIFICATIONS,
 			SETTINGS_SHOW_RASPI_BRICKS,
 			SETTINGS_CAST_GLOBALLY_ENABLED));
 	private Map<String, Boolean> initialSettings = new HashMap<>();

--- a/catroid/src/main/java/org/catrobat/catroid/CatroidApplication.java
+++ b/catroid/src/main/java/org/catrobat/catroid/CatroidApplication.java
@@ -27,8 +27,10 @@ import android.support.multidex.MultiDex;
 import android.support.multidex.MultiDexApplication;
 import android.util.Log;
 
+import com.google.firebase.iid.FirebaseInstanceId;
 import com.parrot.freeflight.settings.ApplicationSettings;
 
+import org.catrobat.catroid.cloudmessaging.CloudMessaging;
 import org.catrobat.catroid.utils.CrashReporter;
 
 public class CatroidApplication extends MultiDexApplication {
@@ -46,7 +48,9 @@ public class CatroidApplication extends MultiDexApplication {
 	public void onCreate() {
 		super.onCreate();
 		CrashReporter.initialize(this);
+		CloudMessaging.initialize(this);
 		Log.d(TAG, "CatroidApplication onCreate");
+		Log.v(TAG, "Firebase Cloud Messaging Token : " + FirebaseInstanceId.getInstance().getToken());
 		settings = new ApplicationSettings(this);
 		CatroidApplication.context = getApplicationContext();
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/cloudmessaging/CloudMessagingInterface.java
+++ b/catroid/src/main/java/org/catrobat/catroid/cloudmessaging/CloudMessagingInterface.java
@@ -1,0 +1,29 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.cloudmessaging;
+
+public interface CloudMessagingInterface {
+	void subscribe();
+	void unsubscribe();
+}

--- a/catroid/src/main/java/org/catrobat/catroid/cloudmessaging/FirebaseCloudMessaging.java
+++ b/catroid/src/main/java/org/catrobat/catroid/cloudmessaging/FirebaseCloudMessaging.java
@@ -1,0 +1,41 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.cloudmessaging;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+
+public class FirebaseCloudMessaging implements CloudMessagingInterface {
+
+	private static final String DEFAULT_TOPIC = "notification_enabled";
+
+	@Override
+	public void subscribe() {
+		FirebaseMessaging.getInstance().subscribeToTopic(DEFAULT_TOPIC);
+	}
+
+	@Override
+	public void unsubscribe() {
+		FirebaseMessaging.getInstance().unsubscribeFromTopic(DEFAULT_TOPIC);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SettingsActivity.java
@@ -39,6 +39,7 @@ import android.view.MenuItem;
 
 import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.cloudmessaging.CloudMessaging;
 import org.catrobat.catroid.common.DroneConfigPreference;
 import org.catrobat.catroid.devices.mindstorms.ev3.sensors.EV3Sensor;
 import org.catrobat.catroid.devices.mindstorms.nxt.sensors.NXTSensor;
@@ -87,6 +88,7 @@ public class SettingsActivity extends PreferenceActivity {
 	public static final String RASPI_VERSION_SPINNER = "setting_raspi_version_preference";
 
 	public static final String SETTINGS_CRASH_REPORTS = "setting_enable_crash_reports";
+	public static final String SETTINGS_CLOUD_NOTIFICATIONS = "setting_enable_cloud_notifications";
 
 	@SuppressWarnings("deprecation")
 	@Override
@@ -96,6 +98,7 @@ public class SettingsActivity extends PreferenceActivity {
 		addPreferencesFromResource(R.xml.preferences);
 
 		setAnonymousCrashReportPreference();
+		setCloudNotificationPreference();
 		setNXTSensors();
 		setEV3Sensors();
 		setDronePreferences();
@@ -160,6 +163,12 @@ public class SettingsActivity extends PreferenceActivity {
 			crashlyticsPreference.setEnabled(false);
 			screen.removePreference(crashlyticsPreference);
 		}
+
+		if (!BuildConfig.FEATURE_CLOUD_MESSAGING_ENABLED) {
+			CheckBoxPreference cloudMessagingPreference = (CheckBoxPreference) findPreference(SETTINGS_CLOUD_NOTIFICATIONS);
+			cloudMessagingPreference.setEnabled(false);
+			screen.removePreference(cloudMessagingPreference);
+		}
 	}
 
 	@SuppressWarnings("deprecation")
@@ -169,6 +178,18 @@ public class SettingsActivity extends PreferenceActivity {
 			@Override
 			public boolean onPreferenceChange(Preference preference, Object isChecked) {
 				setAutoCrashReportingEnabled(getApplicationContext(), (Boolean) isChecked);
+				return true;
+			}
+		});
+	}
+
+	@SuppressWarnings("deprecation")
+	private void setCloudNotificationPreference() {
+		CheckBoxPreference reportCheckBoxPreference = (CheckBoxPreference) findPreference(SETTINGS_CLOUD_NOTIFICATIONS);
+		reportCheckBoxPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+			@Override
+			public boolean onPreferenceChange(Preference preference, Object isChecked) {
+				setCloudNotificationsEnabled(getApplicationContext(), (Boolean) isChecked);
 				return true;
 			}
 		});
@@ -404,6 +425,12 @@ public class SettingsActivity extends PreferenceActivity {
 		if (isEnabled) {
 			CrashReporter.initialize(context);
 		}
+	}
+
+	public static void setCloudNotificationsEnabled(Context context, boolean isEnabled) {
+		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
+		editor.putBoolean(SETTINGS_CLOUD_NOTIFICATIONS, isEnabled).commit();
+		CloudMessaging.initialize(context);
 	}
 
 	private static void setBooleanSharedPreference(boolean value, String settingsString, Context context) {

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -131,6 +131,8 @@
     <string name="preference_description_nfc_bricks">Allow to use NFC tags in programs</string>
     <string name="preference_description_crash_reports">Allow to send crash reports automatically</string>
     <string name="preference_title_enable_crash_reports">Send anonymous crash reports</string>
+    <string name="preference_title_enable_cloud_notifications">Enable Cloud Notifications</string>
+    <string name="preference_description_cloud_notifications">Allow to receive cloud notifications</string>
     <!-- -->
     <string name="preference_description_arduino_bricks">Allow to control Arduino boards</string>
     <string name="preference_title_enable_raspi_bricks">Raspberry Pi bricks</string>

--- a/catroid/src/main/res/xml/preferences.xml
+++ b/catroid/src/main/res/xml/preferences.xml
@@ -234,4 +234,10 @@
         android:summary="@string/preference_description_cast_feature_globally_enabled"
         android:title="@string/preference_title_cast_feature_globally_enabled" />
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="setting_enable_cloud_notifications"
+        android:summary="@string/preference_description_cloud_notifications"
+        android:title="@string/preference_title_enable_cloud_notifications" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Added the feature for enabling/disabling the notifications through settings. It uses the firebase cloud messaging's topics subscribe/unsubscribe feature to enable/disable notifications.

Note: This PR also includes the test file.