### PR TITLE
CAT-2573 Use Scratch random function

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -712,23 +712,26 @@ public class FormulaElement implements Serializable {
 		return dividend % divisor;
 	}
 
-	private Object interpretFunctionRand(Object right, Object left) {
-		Double minimum = java.lang.Math.min((Double) left, (Double) right);
-		Double maximum = java.lang.Math.max((Double) left, (Double) right);
+	private Object interpretFunctionRand(Object left, Object right) {
+		double from = (double) left;
+		double to = (double) right;
+		double low = (from <= to) ? from : to;
+		double high = (from <= to) ? to : from;
 
-		Double randomDouble = minimum + (java.lang.Math.random() * (maximum - minimum));
-
-		if (isInteger(minimum) && isInteger(maximum)
-				&& !(rightChild.type == ElementType.NUMBER && rightChild.value.contains("."))
-				&& !(leftChild.type == ElementType.NUMBER && leftChild.value.contains("."))) {
-			if ((Math.abs(randomDouble) - (int) Math.abs(randomDouble)) >= 0.5) {
-				return (double) randomDouble.intValue() + 1;
-			} else {
-				return (double) randomDouble.intValue();
-			}
-		} else {
-			return randomDouble;
+		if (low == high) {
+			return low;
 		}
+
+		if (isInteger(low) && isInteger(high)
+				&& !isNumberWithDecimalPoint(leftChild) && !isNumberWithDecimalPoint(rightChild)) {
+			return low + Math.floor(Math.random() * ((high + 1) - low));
+		} else {
+			return (Math.random() * (high - low)) + low;
+		}
+	}
+
+	private static boolean isNumberWithDecimalPoint(FormulaElement element) {
+		return element.type == ElementType.NUMBER && element.value.contains(".");
 	}
 
 	private Object interpretOperator(Operators operator, Sprite sprite) {


### PR DESCRIPTION
Fixes CAT-2573 by using the [Scratch random function implementation](https://github.com/LLK/scratch-vm/blob/c807f02e37b4746bc503929ae10059de5baa5105/src/blocks/scratch3_operators.js#L80-L91) to
generate random numbers within a specific range.
___
I manually tested it with `[0,1], [0,10], [1,10], [-1,1], [-1.5,1.5], [0, 10.0]`. Please test it as well.
JFI: If you use e.g. `10.0`, the random value will be a double with decimal places, whereas using `10` will result in integers.