### PR TITLE
CAT-FIX Null Value at Sprite's getNumberOfWhenBackgroundChangesScripts()

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -631,7 +631,7 @@ public class Sprite implements Serializable, Cloneable {
 	public int getNumberOfWhenBackgroundChangesScripts(LookData lookData) {
 		int numberOfScripts = 0;
 		for (Script s : scriptList) {
-			if (s instanceof WhenBackgroundChangesScript
+			if (s instanceof WhenBackgroundChangesScript && ((WhenBackgroundChangesScript) s).getLook() != null
 					&& ((WhenBackgroundChangesScript) s).getLook().equals(lookData)) {
 				numberOfScripts++;
 			}


### PR DESCRIPTION
Error URL:-
https://console.firebase.google.com/u/0/project/firebase-catrobat/monitoring/app/android:org.catrobat.catroid/cluster/47c5472e?duration=2592000000

LookData value received by the method getNumberOfWhenBackgroundChangesScripts(LookData lookdata) is null

Origin of the error:- org.catrobat.catroid.stage.StageListener.render (StageListener.java:491)