### PR TITLE
CAT-2603 Support more flexible, arabic sentence structure in brick names

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/BrickValueParameterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/BrickValueParameterTest.java
@@ -30,6 +30,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
@@ -191,6 +192,7 @@ import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_NFC_BRICKS;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_PHIRO_BRICKS;
 import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_RASPI_BRICKS;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.getResources;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
@@ -713,7 +715,8 @@ public class BrickValueParameterTest {
 
 		checkIfBrickShowsText(LegoNxtPlayToneBrick.class, R.string.nxt_play_tone);
 		checkIfBrickShowsText(LegoNxtPlayToneBrick.class, R.string.nxt_tone_duration);
-		checkIfBrickShowsText(LegoNxtPlayToneBrick.class, R.string.nxt_seconds);
+		checkIfBrickShowsText(LegoNxtPlayToneBrick.class, getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.LEGO_DURATION)));
 		checkIfBrickShowsText(LegoNxtPlayToneBrick.class, R.string.nxt_tone_frequency);
 		checkIfBrickShowsText(LegoNxtPlayToneBrick.class, R.string.nxt_tone_hundred_hz);
 		checkIfBrickShowsText(LegoNxtPlayToneBrick.class, "1.0");
@@ -749,7 +752,8 @@ public class BrickValueParameterTest {
 
 		checkIfBrickShowsText(LegoEv3PlayToneBrick.class, R.string.ev3_play_tone);
 		checkIfBrickShowsText(LegoEv3PlayToneBrick.class, R.string.ev3_tone_duration_for);
-		checkIfBrickShowsText(LegoEv3PlayToneBrick.class, R.string.nxt_seconds);
+		checkIfBrickShowsText(LegoEv3PlayToneBrick.class, getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.LEGO_DURATION)));
 		checkIfBrickShowsText(LegoEv3PlayToneBrick.class, R.string.nxt_tone_frequency);
 		checkIfBrickShowsText(LegoEv3PlayToneBrick.class, R.string.nxt_tone_hundred_hz);
 		checkIfBrickShowsText(LegoEv3PlayToneBrick.class, R.string.ev3_tone_volume);
@@ -774,66 +778,80 @@ public class BrickValueParameterTest {
 		checkIfBrickShowsText(DroneEmergencyBrick.class, R.string.brick_drone_emergency);
 
 		checkIfBrickShowsText(DroneMoveUpBrick.class, R.string.brick_drone_move_up);
-		checkIfBrickShowsText(DroneMoveUpBrick.class, R.string.brick_drone_with);
-		checkIfBrickShowsText(DroneMoveUpBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol)
-				+ " "
-				+ UiTestUtils.getResourcesString(R.string.formula_editor_function_power));
+		checkIfBrickShowsText(DroneMoveUpBrick.class, getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000)));
+		checkIfBrickShowsText(DroneMoveUpBrick.class, R.string.brick_drone_with_);
+		checkIfBrickShowsText(DroneMoveUpBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol));
+		checkIfBrickShowsText(DroneMoveUpBrick.class, UiTestUtils.getResourcesString(R.string.formula_editor_function_power));
 		checkIfBrickShowsText(DroneMoveUpBrick.class, "1");
 		checkIfBrickShowsText(DroneMoveUpBrick.class, "20");
 
 		checkIfBrickShowsText(DroneMoveDownBrick.class, R.string.brick_drone_move_down);
-		checkIfBrickShowsText(DroneMoveDownBrick.class, R.string.brick_drone_with);
-		checkIfBrickShowsText(DroneMoveDownBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol)
-				+ " "
-				+ UiTestUtils.getResourcesString(R.string.formula_editor_function_power));
+		checkIfBrickShowsText(DroneMoveDownBrick.class, getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000)));
+		checkIfBrickShowsText(DroneMoveDownBrick.class, R.string.brick_drone_with_);
+		checkIfBrickShowsText(DroneMoveDownBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol));
+		checkIfBrickShowsText(DroneMoveDownBrick.class, UiTestUtils.getResourcesString(R.string
+				.formula_editor_function_power));
 		checkIfBrickShowsText(DroneMoveDownBrick.class, "1");
 		checkIfBrickShowsText(DroneMoveDownBrick.class, "20");
 
 		checkIfBrickShowsText(DroneMoveLeftBrick.class, R.string.brick_drone_move_left);
-		checkIfBrickShowsText(DroneMoveLeftBrick.class, R.string.brick_drone_with);
-		checkIfBrickShowsText(DroneMoveLeftBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol)
-				+ " "
-				+ UiTestUtils.getResourcesString(R.string.formula_editor_function_power));
+		checkIfBrickShowsText(DroneMoveLeftBrick.class, getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000)));
+		checkIfBrickShowsText(DroneMoveLeftBrick.class, R.string.brick_drone_with_);
+		checkIfBrickShowsText(DroneMoveLeftBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol));
+		checkIfBrickShowsText(DroneMoveLeftBrick.class, UiTestUtils.getResourcesString(R.string
+				.formula_editor_function_power));
 		checkIfBrickShowsText(DroneMoveLeftBrick.class, "1");
 		checkIfBrickShowsText(DroneMoveLeftBrick.class, "20");
 
 		checkIfBrickShowsText(DroneMoveRightBrick.class, R.string.brick_drone_move_right);
-		checkIfBrickShowsText(DroneMoveRightBrick.class, R.string.brick_drone_with);
-		checkIfBrickShowsText(DroneMoveRightBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol)
-				+ " "
-				+ UiTestUtils.getResourcesString(R.string.formula_editor_function_power));
+		checkIfBrickShowsText(DroneMoveRightBrick.class, getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000)));
+		checkIfBrickShowsText(DroneMoveRightBrick.class, R.string.brick_drone_with_);
+		checkIfBrickShowsText(DroneMoveRightBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol));
+		checkIfBrickShowsText(DroneMoveRightBrick.class, UiTestUtils.getResourcesString(R.string
+				.formula_editor_function_power));
 		checkIfBrickShowsText(DroneMoveRightBrick.class, "1");
 		checkIfBrickShowsText(DroneMoveRightBrick.class, "20");
 
 		checkIfBrickShowsText(DroneMoveForwardBrick.class, R.string.brick_drone_move_forward);
-		checkIfBrickShowsText(DroneMoveForwardBrick.class, R.string.brick_drone_with);
-		checkIfBrickShowsText(DroneMoveForwardBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol)
-				+ " "
-				+ UiTestUtils.getResourcesString(R.string.formula_editor_function_power));
+		checkIfBrickShowsText(DroneMoveForwardBrick.class, getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000)));
+		checkIfBrickShowsText(DroneMoveForwardBrick.class, R.string.brick_drone_with_);
+		checkIfBrickShowsText(DroneMoveForwardBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol));
+		checkIfBrickShowsText(DroneMoveForwardBrick.class, UiTestUtils.getResourcesString(R.string
+				.formula_editor_function_power));
 		checkIfBrickShowsText(DroneMoveForwardBrick.class, "1");
 		checkIfBrickShowsText(DroneMoveForwardBrick.class, "20");
 
 		checkIfBrickShowsText(DroneMoveBackwardBrick.class, R.string.brick_drone_move_backward);
-		checkIfBrickShowsText(DroneMoveBackwardBrick.class, R.string.brick_drone_with);
-		checkIfBrickShowsText(DroneMoveBackwardBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol)
-				+ " "
-				+ UiTestUtils.getResourcesString(R.string.formula_editor_function_power));
+		checkIfBrickShowsText(DroneMoveBackwardBrick.class, getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000)));
+		checkIfBrickShowsText(DroneMoveBackwardBrick.class, R.string.brick_drone_with_);
+		checkIfBrickShowsText(DroneMoveBackwardBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol));
+		checkIfBrickShowsText(DroneMoveBackwardBrick.class, UiTestUtils.getResourcesString(R.string
+				.formula_editor_function_power));
 		checkIfBrickShowsText(DroneMoveBackwardBrick.class, "1");
 		checkIfBrickShowsText(DroneMoveBackwardBrick.class, "20");
 
 		checkIfBrickShowsText(DroneTurnLeftBrick.class, R.string.brick_drone_turn_left);
-		checkIfBrickShowsText(DroneTurnLeftBrick.class, R.string.brick_drone_with);
-		checkIfBrickShowsText(DroneTurnLeftBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol)
-				+ " "
-				+ UiTestUtils.getResourcesString(R.string.formula_editor_function_power));
+		checkIfBrickShowsText(DroneTurnLeftBrick.class, getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000)));
+		checkIfBrickShowsText(DroneTurnLeftBrick.class, R.string.brick_drone_with_);
+		checkIfBrickShowsText(DroneTurnLeftBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol));
+		checkIfBrickShowsText(DroneTurnLeftBrick.class, UiTestUtils.getResourcesString(R.string.formula_editor_function_power));
 		checkIfBrickShowsText(DroneTurnLeftBrick.class, "1");
 		checkIfBrickShowsText(DroneTurnLeftBrick.class, "20");
 
 		checkIfBrickShowsText(DroneTurnRightBrick.class, R.string.brick_drone_turn_right);
-		checkIfBrickShowsText(DroneTurnRightBrick.class, R.string.brick_drone_with);
-		checkIfBrickShowsText(DroneTurnRightBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol)
-				+ " "
-				+ UiTestUtils.getResourcesString(R.string.formula_editor_function_power));
+		checkIfBrickShowsText(DroneTurnRightBrick.class, getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000)));
+		checkIfBrickShowsText(DroneTurnRightBrick.class, R.string.brick_drone_with_);
+		checkIfBrickShowsText(DroneTurnRightBrick.class, UiTestUtils.getResourcesString(R.string.percent_symbol));
+		checkIfBrickShowsText(DroneTurnRightBrick.class, UiTestUtils.getResourcesString(R.string
+				.formula_editor_function_power));
 		checkIfBrickShowsText(DroneTurnRightBrick.class, "1");
 		checkIfBrickShowsText(DroneTurnRightBrick.class, "20");
 
