### PR TITLE
CAT-2676 refactoring Lego Nxt/Ev3 Brick-layouts

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/rtl/ArabicSentenceStructureInBricksNameTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/rtl/ArabicSentenceStructureInBricksNameTest.java
@@ -168,7 +168,7 @@ public class ArabicSentenceStructureInBricksNameTest {
 
 		onView(withId(R.id.brick_ev3_motor_move_spinner))
 				.check(matches(isDisplayed()))
-				.check(isLeftOf(withId(R.id.brick_ev3_motor_move_label)));
+				.check(isBelow(withId(R.id.brick_ev3_motor_move_label)));
 
 		onView(withId(R.id.ev3_motor_move_speed_edit_text))
 				.check(matches(isDisplayed()))
@@ -185,7 +185,7 @@ public class ArabicSentenceStructureInBricksNameTest {
 
 		onView(withId(R.id.lego_motor_action_spinner))
 				.check(matches(isDisplayed()))
-				.check(isLeftOf(withId(R.id.lego_motor_action_label)));
+				.check(isBelow(withId(R.id.lego_motor_action_label)));
 
 		onView(withId(R.id.motor_action_speed_edit_text))
 				.check(matches(isDisplayed()))

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/FormulaEditorComputeDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/FormulaEditorComputeDialog.java
@@ -144,7 +144,7 @@ public class FormulaEditorComputeDialog extends AlertDialog implements SensorEve
 				ViewGroup.LayoutParams params = computeTextView.getLayoutParams();
 				int height = computeTextView.getLineCount() * computeTextView.getLineHeight();
 				int heightMargin = (int) (height * 0.5);
-				params.width = ViewGroup.LayoutParams.FILL_PARENT;
+				params.width = ViewGroup.LayoutParams.MATCH_PARENT;
 				params.height = height + heightMargin;
 				computeTextView.setLayoutParams(params);
 			}

--- a/catroid/src/main/res/layout-ar/brick_ev3_motor_move.xml
+++ b/catroid/src/main/res/layout-ar/brick_ev3_motor_move.xml
@@ -48,15 +48,6 @@
 
         <include layout="@layout/icon_brick_category_legonxt"/>
 
-        <RelativeLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-            <LinearLayout
-                android:id="@+id/brick_ev3_motor_move_first_line"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
                 <TextView
                     android:id="@+id/brick_ev3_motor_move_label"
                     style="@style/BrickText.SingleLine"
@@ -68,18 +59,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textDirection="locale"
-                    android:gravity="center"
                     android:clickable="false"
                     android:focusable="false" >
                 </Spinner>
-            </LinearLayout>
-
-            <LinearLayout
-              android:id="@+id/brick_ev3_motor_move_second_line"
-              android:layout_below="@+id/brick_ev3_motor_move_first_line"
-              android:layout_width="fill_parent"
-              android:layout_height="wrap_content"
-              android:orientation="horizontal">
 
                 <TextView
                     android:id="@+id/lego_motor_action_to_text"
@@ -101,7 +83,6 @@
                     android:layout_height="wrap_content"
                     app:layout_inputType="number"
                     app:layout_textField="true"
-                    android:clickable="false"
                     android:maxEms="5" >
                 </TextView >
 
@@ -110,8 +91,7 @@
                     style="@style/BrickText"
                     android:text="@string/percent_symbol" >
                 </TextView >
-            </LinearLayout>
-        </RelativeLayout>
+
     </org.catrobat.catroid.ui.BrickLayout >
 
 </LinearLayout>

--- a/catroid/src/main/res/layout-ar/brick_nxt_motor_action.xml
+++ b/catroid/src/main/res/layout-ar/brick_nxt_motor_action.xml
@@ -48,15 +48,6 @@
 
         <include layout="@layout/icon_brick_category_legonxt"/>
 
-        <RelativeLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-            <LinearLayout
-                android:id="@+id/brick_nxt_motor_action_first_line"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
                 <TextView
                     android:id="@+id/lego_motor_action_label"
                     style="@style/BrickText.Multiple"
@@ -68,23 +59,16 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textDirection="locale"
-                    android:gravity="center"
                     android:clickable="false"
                     android:focusable="false" >
 
                     <!-- do not add spinner items here! -->
                 </Spinner >
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_below="@+id/brick_nxt_motor_action_first_line"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
 
                 <TextView
                     android:id="@+id/lego_motor_action_to_text"
                     style="@style/BrickText.Multiple"
+                    app:layout_newLine="true"
                     android:text="@string/nxt_motor_speed_to" >
                 </TextView >
                 <TextView
@@ -98,8 +82,7 @@
                     android:id="@+id/motor_action_speed_edit_text"
                     style="@style/BrickEditText"
                     app:layout_inputType="number"
-                    app:layout_textField="true"
-                    android:clickable="false" >
+                    app:layout_textField="true">
                 </TextView >
 
                 <TextView
@@ -107,10 +90,6 @@
                     style="@style/BrickText"
                     android:text="@string/percent_symbol" >
                 </TextView >
-
-
-            </LinearLayout>
-        </RelativeLayout>
 
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/activity_main_menu_splashscreen.xml
+++ b/catroid/src/main/res/layout/activity_main_menu_splashscreen.xml
@@ -23,14 +23,14 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
               android:orientation="vertical" >
 
     <ImageView
         android:src="@drawable/icon"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:scaleType="fitCenter" />
 
 

--- a/catroid/src/main/res/layout/activity_scratch_project_details.xml
+++ b/catroid/src/main/res/layout/activity_scratch_project_details.xml
@@ -58,7 +58,7 @@
 
     <View
         android:id="@+id/separation_line_top"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="@color/spritelist_separation_line_color"
         android:layout_below="@+id/scratch_project_owner" />
@@ -96,7 +96,7 @@
 
             <uk.co.deanwild.flowtextview.FlowTextView
                 android:id="@+id/scratch_project_instructions_flow_text"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
                 <ImageView
@@ -259,14 +259,14 @@
 
     <View
         android:id="@+id/separation_line_bottom"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="@color/spritelist_separation_line_color"
         android:layout_above="@+id/scratch_project_convert_button" />
 
     <Button
         android:id="@+id/scratch_project_convert_button"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/convert"
         android:textAlignment="center"

--- a/catroid/src/main/res/layout/brick_drone_play_led_animation.xml
+++ b/catroid/src/main/res/layout/brick_drone_play_led_animation.xml
@@ -57,6 +57,7 @@
             android:id="@+id/brick_drone_play_led_animation_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
 

--- a/catroid/src/main/res/layout/brick_ev3_motor_move.xml
+++ b/catroid/src/main/res/layout/brick_ev3_motor_move.xml
@@ -23,11 +23,11 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:gravity="center_vertical"
-              android:orientation="horizontal" >
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
 
     <CheckBox
         android:id="@+id/brick_ev3_motor_move_checkbox"
@@ -44,74 +44,55 @@
         android:gravity="center_vertical"
         android:orientation="horizontal"
         app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
-        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing">
 
-        <include layout="@layout/icon_brick_category_legonxt"/>
-
-        <RelativeLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-            <LinearLayout
-                android:id="@+id/brick_ev3_motor_move_first_line"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
+        <include layout="@layout/icon_brick_category_legonxt" />
 
                 <TextView
                     android:id="@+id/brick_ev3_motor_move_label"
                     style="@style/BrickText.SingleLine"
-                    android:text="@string/ev3_motor_move" >
-                </TextView >
+                    android:text="@string/ev3_motor_move">
+                </TextView>
 
                 <Spinner
                     android:id="@+id/brick_ev3_motor_move_spinner"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
+                    android:textDirection="locale"
                     android:clickable="false"
-                    android:focusable="false" >
+                    android:focusable="false">
                 </Spinner>
-            </LinearLayout>
-
-            <LinearLayout
-              android:id="@+id/brick_ev3_motor_move_second_line"
-              android:layout_below="@+id/brick_ev3_motor_move_first_line"
-              android:layout_width="fill_parent"
-              android:layout_height="wrap_content"
-              android:orientation="horizontal">
 
                 <TextView
                     android:id="@+id/lego_motor_action_to_text"
                     style="@style/BrickText.Multiple"
-                    android:text="@string/nxt_motor_speed_to" >
-                </TextView >
+                    app:layout_newLine="true"
+                    android:text="@string/nxt_motor_speed_to">
+                </TextView>
 
                 <TextView
                     android:id="@+id/ev3_motor_move_speed_edit_text"
                     style="@style/BrickEditText"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:maxEms="5"
                     app:layout_inputType="number"
-                    app:layout_textField="true"
-                    android:clickable="false"
-                    android:maxEms="5" >
-                </TextView >
+                    app:layout_textField="true">
+                </TextView>
 
                 <TextView
                     android:id="@+id/brick_ev3_motor_move_percent"
                     style="@style/BrickText"
-                    android:text="@string/percent_symbol" >
-                </TextView >
+                    android:text="@string/percent_symbol">
+                </TextView>
 
                 <TextView
                     android:id="@+id/brick_ev3_motor_move_speed_text"
                     style="@style/BrickText"
                     android:layout_marginStart="3sp"
-                    android:text="@string/nxt_motor_speed" >
-                </TextView >
+                    android:text="@string/nxt_motor_speed">
+                </TextView>
 
-            </LinearLayout>
-        </RelativeLayout>
-    </org.catrobat.catroid.ui.BrickLayout >
+    </org.catrobat.catroid.ui.BrickLayout>
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_ev3_motor_stop.xml
+++ b/catroid/src/main/res/layout/brick_ev3_motor_stop.xml
@@ -42,15 +42,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:gravity="center_vertical"
         app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
         app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
 
         <include layout="@layout/icon_brick_category_legonxt"/>
-
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal" >
 
             <TextView
                 android:id="@+id/ev3_motor_stop_text_view"
@@ -62,10 +58,9 @@
                 android:id="@+id/ev3_stop_motor_spinner"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center"
+                android:textDirection="locale"
                 android:clickable="false"
                 android:focusable="false" />
-        </LinearLayout>
 
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_ev3_motor_turn_angle.xml
+++ b/catroid/src/main/res/layout/brick_ev3_motor_turn_angle.xml
@@ -48,15 +48,6 @@
 
         <include layout="@layout/icon_brick_category_legonxt"/>
 
-        <RelativeLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-            <LinearLayout
-                android:id="@+id/brick_ev3_motor_turn_first_line"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
                 <TextView
                     android:id="@+id/brick_ev3_motor_turn_label"
                     style="@style/BrickText.Multiple"
@@ -67,21 +58,15 @@
                     android:id="@+id/lego_ev3_motor_turn_angle_spinner"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
+                    android:textDirection="locale"
                     android:clickable="false"
                     android:focusable="false" >
                 </Spinner >
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_below="@+id/brick_ev3_motor_turn_first_line"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
 
                 <TextView
                     android:id="@+id/brick_ev3_motor_turn_angle"
                     style="@style/BrickText.Multiple"
+                    app:layout_newLine="true"
                     android:text="@string/ev3_motor_move_by" >
                 </TextView >
 
@@ -92,7 +77,6 @@
                     android:layout_height="wrap_content"
                     app:layout_inputType="number"
                     app:layout_textField="true"
-                    android:clickable="false"
                     android:maxEms="5" >
                 </TextView >
 
@@ -101,8 +85,7 @@
                     style="@style/BrickText"
                     android:text="@string/degree_symbol" >
                 </TextView >
-            </LinearLayout>
-        </RelativeLayout>
+
     </org.catrobat.catroid.ui.BrickLayout >
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_ev3_play_tone.xml
+++ b/catroid/src/main/res/layout/brick_ev3_play_tone.xml
@@ -68,7 +68,6 @@
             android:layout_height="wrap_content"
             app:layout_inputType="number"
             app:layout_textField="true"
-            android:clickable="false"
             android:maxEms="5" >
         </TextView >
 
@@ -91,7 +90,6 @@
             android:layout_height="wrap_content"
             app:layout_inputType="number"
             app:layout_textField="true"
-            android:clickable="false"
             android:maxEms="5" >
         </TextView >
 
@@ -115,7 +113,6 @@
             android:layout_height="wrap_content"
             app:layout_inputType="number"
             app:layout_textField="true"
-            android:clickable="false"
             android:maxEms="5" >
         </TextView >
 

--- a/catroid/src/main/res/layout/brick_jumping_sumo_sound.xml
+++ b/catroid/src/main/res/layout/brick_jumping_sumo_sound.xml
@@ -73,8 +73,7 @@
             android:id="@+id/brick_jumping_sumo_sound_edit_text"
             style="@style/BrickEditText"
             app:layout_inputType="number"
-            app:layout_textField="true"
-            android:clickable="false" >
+            app:layout_textField="true">
         </TextView >
 
         <TextView

--- a/catroid/src/main/res/layout/brick_nxt_motor_action.xml
+++ b/catroid/src/main/res/layout/brick_nxt_motor_action.xml
@@ -48,15 +48,6 @@
 
         <include layout="@layout/icon_brick_category_legonxt"/>
 
-        <RelativeLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-            <LinearLayout
-                android:id="@+id/brick_nxt_motor_action_first_line"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
                 <TextView
                     android:id="@+id/lego_motor_action_label"
                     style="@style/BrickText.Multiple"
@@ -67,24 +58,17 @@
                     android:id="@+id/lego_motor_action_spinner"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
                     android:textDirection="locale"
                     android:clickable="false"
                     android:focusable="false" >
 
                     <!-- do not add spinner items here! -->
                 </Spinner >
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_below="@+id/brick_nxt_motor_action_first_line"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
 
                 <TextView
                     android:id="@+id/lego_motor_action_to_text"
                     style="@style/BrickText.Multiple"
+                    app:layout_newLine="true"
                     android:text="@string/nxt_motor_speed_to" >
                 </TextView >
 
@@ -92,8 +76,7 @@
                     android:id="@+id/motor_action_speed_edit_text"
                     style="@style/BrickEditText"
                     app:layout_inputType="number"
-                    app:layout_textField="true"
-                    android:clickable="false" >
+                    app:layout_textField="true">
                 </TextView >
 
                 <TextView
@@ -108,8 +91,6 @@
                     android:layout_marginStart="3sp"
                     android:text="@string/nxt_motor_speed" >
                 </TextView >
-            </LinearLayout>
-        </RelativeLayout>
 
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_nxt_motor_stop.xml
+++ b/catroid/src/main/res/layout/brick_nxt_motor_stop.xml
@@ -42,15 +42,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:gravity="center_vertical"
         app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
         app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing" >
 
         <include layout="@layout/icon_brick_category_legonxt"/>
-
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
 
             <TextView
                 android:id="@+id/ValueTextView"
@@ -62,11 +58,9 @@
                 android:id="@+id/stop_motor_spinner"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center"
                 android:textDirection="locale"
                 android:clickable="false"
                 android:focusable="false" />
-        </LinearLayout>
 
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_nxt_motor_turn_angle.xml
+++ b/catroid/src/main/res/layout/brick_nxt_motor_turn_angle.xml
@@ -48,15 +48,6 @@
 
         <include layout="@layout/icon_brick_category_legonxt"/>
 
-        <RelativeLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-            <LinearLayout
-                android:id="@+id/brick_nxt_motor_turn_first_line"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
                 <TextView
                     android:id="@+id/brick_nxt_motor_turn_label"
                     style="@style/BrickText.Multiple"
@@ -67,22 +58,15 @@
                     android:id="@+id/lego_motor_turn_angle_spinner"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
                     android:textDirection="locale"
                     android:clickable="false"
                     android:focusable="false" >
                 </Spinner >
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_below="@+id/brick_nxt_motor_turn_first_line"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
 
                 <TextView
                     android:id="@+id/brick_nxt_motor_turn_angle"
                     style="@style/BrickText.Multiple"
+                    app:layout_newLine="true"
                     android:text="@string/nxt_motor_move_by" >
                 </TextView >
 
@@ -93,7 +77,6 @@
                     android:layout_height="wrap_content"
                     app:layout_inputType="number"
                     app:layout_textField="true"
-                    android:clickable="false"
                     android:maxEms="5" >
                 </TextView >
 
@@ -102,8 +85,7 @@
                     style="@style/BrickText"
                     android:text="@string/degree_symbol" >
                 </TextView >
-            </LinearLayout>
-        </RelativeLayout>
+
     </org.catrobat.catroid.ui.BrickLayout >
 
 </LinearLayout>

--- a/catroid/src/main/res/layout/brick_nxt_play_tone.xml
+++ b/catroid/src/main/res/layout/brick_nxt_play_tone.xml
@@ -65,8 +65,7 @@
             android:id="@+id/nxt_tone_duration_edit_text"
             style="@style/BrickEditText"
             app:layout_inputType="number"
-            app:layout_textField="true"
-            android:clickable="false"/>
+            app:layout_textField="true" />
 
         <TextView
             android:id="@+id/brick_nxt_play_tone_seconds"
@@ -85,8 +84,7 @@
             android:id="@+id/nxt_tone_freq_edit_text"
             style="@style/BrickEditText"
             app:layout_inputType="number"
-            app:layout_textField="true"
-            android:clickable="false" />
+            app:layout_textField="true" />
 
         <TextView
             android:id="@+id/brick_nxt_play_tone_hundred_hz"

--- a/catroid/src/main/res/layout/brick_phiro_motor_backward.xml
+++ b/catroid/src/main/res/layout/brick_phiro_motor_backward.xml
@@ -75,8 +75,7 @@
             android:id="@+id/brick_phiro_motor_backward_action_speed_edit_text"
             style="@style/BrickEditText"
             app:layout_inputType="number"
-            app:layout_textField="true"
-            android:clickable="false" >
+            app:layout_textField="true">
         </TextView >
 
         <TextView

--- a/catroid/src/main/res/layout/brick_phiro_play_tone.xml
+++ b/catroid/src/main/res/layout/brick_phiro_play_tone.xml
@@ -81,7 +81,6 @@
             android:layout_height="wrap_content"
             app:layout_inputType="number"
             app:layout_textField="true"
-            android:clickable="false"
             android:maxEms="5" >
         </TextView >
 

--- a/catroid/src/main/res/layout/brick_play_sound_and_wait.xml
+++ b/catroid/src/main/res/layout/brick_play_sound_and_wait.xml
@@ -58,6 +58,7 @@
             android:id="@+id/playsound_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/brick_raspi_pin_changed.xml
+++ b/catroid/src/main/res/layout/brick_raspi_pin_changed.xml
@@ -46,21 +46,10 @@
 
         <include layout="@layout/icon_brick_category_raspberrypi"/>
 
-            <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent">
-
-                <TableRow
-                    android:id="@+id/tr"
-                    android:layout_width = "match_parent"
-                    android:layout_height = "wrap_content"
-                    android:orientation = "horizontal">
                     <TextView
                         android:id="@+id/raspi_when_label"
                         style="@style/BrickText.Multiple"
-                        android:text="@string/brick_raspi_when_begin"
-                        android:layout_weight="1">
+                        android:text="@string/brick_raspi_when_begin">
                     </TextView >
 
                     <Spinner
@@ -68,18 +57,13 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:textDirection="locale"
-                        android:layout_weight="1" />
-                </TableRow>
+                        android:clickable="false"
+                        android:focusable="false"/>
 
-                <TableRow
-                    android:id="@+id/tr2"
-                    android:layout_width = "match_parent"
-                    android:layout_height = "wrap_content"
-                    android:orientation = "horizontal">
                     <TextView
                         android:id="@+id/brick_raspi_when_label_second_part"
                         style="@style/BrickText.Multiple"
-                        android:paddingStart="5dip"
+                        app:layout_newLine="true"
                         android:text="@string/brick_raspi_when_equals" >
                     </TextView >
 
@@ -88,9 +72,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:textDirection="locale"
-                        android:layout_weight="1" />
-                </TableRow>
-            </LinearLayout>
+                        android:clickable="false"
+                        android:focusable="false" />
 
     </org.catrobat.catroid.ui.BrickLayout >
 

--- a/catroid/src/main/res/layout/brick_scene_transition.xml
+++ b/catroid/src/main/res/layout/brick_scene_transition.xml
@@ -56,6 +56,7 @@
             android:id="@+id/brick_scene_transition_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textDirection="locale"
             android:clickable="false"
             android:focusable="false" />
     </org.catrobat.catroid.ui.BrickLayout >

--- a/catroid/src/main/res/layout/device_list.xml
+++ b/catroid/src/main/res/layout/device_list.xml
@@ -28,7 +28,7 @@
 
     <TextView
         android:id="@+id/title_paired_devices"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/device_text_view_margin_small"
         android:paddingStart="@dimen/device_text_view_padding"
@@ -37,20 +37,20 @@
         android:visibility="gone" />
 
     <View
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="@color/bluetooth_device_list_divider_color" />
 
     <ListView
         android:id="@+id/paired_devices"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:stackFromBottom="true" />
 
     <TextView
         android:id="@+id/title_new_devices"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingStart="@dimen/device_text_view_padding"
         android:layout_marginTop="@dimen/device_text_view_margin_small"
@@ -60,7 +60,7 @@
 
     <LinearLayout
         android:id="@+id/device_list_progress_bar"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:visibility="gone" >
@@ -68,7 +68,7 @@
         <ProgressBar
             style="?android:attr/progressBarStyle"
             android:layout_width="wrap_content"
-            android:layout_height="fill_parent" />
+            android:layout_height="match_parent" />
 
         <TextView
         android:id="@+id/device_list_loading_text"
@@ -80,13 +80,13 @@
 
 
     <View
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="@color/bluetooth_device_list_divider_color" />
 
     <ListView
         android:id="@+id/new_devices"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_weight="2"
         android:stackFromBottom="true" />

--- a/catroid/src/main/res/layout/device_name.xml
+++ b/catroid/src/main/res/layout/device_name.xml
@@ -22,7 +22,7 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingBottom="11dp"
     android:paddingStart="6dp"

--- a/catroid/src/main/res/layout/dialog_formulaeditor_compute.xml
+++ b/catroid/src/main/res/layout/dialog_formulaeditor_compute.xml
@@ -22,15 +22,15 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:orientation="vertical"
     android:paddingStart="@dimen/dialog_relative_layout_padding"
     android:paddingEnd="@dimen/dialog_relative_layout_padding" >
 
     <TextView
         android:id="@+id/formula_editor_compute_dialog_textview"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="100dp"
         android:background="@color/white"
         android:textColor="@color/solid_black"

--- a/catroid/src/main/res/layout/dialog_formulaeditor_compute_landscape.xml
+++ b/catroid/src/main/res/layout/dialog_formulaeditor_compute_landscape.xml
@@ -22,7 +22,7 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="500dp"
     android:gravity="center"
     android:orientation="vertical"
@@ -32,7 +32,7 @@
 
     <TextView
         android:id="@+id/formula_editor_compute_dialog_textview_landscape_mode"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="100dp"
         android:background="@color/white"
         android:textColor="@color/solid_black"

--- a/catroid/src/main/res/layout/fragment_brick_add.xml
+++ b/catroid/src/main/res/layout/fragment_brick_add.xml
@@ -28,7 +28,7 @@
               xmlns:tools="http://schemas.android.com/tools"
               android:id="@+id/add_brick_fragment_list"
               android:layout_width="match_parent"
-              android:layout_height="fill_parent"
+              android:layout_height="match_parent"
               android:background="@color/application_background_color"
               android:orientation="vertical"
               tools:ignore="Overdraw" >
@@ -36,7 +36,7 @@
     <ListView
         android:id="@android:id/list"
         android:layout_width="match_parent"
-        android:layout_height="fill_parent"
+        android:layout_height="match_parent"
         android:cacheColorHint="#00000000"
         android:divider="@android:color/transparent" />
 

--- a/catroid/src/main/res/layout/fragment_brick_data_editor.xml
+++ b/catroid/src/main/res/layout/fragment_brick_data_editor.xml
@@ -22,8 +22,8 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:background="@color/application_background_color">
 
     <LinearLayout

--- a/catroid/src/main/res/layout/fragment_cast_device_list_item.xml
+++ b/catroid/src/main/res/layout/fragment_cast_device_list_item.xml
@@ -32,7 +32,7 @@
 		android:layout_marginStart="18dp"
 		android:drawableStart="@drawable/ic_cast_white"
 		android:drawablePadding="18dp"
-		android:layout_width="fill_parent"
+		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:id="@+id/cast_device_name"
 		android:textSize="17sp"/>

--- a/catroid/src/main/res/layout/fragment_drone_config_cooser.xml
+++ b/catroid/src/main/res/layout/fragment_drone_config_cooser.xml
@@ -31,8 +31,8 @@
     android:stretchColumns="1" >
 
     <TableRow
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:paddingBottom="30dp"
         android:paddingTop="30dp"
         android:weightSum="100">
@@ -88,8 +88,8 @@
     </TableRow>
 
     <TableRow
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:paddingBottom="30dp"
         android:paddingTop="30dp"
         android:weightSum="100" >
@@ -145,8 +145,8 @@
     </TableRow>
 
     <TableRow
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:paddingBottom="30dp"
         android:paddingTop="30dp"
         android:weightSum="100" >
@@ -201,8 +201,8 @@
     </TableRow>
 
     <TableRow
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:paddingBottom="30dp"
         android:paddingTop="30dp"
         android:weightSum="100" >

--- a/catroid/src/main/res/layout/fragment_formula_editor.xml
+++ b/catroid/src/main/res/layout/fragment_formula_editor.xml
@@ -22,13 +22,13 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:orientation="vertical"
     android:theme="@android:style/Theme.Light" >
 
     <LinearLayout
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_weight="1"
         android:orientation="vertical"

--- a/catroid/src/main/res/layout/fragment_rgb_color_chooser.xml
+++ b/catroid/src/main/res/layout/fragment_rgb_color_chooser.xml
@@ -63,8 +63,8 @@
         android:stretchColumns="1" >
 
         <TableRow
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:paddingBottom="30dp"
             android:paddingTop="30dp"
             android:weightSum="100">
@@ -120,8 +120,8 @@
         </TableRow>
 
         <TableRow
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:paddingBottom="30dp"
             android:paddingTop="30dp"
             android:weightSum="100" >
@@ -177,8 +177,8 @@
         </TableRow>
 
         <TableRow
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:paddingBottom="30dp"
             android:paddingTop="30dp"
             android:weightSum="100" >

--- a/catroid/src/main/res/layout/fragment_scratch_converter_sliding_up_panel.xml
+++ b/catroid/src/main/res/layout/fragment_scratch_converter_sliding_up_panel.xml
@@ -34,7 +34,7 @@
 
     <View
         android:id="@+id/separation_line_top"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="@color/spritelist_separation_line_color" />
 
@@ -125,7 +125,7 @@
 
     <View
         android:id="@+id/separation_line_bottom"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="@color/spritelist_separation_line_color" />
 
@@ -146,7 +146,7 @@
 
                 <TextView
                     android:id="@+id/scratch_conversion_list_view_section_title"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:ellipsize="end"
                     android:text="@string/list_view_section_title_in_progress"
@@ -175,7 +175,7 @@
 
                 <TextView
                     android:id="@+id/scratch_converted_programs_list_view_section_title"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:ellipsize="end"
                     android:text="@string/list_view_section_title_converted_programs"

--- a/catroid/src/main/res/layout/fragment_scratch_job_details_view.xml
+++ b/catroid/src/main/res/layout/fragment_scratch_job_details_view.xml
@@ -32,7 +32,7 @@
 
     <TextView
         android:id="@+id/scratch_job_list_item_title"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:maxLines="2"
         android:text="@string/title" />
@@ -40,7 +40,7 @@
     <TextView
         android:id="@+id/scratch_job_list_item_status"
         android:paddingStart="12.5dp"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:text="@string/status"

--- a/catroid/src/main/res/layout/fragment_scratch_job_list_item.xml
+++ b/catroid/src/main/res/layout/fragment_scratch_job_list_item.xml
@@ -23,7 +23,7 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="@dimen/my_projects_list_item_height"
     android:orientation="horizontal"
     android:minHeight="@dimen/my_projects_list_item_height">
@@ -39,7 +39,7 @@
 
     <RelativeLayout
         android:id="@+id/scratch_job_list_item_background"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@drawable/button_background_selector">
 

--- a/catroid/src/main/res/layout/fragment_scratch_project_list_item.xml
+++ b/catroid/src/main/res/layout/fragment_scratch_project_list_item.xml
@@ -23,7 +23,7 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="@dimen/my_projects_list_item_height"
     android:orientation="horizontal"
     android:minHeight="@dimen/my_projects_list_item_height">
@@ -39,7 +39,7 @@
 
     <RelativeLayout
         android:id="@+id/scratch_projects_list_item_background"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@drawable/button_background_selector">
 

--- a/catroid/src/main/res/layout/fragment_scratch_project_title_details_view.xml
+++ b/catroid/src/main/res/layout/fragment_scratch_project_title_details_view.xml
@@ -32,7 +32,7 @@
 
     <TextView
         android:id="@+id/scratch_projects_list_item_title"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:maxLines="2" />

--- a/catroid/src/main/res/layout/fragment_scratch_search_projects_list.xml
+++ b/catroid/src/main/res/layout/fragment_scratch_search_projects_list.xml
@@ -24,8 +24,8 @@
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/search_view_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:orientation="horizontal">
 
 <View

--- a/catroid/src/main/res/layout/single_seekbar_value_chooser.xml
+++ b/catroid/src/main/res/layout/single_seekbar_value_chooser.xml
@@ -30,8 +30,8 @@
     android:stretchColumns="1">
 
     <TableRow
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:paddingBottom="30dp"
         android:paddingTop="40dp"
         android:weightSum="100"

--- a/catroid/src/main/res/values/styles.xml
+++ b/catroid/src/main/res/values/styles.xml
@@ -481,7 +481,7 @@
         <item name="android:clickable">true</item>
         <item name="android:orientation">vertical</item>
         <item name="android:visibility">gone</item>
-        <item name="android:layout_width">fill_parent</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
     </style>
 
@@ -501,7 +501,7 @@
         <item name="android:layout_marginBottom">8dp</item>
         <item name="android:layout_marginStart">5dp</item>
         <item name="android:layout_marginEnd">50dp</item>
-        <item name="android:layout_width">fill_parent</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">1.5dp</item>
     </style>
 


### PR DESCRIPTION
also fix wrong usage of xml attributes:
* replace "fill_parent" with "match_parent"
* remove duplicated attributes "android:clickable" which already defined in the used Style.
* add missing attribute 'textDirection="locale"' to some spinners.