### PR TITLE
[CAT-2366] Remove script-sprite pair from script-sprite-map when removing cloned sprites

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/BroadcastHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/BroadcastHandler.java
@@ -36,6 +36,7 @@ import org.catrobat.catroid.content.actions.BroadcastNotifyAction;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 
 public final class BroadcastHandler {
@@ -196,6 +197,15 @@ public final class BroadcastHandler {
 			}
 		}
 		return false;
+	}
+
+	public static void removeSpriteFromScriptSpriteMap(Sprite sprite) {
+		Iterator<Script> it = scriptSpriteMap.keySet().iterator();
+		while (it.hasNext()) {
+			if (scriptSpriteMap.get(it.next()) == sprite) {
+				it.remove();
+			}
+		}
 	}
 
 	public static void clearActionMaps() {

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -280,9 +280,7 @@ public class StageListener implements ApplicationListener {
 		Scene currentScene = ProjectManager.getInstance().getSceneToPlay();
 		DataContainer userVariables = currentScene.getDataContainer();
 		userVariables.removeVariableListForSprite(sprite);
-
-		BroadcastHandler.getScriptSpriteMap().remove(sprite);
-
+		BroadcastHandler.removeSpriteFromScriptSpriteMap(sprite);
 		sprite.look.setLookVisible(false);
 		sprite.look.remove();
 		sprites.remove(sprite);
@@ -295,7 +293,7 @@ public class StageListener implements ApplicationListener {
 		for (Sprite sprite : clonedSprites) {
 			userVariables.removeVariableListForSprite(sprite);
 
-			BroadcastHandler.getScriptSpriteMap().remove(sprite);
+			BroadcastHandler.removeSpriteFromScriptSpriteMap(sprite);
 
 			sprite.look.setLookVisible(false);
 			sprite.look.remove();


### PR DESCRIPTION
When clones were removed, their corresponding entries in the ScriptSprite map were not removed up until now (due to incorrect usage of Map.remove(...)). 

This pull requests now removes those entries, fixing a minor memory leak.