@@ -873,7 +891,8 @@ public class BrickValueParameterTest {
 
 		checkIfBrickShowsText(PhiroPlayToneBrick.class, R.string.phiro_play_tone);
 		checkIfBrickShowsText(PhiroPlayToneBrick.class, R.string.phiro_tone_duration);
-		checkIfBrickShowsText(PhiroPlayToneBrick.class, R.string.phiro_seconds);
+		checkIfBrickShowsText(PhiroPlayToneBrick.class, getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.PHIRO_DURATION)));
 		checkIfBrickShowsText(PhiroPlayToneBrick.class, "1");
 		checkIfBrickShowsSpinnerWithEditTextOverlayWithText(PhiroPlayToneBrick.class,
 				R.id.brick_phiro_select_tone_spinner,
@@ -1005,7 +1024,7 @@ public class BrickValueParameterTest {
 		//wait - edit text "1" - second
 		checkIfBrickShowsText(WaitBrick.class, R.string.brick_wait);
 		checkIfBrickShowsEditTextWithText(WaitBrick.class, R.id.brick_wait_edit_text, "1");
-		checkIfBrickShowsText(WaitBrick.class, UiTestUtils.getResources().getQuantityString(R.plurals.second_plural,
+		checkIfBrickShowsText(WaitBrick.class, getResources().getQuantityString(R.plurals.second_plural,
 				Utils.convertDoubleToPluralInteger(1)));
 
 		//note - edit text "add comment here..."
@@ -1036,7 +1055,7 @@ public class BrickValueParameterTest {
 		//repeat  - edit text "10" - times
 		checkIfBrickShowsText(RepeatBrick.class, R.string.brick_repeat);
 		checkIfBrickShowsEditTextWithText(RepeatBrick.class, R.id.brick_repeat_edit_text, "10");
-		checkIfBrickShowsText(RepeatBrick.class, UiTestUtils.getResources().getQuantityString(R.plurals.time_plural,
+		checkIfBrickShowsText(RepeatBrick.class, getResources().getQuantityString(R.plurals.time_plural,
 				Utils.convertDoubleToPluralInteger(10)));
 
 		//repeat until - edit text "1 st 2" - is true

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/rtl/ArabicSentenceStructureInBricksNameTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/rtl/ArabicSentenceStructureInBricksNameTest.java
@@ -1,0 +1,623 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2017 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.content.brick.rtl;
+
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.DroneMoveBackwardBrick;
+import org.catrobat.catroid.content.bricks.DroneMoveDownBrick;
+import org.catrobat.catroid.content.bricks.DroneMoveForwardBrick;
+import org.catrobat.catroid.content.bricks.DroneMoveLeftBrick;
+import org.catrobat.catroid.content.bricks.DroneMoveRightBrick;
+import org.catrobat.catroid.content.bricks.DroneMoveUpBrick;
+import org.catrobat.catroid.content.bricks.DroneTurnLeftBrick;
+import org.catrobat.catroid.content.bricks.DroneTurnRightBrick;
+import org.catrobat.catroid.content.bricks.IfLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.JumpingSumoMoveBackwardBrick;
+import org.catrobat.catroid.content.bricks.JumpingSumoMoveForwardBrick;
+import org.catrobat.catroid.content.bricks.JumpingSumoRotateLeftBrick;
+import org.catrobat.catroid.content.bricks.JumpingSumoRotateRightBrick;
+import org.catrobat.catroid.content.bricks.LegoEv3MotorMoveBrick;
+import org.catrobat.catroid.content.bricks.LegoNxtMotorMoveBrick;
+import org.catrobat.catroid.content.bricks.RepeatUntilBrick;
+import org.catrobat.catroid.content.bricks.SetNfcTagBrick;
+import org.catrobat.catroid.content.bricks.WaitUntilBrick;
+import org.catrobat.catroid.content.bricks.WhenConditionBrick;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.catrobat.catroid.formulaeditor.Sensors;
+import org.catrobat.catroid.ui.SettingsActivity;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.ui.activity.rtl.RtlUiTestUtils;
+import org.catrobat.catroid.uiespresso.util.matchers.ScriptListMatchers;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static android.support.test.InstrumentationRegistry.getTargetContext;
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.PositionAssertions.isBelow;
+import static android.support.test.espresso.assertion.PositionAssertions.isLeftOf;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED;
+import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED;
+import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_ARDUINO_BRICKS;
+import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_NFC_BRICKS;
+import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS;
+import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_PARROT_JUMPING_SUMO_BRICKS;
+import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_PHIRO_BRICKS;
+import static org.catrobat.catroid.ui.SettingsActivity.SETTINGS_SHOW_RASPI_BRICKS;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.getResourcesString;
+import static org.catrobat.catroid.uiespresso.util.matchers.rtl.RtlViewDirection.isViewRtl;
+import static org.hamcrest.Matchers.instanceOf;
+
+@RunWith(AndroidJUnit4.class)
+public class ArabicSentenceStructureInBricksNameTest {
+	@Rule
+	public BaseActivityInstrumentationRule<SpriteActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(SpriteActivity.class, true, false);
+	private Locale arLocale = new Locale("ar");
+	private List<String> allPeripheralCategories = new ArrayList<>(Arrays.asList(SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED,
+			SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED, SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS, SETTINGS_SHOW_PHIRO_BRICKS,
+			SETTINGS_SHOW_ARDUINO_BRICKS, SETTINGS_SHOW_RASPI_BRICKS, SETTINGS_SHOW_NFC_BRICKS, SETTINGS_SHOW_PARROT_JUMPING_SUMO_BRICKS));
+	private List<String> enabledByThisTestPeripheralCategories = new ArrayList<>();
+
+	@Before
+	public void setUp() throws Exception {
+		createProject("ArabicSentenceInBricksName");
+		SettingsActivity.setLanguageSharedPreference(getTargetContext(), "ar");
+		baseActivityTestRule.launchActivity(null);
+
+		SharedPreferences sharedPreferences = PreferenceManager
+				.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext());
+
+		for (String category : allPeripheralCategories) {
+			boolean categoryEnabled = sharedPreferences.getBoolean(category, false);
+			if (!categoryEnabled) {
+				sharedPreferences.edit().putBoolean(category, true).commit();
+				enabledByThisTestPeripheralCategories.add(category);
+			}
+		}
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testElementsOrderInAdaptedBricksForArabicLanguage() throws Exception {
+		assertEquals(Locale.getDefault().getDisplayLanguage(), arLocale.getDisplayLanguage());
+		assertTrue(RtlUiTestUtils.checkTextDirectionIsRtl(Locale.getDefault().getDisplayName()));
+
+		// if is true then ... else ...
+		checkIfBrickISRtl(IfLogicBeginBrick.class, R.id.brick_if_begin_layout);
+		onView(withId(R.id.if_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.if_label_second_part))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.if_label)));
+
+		onView(withId(R.id.brick_if_begin_edit_text))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.if_label_second_part)));
+
+		// repeat until is true
+		checkIfBrickISRtl(RepeatUntilBrick.class, R.id.brick_repeat_until_layout);
+		onView(withId(R.id.brick_repeat_until_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.wait_until_label_second_part))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id
+						.brick_repeat_until_label)));
+
+		onView(withId(R.id.brick_repeat_until_edit_text))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.wait_until_label_second_part)));
+
+		// Set Ev3 motor to speed
+		checkIfBrickISRtl(LegoEv3MotorMoveBrick.class, R.id.brick_ev3_motor_move_layout);
+		onView(withId(R.id.brick_ev3_motor_move_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_ev3_motor_move_spinner))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_ev3_motor_move_label)));
+
+		onView(withId(R.id.ev3_motor_move_speed_edit_text))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_ev3_motor_move_speed_text)));
+
+		onView(withId(R.id.brick_ev3_motor_move_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.ev3_motor_move_speed_edit_text)));
+
+		// Set NXT motor to speed
+		checkIfBrickISRtl(LegoNxtMotorMoveBrick.class, R.id.brick_nxt_motor_action_layout);
+		onView(withId(R.id.lego_motor_action_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.lego_motor_action_spinner))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.lego_motor_action_label)));
+
+		onView(withId(R.id.motor_action_speed_edit_text))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.lego_motor_action_speed_text)));
+
+		onView(withId(R.id.lego_motor_action_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.motor_action_speed_edit_text)));
+
+		// Move Jumping Sumo backward
+		checkIfBrickISRtl(JumpingSumoMoveBackwardBrick.class, R.id.brick_jumping_sumo_move_backward_layout);
+		onView(withId(R.id.brick_jumping_sumo_move_backward_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_jumping_sumo_move_backward_edit_text_second))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_jumping_sumo_move_backward_label)));
+
+		onView(withId(R.id.brick_jumping_sumo_move_forward_text_second))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_move_backward_edit_text_second)));
+
+		onView(withId(R.id.brick_jumping_sumo_move_backward_text_with))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_move_forward_text_second)));
+
+		onView(withId(R.id.brick_jumping_sumo_move_backward_set_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_move_backward_text_with)));
+
+		onView(withId(R.id.brick_jumping_sumo_move_backward_edit_text_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_move_backward_set_power)));
+
+		onView(withId(R.id.brick_jumping_sumo_move_backward_set_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_move_backward_edit_text_power)));
+
+		// Move Jumping Sumo forward
+		checkIfBrickISRtl(JumpingSumoMoveForwardBrick.class, R.id.brick_jumping_sumo_move_forward_layout);
+		onView(withId(R.id.brick_jumping_sumo_move_forward_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_jumping_sumo_move_forward_edit_text_second))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_jumping_sumo_move_forward_label)));
+
+		onView(withId(R.id.brick_jumping_sumo_move_forward_text_second))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_move_forward_edit_text_second)));
+
+		onView(withId(R.id.brick_jumping_sumo_move_forward_text_with))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_move_forward_text_second)));
+
+		onView(withId(R.id.brick_jumping_sumo_move_forward_set_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_move_forward_text_with)));
+
+		onView(withId(R.id.brick_jumping_sumo_move_forward_edit_text_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_move_forward_set_power)));
+
+		onView(withId(R.id.brick_jumping_sumo_move_forward_set_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_move_forward_edit_text_power)));
+
+		// JumpingSumoRotateLeftBrick
+		checkIfBrickISRtl(JumpingSumoRotateLeftBrick.class, R.id.brick_jumping_sumo_rotate_left_layout);
+		onView(withId(R.id.brick_jumping_sumo_rotate_left_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_jumping_sumo_change_left_variable_edit_text))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_jumping_sumo_rotate_left_label)));
+
+		onView(withId(R.id.brick_jumping_sumo_rotate_left_text))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_change_left_variable_edit_text)));
+
+		// JumpingSumoRotateRightBrick
+		checkIfBrickISRtl(JumpingSumoRotateRightBrick.class, R.id.brick_jumping_sumo_rotate_right_layout);
+		onView(withId(R.id.brick_jumping_sumo_rotate_right_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_jumping_sumo_change_right_variable_edit_text))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_jumping_sumo_rotate_right_label)));
+
+		onView(withId(R.id.brick_jumping_sumo_rotate_right_text))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_jumping_sumo_change_right_variable_edit_text)));
+
+		// set next NFC tag to
+		checkIfBrickISRtl(SetNfcTagBrick.class, R.id.brick_set_nfc_tag_layout);
+		onView(withId(R.id.brick_set_nfc_tag_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_set_nfc_tag_edit_text))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_set_nfc_tag_label)));
+
+		onView(withId(R.id.brick_set_nfc_tag_ndef_record_textview))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_set_nfc_tag_edit_text)));
+
+		onView(withId(R.id.brick_set_nfc_tag_ndef_record_spinner))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_set_nfc_tag_ndef_record_textview)));
+
+		// wait until  is true
+		checkIfBrickISRtl(WaitUntilBrick.class, R.id.brick_wait_until_layout);
+		onView(withId(R.id.wait_until_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.wait_until_label_second_part))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.wait_until_label)));
+
+		onView(withId(R.id.brick_wait_until_edit_text))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.wait_until_label_second_part)));
+
+		// When  becomes true
+		checkIfBrickISRtl(WhenConditionBrick.class, R.id.brick_when_condition_layout);
+		onView(withId(R.id.when_conditon_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.when_condition_label_second_part))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.when_conditon_label)));
+
+		onView(withId(R.id.brick_when_condition_edit_text))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.when_condition_label_second_part)));
+
+		// DroneMoveDownBrick
+		checkIfBrickISRtl(DroneMoveDownBrick.class, R.id.brick_drone_move_down_layout);
+		onView(withId(R.id.brick_drone_move_down_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_drone_move_down_edit_text_second))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_drone_move_down_label)));
+
+		onView(withId(R.id.brick_drone_move_down_text_second))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_down_edit_text_second)));
+
+		onView(withId(R.id.brick_drone_move_down_text_with))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_down_text_second)));
+
+		onView(withId(R.id.brick_drone_move_down_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_down_text_with)));
+
+		onView(withId(R.id.brick_drone_move_down_edit_text_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_down_power)));
+
+		onView(withId(R.id.brick_drone_move_down_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_down_edit_text_power)));
+
+		// DroneMoveUpBrick
+		checkIfBrickISRtl(DroneMoveUpBrick.class, R.id.brick_drone_move_up_layout);
+		onView(withId(R.id.brick_drone_move_up_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_drone_move_up_edit_text_second))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_drone_move_up_label)));
+
+		onView(withId(R.id.brick_drone_move_up_text_second))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_up_edit_text_second)));
+
+		onView(withId(R.id.brick_drone_move_up_text_with))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_up_text_second)));
+
+		onView(withId(R.id.brick_drone_move_up_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_up_text_with)));
+
+		onView(withId(R.id.brick_drone_move_up_edit_text_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_up_power)));
+
+		onView(withId(R.id.brick_drone_move_up_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_up_edit_text_power)));
+
+		//DroneMoveLeftBrick
+		checkIfBrickISRtl(DroneMoveLeftBrick.class, R.id.brick_drone_move_left_layout);
+		onView(withId(R.id.brick_drone_move_left_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_drone_move_left_edit_text_second))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_drone_move_left_label)));
+
+		onView(withId(R.id.brick_drone_move_left_text_second))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_left_edit_text_second)));
+
+		onView(withId(R.id.brick_drone_move_left_text_with))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_left_text_second)));
+
+		onView(withId(R.id.brick_drone_move_left_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_left_text_with)));
+
+		onView(withId(R.id.brick_drone_move_left_edit_text_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_left_power)));
+
+		onView(withId(R.id.brick_drone_move_left_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_left_edit_text_power)));
+
+		//DroneMoveRightBrick
+		checkIfBrickISRtl(DroneMoveRightBrick.class, R.id.brick_drone_move_right_layout);
+		onView(withId(R.id.brick_drone_move_right_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_drone_move_right_edit_text_second))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_drone_move_right_label)));
+
+		onView(withId(R.id.brick_drone_move_right_text_second))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_right_edit_text_second)));
+
+		onView(withId(R.id.brick_drone_move_right_text_with))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_right_text_second)));
+
+		onView(withId(R.id.brick_drone_move_right_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_right_text_with)));
+
+		onView(withId(R.id.brick_drone_move_right_edit_text_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_right_power)));
+
+		onView(withId(R.id.brick_drone_move_right_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_right_edit_text_power)));
+
+		//DroneMoveBackwardBrick
+		checkIfBrickISRtl(DroneMoveBackwardBrick.class, R.id.brick_drone_move_backward_layout);
+		onView(withId(R.id.brick_drone_move_backward_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_drone_move_backward_edit_text_second))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_drone_move_backward_label)));
+
+		onView(withId(R.id.brick_drone_move_backward_text_second))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_backward_edit_text_second)));
+
+		onView(withId(R.id.brick_drone_move_backward_text_with))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_backward_text_second)));
+
+		onView(withId(R.id.brick_drone_move_backward_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_backward_text_with)));
+
+		onView(withId(R.id.brick_drone_move_backward_edit_text_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_backward_power)));
+
+		onView(withId(R.id.brick_drone_move_backward_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_backward_edit_text_power)));
+
+		//DroneMoveForwardBrick
+		checkIfBrickISRtl(DroneMoveForwardBrick.class, R.id.brick_drone_move_forward_layout);
+		onView(withId(R.id.brick_drone_move_forward_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_drone_move_forward_edit_text_second))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_drone_move_forward_label)));
+
+		onView(withId(R.id.brick_drone_move_forward_text_second))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_forward_edit_text_second)));
+
+		onView(withId(R.id.brick_drone_move_forward_text_with))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_forward_text_second)));
+
+		onView(withId(R.id.brick_drone_move_forward_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_forward_text_with)));
+
+		onView(withId(R.id.brick_drone_move_forward_edit_text_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_forward_power)));
+
+		onView(withId(R.id.brick_drone_move_forward_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_move_forward_edit_text_power)));
+
+		//DroneTurnLeftBrick
+		checkIfBrickISRtl(DroneTurnLeftBrick.class, R.id.brick_drone_turn_left_layout);
+		onView(withId(R.id.brick_drone_turn_left_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_drone_turn_left_edit_text_second))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_drone_turn_left_label)));
+
+		onView(withId(R.id.brick_drone_turn_left_text_second))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_turn_left_edit_text_second)));
+
+		onView(withId(R.id.brick_drone_turn_left_text_with))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_turn_left_text_second)));
+
+		onView(withId(R.id.brick_drone_turn_left_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_turn_left_text_with)));
+
+		onView(withId(R.id.brick_drone_turn_left_edit_text_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_turn_left_power)));
+
+		onView(withId(R.id.brick_drone_turn_left_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_turn_left_edit_text_power)));
+
+		//DroneTurnRightBrick
+		checkIfBrickISRtl(DroneTurnRightBrick.class, R.id.brick_drone_turn_right_layout);
+		onView(withId(R.id.brick_drone_turn_right_label))
+				.check(matches(isDisplayed()));
+
+		onView(withId(R.id.brick_drone_turn_right_edit_text_second))
+				.check(matches(isDisplayed()))
+				.check(isBelow(withId(R.id.brick_drone_turn_right_label)));
+
+		onView(withId(R.id.brick_drone_turn_right_text_second))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_turn_right_edit_text_second)));
+
+		onView(withId(R.id.brick_drone_turn_right_text_with))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_turn_right_text_second)));
+
+		onView(withId(R.id.brick_drone_turn_right_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_turn_right_text_with)));
+
+		onView(withId(R.id.brick_drone_turn_right_edit_text_power))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_turn_right_power)));
+
+		onView(withId(R.id.brick_drone_turn_right_percent))
+				.check(matches(isDisplayed()))
+				.check(isLeftOf(withId(R.id.brick_drone_turn_right_edit_text_power)));
+	}
+
+	@After
+	public void tearDown() {
+		SharedPreferences sharedPreferences = PreferenceManager
+				.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext());
+		for (String category : enabledByThisTestPeripheralCategories) {
+			sharedPreferences.edit().putBoolean(category, false).commit();
+		}
+		enabledByThisTestPeripheralCategories.clear();
+		resetToDefaultLanguage();
+	}
+
+	public static void resetToDefaultLanguage() {
+		SettingsActivity.removeLanguageSharedPreference(getTargetContext());
+	}
+
+	private void createProject(String projectName) {
+		String nameSpriteTwo = "testSpriteTwo";
+
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
+		Sprite spriteOne = new Sprite("testSpriteOne");
+		project.getDefaultScene().addSprite(spriteOne);
+
+		Sprite spriteTwo = new Sprite(nameSpriteTwo);
+		Script script = new StartScript();
+
+		script.addBrick(new IfLogicBeginBrick());
+		script.addBrick(new RepeatUntilBrick(5));
+
+		script.addBrick(new LegoEv3MotorMoveBrick(LegoEv3MotorMoveBrick.Motor.MOTOR_B, 5));
+		script.addBrick(new LegoNxtMotorMoveBrick(LegoNxtMotorMoveBrick.Motor.MOTOR_B_C, 10));
+
+		script.addBrick(new JumpingSumoMoveBackwardBrick(2000, 20));
+		script.addBrick(new JumpingSumoMoveForwardBrick(2000, 20));
+
+		script.addBrick(new JumpingSumoRotateLeftBrick(90));
+		script.addBrick(new JumpingSumoRotateRightBrick(90));
+
+		script.addBrick(new SetNfcTagBrick(getResourcesString(R.string.brick_set_nfc_tag_default_value)));
+		script.addBrick(new WaitUntilBrick(new Formula(1)));
+		Formula condition = new Formula(new FormulaElement(FormulaElement.ElementType.SENSOR,
+				Sensors.COLLIDES_WITH_FINGER.name(), null));
+
+		script.addBrick(new WhenConditionBrick(condition));
+
+		script.addBrick(new DroneMoveDownBrick(2000, 20));
+		script.addBrick(new DroneMoveUpBrick(2000, 20));
+		script.addBrick(new DroneMoveLeftBrick(2000, 20));
+		script.addBrick(new DroneMoveRightBrick(2000, 20));
+		script.addBrick(new DroneMoveBackwardBrick(2000, 20));
+		script.addBrick(new DroneMoveForwardBrick(2000, 20));
+		script.addBrick(new DroneTurnLeftBrick(2000, 20));
+		script.addBrick(new DroneTurnRightBrick(2000, 20));
+
+		spriteTwo.addScript(script);
+		project.getDefaultScene().addSprite(spriteTwo);
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(spriteTwo);
+	}
+
+	private void checkIfBrickISRtl(Class brickClass, int bricksId) {
+		onData(instanceOf(brickClass)).inAdapterView(ScriptListMatchers.isScriptListView())
+				.onChildView(withId(bricksId))
+				.check(matches(isDisplayed()))
+				.check(matches(isViewRtl()));
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveBackwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveBackwardBrick.java
@@ -82,6 +82,10 @@ public class DroneMoveBackwardBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_drone_move_backward_checkbox);
 
