### PR TITLE
CAT-2083 Fixed rename variables bug

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
@@ -179,6 +179,28 @@ public class FormulaEditorEditText extends EditText implements OnTouchListener {
 		formulaEditorFragment.refreshFormulaPreviewString(resultingText);
 	}
 
+	public void updateVariableReferences(String oldName, String newName) {
+		if (internFormula == null) {
+			return;
+		}
+		internFormula.updateVariableReferences(oldName, newName, this.context);
+		history.push(internFormula.getInternFormulaState());
+		String resultingText = updateTextAndCursorFromInternFormula();
+		setSelection(absoluteCursorPosition);
+		formulaEditorFragment.refreshFormulaPreviewString(resultingText);
+	}
+
+	public void updateListReferences(String oldName, String newName) {
+		if (internFormula == null) {
+			return;
+		}
+		internFormula.updateListReferences(oldName, newName, this.context);
+		history.push(internFormula.getInternFormulaState());
+		String resultingText = updateTextAndCursorFromInternFormula();
+		setSelection(absoluteCursorPosition);
+		formulaEditorFragment.refreshFormulaPreviewString(resultingText);
+	}
+
 	private Runnable cursorAnimation = new Runnable() {
 		@Override
 		public void run() {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
@@ -141,6 +141,13 @@ public class InternFormula {
 		generateExternFormulaStringAndInternExternMapping(context);
 	}
 
+	public void updateListReferences(String oldName, String newName, Context context) {
+		for (InternToken internToken : internTokenFormulaList) {
+			internToken.updateListReferences(oldName, newName);
+		}
+		generateExternFormulaStringAndInternExternMapping(context);
+	}
+
 	public void getVariableAndListNames(List<String> variables, List<String> lists) {
 		for (InternToken internToken : internTokenFormulaList) {
 			internToken.getVariableAndListNames(variables, lists);

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
@@ -54,6 +54,12 @@ public class InternToken {
 		}
 	}
 
+	public void updateListReferences(String oldName, String newName) {
+		if (internTokenType == InternTokenType.USER_LIST && tokenStringValue.equals(oldName)) {
+			tokenStringValue = newName;
+		}
+	}
+
 	public void getVariableAndListNames(List<String> variables, List<String> lists) {
 		if (internTokenType == InternTokenType.USER_VARIABLE && !variables.contains(tokenStringValue)) {
 			variables.add(tokenStringValue);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/RenameVariableDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/RenameVariableDialog.java
@@ -43,6 +43,7 @@ import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.formulaeditor.datacontainer.DataContainer;
 import org.catrobat.catroid.ui.adapter.DataAdapter;
+import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import org.catrobat.catroid.utils.ToastUtil;
 
 import java.util.List;
@@ -145,6 +146,8 @@ public class RenameVariableDialog extends DialogFragment {
 			if (!isVariableNameValid(newName)) {
 				ToastUtil.showError(getActivity(), R.string.formula_editor_existing_variable);
 			} else {
+				((FormulaEditorFragment) getActivity().getFragmentManager().findFragmentByTag(FormulaEditorFragment
+						.FORMULA_EDITOR_FRAGMENT_TAG)).updateFormulaUserList(userList.getName(), newName);
 				ProjectManager.getInstance().getCurrentScene().getDataContainer()
 						.renameProjectUserList(newName, userList.getName());
 			}
@@ -161,6 +164,8 @@ public class RenameVariableDialog extends DialogFragment {
 			if (!isVariableNameValid(newName)) {
 				ToastUtil.showError(getActivity(), R.string.formula_editor_existing_variable);
 			} else {
+				((FormulaEditorFragment) getActivity().getFragmentManager().findFragmentByTag(FormulaEditorFragment
+						.FORMULA_EDITOR_FRAGMENT_TAG)).updateFormulaUserVariable(userVariable.getName(), newName);
 				ProjectManager.getInstance().getCurrentScene().getDataContainer()
 						.renameProjectUserVariable(newName, userVariable.getName());
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -762,6 +762,20 @@ public class FormulaEditorFragment extends Fragment implements OnKeyListener,
 		}
 	}
 
+	public void updateFormulaUserVariable(String oldName, String newName) {
+		if (formulaEditorEditText == null) {
+			return;
+		}
+		formulaEditorEditText.updateVariableReferences(oldName, newName);
+	}
+
+	public void updateFormulaUserList(String oldName, String newName) {
+		if (formulaEditorEditText == null) {
+			return;
+		}
+		formulaEditorEditText.updateListReferences(oldName, newName);
+	}
+
 	private void showFormularEditorCategorylistFragment(String tag, int actionbarResId) {
 		FragmentManager fragmentManager = ((Activity) context).getFragmentManager();
 		Fragment fragment = fragmentManager.findFragmentByTag(tag);


### PR DESCRIPTION
The problem was that the FormulaEditorEditText field is not getting updated after renaming variables or lists.
All tokens inside the InternFormula are changed which share the same name as the renamed variable (before renaming)
Inside the RenameVariableDialog the updateVariableReferences(...) or updateListReferences(...) is called, which updates all tokens inside the InternFormula object.