### PR TITLE
CAT-FIX Crash when opening project on first app startup

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/utils/CrashReporter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/CrashReporter.java
@@ -48,7 +48,8 @@ public final class CrashReporter {
 	}
 
 	private static boolean isReportingEnabled() {
-		return preferences != null && preferences.getBoolean(SettingsActivity.SETTINGS_CRASH_REPORTS, false) && isCrashReportEnabled;
+		return preferences != null && preferences.getBoolean(SettingsActivity.SETTINGS_CRASH_REPORTS, true)
+				&& isCrashReportEnabled;
 	}
 
 	@VisibleForTesting


### PR DESCRIPTION
**Issue**
The app crashes when opening some projects like:
https://share.catrob.at/pocketcode/program/40654
https://share.catrob.at/pocketcode/program/26670
but only on first application startup.

**Explanation**
This happens because Crashlytics is disabled per default -> therefore it is not initialized.
However in onCreate of MainMenuActivity Crashlytics is enabled by writing R.xml.preferences to the SharedPreferences.

When a crash occurs, the app thinks Crashlytics is enabled (because the SharedPreferences say so) and tries to log with it. This results in a crash because it isn't initialized.

**Solution**
If no SharedPreference is set for Crashlytics yet, we assume true so that it will be initialized. (On first startup it  (= the shared preference) will be initialized to true by onCreate of MainMenuActivity anyways)