+		setSecondText(view, R.id.brick_drone_move_backward_text_second, R.id
+				.brick_drone_move_backward_edit_text_second, BrickField
+				.DRONE_TIME_TO_FLY_IN_SECONDS);
+
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_move_backward_edit_text_second);
 		getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS)
 				.setTextFieldId(R.id.brick_drone_move_backward_edit_text_second);
@@ -109,6 +113,7 @@ public class DroneMoveBackwardBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_POWER_PERCENT));
+		setSecondText(context, prototypeView, R.id.brick_drone_move_backward_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveDownBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveDownBrick.java
@@ -81,6 +81,9 @@ public class DroneMoveDownBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_drone_move_down_checkbox);
 
+		setSecondText(view, R.id.brick_drone_move_down_text_second, R.id
+				.brick_drone_move_down_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
+
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_move_down_edit_text_second);
 		getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS)
 				.setTextFieldId(R.id.brick_drone_move_down_edit_text_second);
@@ -108,6 +111,8 @@ public class DroneMoveDownBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_POWER_PERCENT));
+
+		setSecondText(context, prototypeView, R.id.brick_drone_move_down_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveForwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveForwardBrick.java
@@ -80,6 +80,9 @@ public class DroneMoveForwardBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_drone_move_forward_checkbox);
 
+		setSecondText(view, R.id.brick_drone_move_forward_text_second, R.id
+				.brick_drone_move_forward_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
+
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_move_forward_edit_text_second);
 		getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS)
 				.setTextFieldId(R.id.brick_drone_move_forward_edit_text_second);
@@ -107,6 +110,8 @@ public class DroneMoveForwardBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_POWER_PERCENT));
+
+		setSecondText(context, prototypeView, R.id.brick_drone_move_forward_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveLeftBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveLeftBrick.java
@@ -81,6 +81,9 @@ public class DroneMoveLeftBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_drone_move_left_checkbox);
 
+		setSecondText(view, R.id.brick_drone_move_left_text_second, R.id.brick_drone_move_left_edit_text_second, BrickField
+				.DRONE_TIME_TO_FLY_IN_SECONDS);
+
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_move_left_edit_text_second);
 		getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS)
 				.setTextFieldId(R.id.brick_drone_move_left_edit_text_second);
@@ -108,6 +111,8 @@ public class DroneMoveLeftBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_POWER_PERCENT));
+
+		setSecondText(context, prototypeView, R.id.brick_drone_move_left_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveRightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveRightBrick.java
@@ -81,6 +81,10 @@ public class DroneMoveRightBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_drone_move_right_checkbox);
 
+		setSecondText(view, R.id.brick_drone_move_right_text_second, R.id
+				.brick_drone_move_right_edit_text_second, BrickField
+				.DRONE_TIME_TO_FLY_IN_SECONDS);
+
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_move_right_edit_text_second);
 		getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS)
 				.setTextFieldId(R.id.brick_drone_move_right_edit_text_second);
@@ -108,6 +112,8 @@ public class DroneMoveRightBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_POWER_PERCENT));
+
+		setSecondText(context, prototypeView, R.id.brick_drone_move_right_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveUpBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveUpBrick.java
@@ -81,6 +81,8 @@ public class DroneMoveUpBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_drone_move_up_checkbox);
 
+		setSecondText(view, R.id.brick_drone_move_up_text_second, R.id.brick_drone_move_up_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
+
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_move_up_edit_text_second);
 		getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS)
 				.setTextFieldId(R.id.brick_drone_move_up_edit_text_second);
@@ -108,6 +110,8 @@ public class DroneMoveUpBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_POWER_PERCENT));
+
+		setSecondText(context, prototypeView, R.id.brick_drone_move_up_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftBrick.java
@@ -81,6 +81,8 @@ public class DroneTurnLeftBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_drone_turn_left_checkbox);
 
+		setSecondText(view, R.id.brick_drone_turn_left_text_second, R.id.brick_drone_turn_left_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
+
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_turn_left_edit_text_second);
 		getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS)
 				.setTextFieldId(R.id.brick_drone_turn_left_edit_text_second);
@@ -108,6 +110,8 @@ public class DroneTurnLeftBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_POWER_PERCENT));
+
+		setSecondText(context, prototypeView, R.id.brick_drone_turn_left_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftMagnetoBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftMagnetoBrick.java
@@ -80,6 +80,7 @@ public class DroneTurnLeftMagnetoBrick extends FormulaBrick {
 		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
 
 		setCheckboxView(R.id.brick_drone_turn_left_magneto_checkbox);
+		setSecondText(view, R.id.brick_drone_turn_left_magneto_text_second, R.id.brick_drone_turn_left_magneto_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
 
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_turn_left_magneto_edit_text_second);
 		getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS)
@@ -108,6 +109,7 @@ public class DroneTurnLeftMagnetoBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_POWER_PERCENT));
+		setSecondText(context, prototypeView, R.id.brick_drone_turn_left_magneto_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightBrick.java
@@ -81,6 +81,8 @@ public class DroneTurnRightBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_drone_turn_right_checkbox);
 
