### PR TITLE
[CAT-2395] Update the comparison functionality

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestOperators.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestOperators.java
@@ -88,56 +88,168 @@ public class ParserTestOperators extends AndroidTestCase {
 		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "2", Operators.GREATER_THAN,
 				InternTokenType.NUMBER, "1", TRUE, testSprite);
 		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.GREATER_THAN,
+				InternTokenType.NUMBER, "2", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.GREATER_THAN,
 				InternTokenType.NUMBER, "1", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "-2", Operators.GREATER_THAN,
+				InternTokenType.NUMBER, "0", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "-0", Operators.GREATER_THAN,
+				InternTokenType.NUMBER, "0", FALSE, testSprite);
 
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "2", Operators.GREATER_THAN,
-				InternTokenType.STRING, "1", TRUE, testSprite);
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "1", Operators.GREATER_THAN,
-				InternTokenType.STRING, "1", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc", Operators.GREATER_THAN,
+				InternTokenType.STRING, "abc", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc0", Operators.GREATER_THAN,
+				InternTokenType.STRING, "abc", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc", Operators.GREATER_THAN,
+				InternTokenType.STRING, "abc0", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "A", Operators.GREATER_THAN,
+				InternTokenType.STRING, "a", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "a", Operators.GREATER_THAN,
+				InternTokenType.STRING, "A", FALSE, testSprite);
+
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.GREATER_THAN, InternTokenType.NUMBER, "1", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.GREATER_THAN,
+				InternTokenType.STRING, String.valueOf(Double.NaN), FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.GREATER_THAN, InternTokenType.STRING, "nan", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "NAN", Operators
+				.GREATER_THAN, InternTokenType.STRING, String.valueOf(Double.NaN), FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "NaN0", Operators
+				.GREATER_THAN, InternTokenType.STRING, String.valueOf(Double.NaN), TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.GREATER_THAN, InternTokenType.STRING, "abc", TRUE, testSprite);
+
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "a", Operators.GREATER_THAN,
+				InternTokenType.NUMBER, "1", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.GREATER_THAN,
+				InternTokenType.STRING, "a", FALSE, testSprite);
 	}
 
 	public void testGreaterOrEqualThan() {
 		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "2", Operators.GREATER_OR_EQUAL,
 				InternTokenType.NUMBER, "1", TRUE, testSprite);
 		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.GREATER_OR_EQUAL,
