### PR TITLE
CAT-2430 Negative Value Sets Object In Front Of PasspartOut

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/GoNStepsBackAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/GoNStepsBackAction.java
@@ -54,6 +54,7 @@ public class GoNStepsBackAction extends TemporalAction {
 			toFront(delta);
 		} else {
 			goNStepsBack(stepsValue.intValue());
+			toFront(delta);
 		}
 	}
 


### PR DESCRIPTION
Negative value sets at GoBackN makes the object in front of PasspartOut
and in actual no object needs to be in fron of the passpartout.