### PR TITLE
CAT-FIX ProgressDialog Error On Activity Finished

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
@@ -337,4 +337,10 @@ public class WebViewActivity extends BaseActivity {
 			return false;
 		}
 	}
+
+	@Override
+	protected void onDestroy() {
+		webView.setDownloadListener(null);
+		super.onDestroy();
+	}
 }


### PR DESCRIPTION
progressDialog.show() was throwing an exception on activity finished.

Error URL:
https://console.firebase.google.com/u/0/project/firebase-catrobat/monitoring/app/android:org.catrobat.catroid/cluster/e0c21001