### PR TITLE
[CAT-2571] Exclude native libs with arm64-v8a architecture 

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -78,6 +78,7 @@ android {
         exclude 'META-INF/maven/com.google.guava/guava/pom.properties'
         exclude 'META-INF/maven/com.google.guava/guava/pom.xml'
         exclude 'META-INF/INDEX.LIST'  //compile problem with parrot arsdk
+        exclude 'lib/arm64-v8a/*' // exclude all arm64-v8a libs as we don't have all libs for that architecture
     }
 
     buildTypes {


### PR DESCRIPTION
If one of the native libs is loaded for arm64-v8a, the app expects all libs to be available for that architecture. Only some libs were available (from the parrot sdk) - the app crashed when looking for libgdx.so.
This way 32bit libs are used on 64 bit devices. 

This is a quick fix - to support 64 bit, we need to include the remaining native libs for 64 bit architecture.