### PR TITLE
CAT-2350 Fixed "Rename Program" bug

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CheckBoxListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CheckBoxListFragment.java
@@ -53,8 +53,6 @@ public abstract class CheckBoxListFragment extends ListFragment implements Check
 	protected String singleItemTitle;
 	protected String multipleItemsTitle;
 
-	protected boolean isRenameActionMode = false;
-
 	protected CapitalizedTextView selectAllView;
 
 	@Override
@@ -109,7 +107,7 @@ public abstract class CheckBoxListFragment extends ListFragment implements Check
 
 	@Override
 	public void onItemChecked() {
-		if (isRenameActionMode || actionMode == null || actionModeTitle == null) {
+		if (actionMode == null) {
 			return;
 		}
 		updateActionModeTitle();
@@ -117,6 +115,10 @@ public abstract class CheckBoxListFragment extends ListFragment implements Check
 	}
 
 	protected void updateActionModeTitle() {
+		if (getSelectMode() == ListView.CHOICE_MODE_SINGLE) {
+			return;
+		}
+
 		int numberOfSelectedItems = adapter.getCheckedItems().size();
 
 		if (numberOfSelectedItems == 0) {
@@ -162,6 +164,9 @@ public abstract class CheckBoxListFragment extends ListFragment implements Check
 	}
 
 	protected void updateSelectAllView() {
+		if (getSelectMode() == ListView.CHOICE_MODE_SINGLE) {
+			return;
+		}
 		if (areAllItemsChecked()) {
 			selectAllView.setText(R.string.deselect_all);
 		} else {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ListActivityFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ListActivityFragment.java
@@ -116,10 +116,9 @@ public abstract class ListActivityFragment extends CheckBoxListFragment implemen
 		@Override
 		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
 			setSelectMode(ListView.CHOICE_MODE_SINGLE);
+			actionModeTitle = getString(R.string.rename);
+			mode.setTitle(actionModeTitle);
 
-			mode.setTitle(R.string.rename);
-
-			isRenameActionMode = true;
 			return true;
 		}
 
@@ -130,7 +129,6 @@ public abstract class ListActivityFragment extends CheckBoxListFragment implemen
 
 		@Override
 		public void onDestroyActionMode(ActionMode mode) {
-			isRenameActionMode = false;
 			if (adapter.getCheckedItems().isEmpty()) {
 				clearCheckedItems();
 			} else {
@@ -205,7 +203,6 @@ public abstract class ListActivityFragment extends CheckBoxListFragment implemen
 		} else {
 			actionMode = getActivity().startActionMode(actionModeCallback);
 			BottomBar.hideBottomBar(getActivity());
-			isRenameActionMode = actionModeCallback.equals(renameModeCallBack);
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/LookFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/LookFragment.java
@@ -118,7 +118,6 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 	private LookListTouchActionUpReceiver lookListTouchActionUpReceiver;
 	private ActionMode actionMode;
 	private View selectAllActionModeButton;
-	private boolean isRenameActionMode;
 	private boolean isResultHandled = false;
 	private OnLookDataListChangedAfterNewListener lookDataListChangedAfterNewListener;
 	private Lock viewSwitchLock = new ViewSwitchLock();
@@ -169,8 +168,9 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 		@Override
 		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
 			setSelectMode(ListView.CHOICE_MODE_SINGLE);
-			mode.setTitle(R.string.rename);
 
+			actionModeTitle = getString(R.string.rename);
+			mode.setTitle(actionModeTitle);
 			setActionModeActive(true);
 
 			return true;
@@ -241,7 +241,6 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 
 		@Override
 		public boolean onCreateActionMode(ActionMode mode, Menu menu) {
-
 			setSelectMode(ListView.CHOICE_MODE_MULTIPLE);
 			setActionModeActive(true);
 
@@ -642,7 +641,7 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 
 	@Override
 	public void startCopyActionMode() {
-		startActionMode(copyModeCallBack, false);
+		startActionMode(copyModeCallBack);
 	}
 
 	@Override
@@ -652,20 +651,20 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 
 	@Override
 	public void startRenameActionMode() {
-		startActionMode(renameModeCallBack, true);
+		startActionMode(renameModeCallBack);
 	}
 
 	@Override
 	public void startDeleteActionMode() {
-		startActionMode(deleteModeCallBack, false);
+		startActionMode(deleteModeCallBack);
 	}
 
 	@Override
 	public void startBackPackActionMode() {
-		startActionMode(backPackModeCallBack, false);
+		startActionMode(backPackModeCallBack);
 	}
 
-	private void startActionMode(ActionMode.Callback actionModeCallback, boolean isRenameMode) {
+	private void startActionMode(ActionMode.Callback actionModeCallback) {
 		if (actionMode == null) {
 			if (adapter.isEmpty()) {
 				if (actionModeCallback.equals(copyModeCallBack)) {
@@ -685,7 +684,6 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 				actionMode = getActivity().startActionMode(actionModeCallback);
 				unregisterForContextMenu(listView);
 				BottomBar.hideBottomBar(getActivity());
-				isRenameActionMode = isRenameMode;
 			}
 		}
 	}
@@ -763,7 +761,7 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 
 	@Override
 	public void onLookChecked() {
-		if (isRenameActionMode || actionMode == null) {
+		if (actionMode == null) {
 			return;
 		}
 
@@ -773,6 +771,10 @@ public class LookFragment extends ScriptActivityFragment implements LookBaseAdap
 	}
 
 	private void updateActionModeTitle() {
+		if (getSelectMode() == ListView.CHOICE_MODE_SINGLE) {
+			return;
+		}
+
 		int numberOfSelectedItems = adapter.getAmountOfCheckedItems();
 
 		if (numberOfSelectedItems == 0) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/NfcTagFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/NfcTagFragment.java
@@ -102,7 +102,6 @@ public class NfcTagFragment extends ScriptActivityFragment implements NfcTagBase
 	private List<NfcTagData> nfcTagDataList;
 	private NfcTagData selectedNfcTag;
 
-	private boolean isRenameActionMode;
 	private boolean isResultHandled = false;
 
 	NfcAdapter nfcAdapter;
@@ -346,7 +345,6 @@ public class NfcTagFragment extends ScriptActivityFragment implements NfcTagBase
 			actionMode = getActivity().startActionMode(copyModeCallBack);
 			unregisterForContextMenu(listView);
 			BottomBar.hideBottomBar(getActivity());
-			isRenameActionMode = false;
 		}
 	}
 
@@ -361,7 +359,6 @@ public class NfcTagFragment extends ScriptActivityFragment implements NfcTagBase
 			actionMode = getActivity().startActionMode(renameModeCallBack);
 			unregisterForContextMenu(listView);
 			BottomBar.hideBottomBar(getActivity());
-			isRenameActionMode = true;
 		}
 	}
 
@@ -371,7 +368,6 @@ public class NfcTagFragment extends ScriptActivityFragment implements NfcTagBase
 			actionMode = getActivity().startActionMode(deleteModeCallBack);
 			unregisterForContextMenu(listView);
 			BottomBar.hideBottomBar(getActivity());
-			isRenameActionMode = false;
 		}
 	}
 
@@ -389,7 +385,7 @@ public class NfcTagFragment extends ScriptActivityFragment implements NfcTagBase
 	}
 
 	public void onNfcTagChecked() {
-		if (isRenameActionMode || actionMode == null) {
+		if (actionMode == null) {
 			return;
 		}
 
@@ -399,6 +395,10 @@ public class NfcTagFragment extends ScriptActivityFragment implements NfcTagBase
 	}
 
 	private void updateActionModeTitle() {
+		if (getSelectMode() == ListView.CHOICE_MODE_SINGLE) {
+			return;
+		}
+
 		int numberOfSelectedItems = adapter.getAmountOfCheckedItems();
 
 		if (numberOfSelectedItems == 0) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SceneListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SceneListFragment.java
@@ -168,7 +168,6 @@ public class SceneListFragment extends ListActivityFragment implements CheckBoxL
 		} else {
 			actionMode = getActivity().startActionMode(actionModeCallback);
 			BottomBar.hideBottomBar(getActivity());
-			isRenameActionMode = actionModeCallback.equals(renameModeCallBack);
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SoundFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SoundFragment.java
@@ -124,7 +124,6 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 	private ActionMode actionMode;
 	private View selectAllActionModeButton;
 
-	private boolean isRenameActionMode;
 	private boolean isResultHandled = false;
 	private Activity activity;
 
@@ -356,7 +355,7 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 
 	@Override
 	public void startCopyActionMode() {
-		startActionMode(copyModeCallBack, false);
+		startActionMode(copyModeCallBack);
 	}
 
 	@Override
@@ -366,20 +365,20 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 
 	@Override
 	public void startBackPackActionMode() {
-		startActionMode(backPackModeCallBack, false);
+		startActionMode(backPackModeCallBack);
 	}
 
 	@Override
 	public void startRenameActionMode() {
-		startActionMode(renameModeCallBack, true);
+		startActionMode(renameModeCallBack);
 	}
 
 	@Override
 	public void startDeleteActionMode() {
-		startActionMode(deleteModeCallBack, false);
+		startActionMode(deleteModeCallBack);
 	}
 
-	private void startActionMode(ActionMode.Callback actionModeCallback, boolean isRenameMode) {
+	private void startActionMode(ActionMode.Callback actionModeCallback) {
 		if (actionMode == null) {
 			if (adapter.isEmpty()) {
 				if (actionModeCallback.equals(copyModeCallBack)) {
@@ -400,7 +399,6 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 				actionMode = getActivity().startActionMode(actionModeCallback);
 				unregisterForContextMenu(listView);
 				BottomBar.hideBottomBar(getActivity());
-				isRenameActionMode = isRenameMode;
 			}
 		}
 	}
@@ -463,7 +461,7 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 
 	@Override
 	public void onSoundChecked() {
-		if (isRenameActionMode || actionMode == null) {
+		if (actionMode == null) {
 			return;
 		}
 
@@ -473,6 +471,10 @@ public class SoundFragment extends ScriptActivityFragment implements SoundBaseAd
 	}
 
 	private void updateActionModeTitle() {
+		if (getSelectMode() == ListView.CHOICE_MODE_SINGLE) {
+			return;
+		}
+
 		int numberOfSelectedItems = adapter.getAmountOfCheckedItems();
 
 		if (numberOfSelectedItems == 0) {


### PR DESCRIPTION
There were two issues why this did not work.
1. The actionModeTitle was not set correctly. thats why a null pointer exception is thrown on actionModeTitle.length()
2. The CHOICE_MODE_SINGLE is not handled correctly in the CheckBoxListFragment. The isRenameActionMode was implemented in a very dirty way, even tho this variable is not necessary. The updateActionModeTitle() should not be called if the "SelectMode" equals CHOICE_MODE_SINGLE, because there is nothing to update if the "SelectMode" equals CHOICE_MODE_SINGLE.

I removed the isRenameActionMode, because "if(getSelectMode() == ListView.CHOICE_MODE_SINGLE)" should be used instead of "if(isRenameActionMode)"

isRenameActionMode is removed everywhere, except in the SpritesListFragment, because it seems to be necessary there.