### PR TITLE
CAT-2576 Fix crash when replacing sound from media library

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/SoundAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/SoundAdapter.java
@@ -61,6 +61,13 @@ public class SoundAdapter extends SoundBaseAdapter implements ActionModeActivity
 			return INVALID_ID;
 		}
 		SoundInfo item = getItem(position);
+
+		if (!idMap.containsKey(item)) {
+			idMap.clear();
+			for (int i = 0; i < getCount(); i++) {
+				idMap.put(getItem(i), i);
+			}
+		}
 		return idMap.get(item);
 	}
 


### PR DESCRIPTION
Added check to SoundAdapter getItemId to see if the SoundInfo
is in the idMap.