### PR TITLE
Revert "CAT-2400 Automatize the creation of independent APKs."

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -50,20 +50,6 @@ apply from: 'gradle/standalone_apk_tasks.gradle'
 check.dependsOn 'checkstyle'
 check.dependsOn 'pmd'
 
-def appId = 'org.catrobat.catroid'
-def appName = '@string/app_name'
-
-// When -Pindependent was provided on the gradle command the APP name is changed.
-// This allows to have multiple Catroid versions installed in parallel for testing purposes.
-// Furthermore these installations do not interfere with the actual Catroid app.
-if (project.hasProperty('independent')) {
-    def today = new Date()
-    appId += '.independent_' + today.format('YYYYMMdd_HHmm')
-    appName = property('independent') ?: 'Code ' + today.format('MMdd HH:mm')
-}
-ant.copy(file: 'google-services-template.json', tofile: 'google-services.json', overwrite: true)
-ant.replace(file: 'google-services.json', token: '@appId@', value: appId)
-
 android {
     dexOptions {
         javaMaxHeapSize "4g"
@@ -115,7 +101,7 @@ android {
 
     productFlavors {
         catroid {
-            applicationId appId
+            applicationId 'org.catrobat.catroid'
             buildConfigField "String", "START_PROJECT", "\"No Starting Project\""
             buildConfigField "String", "PROJECT_NAME", "\"No Standalone Project\""
             buildConfigField "boolean", "FEATURE_APK_GENERATOR_ENABLED", "false"
@@ -124,7 +110,7 @@ android {
         }
 
         standalone {
-            applicationId appId + '.' + getPackageNameSuffix()
+            applicationId 'org.catrobat.catroid.' + getPackageNameSuffix()
             versionCode 1
             versionName '1.0'
 
@@ -232,7 +218,8 @@ android {
     defaultConfig {
         minSdkVersion 17
         targetSdkVersion 22
-        applicationId appId
+        applicationId 'org.catrobat.catroid'
+        testApplicationId "org.catrobat.catroid.test"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
         versionCode 38
         println "VersionCode is " + versionCode
@@ -241,7 +228,6 @@ android {
         buildConfigField "String", "GIT_DESCRIBE", "\"${versionName}\""
         buildConfigField "String", "GIT_CURRENT_BRANCH", "\"${getCurrentGitBranch()}\""
         multiDexEnabled true
-        manifestPlaceholders += [appName: appName]
     }
 
     packagingOptions {

--- a/catroid/google-services.json
+++ b/catroid/google-services.json
@@ -10,7 +10,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:713919797763:android:d9d5e2274e070833",
         "android_client_info": {
-          "package_name": "@appId@"
+          "package_name": "org.catrobat.catroid"
         }
       },
       "oauth_client": [
@@ -41,7 +41,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:713919797763:android:c03d22e27263cfca",
         "android_client_info": {
-          "package_name": "@appId@.gnoID"
+          "package_name": "org.catrobat.catroid.gnoID"
         }
       },
       "oauth_client": [

--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -85,7 +85,7 @@
         android:name=".CatroidApplication"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
-        android:label="${appName}"
+        android:label="@string/app_name"
         android:theme="@style/Theme.Catroid"
         android:supportsRtl="true">
 
@@ -96,7 +96,7 @@
         <activity
             android:name="com.facebook.FacebookActivity"
             android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-            android:label="${appName}"
+            android:label="@string/app_name"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
         <activity


### PR DESCRIPTION
This reverts commit f78114277b7d82a529bf2e1e0f4e481c9cde09fd.

Adding the JumpingSumo Drone Support collides with the initial commit.
Even worse: This commit broke the standalone APK creation.
Thus the most sensible way is to revert it and find a better solution.
More details are outlined at CAT-2400.