### PR TITLE
CAT-2625 Fix computeTextView height bug

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/FormulaEditorComputeDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/FormulaEditorComputeDialog.java
@@ -28,7 +28,6 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.os.Bundle;
-import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.ViewGroup;
 import android.widget.TextView;
@@ -143,11 +142,10 @@ public class FormulaEditorComputeDialog extends AlertDialog implements SensorEve
 				computeTextView.setText(newString);
 
 				ViewGroup.LayoutParams params = computeTextView.getLayoutParams();
-				int heightPixels = computeTextView.getLineCount() * computeTextView.getLineHeight();
-				int height = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, heightPixels / 2, context
-						.getResources().getDisplayMetrics());
+				int height = computeTextView.getLineCount() * computeTextView.getLineHeight();
+				int heightMargin = (int) (height * 0.5);
 				params.width = ViewGroup.LayoutParams.FILL_PARENT;
-				params.height = height;
+				params.height = height + heightMargin;
 				computeTextView.setLayoutParams(params);
 			}
 		});


### PR DESCRIPTION
This was pure luck that this has ever worked correctly.
The height of the computeTextView was calculated wrong.

First the height in px was calculated (heightPixels). 
Then the heightPixels were divided by 2 (whyever someone wants to do this) and converted from dp to pixel with TypedValue.applyDimension(...)
In other words: The pixels were converted into pixels.

I removed this calculation and just used the heightPixels as TextView height and added a height margin (50% of calculated line height) to it so it looks better. 

 