### PR TITLE
CAT-2524 Pen bricks should also work for clones

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -377,6 +377,7 @@ public class Sprite implements Serializable, Cloneable {
 		cloneLook(cloneSprite);
 		setUserAndVariableBrickReferences(cloneSprite, userBricks);
 
+		ProjectManager.getInstance().addSprite(cloneSprite);
 		ProjectManager.getInstance().setCurrentSprite(originalSprite);
 
 		return cloneSprite;


### PR DESCRIPTION
A Sprite created through the CloneBrick action, is correctly created
but it is never added to the Sprite List in the ProjectManager Class.
When the draw function of the PenActor Class is called to perform the
Pen Brick actions it looks through the List of Sprites in the
ProjectManager Class, and performs the necessary actions according to
the values of the PenConfiguration Flags of every Sprite in the List.
Since the Cloned Sprite is not in the List, no Pen actions are
performed for it. To resolve this issue the Cloned sprite is added to
the Sprite List of the ProjectManager Class. This way when the draw
function is called, the the Cloned Sprite is also found in the List and
the necessary Pen Brick actions(PenUP/down/Stamp..) are Performed.