+		setSecondText(view, R.id.brick_drone_turn_right_text_second, R.id.brick_drone_turn_right_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
+
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_turn_right_edit_text_second);
 		getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS)
 				.setTextFieldId(R.id.brick_drone_turn_right_edit_text_second);
@@ -108,6 +110,8 @@ public class DroneTurnRightBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_POWER_PERCENT));
+
+		setSecondText(context, prototypeView, R.id.brick_drone_turn_right_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightMagnetoBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightMagnetoBrick.java
@@ -81,6 +81,8 @@ public class DroneTurnRightMagnetoBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_drone_turn_right_magneto_checkbox);
 
+		setSecondText(view, R.id.brick_drone_turn_right_magneto_text_second, R.id.brick_drone_turn_right_magneto_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
+
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_turn_right_magneto_edit_text_second);
 		getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS)
 				.setTextFieldId(R.id.brick_drone_turn_right_magneto_edit_text_second);
@@ -108,6 +110,8 @@ public class DroneTurnRightMagnetoBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.DRONE_MOVE_BRICK_DEFAULT_POWER_PERCENT));
+
+		setSecondText(context, prototypeView, R.id.brick_drone_turn_right_magneto_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
@@ -23,19 +23,25 @@
 package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
+import android.util.Log;
 import android.view.View;
 import android.widget.BaseAdapter;
+import android.widget.TextView;
 
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.InterpretationException;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.formulaeditor.datacontainer.DataContainer;
 import org.catrobat.catroid.ui.adapter.BrickAdapter;
+import org.catrobat.catroid.utils.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -114,6 +120,38 @@ public abstract class FormulaBrick extends BrickBaseType implements View.OnClick
 	public abstract void showFormulaEditorToEditFormula(View view);
 
 	public void updateReferenceAfterMerge(Scene into, Scene from) {
+	}
+
+	public void setSecondText(View view, int textViewId, int editTextDurationId, BrickField brickField) {
+		TextView editDuration = (TextView) view.findViewById(editTextDurationId);
+		getFormulaWithBrickField(brickField)
+				.setTextFieldId(editTextDurationId);
+		getFormulaWithBrickField(brickField).refreshTextField(view);
+
+		TextView times = (TextView) view.findViewById(textViewId);
+
+		if (getFormulaWithBrickField(brickField).isSingleNumberFormula()) {
+			try {
+				times.setText(view.getResources().getQuantityString(
+						R.plurals.second_plural,
+						Utils.convertDoubleToPluralInteger(getFormulaWithBrickField(brickField)
+								.interpretDouble(ProjectManager.getInstance().getCurrentSprite()))
+				));
+			} catch (InterpretationException interpretationException) {
+				Log.d(getClass().getSimpleName(), "Couldn't interpret Formula.", interpretationException);
+			}
+		} else {
+			times.setText(view.getResources().getQuantityString(R.plurals.second_plural,
+					Utils.TRANSLATION_PLURAL_OTHER_INTEGER));
+		}
+
+		editDuration.setOnClickListener(this);
+	}
+
+	public void setSecondText(Context context, View prototypeView, int textViewId) {
+		TextView second = (TextView) prototypeView.findViewById(textViewId);
+		second.setText(context.getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.DRONE_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000)));
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveBackwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveBackwardBrick.java
@@ -82,6 +82,8 @@ public class JumpingSumoMoveBackwardBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_jumping_sumo_move_backward_checkbox);
 
+		setSecondText(view, R.id.brick_jumping_sumo_move_backward_text_second, R.id.brick_jumping_sumo_move_backward_edit_text_second, BrickField.JUMPING_SUMO_TIME_TO_DRIVE_IN_SECONDS);
+
 		TextView editTime = (TextView) view.findViewById(R.id.brick_jumping_sumo_move_backward_edit_text_second);
 		getFormulaWithBrickField(BrickField.JUMPING_SUMO_TIME_TO_DRIVE_IN_SECONDS)
 				.setTextFieldId(R.id.brick_jumping_sumo_move_backward_edit_text_second);
@@ -108,6 +110,7 @@ public class JumpingSumoMoveBackwardBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.JUMPING_SUMO_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.JUMPING_SUMO_MOVE_BRICK_DEFAULT_MOVE_POWER_PERCENT));
+		setSecondText(context, prototypeView, R.id.brick_jumping_sumo_move_backward_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveForwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveForwardBrick.java
@@ -85,6 +85,9 @@ public class JumpingSumoMoveForwardBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_jumping_sumo_move_forward_checkbox);
 
+		setSecondText(view, R.id.brick_jumping_sumo_move_forward_text_second, R.id
+				.brick_jumping_sumo_move_forward_edit_text_second, BrickField.JUMPING_SUMO_TIME_TO_DRIVE_IN_SECONDS);
+
 		TextView editTime = (TextView) view.findViewById(R.id.brick_jumping_sumo_move_forward_edit_text_second);
 		getFormulaWithBrickField(BrickField.JUMPING_SUMO_TIME_TO_DRIVE_IN_SECONDS)
 				.setTextFieldId(R.id.brick_jumping_sumo_move_forward_edit_text_second);
@@ -111,6 +114,7 @@ public class JumpingSumoMoveForwardBrick extends FormulaBrick {
 		textTime.setText(String.valueOf(BrickValues.JUMPING_SUMO_MOVE_BRICK_DEFAULT_TIME_MILLISECONDS / 1000));
 
 		textPower.setText(String.valueOf(BrickValues.JUMPING_SUMO_MOVE_BRICK_DEFAULT_MOVE_POWER_PERCENT));
+		setSecondText(context, prototypeView, R.id.brick_jumping_sumo_move_forward_text_second);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3PlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3PlayToneBrick.java
@@ -34,6 +34,7 @@ import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
+import org.catrobat.catroid.utils.Utils;
 
 import java.text.NumberFormat;
 import java.util.List;
@@ -82,6 +83,9 @@ public class LegoEv3PlayToneBrick extends FormulaBrick {
 		NumberFormat nf = NumberFormat.getInstance(context.getResources().getConfiguration().locale);
 		nf.setMinimumFractionDigits(1);
 		textDuration.setText(nf.format(BrickValues.LEGO_DURATION));
+		TextView times = (TextView) prototypeView.findViewById(R.id.brick_ev3_tone_seconds);
+		times.setText(context.getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.LEGO_DURATION)));
 
 		TextView textFreq = (TextView) prototypeView.findViewById(R.id.brick_ev3_tone_freq_edit_text);
 		textFreq.setText(String.valueOf(BrickValues.LEGO_FREQUENCY));
@@ -105,12 +109,7 @@ public class LegoEv3PlayToneBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_ev3_play_tone_checkbox);
 
-		TextView editDuration = (TextView) view.findViewById(R.id.brick_ev3_tone_duration_edit_text);
-		getFormulaWithBrickField(BrickField.LEGO_EV3_DURATION_IN_SECONDS)
-				.setTextFieldId(R.id.brick_ev3_tone_duration_edit_text);
-		getFormulaWithBrickField(BrickField.LEGO_EV3_DURATION_IN_SECONDS).refreshTextField(view);
-
-		editDuration.setOnClickListener(this);
+		setSecondText(view, R.id.brick_ev3_tone_seconds, R.id.brick_ev3_tone_duration_edit_text, BrickField.LEGO_EV3_DURATION_IN_SECONDS);
 
 		TextView editFreq = (TextView) view.findViewById(R.id.brick_ev3_tone_freq_edit_text);
 		getFormulaWithBrickField(BrickField.LEGO_EV3_FREQUENCY).setTextFieldId(R.id.brick_ev3_tone_freq_edit_text);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtPlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtPlayToneBrick.java
@@ -34,6 +34,7 @@ import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
+import org.catrobat.catroid.utils.Utils;
 
 import java.text.NumberFormat;
 import java.util.List;
@@ -78,6 +79,9 @@ public class LegoNxtPlayToneBrick extends FormulaBrick {
 		NumberFormat nf = NumberFormat.getInstance(context.getResources().getConfiguration().locale);
 		nf.setMinimumFractionDigits(1);
 		textDuration.setText(nf.format(BrickValues.LEGO_DURATION));
+		TextView times = (TextView) prototypeView.findViewById(R.id.brick_nxt_play_tone_seconds);
+		times.setText(context.getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.LEGO_DURATION)));
 		TextView textFreq = (TextView) prototypeView.findViewById(R.id.nxt_tone_freq_edit_text);
 
 		textFreq.setText(String.valueOf(BrickValues.LEGO_FREQUENCY));
