### PR TITLE
CAT-2558 Evaluate empty list to empty string ""

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestUserLists.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestUserLists.java
@@ -48,9 +48,8 @@ public class ParserTestUserLists extends AndroidTestCase {
 	private static final String PROJECT_USER_LIST_NAME = "project_user_list";
 	private static final String SPRITE_USER_LIST_NAME = "sprite_user_list";
 	private Sprite firstSprite;
-	private static final Double DELTA = 0.01;
 
-	private static final Double EMPTY_USER_LIST_INTERPRETATION_VALUE = 0d;
+	private static final String EMPTY_USER_LIST_INTERPRETATION_VALUE = "";
 
 	private static final String USER_LIST_VALUES_SINGLE_NUMBER_STRING_INTERPRETATION_VALUE = "1";
 	private static final List<Object> USER_LIST_VALUES_SINGLE_NUMBER_STRING = new ArrayList<Object>();
@@ -161,7 +160,7 @@ public class ParserTestUserLists extends AndroidTestCase {
 		dataContainer.getUserList(firstSprite, PROJECT_USER_LIST_NAME).getList().clear();
 
 		assertEquals("Formula interpretation of List is not as expected", EMPTY_USER_LIST_INTERPRETATION_VALUE,
-				(Double) interpretUserList(PROJECT_USER_LIST_NAME), DELTA);
+				interpretUserList(PROJECT_USER_LIST_NAME));
 	}
 
 	public void testUserListReset() {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -59,6 +59,7 @@ public class FormulaElement implements Serializable {
 
 	public static final Double NOT_EXISTING_USER_VARIABLE_INTERPRETATION_VALUE = 0d;
 	public static final Double NOT_EXISTING_USER_LIST_INTERPRETATION_VALUE = 0d;
+	private static final String EMPTY_USER_LIST_INTERPRETATION_VALUE = "";
 
 	private ElementType type;
 	private String value;
@@ -311,7 +312,7 @@ public class FormulaElement implements Serializable {
 		List<Object> userListValues = userList.getList();
 
 		if (userListValues.size() == 0) {
-			return 0d;
+			return EMPTY_USER_LIST_INTERPRETATION_VALUE;
 		} else if (userListValues.size() == 1) {
 			Object userListValue = userListValues.get(0);
 			if (userListValue instanceof String) {


### PR DESCRIPTION
To be Scratch compatible, an empty list evaluates to an empty string "".
Previously was 0.0.