### PR TITLE
CAT-2671 Fix Show/HideTextBrick not backward compatible

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/io/StorageHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/StorageHandler.java
@@ -327,6 +327,9 @@ public final class StorageHandler {
 		xstream.omitField(FlashBrick.class, "spinnerValues");
 		xstream.omitField(StopScriptBrick.class, "spinnerValue");
 
+		xstream.omitField(ShowTextBrick.class, "userVariableName");
+		xstream.omitField(HideTextBrick.class, "userVariableName");
+
 		setProgramXstreamAliases();
 	}
 


### PR DESCRIPTION
The unused member "userVariableName" has been removed from ShowTextBrick
and HideTextBrick in commit 20638ec4f. Loading older programs (Catrobat
language <= 0.991) which stored this member in the code.xml will crash
on load.

Omiting the member in XStream fixes the crash.