@@ -97,12 +101,7 @@ public class LegoNxtPlayToneBrick extends FormulaBrick {
 
 		setCheckboxView(R.id.brick_nxt_play_tone_checkbox);
 
-		TextView editDuration = (TextView) view.findViewById(R.id.nxt_tone_duration_edit_text);
-		getFormulaWithBrickField(BrickField.LEGO_NXT_DURATION_IN_SECONDS)
-				.setTextFieldId(R.id.nxt_tone_duration_edit_text);
-		getFormulaWithBrickField(BrickField.LEGO_NXT_DURATION_IN_SECONDS).refreshTextField(view);
-
-		editDuration.setOnClickListener(this);
+		setSecondText(view, R.id.brick_nxt_play_tone_seconds, R.id.nxt_tone_duration_edit_text, BrickField.LEGO_NXT_DURATION_IN_SECONDS);
 
 		editFreq = (TextView) view.findViewById(R.id.nxt_tone_freq_edit_text);
 		getFormulaWithBrickField(BrickField.LEGO_NXT_FREQUENCY).setTextFieldId(R.id.nxt_tone_freq_edit_text);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroPlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroPlayToneBrick.java
@@ -38,6 +38,7 @@ import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
+import org.catrobat.catroid.utils.Utils;
 
 import java.util.List;
 
@@ -49,7 +50,6 @@ public class PhiroPlayToneBrick extends FormulaBrick {
 
 	private String tone;
 	private transient Tone toneEnum;
-	private transient TextView editDuration;
 
 	public enum Tone {
 		DO, RE, MI, FA, SO, LA, TI
@@ -93,6 +93,9 @@ public class PhiroPlayToneBrick extends FormulaBrick {
 		prototypeView = View.inflate(context, R.layout.brick_phiro_play_tone, null);
 		TextView textDuration = (TextView) prototypeView.findViewById(R.id.brick_phiro_play_tone_duration_edit_text);
 		textDuration.setText(String.valueOf(BrickValues.PHIRO_DURATION));
+		TextView times = (TextView) prototypeView.findViewById(R.id.brick_phiro_play_tone_seconds_text_view);
+		times.setText(context.getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.PHIRO_DURATION)));
 
 		Spinner phiroProToneSpinner = (Spinner) prototypeView.findViewById(R.id.brick_phiro_select_tone_spinner);
 
@@ -115,11 +118,7 @@ public class PhiroPlayToneBrick extends FormulaBrick {
 		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
 		setCheckboxView(R.id.brick_phiro_play_tone_checkbox);
 
-		editDuration = (TextView) view.findViewById(R.id.brick_phiro_play_tone_duration_edit_text);
-		getFormulaWithBrickField(BrickField.PHIRO_DURATION_IN_SECONDS).setTextFieldId(R.id.brick_phiro_play_tone_duration_edit_text);
-		getFormulaWithBrickField(BrickField.PHIRO_DURATION_IN_SECONDS).refreshTextField(view);
-
-		editDuration.setOnClickListener(this);
+		setSecondText(view, R.id.brick_phiro_play_tone_seconds_text_view, R.id.brick_phiro_play_tone_duration_edit_text, BrickField.PHIRO_DURATION_IN_SECONDS);
 
 		ArrayAdapter<CharSequence> toneAdapter = ArrayAdapter.createFromResource(context, R.array.brick_phiro_select_tone_spinner,
 				android.R.layout.simple_spinner_item);

--- a/catroid/src/main/res/layout-ar/brick_drone_move_backward.xml
+++ b/catroid/src/main/res/layout-ar/brick_drone_move_backward.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_drone_move_backward_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_drone_move_backward_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_drone_move_backward_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_move_backward" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_backward_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_backward_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_backward_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+         <TextView
+             android:id="@+id/brick_drone_move_backward_power"
+             style="@style/BrickText.SingleLine"
+             android:paddingStart="5dip"
+             android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_backward_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_backward_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_drone_move_down.xml
+++ b/catroid/src/main/res/layout-ar/brick_drone_move_down.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_drone_move_down_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_drone_move_down_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_drone_move_down_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_move_down" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_down_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_down_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_down_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+        <TextView
+            android:id="@+id/brick_drone_move_down_power"
+            style="@style/BrickText.SingleLine"
+            android:paddingStart="5dip"
+            android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_down_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_down_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_drone_move_forward.xml
+++ b/catroid/src/main/res/layout-ar/brick_drone_move_forward.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_drone_move_forward_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_drone_move_forward_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_drone_move_forward_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_move_forward" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_forward_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_forward_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_forward_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+        <TextView
+            android:id="@+id/brick_drone_move_forward_power"
+            style="@style/BrickText.SingleLine"
+            android:paddingStart="5dip"
+            android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_forward_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_forward_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_drone_move_left.xml
+++ b/catroid/src/main/res/layout-ar/brick_drone_move_left.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_drone_move_left_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_drone_move_left_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_drone_move_left_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_move_left" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_left_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_left_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_left_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+        <TextView
+            android:id="@+id/brick_drone_move_left_power"
+            style="@style/BrickText.SingleLine"
+            android:paddingStart="5dip"
+            android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_left_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_left_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_drone_move_right.xml
+++ b/catroid/src/main/res/layout-ar/brick_drone_move_right.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_drone_move_right_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_drone_move_right_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_drone_move_right_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_move_right" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_right_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_right_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_right_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+        <TextView
+            android:id="@+id/brick_drone_move_right_power"
+            style="@style/BrickText.SingleLine"
+            android:paddingStart="5dip"
+            android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_right_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_right_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_drone_move_up.xml
+++ b/catroid/src/main/res/layout-ar/brick_drone_move_up.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_drone_move_up_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_drone_move_up_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_drone_move_up_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_move_up" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_up_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_up_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_up_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+        <TextView
+            android:id="@+id/brick_drone_move_up_power"
+            style="@style/BrickText.SingleLine"
+            android:paddingStart="5dip"
+            android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_up_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_up_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_drone_turn_left.xml
+++ b/catroid/src/main/res/layout-ar/brick_drone_turn_left.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_drone_turn_left_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_drone_turn_left_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_turn_left" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_power"
+            style="@style/BrickText.SingleLine"
+            android:paddingStart="5dip"
+            android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_drone_turn_left_magneto.xml
+++ b/catroid/src/main/res/layout-ar/brick_drone_turn_left_magneto.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_drone_turn_left_magneto_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_drone_turn_left_magneto_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_magneto_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_turn_left_magneto" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_magneto_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_magneto_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_magneto_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+        <TextView
+            android:id="@+id/brick_drone_power"
+            style="@style/BrickText.SingleLine"
+            android:paddingStart="5dip"
+            android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_magneto_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_drone_turn_right.xml
+++ b/catroid/src/main/res/layout-ar/brick_drone_turn_right.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_drone_turn_right_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_drone_turn_right_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_turn_right" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_power"
+            style="@style/BrickText.SingleLine"
+            android:paddingStart="5dip"
+            android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_drone_turn_right_magneto.xml
+++ b/catroid/src/main/res/layout-ar/brick_drone_turn_right_magneto.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_drone_turn_right_magneto_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_drone_turn_right_magneto_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_magneto_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_turn_right_magneto" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_magneto_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_magneto_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_magneto_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+        <TextView
+            android:id="@+id/brick_drone_power"
+            style="@style/BrickText.SingleLine"
+            android:paddingStart="5dip"
+            android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_magneto_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_drone_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_ev3_motor_move.xml
+++ b/catroid/src/main/res/layout-ar/brick_ev3_motor_move.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:gravity="center_vertical"
+              android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_ev3_motor_move_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_ev3_motor_move_layout"
+        style="@style/BrickContainer.Lego.Big"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <RelativeLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content">
+            <LinearLayout
+                android:id="@+id/brick_ev3_motor_move_first_line"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/brick_ev3_motor_move_label"
+                    style="@style/BrickText.SingleLine"
+                    android:text="@string/ev3_motor_move" >
+                </TextView >
+
+                <Spinner
+                    android:id="@+id/brick_ev3_motor_move_spinner"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textDirection="locale"
+                    android:gravity="center"
+                    android:clickable="false"
+                    android:focusable="false" >
+                </Spinner>
+            </LinearLayout>
+
+            <LinearLayout
+              android:id="@+id/brick_ev3_motor_move_second_line"
+              android:layout_below="@+id/brick_ev3_motor_move_first_line"
+              android:layout_width="fill_parent"
+              android:layout_height="wrap_content"
+              android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/lego_motor_action_to_text"
+                    style="@style/BrickText.Multiple"
+                    android:text="@string/nxt_motor_speed_to" >
+                </TextView >
+
+                <TextView
+                    android:id="@+id/brick_ev3_motor_move_speed_text"
+                    style="@style/BrickText"
+                    android:paddingStart="5dip"
+                    android:text="@string/nxt_motor_speed" >
+                </TextView >
+
+                <TextView
+                    android:id="@+id/ev3_motor_move_speed_edit_text"
+                    style="@style/BrickEditText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_inputType="number"
+                    app:layout_textField="true"
+                    android:clickable="false"
+                    android:maxEms="5" >
+                </TextView >
+
+                <TextView
+                    android:id="@+id/brick_ev3_motor_move_percent"
+                    style="@style/BrickText"
+                    android:text="@string/percent_symbol" >
+                </TextView >
+            </LinearLayout>
+        </RelativeLayout>
+    </org.catrobat.catroid.ui.BrickLayout >
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_if_begin_if.xml
+++ b/catroid/src/main/res/layout-ar/brick_if_begin_if.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:gravity="center_vertical"
+              android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_if_begin_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_if_begin_layout"
+        style="@style/BrickContainer.Control.Small"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/if_label"
+            style="@style/BrickText.Multiple"
+            android:text="@string/brick_if_begin" />
+
+        <TextView
+            android:id="@+id/if_label_second_part"
+            style="@style/BrickText.Multiple"
+            android:paddingStart="5dip"
+            android:text="@string/brick_if_begin_second_part" />
+
+        <TextView
+            android:id="@+id/brick_if_begin_edit_text"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/if_else_prototype_punctuation"
+            style="@style/BrickText.Multiple"
+            app:layout_newLine="true"
+            android:paddingStart="5dip"
+            android:text="@string/punctuation_mark" />
+
+         <TextView
+             android:id="@+id/if_prototype_else"
+             style="@style/BrickText.Multiple"
+             android:paddingStart="5dip"
+             android:text="@string/brick_if_else" />
+
+       <TextView
+           android:id="@+id/if_else_prototype_punctuation2"
+           style="@style/BrickText.Multiple"
+           android:paddingStart="5dip"
+           android:text="@string/punctuation_mark" />
+    </org.catrobat.catroid.ui.BrickLayout >
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_jumping_sumo_move_backward.xml
+++ b/catroid/src/main/res/layout-ar/brick_jumping_sumo_move_backward.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_jumping_sumo_move_backward_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_jumping_sumo_move_backward_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_backward_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_jumping_sumo_move_backward" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_backward_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_backward_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_backward_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_backward_set_power"
+            android:paddingStart="5dip"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_backward_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_backward_set_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_jumping_sumo_move_forward.xml
+++ b/catroid/src/main/res/layout-ar/brick_jumping_sumo_move_forward.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <CheckBox
+        android:id="@+id/brick_jumping_sumo_move_forward_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_jumping_sumo_move_forward_layout"
+        style="@style/BrickContainer.Motion.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing">
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_forward_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_jumping_sumo_move_forward" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_forward_edit_text_second"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_newLine="true"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_forward_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_forward_text_with"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_with." />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_forward_set_power"
+            style="@style/BrickText.SingleLine"
+            android:paddingStart="5dip"
+            android:text="@string/brick_drone_power" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_forward_edit_text_power"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_forward_set_percent"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/percent_symbol" />
+
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_nxt_motor_action.xml
+++ b/catroid/src/main/res/layout-ar/brick_nxt_motor_action.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:gravity="center_vertical"
+              android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_nxt_motor_action_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_nxt_motor_action_layout"
+        style="@style/BrickContainer.Lego.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing">
+
+        <RelativeLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content">
+            <LinearLayout
+                android:id="@+id/brick_nxt_motor_action_first_line"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/lego_motor_action_label"
+                    style="@style/BrickText.Multiple"
+                    android:text="@string/nxt_brick_motor_move" >
+                </TextView >
+
+                <Spinner
+                    android:id="@+id/lego_motor_action_spinner"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textDirection="locale"
+                    android:gravity="center"
+                    android:clickable="false"
+                    android:focusable="false" >
+
+                    <!-- do not add spinner items here! -->
+                </Spinner >
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_below="@+id/brick_nxt_motor_action_first_line"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/lego_motor_action_to_text"
+                    style="@style/BrickText.Multiple"
+                    android:text="@string/nxt_motor_speed_to" >
+                </TextView >
+                <TextView
+                    android:id="@+id/lego_motor_action_speed_text"
+                    style="@style/BrickText"
+                    android:paddingStart="5dip"
+                    android:text="@string/nxt_motor_speed" >
+                </TextView >
+
+                <TextView
+                    android:id="@+id/motor_action_speed_edit_text"
+                    style="@style/BrickEditText"
+                    app:layout_inputType="number"
+                    app:layout_textField="true"
+                    android:clickable="false" >
+                </TextView >
+
+                <TextView
+                    android:id="@+id/lego_motor_action_percent"
+                    style="@style/BrickText"
+                    android:text="@string/percent_symbol" >
+                </TextView >
+
+
+            </LinearLayout>
+        </RelativeLayout>
+
+    </org.catrobat.catroid.ui.BrickLayout >
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_repeat_until.xml
+++ b/catroid/src/main/res/layout-ar/brick_repeat_until.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:gravity="center_vertical"
+              android:orientation="horizontal" >
+
+    <CheckBox
+        android:id="@+id/brick_repeat_until_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_repeat_until_layout"
+        style="@style/BrickContainer.Control.Small"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+
+        <TextView
+            android:id="@+id/brick_repeat_until_label"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_repeat_until" >
+        </TextView >
+
+        <TextView
+            android:id="@+id/wait_until_label_second_part"
+            style="@style/BrickText.Multiple"
+            android:paddingStart="5dip"
+            android:text="@string/brick_wait_until_second_part" >
+        </TextView >
+
+        <TextView
+            android:id="@+id/brick_repeat_until_edit_text"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" >
+        </TextView >
+    </org.catrobat.catroid.ui.BrickLayout >
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_set_nfc_tag.xml
+++ b/catroid/src/main/res/layout-ar/brick_set_nfc_tag.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:baselineAligned="false"
+    android:gravity="center_vertical">
+
+    <CheckBox
+        android:id="@+id/brick_set_nfc_tag_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_set_nfc_tag_layout"
+        style="@style/BrickContainer.Control.Big"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing">
+
+        <TextView
+            android:id="@+id/brick_set_nfc_tag_label"
+            android:labelFor="@+id/brick_set_nfc_tag_edit_text"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_set_nfc_tag" />
+
+        <EditText
+            android:id="@+id/brick_set_nfc_tag_edit_text"
+            style="@style/BrickEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="start"
+            android:maxLines="3"
+            android:minLines="1"
+            app:layout_inputType="text"
+            app:layout_textField="true"
+            app:layout_newLine="true" />
+
+        <TextView
+            android:id="@+id/brick_set_nfc_tag_ndef_record_textview"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/ndef_record_label"
+            app:layout_newLine="true" />
+
+        <Spinner
+            android:id="@+id/brick_set_nfc_tag_ndef_record_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clickable="false"
+            android:focusable="false"
+            android:textDirection="locale"
+            app:layout_newLine="true" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_wait_until.xml
+++ b/catroid/src/main/res/layout-ar/brick_wait_until.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <CheckBox
+        android:id="@+id/brick_wait_until_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_wait_until_layout"
+        style="@style/BrickContainer.Control.Small"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing">
+
+        <TextView
+            android:id="@+id/wait_until_label"
+            style="@style/BrickText.Multiple"
+            android:text="@string/brick_wait_until">
+        </TextView>
+
+        <TextView
+            android:id="@+id/wait_until_label_second_part"
+            style="@style/BrickText.Multiple"
+            android:paddingStart="5dip"
+            android:text="@string/brick_wait_until_second_part">
+        </TextView>
+
+        <TextView
+            android:id="@+id/brick_wait_until_edit_text"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_when_condition_true.xml
+++ b/catroid/src/main/res/layout-ar/brick_when_condition_true.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2017 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <CheckBox
+        android:id="@+id/brick_when_condition_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:visibility="gone" />
+
+    <org.catrobat.catroid.ui.BrickLayout
+        android:id="@+id/brick_when_condition_layout"
+        style="@style/BrickContainer.Event.MediumWhen"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing">
+
+        <TextView
+            android:id="@+id/when_conditon_label"
+            style="@style/BrickText.Multiple"
+            android:text="@string/brick_when_condition_when">
+        </TextView>
+
+        <TextView
+            android:id="@+id/when_condition_label_second_part"
+            style="@style/BrickText.Multiple"
+            android:paddingStart="5dip"
+            android:text="@string/brick_when_becomes_true">
+        </TextView>
+
+        <TextView
+            android:id="@+id/brick_when_condition_edit_text"
+            style="@style/BrickEditText"
+            app:layout_inputType="number"
+            app:layout_textField="true" />
+
+    </org.catrobat.catroid.ui.BrickLayout>
+
+</LinearLayout>

--- a/catroid/src/main/res/layout/brick_add_item_to_userlist.xml
+++ b/catroid/src/main/res/layout/brick_add_item_to_userlist.xml
@@ -69,6 +69,7 @@
              android:layout_width="match_parent"
              android:layout_height="wrap_content"
              android:clickable="false"
+             android:textDirection="locale"
              android:focusable="false" />
 
     </org.catrobat.catroid.ui.BrickLayout>

--- a/catroid/src/main/res/layout/brick_ask.xml
+++ b/catroid/src/main/res/layout/brick_ask.xml
@@ -66,6 +66,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false"
             app:layout_newLine="true" />
 

--- a/catroid/src/main/res/layout/brick_ask_speech.xml
+++ b/catroid/src/main/res/layout/brick_ask_speech.xml
@@ -67,6 +67,7 @@
             android:layout_height="wrap_content"
             android:clickable="false"
             android:focusable="false"
+            android:textDirection="locale"
             app:layout_newLine="true" />
 
     </org.catrobat.catroid.ui.BrickLayout>

--- a/catroid/src/main/res/layout/brick_broadcast.xml
+++ b/catroid/src/main/res/layout/brick_broadcast.xml
@@ -55,6 +55,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_broadcast_receive.xml
+++ b/catroid/src/main/res/layout/brick_broadcast_receive.xml
@@ -55,6 +55,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout>
 

--- a/catroid/src/main/res/layout/brick_broadcast_wait.xml
+++ b/catroid/src/main/res/layout/brick_broadcast_wait.xml
@@ -55,6 +55,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_change_variable_by.xml
+++ b/catroid/src/main/res/layout/brick_change_variable_by.xml
@@ -55,6 +55,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
 
         <TextView

--- a/catroid/src/main/res/layout/brick_choose_camera.xml
+++ b/catroid/src/main/res/layout/brick_choose_camera.xml
@@ -56,6 +56,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_clone.xml
+++ b/catroid/src/main/res/layout/brick_clone.xml
@@ -56,6 +56,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout>
 

--- a/catroid/src/main/res/layout/brick_drone_move_backward.xml
+++ b/catroid/src/main/res/layout/brick_drone_move_backward.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_drone_move_backward_text_view_power"
+            android:id="@+id/brick_drone_move_backward_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_backward_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_drone_move_backward_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_drone_set_power_to_percent"
+            android:id="@+id/brick_drone_move_backward_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_backward_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_drone_move_down.xml
+++ b/catroid/src/main/res/layout/brick_drone_move_down.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_drone_move_down_text_view_power"
+            android:id="@+id/brick_drone_move_down_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_down_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_drone_move_down_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_drone_set_power_to_percent"
+            android:id="@+id/brick_drone_move_down_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_down_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_drone_move_forward.xml
+++ b/catroid/src/main/res/layout/brick_drone_move_forward.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_drone_move_forward_text_view_power"
+            android:id="@+id/brick_drone_move_forward_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_forward_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_drone_move_forward_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_drone_set_power_to_percent"
+            android:id="@+id/brick_drone_move_forward_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_forward_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_drone_move_left.xml
+++ b/catroid/src/main/res/layout/brick_drone_move_left.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_drone_move_left_text_view_power"
+            android:id="@+id/brick_drone_move_left_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_left_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_drone_move_left_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_drone_set_power_to_percent"
+            android:id="@+id/brick_drone_move_left_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_left_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_drone_move_right.xml
+++ b/catroid/src/main/res/layout/brick_drone_move_right.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_drone_move_right_text_view_power"
+            android:id="@+id/brick_drone_move_right_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_right_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_drone_move_right_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_drone_set_power_to_percent"
+            android:id="@+id/brick_drone_move_right_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_right_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_drone_move_up.xml
+++ b/catroid/src/main/res/layout/brick_drone_move_up.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_drone_move_up_text_view_power"
+            android:id="@+id/brick_drone_move_up_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_up_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_drone_move_up_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_drone_set_power_to_percent"
+            android:id="@+id/brick_drone_move_up_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_drone_move_up_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_drone_spinner.xml
+++ b/catroid/src/main/res/layout/brick_drone_spinner.xml
@@ -56,6 +56,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_drone_turn_left.xml
+++ b/catroid/src/main/res/layout/brick_drone_turn_left.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_drone_turn_left_text_view_power"
+            android:id="@+id/brick_drone_turn_left_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_drone_turn_left_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_drone_set_power_to_percent"
+            android:id="@+id/brick_drone_turn_left_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_drone_turn_left_magneto.xml
+++ b/catroid/src/main/res/layout/brick_drone_turn_left_magneto.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_drone_turn_left_magneto_text_view_power"
+            android:id="@+id/brick_drone_turn_left_magneto_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_left_magneto_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_drone_turn_left_magneto_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_drone_set_power_to_percent"
+            android:id="@+id/brick_drone_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_drone_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_drone_turn_right.xml
+++ b/catroid/src/main/res/layout/brick_drone_turn_right.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_drone_turn_right_text_view_power"
+            android:id="@+id/brick_drone_turn_right_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_drone_turn_right_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_drone_set_power_to_percent"
+            android:id="@+id/brick_drone_turn_right_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_drone_turn_right_magneto.xml
+++ b/catroid/src/main/res/layout/brick_drone_turn_right_magneto.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_drone_turn_right_magneto_text_view_power"
+            android:id="@+id/brick_drone_turn_right_magneto_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_drone_turn_right_magneto_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_drone_turn_right_magneto_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_drone_set_power_to_percent"
+            android:id="@+id/brick_drone_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_drone_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_ev3_motor_move.xml
+++ b/catroid/src/main/res/layout/brick_ev3_motor_move.xml
@@ -104,7 +104,7 @@
                 <TextView
                     android:id="@+id/brick_ev3_motor_move_speed_text"
                     style="@style/BrickText"
-                    android:layout_marginLeft="3sp"
+                    android:layout_marginStart="3sp"
                     android:text="@string/nxt_motor_speed" >
                 </TextView >
 

--- a/catroid/src/main/res/layout/brick_ev3_play_tone.xml
+++ b/catroid/src/main/res/layout/brick_ev3_play_tone.xml
@@ -72,8 +72,7 @@
 
         <TextView
             android:id="@+id/brick_ev3_tone_seconds"
-            style="@style/BrickText.SingleLine"
-            android:text="@string/nxt_seconds" >
+            style="@style/BrickText.SingleLine">
         </TextView >
 
         <TextView

--- a/catroid/src/main/res/layout/brick_ev3_set_led.xml
+++ b/catroid/src/main/res/layout/brick_ev3_set_led.xml
@@ -57,6 +57,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_newLine="true"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" >
         </Spinner>

--- a/catroid/src/main/res/layout/brick_flash.xml
+++ b/catroid/src/main/res/layout/brick_flash.xml
@@ -56,6 +56,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_go_to.xml
+++ b/catroid/src/main/res/layout/brick_go_to.xml
@@ -56,6 +56,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_hide_variable.xml
+++ b/catroid/src/main/res/layout/brick_hide_variable.xml
@@ -57,6 +57,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_if_begin_if.xml
+++ b/catroid/src/main/res/layout/brick_if_begin_if.xml
@@ -59,26 +59,26 @@
         <TextView
             android:id="@+id/if_label_second_part"
             style="@style/BrickText.Multiple"
-            android:paddingLeft="5dip"
+            android:paddingStart="5dip"
             android:text="@string/brick_if_begin_second_part" />
 
         <TextView
             android:id="@+id/if_else_prototype_punctuation"
             style="@style/BrickText.Multiple"
             app:layout_newLine="true"
-            android:paddingLeft="5dip"
+            android:paddingStart="5dip"
             android:text="@string/punctuation_mark" />
 
          <TextView
              android:id="@+id/if_prototype_else"
              style="@style/BrickText.Multiple"
-             android:paddingLeft="5dip"
+             android:paddingStart="5dip"
              android:text="@string/brick_if_else" />
 
        <TextView
            android:id="@+id/if_else_prototype_punctuation2"
            style="@style/BrickText.Multiple"
-           android:paddingLeft="5dip"
+           android:paddingStart="5dip"
            android:text="@string/punctuation_mark" />
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_insert_item_into_userlist.xml
+++ b/catroid/src/main/res/layout/brick_insert_item_into_userlist.xml
@@ -65,6 +65,7 @@
             android:id="@+id/insert_item_into_userlist_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
          

--- a/catroid/src/main/res/layout/brick_jumping_sumo_animations.xml
+++ b/catroid/src/main/res/layout/brick_jumping_sumo_animations.xml
@@ -56,6 +56,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
 
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_jumping_sumo_move_backward.xml
+++ b/catroid/src/main/res/layout/brick_jumping_sumo_move_backward.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_jumping_sumo_move_backward_text_view_power"
+            android:id="@+id/brick_jumping_sumo_move_backward_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_backward_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_jumping_sumo_move_backward_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_jumping_sumo_set_power_to_percent"
+            android:id="@+id/brick_jumping_sumo_move_backward_set_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_jumping_sumo_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_backward_set_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_jumping_sumo_move_forward.xml
+++ b/catroid/src/main/res/layout/brick_jumping_sumo_move_forward.xml
@@ -58,9 +58,13 @@
             app:layout_newLine="true" />
 
         <TextView
-            android:id="@+id/brick_jumping_sumo_move_forward_text_view_power"
+            android:id="@+id/brick_jumping_sumo_move_forward_text_second"
+            style="@style/BrickText.SingleLine" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_forward_text_with"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_drone_with" />
+            android:text="@string/brick_drone_with." />
 
         <TextView
             android:id="@+id/brick_jumping_sumo_move_forward_edit_text_power"
@@ -69,9 +73,14 @@
             app:layout_textField="true" />
 
         <TextView
-            android:id="@+id/brick_jumping_sumo_set_power_to_percent"
+            android:id="@+id/brick_jumping_sumo_move_forward_set_percent"
             style="@style/BrickText.SingleLine"
-            android:text="@string/brick_jumping_sumo_percent_power" />
+            android:text="@string/percent_symbol" />
+
+        <TextView
+            android:id="@+id/brick_jumping_sumo_move_forward_set_power"
+            style="@style/BrickText.SingleLine"
+            android:text="@string/brick_drone_power" />
     </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_jumping_sumo_rotate_left.xml
+++ b/catroid/src/main/res/layout/brick_jumping_sumo_rotate_left.xml
@@ -54,6 +54,7 @@
             android:id="@+id/brick_jumping_sumo_change_left_variable_edit_text"
             style="@style/BrickEditText"
             app:layout_inputType="number"
+            app:layout_newLine="true"
             app:layout_textField="true" />
 
         <TextView

--- a/catroid/src/main/res/layout/brick_jumping_sumo_rotate_right.xml
+++ b/catroid/src/main/res/layout/brick_jumping_sumo_rotate_right.xml
@@ -54,6 +54,7 @@
             android:id="@+id/brick_jumping_sumo_change_right_variable_edit_text"
             style="@style/BrickEditText"
             app:layout_inputType="number"
+            app:layout_newLine="true"
             app:layout_textField="true" />
 
         <TextView

--- a/catroid/src/main/res/layout/brick_jumping_sumo_sound.xml
+++ b/catroid/src/main/res/layout/brick_jumping_sumo_sound.xml
@@ -57,6 +57,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" >
         </Spinner >
 

--- a/catroid/src/main/res/layout/brick_note.xml
+++ b/catroid/src/main/res/layout/brick_note.xml
@@ -57,7 +57,7 @@
             android:layout_gravity="center_vertical"
             app:layout_inputType="text"
             app:layout_textField="true"
-            android:gravity="left"
+            android:gravity="start"
             android:maxLines="3"
             android:minLines="1" />
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_nxt_motor_action.xml
+++ b/catroid/src/main/res/layout/brick_nxt_motor_action.xml
@@ -66,6 +66,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:gravity="center"
+                    android:textDirection="locale"
                     android:clickable="false"
                     android:focusable="false" >
 
@@ -102,7 +103,7 @@
                 <TextView
                     android:id="@+id/lego_motor_action_speed_text"
                     style="@style/BrickText"
-                    android:layout_marginLeft="3sp"
+                    android:layout_marginStart="3sp"
                     android:text="@string/nxt_motor_speed" >
                 </TextView >
             </LinearLayout>

--- a/catroid/src/main/res/layout/brick_nxt_motor_stop.xml
+++ b/catroid/src/main/res/layout/brick_nxt_motor_stop.xml
@@ -61,6 +61,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center"
+                android:textDirection="locale"
                 android:clickable="false"
                 android:focusable="false" />
         </LinearLayout>

--- a/catroid/src/main/res/layout/brick_nxt_motor_turn_angle.xml
+++ b/catroid/src/main/res/layout/brick_nxt_motor_turn_angle.xml
@@ -66,6 +66,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:gravity="center"
+                    android:textDirection="locale"
                     android:clickable="false"
                     android:focusable="false" >
                 </Spinner >

--- a/catroid/src/main/res/layout/brick_nxt_play_tone.xml
+++ b/catroid/src/main/res/layout/brick_nxt_play_tone.xml
@@ -68,8 +68,7 @@
 
         <TextView
             android:id="@+id/brick_nxt_play_tone_seconds"
-            style="@style/BrickText.Multiple"
-            android:text="@string/nxt_seconds" />
+            style="@style/BrickText.Multiple" />
 
         <!--- Frequency -->
 

--- a/catroid/src/main/res/layout/brick_phiro_if_sensor.xml
+++ b/catroid/src/main/res/layout/brick_phiro_if_sensor.xml
@@ -55,6 +55,7 @@
             android:id="@+id/brick_phiro_sensor_action_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" >
 
@@ -64,7 +65,7 @@
         <TextView
             android:id="@+id/phiro_sensor_label_second_part"
             style="@style/BrickText.SingleLine"
-            android:paddingLeft="5dip"
+            android:paddingStart="5dip"
             android:text="@string/brick_phiro_sensor_second_part" >
         </TextView >
 

--- a/catroid/src/main/res/layout/brick_phiro_motor_backward.xml
+++ b/catroid/src/main/res/layout/brick_phiro_motor_backward.xml
@@ -56,6 +56,7 @@
             android:id="@+id/brick_phiro_motor_backward_action_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" >
 

--- a/catroid/src/main/res/layout/brick_phiro_motor_forward.xml
+++ b/catroid/src/main/res/layout/brick_phiro_motor_forward.xml
@@ -56,6 +56,7 @@
             android:id="@+id/brick_phiro_motor_forward_action_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" >
 

--- a/catroid/src/main/res/layout/brick_phiro_motor_stop.xml
+++ b/catroid/src/main/res/layout/brick_phiro_motor_stop.xml
@@ -56,6 +56,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clickable="false"
+            android:textDirection="locale"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_phiro_play_tone.xml
+++ b/catroid/src/main/res/layout/brick_phiro_play_tone.xml
@@ -60,6 +60,7 @@
             android:id="@+id/brick_phiro_select_tone_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
         <!-- do not add spinner items here! -->
@@ -84,8 +85,7 @@
 
         <TextView
             android:id="@+id/brick_phiro_play_tone_seconds_text_view"
-            style="@style/BrickText.SingleLine"
-            android:text="@string/phiro_seconds" >
+            style="@style/BrickText.SingleLine">
         </TextView >
 
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_phiro_rgb_light.xml
+++ b/catroid/src/main/res/layout/brick_phiro_rgb_light.xml
@@ -56,6 +56,7 @@
         style="@style/BrickText.SingleLine"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:textDirection="locale"
         android:clickable="false"
         android:focusable="false" >
     <!-- do not add spinner items here! -->

--- a/catroid/src/main/res/layout/brick_physics_collision_receive.xml
+++ b/catroid/src/main/res/layout/brick_physics_collision_receive.xml
@@ -54,6 +54,7 @@
             android:id="@+id/brick_collision_receive_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout>

--- a/catroid/src/main/res/layout/brick_physics_set_physics_object_type.xml
+++ b/catroid/src/main/res/layout/brick_physics_set_physics_object_type.xml
@@ -55,6 +55,7 @@
             android:id="@+id/brick_set_physics_object_type_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
 

--- a/catroid/src/main/res/layout/brick_play_sound.xml
+++ b/catroid/src/main/res/layout/brick_play_sound.xml
@@ -56,6 +56,7 @@
             android:id="@+id/playsound_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_point_to.xml
+++ b/catroid/src/main/res/layout/brick_point_to.xml
@@ -55,6 +55,7 @@
             android:id="@+id/brick_point_to_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_raspi_if_begin_if.xml
+++ b/catroid/src/main/res/layout/brick_raspi_if_begin_if.xml
@@ -60,7 +60,7 @@
         <TextView
             android:id="@+id/if_raspi_label_second_part"
             style="@style/BrickText.Multiple"
-            android:paddingLeft="5dip"
+            android:paddingStart="5dip"
             android:text="@string/brick_raspi_if_begin_second_part" >
         </TextView >
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_raspi_pin_changed.xml
+++ b/catroid/src/main/res/layout/brick_raspi_pin_changed.xml
@@ -65,6 +65,7 @@
                         android:id="@+id/brick_raspi_when_pinspinner"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:textDirection="locale"
                         android:layout_weight="1" />
                 </TableRow>
 
@@ -76,7 +77,7 @@
                     <TextView
                         android:id="@+id/brick_raspi_when_label_second_part"
                         style="@style/BrickText.Multiple"
-                        android:paddingLeft="5dip"
+                        android:paddingStart="5dip"
                         android:text="@string/brick_raspi_when_equals" >
                     </TextView >
 
@@ -84,6 +85,7 @@
                         android:id="@+id/brick_raspi_when_valuespinner"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:textDirection="locale"
                         android:layout_weight="1" />
                 </TableRow>
             </LinearLayout>

--- a/catroid/src/main/res/layout/brick_repeat_until.xml
+++ b/catroid/src/main/res/layout/brick_repeat_until.xml
@@ -60,7 +60,7 @@
         <TextView
             android:id="@+id/wait_until_label_second_part"
             style="@style/BrickText.Multiple"
-            android:paddingLeft="5dip"
+            android:paddingStart="5dip"
             android:text="@string/brick_wait_until_second_part" >
         </TextView >
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_replace_item_in_userlist.xml
+++ b/catroid/src/main/res/layout/brick_replace_item_in_userlist.xml
@@ -55,6 +55,7 @@
             android:id="@+id/replace_item_in_userlist_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
          

--- a/catroid/src/main/res/layout/brick_say_bubble.xml
+++ b/catroid/src/main/res/layout/brick_say_bubble.xml
@@ -58,7 +58,7 @@
             android:layout_gravity="center_vertical"
             app:layout_inputType="text"
             app:layout_textField="true"
-            android:gravity="left"
+            android:gravity="start"
             android:maxLines="3"
             android:minLines="1" />
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_scene_start.xml
+++ b/catroid/src/main/res/layout/brick_scene_start.xml
@@ -54,6 +54,7 @@
             android:id="@+id/brick_scene_start_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_set_look.xml
+++ b/catroid/src/main/res/layout/brick_set_look.xml
@@ -55,6 +55,7 @@
             android:id="@+id/brick_set_look_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
 

--- a/catroid/src/main/res/layout/brick_set_nfc_tag.xml
+++ b/catroid/src/main/res/layout/brick_set_nfc_tag.xml
@@ -72,6 +72,7 @@
             android:id="@+id/brick_set_nfc_tag_ndef_record_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false"
             app:layout_newLine="true" />

--- a/catroid/src/main/res/layout/brick_set_rotation_style.xml
+++ b/catroid/src/main/res/layout/brick_set_rotation_style.xml
@@ -55,6 +55,7 @@
             android:id="@+id/brick_set_rotation_style_spinner"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
 

--- a/catroid/src/main/res/layout/brick_set_variable.xml
+++ b/catroid/src/main/res/layout/brick_set_variable.xml
@@ -54,6 +54,7 @@
             android:id="@+id/set_variable_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
 

--- a/catroid/src/main/res/layout/brick_show_variable.xml
+++ b/catroid/src/main/res/layout/brick_show_variable.xml
@@ -56,6 +56,7 @@
             android:id="@+id/show_variable_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
 

--- a/catroid/src/main/res/layout/brick_speak.xml
+++ b/catroid/src/main/res/layout/brick_speak.xml
@@ -58,7 +58,7 @@
             android:layout_width="match_parent"
             app:layout_inputType="text"
             app:layout_textField="true"
-            android:gravity="left" >
+            android:gravity="start" >
         </TextView >
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_speak_and_wait.xml
+++ b/catroid/src/main/res/layout/brick_speak_and_wait.xml
@@ -58,7 +58,7 @@
             android:layout_width="match_parent"
             app:layout_inputType="text"
             app:layout_textField="true"
-            android:gravity="left" >
+            android:gravity="start" >
         </TextView >
 
         <TextView

--- a/catroid/src/main/res/layout/brick_stop_script.xml
+++ b/catroid/src/main/res/layout/brick_stop_script.xml
@@ -54,6 +54,7 @@
             android:id="@+id/brick_stop_script_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
 

--- a/catroid/src/main/res/layout/brick_think_bubble.xml
+++ b/catroid/src/main/res/layout/brick_think_bubble.xml
@@ -58,7 +58,7 @@
             android:layout_gravity="center_vertical"
             app:layout_inputType="text"
             app:layout_textField="true"
-            android:gravity="left"
+            android:gravity="start"
             android:maxLines="3"
             android:minLines="1" />
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_video.xml
+++ b/catroid/src/main/res/layout/brick_video.xml
@@ -55,6 +55,7 @@
             android:id="@+id/brick_video_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_wait_until.xml
+++ b/catroid/src/main/res/layout/brick_wait_until.xml
@@ -21,7 +21,6 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:app="http://schemas.android.com/apk/res-auto"
               android:layout_width="match_parent"
@@ -60,7 +59,7 @@
         <TextView
             android:id="@+id/wait_until_label_second_part"
             style="@style/BrickText.Multiple"
-            android:paddingLeft="5dip"
+            android:paddingStart="5dip"
             android:text="@string/brick_wait_until_second_part" >
         </TextView >
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_when_background_changes_to.xml
+++ b/catroid/src/main/res/layout/brick_when_background_changes_to.xml
@@ -55,6 +55,7 @@
             android:id="@+id/brick_when_background_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout>

--- a/catroid/src/main/res/layout/brick_when_condition_true.xml
+++ b/catroid/src/main/res/layout/brick_when_condition_true.xml
@@ -21,7 +21,6 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -60,7 +59,7 @@
         <TextView
             android:id="@+id/when_condition_label_second_part"
             style="@style/BrickText.Multiple"
-            android:paddingLeft="5dip"
+            android:paddingStart="5dip"
             android:text="@string/brick_when_becomes_true">
         </TextView>
     </org.catrobat.catroid.ui.BrickLayout>

--- a/catroid/src/main/res/layout/brick_when_gamepad_button.xml
+++ b/catroid/src/main/res/layout/brick_when_gamepad_button.xml
@@ -55,8 +55,9 @@
 		android:id="@+id/brick_when_gamepad_button_spinner"
 		android:layout_height="wrap_content"
 		android:layout_width="wrap_content"
-		android:layout_alignParentRight="true"
+		android:layout_alignParentEnd="true"
 		android:layout_centerVertical="true"
+		android:textDirection="locale"
 		android:clickable="false"
 		android:focusable="false"
 	/>

--- a/catroid/src/main/res/layout/brick_when_nfc.xml
+++ b/catroid/src/main/res/layout/brick_when_nfc.xml
@@ -55,6 +55,7 @@
             android:id="@+id/brick_when_nfc_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout>

--- a/catroid/src/main/res/layout/dialog_new_sound.xml
+++ b/catroid/src/main/res/layout/dialog_new_sound.xml
@@ -64,7 +64,7 @@
                 android:id="@+id/dialog_new_sound_gallery"
                 android:layout_width="@dimen/dialog_text_view_layout_width"
                 android:layout_height="match_parent"
-                android:layout_gravity="left|center_vertical"
+                android:layout_gravity="start|center_vertical"
                 android:layout_weight="1"
                 android:background="@drawable/new_object_dialog_selector"
                 android:drawableTop="@drawable/ic_gallery"

--- a/catroid/src/main/res/layout/dialog_privacy_policy.xml
+++ b/catroid/src/main/res/layout/dialog_privacy_policy.xml
@@ -32,7 +32,7 @@
         android:text="@string/dialog_privacy_policy_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="10sp"
-        android:layout_marginRight="10sp"
+        android:layout_marginStart="10sp"
+        android:layout_marginEnd="10sp"
         android:gravity="fill_horizontal"/>
 </ScrollView>

--- a/catroid/src/main/res/layout/dialog_stage.xml
+++ b/catroid/src/main/res/layout/dialog_stage.xml
@@ -108,7 +108,7 @@
         style="@style/StageButton"
         android:layout_width="@dimen/dialog_image_button_layout_width_height"
         android:layout_height="@dimen/dialog_image_button_layout_width_height"
-        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
         android:layout_alignParentTop="true"
         android:background="@color/stage_dialog_background_color"
         android:layout_margin="20dp"

--- a/catroid/src/main/res/layout/fragment_cast_device_list_item.xml
+++ b/catroid/src/main/res/layout/fragment_cast_device_list_item.xml
@@ -29,7 +29,7 @@
     android:orientation="horizontal">
 
 	<TextView
-		android:layout_marginLeft="18dp"
+		android:layout_marginStart="18dp"
 		android:drawableStart="@drawable/ic_cast_white"
 		android:drawablePadding="18dp"
 		android:layout_width="fill_parent"

--- a/catroid/src/main/res/layout/fragment_project_show_details.xml
+++ b/catroid/src/main/res/layout/fragment_project_show_details.xml
@@ -37,7 +37,7 @@
             android:layout_width="72dp"
             android:layout_height="65dp"
             android:id="@+id/image"
-            android:layout_marginLeft="9dp"
+            android:layout_marginStart="9dp"
             android:background="@drawable/spritelist_item_thumbnail_border"
             android:cropToPadding="true"
             android:padding="1.5dp"

--- a/catroid/src/main/res/values/strings-global.xml
+++ b/catroid/src/main/res/values/strings-global.xml
@@ -33,9 +33,7 @@
 
 
     <!-- Symbols -->
-    <string name="degree_symbol" translatable="false">°</string>
-    <string name="percent_symbol" translatable="false">%</string>
-    <string name="hertz_symbol" translatable="false">㎐</string>
+     <string name="degree_symbol" translatable="false">°</string>
      <string name="punctuation_mark" translatable="false">…</string>
     <!--  -->
 

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1184,7 +1184,6 @@
     <string name="nxt_tone_duration">Duration</string>
     <string name="nxt_tone_frequency">Frequency</string>
     <string name="nxt_tone_hundred_hz">×100Hz</string>
-    <string name="nxt_seconds">seconds</string>
 
     <string name="nxt_motor_a">A</string>
     <string name="nxt_motor_b">B</string>
@@ -1291,8 +1290,8 @@
     <string name="brick_drone_set_vertical_speed">Vertical speed limit</string>
     <string name="brick_drone_set_rotation_speed">Rotation speed limit</string>
     <string name="brick_drone_set_tilt_limit">Tilt limit</string>
-    <string name="brick_drone_with">seconds with</string>
-    <string name="brick_drone_percent_power">% power</string>
+    <string name="brick_drone_with.">with</string>
+    <string name="brick_drone_power">power</string>
     <!--  -->
 
     <!-- Drone play led animation strings -->
@@ -1321,7 +1320,6 @@
     <!-- Jumping Sumo Bricks -->
     <string name="brick_jumping_sumo_move_forward">Move Jumping Sumo forward</string>
     <string name="brick_jumping_sumo_move_backward">Move Jumping Sumo backward</string>
-    <string name="brick_jumping_sumo_percent_power">% power</string>
     <string name="brick_jumping_sumo_animation">Animations Jumping Sumo</string>
     <string name="brick_jumping_sumo_no_sound">No Jumping Sumo sound</string>
     <string name="brick_jumping_sumo_sound">Sound</string>
@@ -1807,6 +1805,9 @@
     <!-- Multilingual List -->
     <string name="device_language">Device Language</string>
 
+    <!-- Symbols -->
+    <string name="percent_symbol">%</string>
+    <string name="hertz_symbol">㎐</string>
 
     <!-- UtilFile SizeUnits String -->
      <string name="Byte_short">B</string>

--- a/catroid/src/main/res/values/styles.xml
+++ b/catroid/src/main/res/values/styles.xml
@@ -363,11 +363,6 @@
         <item name="android:drawableEnd">@drawable/main_menu_button_arrow_variables</item>
     </style>
 
-    <style name="BrickCategoryText_Rtl.Data_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_data</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_variables</item>
-    </style>
-
     <style name="BrickContainer.UserBrick.Small" >
         <item name="android:minHeight" >@dimen/brick_height_small</item >
         <item name="android:background" >@drawable/brick_lime_1h</item >
@@ -621,85 +616,40 @@
         <item name="android:textSize" >@dimen/text_size_brick_category</item >
     </style >
 
-    <style name="BrickCategoryText_Rtl" >
-        <item name="android:layout_width" >match_parent</item >
-        <item name="android:layout_height" >@dimen/brick_category_height</item >
-        <item name="android:gravity" >right|center_vertical</item >
-        <item name="android:paddingRight" >21dp</item >
-        <item name="android:paddingLeft" >14dp</item >
-        <item name="android:textColor" >@color/brick_category_fragment_text_color</item >
-        <item name="android:textSize" >@dimen/text_size_brick_category</item >
-    </style >
-
     <style name="BrickCategoryText.Control" >
         <item name="android:background" >@drawable/brick_selection_background_control</item >
         <item name="android:drawableEnd" >@drawable/main_menu_button_arrow_control</item >
     </style >
-
-    <style name="BrickCategoryText_Rtl.Control_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_control</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_control</item>
-    </style>
 
     <style name="BrickCategoryText.Event" >
         <item name="android:background" >@drawable/brick_selection_background_event</item >
         <item name="android:drawableEnd" >@drawable/main_menu_button_arrow_event</item >
     </style >
 
-    <style name="BrickCategoryText_Rtl.Event_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_event</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_event</item>
-    </style>
-
     <style name="BrickCategoryText.Motion" >
         <item name="android:background" >@drawable/brick_selection_background_motion</item >
         <item name="android:drawableEnd" >@drawable/main_menu_button_arrow_motion</item >
     </style >
-
-    <style name="BrickCategoryText_Rtl.Motion_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_motion</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_motion</item>
-    </style>
 
     <style name="BrickCategoryText.Sounds" >
         <item name="android:background" >@drawable/brick_selection_background_sounds</item >
         <item name="android:drawableEnd" >@drawable/main_menu_button_arrow_sounds</item >
     </style >
 
-    <style name="BrickCategoryText_Rtl.Sounds_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_sounds</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_sounds</item>
-    </style>
-
     <style name="BrickCategoryText.Looks" >
         <item name="android:background" >@drawable/brick_selection_background_looks</item >
         <item name="android:drawableEnd" >@drawable/main_menu_button_arrow_looks</item >
     </style >
-
-    <style name="BrickCategoryText_Rtl.Looks_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_looks</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_looks</item>
-    </style>
 
     <style name="BrickCategoryText.Pen" >
         <item name="android:background" >@drawable/brick_selection_background_pen</item >
         <item name="android:drawableEnd" >@drawable/main_menu_button_arrow_looks</item >
     </style >
 
-    <style name="BrickCategoryText_Rtl.Pen_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_pen</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_looks</item>
-    </style>
-
     <style name="BrickCategoryText.UserBricks" >
 		<item name="android:background" >@drawable/brick_selection_background_user_bricks</item >
  		<item name="android:drawableEnd" >@drawable/main_menu_button_arrow_user_bricks</item >
  	</style >
-
-    <style name="BrickCategoryText_Rtl.UserBricks_ldrtl">
-		<item name="android:background">@drawable/brick_selection_background_user_bricks</item>
- 		<item name="android:drawableLeft">@drawable/main_menu_button_arrow_user_bricks</item>
- 	</style>
 
     <style name="BrickCategoryText.Drone" >
         <item name="android:background" >@drawable/brick_selection_background_drone</item >
@@ -711,38 +661,19 @@
         <item name="android:drawableEnd" >@drawable/main_menu_button_arrow_drone</item >
     </style >
 
-    <style name="BrickCategoryText_Rtl.Drone_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_drone</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_drone</item>
-    </style>
-
     <style name="BrickCategoryText.Lego" >
         <item name="android:background" >@drawable/brick_selection_background_lego</item >
         <item name="android:drawableEnd" >@drawable/main_menu_button_arrow_lego</item >
     </style >
-
-    <style name="BrickCategoryText_Rtl.Lego_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_lego</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_lego</item>
-    </style>
 
     <style name="BrickCategoryText.Phiro" >
         <item name="android:background" >@drawable/brick_selection_background_bluetooth</item >
         <item name="android:drawableEnd" >@drawable/main_menu_button_arrow_bluetooth</item >
     </style >
 
-    <style name="BrickCategoryText_Rtl.Phiro_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_bluetooth</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_bluetooth</item>
-    </style>
-
     <style name="BrickCategoryText.Arduino">
         <item name="android:background">@drawable/brick_selection_background_bluetooth</item>
         <item name="android:drawableEnd">@drawable/main_menu_button_arrow_bluetooth</item>
-    </style>
-    <style name="BrickCategoryText_Rtl.Arduino_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_bluetooth</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_bluetooth</item>
     </style>
 
     <style name="BrickCategoryText.Cast">
@@ -750,19 +681,9 @@
         <item name="android:drawableEnd">@drawable/main_menu_button_arrow_chromecast</item>
     </style>
 
-    <style name="BrickCategoryText_Rtl.Cast_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_chromecast</item>
-        <item name="android:drawableRight">@drawable/main_menu_button_arrow_chromecast</item>
-    </style>
-
     <style name="BrickCategoryText.Raspi">
         <item name="android:background">@drawable/brick_selection_background_bluetooth</item>
         <item name="android:drawableEnd">@drawable/main_menu_button_arrow_bluetooth</item>
-    </style>
-
-    <style name="BrickCategoryText_Rtl.Raspi_ldrtl">
-        <item name="android:background">@drawable/brick_selection_background_bluetooth</item>
-        <item name="android:drawableLeft">@drawable/main_menu_button_arrow_bluetooth</item>
     </style>
     
     <style name="userBrickDataTextBackground" >


### PR DESCRIPTION
* delete unused styles
* add android:textDirection="locale" to each brickSpinner " spinnerTextDirection should follow the localeDirection not the textDirection"
* these strings should be transeatable in arabic
<!-- Symbols -->
    <string name="percent_symbol" translatable="false">%</string> // in arabic   ٪
    <string name="hertz_symbol" translatable="false">㎐</string>   // in arabic   "هرتز"
* refactoring the second unit at following java files" LegoEv3PlayToneBrick, LegoNxtPlayToneBrick,PhiroPlayToneBrick" to cover singular and plural form.