### PR TITLE
CAT-FIX Updated MockitoJUnitRunner In CrashReporterTest

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -183,8 +183,8 @@ dependencies {
     compile fileTree(include: '*.jar', dir: 'src/main/libs-natives')
     androidTestCompile fileTree(include: '*.jar', dir: 'src/androidTest/libs')
     androidTestCompile 'com.jayway.android.robotium:robotium-solo:5.2.1'
-    androidTestCompile 'com.linkedin.dexmaker:dexmaker-mockito:1.5.1'
-    androidTestCompile 'org.mockito:mockito-core:1.10.19'
+    androidTestCompile 'com.linkedin.dexmaker:dexmaker-mockito:2.2.0'
+    androidTestCompile 'org.mockito:mockito-core:2.8.47'
 
     androidTestCompile ('com.android.support.test:runner:0.5') {
         exclude group: 'com.android.support'
@@ -204,7 +204,7 @@ dependencies {
     }
 
     testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'org.mockito:mockito-core:2.8.47'
 
     pmd 'net.sourceforge.pmd:pmd:5.1.1'
     checkstyle 'com.puppycrawl.tools:checkstyle:7.6'

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/CrashReporterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/CrashReporterTest.java
@@ -36,7 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
@@ -168,7 +168,7 @@ public class CrashReporterTest {
 
 		CrashReporter.sendUnhandledCaughtException();
 
-		verify(reporter, times(1)).logException(any(Exception.class));
+		verify(reporter, times(1)).logException(any(Throwable.class));
 	}
 
 	@Test


### PR DESCRIPTION
org.mockito.runners.MockitoJUnitRunner is now deprecated, so replaced it
with org.mockito.junit.MockitoJUnitRunner. 

Note:- 
org.mockito:mockito-core:1.10.19 is upgraded to org.mockito:mockito-core:2.8.47
com.linkedin.dexmaker:dexmaker-mockito:1.5.1 is upgraded to com.linkedin.dexmaker:dexmaker-mockito:2.2.0