+				InternTokenType.NUMBER, "2", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.GREATER_OR_EQUAL,
 				InternTokenType.NUMBER, "1", TRUE, testSprite);
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "0", Operators.GREATER_OR_EQUAL,
-				InternTokenType.NUMBER, "1", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "-2", Operators.GREATER_OR_EQUAL,
+				InternTokenType.NUMBER, "0", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "-0", Operators.GREATER_OR_EQUAL,
+				InternTokenType.NUMBER, "0", TRUE, testSprite);
 
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "2", Operators.GREATER_OR_EQUAL,
-				InternTokenType.STRING, "1", TRUE, testSprite);
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "1", Operators.GREATER_OR_EQUAL,
-				InternTokenType.STRING, "1", TRUE, testSprite);
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "0", Operators.GREATER_OR_EQUAL,
-				InternTokenType.STRING, "1", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc", Operators.GREATER_OR_EQUAL,
+				InternTokenType.STRING, "abc", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc0", Operators.GREATER_OR_EQUAL,
+				InternTokenType.STRING, "abc", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc", Operators.GREATER_OR_EQUAL,
+				InternTokenType.STRING, "abc0", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "A", Operators.GREATER_OR_EQUAL,
+				InternTokenType.STRING, "a", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "a", Operators.GREATER_OR_EQUAL,
+				InternTokenType.STRING, "A", TRUE, testSprite);
+
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.GREATER_OR_EQUAL, InternTokenType.NUMBER, "1", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.GREATER_OR_EQUAL,
+				InternTokenType.STRING, String.valueOf(Double.NaN), FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.GREATER_OR_EQUAL, InternTokenType.STRING, "nan", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "NAN", Operators
+				.GREATER_OR_EQUAL, InternTokenType.STRING, String.valueOf(Double.NaN), TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "NaN0", Operators
+				.GREATER_OR_EQUAL, InternTokenType.STRING, String.valueOf(Double.NaN), TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.GREATER_OR_EQUAL, InternTokenType.STRING, "abc", TRUE, testSprite);
+
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "a", Operators.GREATER_OR_EQUAL,
+				InternTokenType.NUMBER, "1", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.GREATER_OR_EQUAL,
+				InternTokenType.STRING, "a", FALSE, testSprite);
 	}
 
 	public void testSmallerThan() {
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "2", Operators.SMALLER_THAN,
+				InternTokenType.NUMBER, "1", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.SMALLER_THAN,
+				InternTokenType.NUMBER, "2", TRUE, testSprite);
 		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.SMALLER_THAN,
 				InternTokenType.NUMBER, "1", FALSE, testSprite);
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "0", Operators.SMALLER_THAN,
-				InternTokenType.NUMBER, "1", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "-2", Operators.SMALLER_THAN,
+				InternTokenType.NUMBER, "0", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "-0", Operators.SMALLER_THAN,
+				InternTokenType.NUMBER, "0", FALSE, testSprite);
 
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "1", Operators.SMALLER_THAN,
-				InternTokenType.STRING, "1", FALSE, testSprite);
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "0", Operators.SMALLER_THAN,
-				InternTokenType.STRING, "1", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc", Operators.SMALLER_THAN,
+				InternTokenType.STRING, "abc", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc0", Operators.SMALLER_THAN,
+				InternTokenType.STRING, "abc", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc", Operators.SMALLER_THAN,
+				InternTokenType.STRING, "abc0", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "A", Operators.SMALLER_THAN,
+				InternTokenType.STRING, "a", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "a", Operators.SMALLER_THAN,
+				InternTokenType.STRING, "A", FALSE, testSprite);
+
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.SMALLER_THAN, InternTokenType.NUMBER, "1", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.SMALLER_THAN,
+				InternTokenType.STRING, String.valueOf(Double.NaN), TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.SMALLER_THAN, InternTokenType.STRING, "nan", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "NAN", Operators
+				.SMALLER_THAN, InternTokenType.STRING, String.valueOf(Double.NaN), FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "NaN0", Operators
+				.SMALLER_THAN, InternTokenType.STRING, String.valueOf(Double.NaN), FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.SMALLER_THAN, InternTokenType.STRING, "abc", FALSE, testSprite);
+
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "a", Operators.SMALLER_THAN,
+				InternTokenType.NUMBER, "1", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.SMALLER_THAN,
+				InternTokenType.STRING, "a", TRUE, testSprite);
 	}
 
 	public void testSmallerOrEqualThan() {
 		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "2", Operators.SMALLER_OR_EQUAL,
 				InternTokenType.NUMBER, "1", FALSE, testSprite);
 		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.SMALLER_OR_EQUAL,
