### PR TITLE
CAT-REF Clean up CrashReporter

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/CrashReporterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/CrashReporterTest.java
@@ -54,7 +54,7 @@ public class CrashReporterTest {
 	private Exception exception;
 
 	@Mock
-	CrashReporterInterface reporter;
+	private CrashReporterInterface reporter;
 
 	@Before
 	public void setUp() {
@@ -146,7 +146,7 @@ public class CrashReporterTest {
 
 		assertFalse(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").isEmpty());
 
-		CrashReporter.sendUnhandledCaughtException();
+		CrashReporter.logUnhandledException();
 
 		assertTrue(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").isEmpty());
 	}
@@ -157,27 +157,27 @@ public class CrashReporterTest {
 
 		assertFalse(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").isEmpty());
 
-		CrashReporter.sendUnhandledCaughtException();
+		CrashReporter.logUnhandledException();
 
 		assertTrue(sharedPreferences.getString(CrashReporter.EXCEPTION_FOR_REPORT, "").isEmpty());
 	}
 
 	@Test
-	public void testUnhandledCaughtExceptionSentOnCrashReportEnabled() {
+	public void testUnhandledExceptionSentOnCrashReportEnabled() {
 		CrashReporter.storeUnhandledException(exception);
 
-		CrashReporter.sendUnhandledCaughtException();
+		CrashReporter.logUnhandledException();
 
 		verify(reporter, times(1)).logException(any(Throwable.class));
 	}
 
 	@Test
-	public void testUnhandledCaughtExceptionSentOnCrashReportDisabled() {
+	public void testUnhandledExceptionSentOnCrashReportDisabled() {
 		CrashReporter.storeUnhandledException(exception);
 		editor.putBoolean(SettingsActivity.SETTINGS_CRASH_REPORTS, false);
 		editor.commit();
 
-		CrashReporter.sendUnhandledCaughtException();
+		CrashReporter.logUnhandledException();
 
 		verify(reporter, times(0)).logException(any(Exception.class));
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.java
@@ -93,8 +93,8 @@ public abstract class BaseActivity extends AppCompatActivity {
 	}
 
 	private void checkIfCrashRecoveryAndFinishActivity(final Activity context) {
-		if (isRecoveredFromCrash()) {
-			CrashReporter.sendUnhandledCaughtException();
+		if (isRecoveringFromCrash()) {
+			CrashReporter.logUnhandledException();
 			if (!(context instanceof MainMenuActivity)) {
 				context.finish();
 			} else {
@@ -103,7 +103,7 @@ public abstract class BaseActivity extends AppCompatActivity {
 		}
 	}
 
-	private boolean isRecoveredFromCrash() {
+	private boolean isRecoveringFromCrash() {
 		return PreferenceManager.getDefaultSharedPreferences(this).getBoolean(RECOVERED_FROM_CRASH, false);
 	}
 


### PR DESCRIPTION
Just renaming, improving log output, access modifiers and splitting code
into methods.
___
Wanted to do this a long time ago :wink: I tested it with a custom Crashlytics project.
Automatically reported
* http://crashes.to/s/781a6e78c2c
* http://crashes.to/s/198ca0651ac

Manually reported
* http://crashes.to/s/ce230838cf1

I don't know why these public reports don't show a stacktrace. Maybe they will later…
All crash reports will show a stacktrace once logged in.