### PR TITLE
CAT-2127 Write stamps to framebuffer instantly

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/StampAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/StampAction.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.content.actions;
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 
 import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.stage.StageActivity;
 
 public class StampAction extends TemporalAction {
 
@@ -33,6 +34,7 @@ public class StampAction extends TemporalAction {
 	@Override
 	protected void update(float delta) {
 		this.sprite.penConfiguration.stamp = true;
+		StageActivity.stageListener.getPenActor().stampToFrameBuffer();
 	}
 
 	public void setSprite(Sprite sprite) {

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -448,6 +448,9 @@ public class StageListener implements ApplicationListener {
 		}
 		PhysicsShapeBuilder.getInstance().reset();
 		CameraManager.getInstance().setToDefaultCamera();
+		if (penActor != null) {
+			penActor.dispose();
+		}
 		finished = true;
 	}
 
@@ -462,6 +465,9 @@ public class StageListener implements ApplicationListener {
 		if (reloadProject) {
 			int spriteSize = sprites.size();
 			stage.clear();
+			if (penActor != null) {
+				penActor.dispose();
+			}
 			SoundManager.getInstance().clear();
 
 			physicsWorld = scene.resetPhysicsWorld();
@@ -697,6 +703,10 @@ public class StageListener implements ApplicationListener {
 		font.draw(batch, String.valueOf((int) virtualHeightHalf), layout.height / 2, virtualHeightHalf - 3);
 		font.draw(batch, "0", layout.height / 2, -layout.height / 2);
 		batch.end();
+	}
+
+	public PenActor getPenActor() {
+		return penActor;
 	}
 
 	@Override


### PR DESCRIPTION
- Write stamps to frame buffer with the stamp action synchronously - this way we don't rely on the right timing of the rendering method.
- Dispose frame buffer and batch when stage is terminated (should have been done before)