+				InternTokenType.NUMBER, "2", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.SMALLER_OR_EQUAL,
 				InternTokenType.NUMBER, "1", TRUE, testSprite);
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "0", Operators.SMALLER_OR_EQUAL,
-				InternTokenType.NUMBER, "1", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "-2", Operators.SMALLER_OR_EQUAL,
+				InternTokenType.NUMBER, "0", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "-0", Operators.SMALLER_OR_EQUAL,
+				InternTokenType.NUMBER, "0", TRUE, testSprite);
 
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "2", Operators.SMALLER_OR_EQUAL,
-				InternTokenType.STRING, "1", FALSE, testSprite);
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "1", Operators.SMALLER_OR_EQUAL,
-				InternTokenType.STRING, "1", TRUE, testSprite);
-		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "0", Operators.SMALLER_OR_EQUAL,
-				InternTokenType.STRING, "1", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc", Operators.SMALLER_OR_EQUAL,
+				InternTokenType.STRING, "abc", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc0", Operators.SMALLER_OR_EQUAL,
+				InternTokenType.STRING, "abc", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "abc", Operators.SMALLER_OR_EQUAL,
+				InternTokenType.STRING, "abc0", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "A", Operators.SMALLER_OR_EQUAL,
+				InternTokenType.STRING, "a", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "a", Operators.SMALLER_OR_EQUAL,
+				InternTokenType.STRING, "A", TRUE, testSprite);
+
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.SMALLER_OR_EQUAL, InternTokenType.NUMBER, "1", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.SMALLER_OR_EQUAL,
+				InternTokenType.STRING, String.valueOf(Double.NaN), TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.SMALLER_OR_EQUAL, InternTokenType.STRING, "nan", TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "NAN", Operators
+				.SMALLER_OR_EQUAL, InternTokenType.STRING, String.valueOf(Double.NaN), TRUE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "NaN0", Operators
+				.SMALLER_OR_EQUAL, InternTokenType.STRING, String.valueOf(Double.NaN), FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, String.valueOf(Double.NaN), Operators
+				.SMALLER_OR_EQUAL, InternTokenType.STRING, "abc", FALSE, testSprite);
+
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.STRING, "a", Operators.SMALLER_OR_EQUAL,
+				InternTokenType.NUMBER, "1", FALSE, testSprite);
+		FormulaEditorTestUtil.testBinaryOperator(InternTokenType.NUMBER, "1", Operators.SMALLER_OR_EQUAL,
+				InternTokenType.STRING, "a", TRUE, testSprite);
 	}
 
 	public void testEqual() {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -551,7 +551,7 @@ public class FormulaElement implements Serializable {
 			}
 
 			for (Object userListElement : userList.getList()) {
-				if (interpretOperatorEqual(userListElement, right) == 1d) {
+				if (interpretOperatorCompare(userListElement, right) == 0d) {
 					return 1d;
 				}
 			}
@@ -777,25 +777,17 @@ public class FormulaElement implements Serializable {
 					right = interpretOperator(rightObject);
 					return java.lang.Math.pow(left, right);
 				case EQUAL:
-					return interpretOperatorEqual(leftObject, rightObject);
+					return interpretOperatorCompare(leftObject, rightObject) == 0 ? 1d : 0d;
 				case NOT_EQUAL:
-					return interpretOperatorEqual(leftObject, rightObject) == 1d ? 0d : 1d;
+					return interpretOperatorCompare(leftObject, rightObject) != 0 ? 1d : 0d;
 				case GREATER_THAN:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left.compareTo(right) > 0 ? 1d : 0d;
+					return interpretOperatorCompare(leftObject, rightObject) > 0 ? 1d : 0d;
 				case GREATER_OR_EQUAL:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left.compareTo(right) >= 0 ? 1d : 0d;
+					return interpretOperatorCompare(leftObject, rightObject) >= 0 ? 1d : 0d;
 				case SMALLER_THAN:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left.compareTo(right) < 0 ? 1d : 0d;
+					return interpretOperatorCompare(leftObject, rightObject) < 0 ? 1d : 0d;
 				case SMALLER_OR_EQUAL:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left.compareTo(right) <= 0 ? 1d : 0d;
+					return interpretOperatorCompare(leftObject, rightObject) <= 0 ? 1d : 0d;
 				case LOGICAL_AND:
 					left = interpretOperator(leftObject);
 					right = interpretOperator(rightObject);
@@ -894,32 +886,16 @@ public class FormulaElement implements Serializable {
 		return returnValue;
 	}
 
-	private Double interpretOperatorEqual(Object left, Object right) {
+	private int interpretOperatorCompare(Object left, Object right) {
 		try {
-			Double tempLeft = Double.valueOf(String.valueOf(left));
-			Double tempRight = Double.valueOf(String.valueOf(right));
-			int compareResult = getCompareResult(tempLeft, tempRight);
-			if (compareResult == 0) {
-				return 1d;
-			}
-			return 0d;
-		} catch (NumberFormatException numberFormatException) {
-			int compareResult = String.valueOf(left).compareTo(String.valueOf(right));
-			if (compareResult == 0) {
-				return 1d;
-			}
-			return 0d;
-		}
-	}
+			if(Math.abs(Double.valueOf(String.valueOf(left))) == 0 &&
+					Math.abs(Double.valueOf(String.valueOf(right)))	== 0)
+				return 0;
 
-	private int getCompareResult(Double left, Double right) {
-		int compareResult;
-		if (left == 0 || right == 0) {
-			compareResult = ((Double) Math.abs(left)).compareTo(Math.abs(right));
-		} else {
-			compareResult = left.compareTo(right);
+			return (Double.valueOf(String.valueOf(left))).compareTo(Double.valueOf(String.valueOf(right)));
+		} catch (NumberFormatException numberFormatException) {
+			return String.valueOf(left).toLowerCase().compareTo(String.valueOf(right).toLowerCase());
 		}
-		return compareResult;
 	}
 
 	private Double interpretOperator(Object object) {


### PR DESCRIPTION
The comparison functionality on formula editor now matches the Scratch
functionality, meaning; number comparison works as usual if anything
else is compared, they will be treated as lowercase strings.(Including
NaN)