### PR TITLE
CAT Use internal storage for standalone builds

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/ProjectManagerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/ProjectManagerTest.java
@@ -158,8 +158,8 @@ public class ProjectManagerTest extends InstrumentationTestCase {
 	}
 
 	public void testLoadProjectWithInvalidNestingBrickReferences() throws CompatibilityProjectException, OutdatedVersionProjectException, LoadingProjectException {
-		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_WRONG_NESTING_BRICKS, Constants.TMP_PATH);
-		UtilZip.unZipFile(Constants.TMP_PATH + "/" + ZIP_FILENAME_WRONG_NESTING_BRICKS, Constants.DEFAULT_ROOT + "/"
+		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_WRONG_NESTING_BRICKS, Constants.DEFAULT_TMP_PATH);
+		UtilZip.unZipFile(Constants.DEFAULT_TMP_PATH + "/" + ZIP_FILENAME_WRONG_NESTING_BRICKS, Constants.DEFAULT_ROOT + "/"
 				+ PROJECT_NAME_NESTING_BRICKS);
 
 		projectManager.loadProject(PROJECT_NAME_NESTING_BRICKS, getInstrumentation().getTargetContext());
@@ -170,7 +170,7 @@ public class ProjectManagerTest extends InstrumentationTestCase {
 
 		assertTrue("Nesting brick references not correct!", projectManager.checkNestingBrickReferences(false, false));
 
-		UtilZip.deleteZipFile(ZIP_FILENAME_WRONG_NESTING_BRICKS, Constants.TMP_PATH);
+		UtilZip.deleteZipFile(ZIP_FILENAME_WRONG_NESTING_BRICKS, Constants.DEFAULT_TMP_PATH);
 		TestUtils.deleteTestProjects(PROJECT_NAME_NESTING_BRICKS);
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/io/BackwardCompatibleCatrobatLanguageXStreamTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/io/BackwardCompatibleCatrobatLanguageXStreamTest.java
@@ -58,12 +58,12 @@ public class BackwardCompatibleCatrobatLanguageXStreamTest extends Instrumentati
 
 	public void testLoadingProjectsOfCatrobatLanguageVersion08() throws Exception {
 		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_FALLING_BALLS,
-				Constants.TMP_PATH);
-		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_COLOR_LEANER_BALLOONS, Constants.TMP_PATH);
+				Constants.DEFAULT_TMP_PATH);
+		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_COLOR_LEANER_BALLOONS, Constants.DEFAULT_TMP_PATH);
 
-		UtilZip.unZipFile(Constants.TMP_PATH + "/" + ZIP_FILENAME_FALLING_BALLS, Constants.DEFAULT_ROOT + "/"
+		UtilZip.unZipFile(Constants.DEFAULT_TMP_PATH + "/" + ZIP_FILENAME_FALLING_BALLS, Constants.DEFAULT_ROOT + "/"
 				+ PROJECT_NAME_FALLING_BALLS);
-		UtilZip.unZipFile(Constants.TMP_PATH + "/" + ZIP_FILENAME_COLOR_LEANER_BALLOONS, Constants.DEFAULT_ROOT + "/"
+		UtilZip.unZipFile(Constants.DEFAULT_TMP_PATH + "/" + ZIP_FILENAME_COLOR_LEANER_BALLOONS, Constants.DEFAULT_ROOT + "/"
 				+ PROJECT_NAME_COLOR_LEANER_BALLOONS);
 
 		Project fallingBallsProject = StorageHandler.getInstance().loadProject(PROJECT_NAME_FALLING_BALLS,
@@ -77,19 +77,19 @@ public class BackwardCompatibleCatrobatLanguageXStreamTest extends Instrumentati
 		assertEquals("Wrong project loaded", PROJECT_NAME_COLOR_LEANER_BALLOONS, colorLeanerBalloonsProject.getName()
 				.toLowerCase(Locale.getDefault()));
 
-		UtilZip.deleteZipFile(ZIP_FILENAME_FALLING_BALLS, Constants.TMP_PATH);
-		UtilZip.deleteZipFile(ZIP_FILENAME_COLOR_LEANER_BALLOONS, Constants.TMP_PATH);
+		UtilZip.deleteZipFile(ZIP_FILENAME_FALLING_BALLS, Constants.DEFAULT_TMP_PATH);
+		UtilZip.deleteZipFile(ZIP_FILENAME_COLOR_LEANER_BALLOONS, Constants.DEFAULT_TMP_PATH);
 
 		TestUtils.deleteTestProjects(PROJECT_NAME_FALLING_BALLS, PROJECT_NAME_COLOR_LEANER_BALLOONS);
 	}
 
 	public void testLoadingProjectsOfCatrobatLanguageVersion09() throws Exception {
-		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_PONG_STARTER, Constants.TMP_PATH);
-		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_WHIP, Constants.TMP_PATH);
+		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_PONG_STARTER, Constants.DEFAULT_TMP_PATH);
+		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_WHIP, Constants.DEFAULT_TMP_PATH);
 
-		UtilZip.unZipFile(Constants.TMP_PATH + "/" + ZIP_FILENAME_PONG_STARTER, Constants.DEFAULT_ROOT + "/"
+		UtilZip.unZipFile(Constants.DEFAULT_TMP_PATH + "/" + ZIP_FILENAME_PONG_STARTER, Constants.DEFAULT_ROOT + "/"
 				+ PROJECT_NAME_PONG_STARTER);
-		UtilZip.unZipFile(Constants.TMP_PATH + "/" + ZIP_FILENAME_WHIP, Constants.DEFAULT_ROOT + "/"
+		UtilZip.unZipFile(Constants.DEFAULT_TMP_PATH + "/" + ZIP_FILENAME_WHIP, Constants.DEFAULT_ROOT + "/"
 				+ PROJECT_NAME_WHIP);
 
 		Project pongStarterProject = StorageHandler.getInstance().loadProject(PROJECT_NAME_PONG_STARTER,
@@ -103,22 +103,22 @@ public class BackwardCompatibleCatrobatLanguageXStreamTest extends Instrumentati
 		assertTrue("Cannot load whip project", whipProject != null);
 		assertEquals("Wrong project loaded", PROJECT_NAME_WHIP, whipProject.getName().toLowerCase(Locale.getDefault()));
 
-		UtilZip.deleteZipFile(ZIP_FILENAME_PONG_STARTER, Constants.TMP_PATH);
-		UtilZip.deleteZipFile(ZIP_FILENAME_WHIP, Constants.TMP_PATH);
+		UtilZip.deleteZipFile(ZIP_FILENAME_PONG_STARTER, Constants.DEFAULT_TMP_PATH);
+		UtilZip.deleteZipFile(ZIP_FILENAME_WHIP, Constants.DEFAULT_TMP_PATH);
 
 		TestUtils.deleteTestProjects(PROJECT_NAME_PONG_STARTER, PROJECT_NAME_WHIP);
 	}
 
 	public void testLoadingProjectsOfCatrobatLanguageVersion091() throws Exception {
-		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_AIR_FIGHT, Constants.TMP_PATH);
-		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_XRAY_PHONE, Constants.TMP_PATH);
-		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_ALL_BRICKS, Constants.TMP_PATH);
+		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_AIR_FIGHT, Constants.DEFAULT_TMP_PATH);
+		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_XRAY_PHONE, Constants.DEFAULT_TMP_PATH);
+		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_ALL_BRICKS, Constants.DEFAULT_TMP_PATH);
 
-		UtilZip.unZipFile(Constants.TMP_PATH + "/" + ZIP_FILENAME_AIR_FIGHT, Constants.DEFAULT_ROOT + "/"
+		UtilZip.unZipFile(Constants.DEFAULT_TMP_PATH + "/" + ZIP_FILENAME_AIR_FIGHT, Constants.DEFAULT_ROOT + "/"
 				+ PROJECT_NAME_AIR_FIGHT);
-		UtilZip.unZipFile(Constants.TMP_PATH + "/" + ZIP_FILENAME_XRAY_PHONE, Constants.DEFAULT_ROOT + "/"
+		UtilZip.unZipFile(Constants.DEFAULT_TMP_PATH + "/" + ZIP_FILENAME_XRAY_PHONE, Constants.DEFAULT_ROOT + "/"
 				+ PROJECT_NAME_XRAY_PHONE);
-		UtilZip.unZipFile(Constants.TMP_PATH + "/" + ZIP_FILENAME_ALL_BRICKS, Constants.DEFAULT_ROOT + "/"
+		UtilZip.unZipFile(Constants.DEFAULT_TMP_PATH + "/" + ZIP_FILENAME_ALL_BRICKS, Constants.DEFAULT_ROOT + "/"
 				+ PROJECT_NAME_ALL_BRICKS);
 
 		Project airFightProject = StorageHandler.getInstance().loadProject(PROJECT_NAME_AIR_FIGHT,
@@ -139,17 +139,17 @@ public class BackwardCompatibleCatrobatLanguageXStreamTest extends Instrumentati
 		assertEquals("Wrong project loaded", PROJECT_NAME_ALL_BRICKS,
 				allBricksProject.getName().toLowerCase(Locale.getDefault()));
 
-		UtilZip.deleteZipFile(ZIP_FILENAME_AIR_FIGHT, Constants.TMP_PATH);
-		UtilZip.deleteZipFile(ZIP_FILENAME_XRAY_PHONE, Constants.TMP_PATH);
-		UtilZip.deleteZipFile(ZIP_FILENAME_ALL_BRICKS, Constants.TMP_PATH);
+		UtilZip.deleteZipFile(ZIP_FILENAME_AIR_FIGHT, Constants.DEFAULT_TMP_PATH);
+		UtilZip.deleteZipFile(ZIP_FILENAME_XRAY_PHONE, Constants.DEFAULT_TMP_PATH);
+		UtilZip.deleteZipFile(ZIP_FILENAME_ALL_BRICKS, Constants.DEFAULT_TMP_PATH);
 
 		TestUtils.deleteTestProjects(PROJECT_NAME_AIR_FIGHT, PROJECT_NAME_XRAY_PHONE, PROJECT_NAME_ALL_BRICKS);
 	}
 
 	public void testLoadingProjectsOfCatrobatLanguageVersion092() throws Exception {
 		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_NOTE_AND_SPEAK_BRICK,
-				Constants.TMP_PATH);
-		UtilZip.unZipFile(Constants.TMP_PATH + "/" + ZIP_FILENAME_NOTE_AND_SPEAK_BRICK, Constants.DEFAULT_ROOT + "/"
+				Constants.DEFAULT_TMP_PATH);
+		UtilZip.unZipFile(Constants.DEFAULT_TMP_PATH + "/" + ZIP_FILENAME_NOTE_AND_SPEAK_BRICK, Constants.DEFAULT_ROOT + "/"
 				+ PROJECT_NAME_NOTE_AND_SPEAK_BRICK);
 
 		Project noteAndSpeakBrickProject = StorageHandler.getInstance().loadProject(PROJECT_NAME_NOTE_AND_SPEAK_BRICK,
@@ -158,14 +158,14 @@ public class BackwardCompatibleCatrobatLanguageXStreamTest extends Instrumentati
 		assertEquals("Wrong project loaded", PROJECT_NAME_NOTE_AND_SPEAK_BRICK, noteAndSpeakBrickProject.getName()
 				.toLowerCase(Locale.getDefault()));
 
-		UtilZip.deleteZipFile(ZIP_FILENAME_NOTE_AND_SPEAK_BRICK, Constants.TMP_PATH);
+		UtilZip.deleteZipFile(ZIP_FILENAME_NOTE_AND_SPEAK_BRICK, Constants.DEFAULT_TMP_PATH);
 		TestUtils.deleteTestProjects(PROJECT_NAME_NOTE_AND_SPEAK_BRICK);
 	}
 
 	public void testLoadingProjectsOfCatrobatLanguageVersion095() throws Exception {
 		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_GHOST_EFFECT_BRICKS,
-				Constants.TMP_PATH);
-		UtilZip.unZipFile(Constants.TMP_PATH + "/" + ZIP_FILENAME_GHOST_EFFECT_BRICKS, Constants.DEFAULT_ROOT + "/"
+				Constants.DEFAULT_TMP_PATH);
+		UtilZip.unZipFile(Constants.DEFAULT_TMP_PATH + "/" + ZIP_FILENAME_GHOST_EFFECT_BRICKS, Constants.DEFAULT_ROOT + "/"
 				+ PROJECT_NAME_GHOST_EFFECT_BRICKS);
 
 		Project ghostBricksProject = StorageHandler.getInstance().loadProject(PROJECT_NAME_GHOST_EFFECT_BRICKS,
@@ -174,13 +174,13 @@ public class BackwardCompatibleCatrobatLanguageXStreamTest extends Instrumentati
 		assertEquals("Wrong project loaded", PROJECT_NAME_GHOST_EFFECT_BRICKS, ghostBricksProject.getName()
 				.toLowerCase(Locale.getDefault()));
 
-		UtilZip.deleteZipFile(ZIP_FILENAME_GHOST_EFFECT_BRICKS, Constants.TMP_PATH);
+		UtilZip.deleteZipFile(ZIP_FILENAME_GHOST_EFFECT_BRICKS, Constants.DEFAULT_TMP_PATH);
 		TestUtils.deleteTestProjects(PROJECT_NAME_GHOST_EFFECT_BRICKS);
 	}
 
 	public void testLoadingLegoNxtProjectsOfCatrobatLanguageVersion092() throws Exception {
-		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_LEGO_NXT, Constants.TMP_PATH);
-		UtilZip.unZipFile(Constants.TMP_PATH + "/" + ZIP_FILENAME_LEGO_NXT, Constants.DEFAULT_ROOT + "/"
+		TestUtils.copyAssetProjectZipFile(getInstrumentation().getContext(), ZIP_FILENAME_LEGO_NXT, Constants.DEFAULT_TMP_PATH);
+		UtilZip.unZipFile(Constants.DEFAULT_TMP_PATH + "/" + ZIP_FILENAME_LEGO_NXT, Constants.DEFAULT_ROOT + "/"
 				+ PROJECT_NAME_LEGO_NXT);
 
 		Project legoProject = StorageHandler.getInstance().loadProject(PROJECT_NAME_LEGO_NXT,
@@ -189,7 +189,7 @@ public class BackwardCompatibleCatrobatLanguageXStreamTest extends Instrumentati
 		assertEquals("Wrong project loaded", PROJECT_NAME_LEGO_NXT,
 				legoProject.getName().toLowerCase(Locale.getDefault()));
 
-		UtilZip.deleteZipFile(ZIP_FILENAME_LEGO_NXT, Constants.TMP_PATH);
+		UtilZip.deleteZipFile(ZIP_FILENAME_LEGO_NXT, Constants.DEFAULT_TMP_PATH);
 		TestUtils.deleteTestProjects(PROJECT_NAME_LEGO_NXT);
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/io/StorageHandlerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/io/StorageHandlerTest.java
@@ -80,6 +80,7 @@ public class StorageHandlerTest extends InstrumentationTestCase {
 	private final StorageHandler storageHandler;
 	private final String projectName = TestUtils.DEFAULT_TEST_PROJECT_NAME;
 	private Project currentProject;
+	private String originalRootDirectory;
 	private static final int SET_SPEED_INITIALLY = -70;
 	private static final int DEFAULT_MOVE_TIME_IN_MILLISECONDS = 2000;
 	private static final int DEFAULT_MOVE_POWER_IN_PERCENT = 20;
@@ -90,6 +91,7 @@ public class StorageHandlerTest extends InstrumentationTestCase {
 
 	@Override
 	public void setUp() throws Exception {
+		originalRootDirectory = storageHandler.getRootDirectory();
 		DefaultProjectHandler.createAndSaveDefaultProject(getInstrumentation().getTargetContext());
 		super.setUp();
 		currentProject = ProjectManager.getInstance().getCurrentProject();
@@ -99,7 +101,19 @@ public class StorageHandlerTest extends InstrumentationTestCase {
 	public void tearDown() throws Exception {
 		ProjectManager.getInstance().setProject(currentProject);
 		TestUtils.deleteTestProjects();
+		storageHandler.setRootDirectory(originalRootDirectory);
 		super.tearDown();
+	}
+
+	public void testSetNewRootDirectory() {
+		String privateFilesDir = getInstrumentation().getTargetContext().getFilesDir().getAbsolutePath();
+
+		File catrobatRootDir = new File(privateFilesDir, "test");
+		assertFalse(catrobatRootDir.exists());
+		storageHandler.setRootDirectory(catrobatRootDir.getAbsolutePath());
+
+		assertEquals(catrobatRootDir.getAbsolutePath(), storageHandler.getRootDirectory());
+		assertTrue(catrobatRootDir.exists());
 	}
 
 	public void testSerializeProject() throws Exception {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/UtilsTest.java
@@ -108,10 +108,10 @@ public class UtilsTest extends AndroidTestCase {
 
 		PrintWriter printWriter = null;
 
-		File tempDir = new File(Constants.TMP_PATH);
+		File tempDir = new File(Constants.DEFAULT_TMP_PATH);
 		tempDir.mkdirs();
 
-		File md5TestFile = new File(Utils.buildPath(Constants.TMP_PATH, "catroid.txt"));
+		File md5TestFile = new File(Utils.buildPath(Constants.DEFAULT_TMP_PATH, "catroid.txt"));
 
 		if (md5TestFile.exists()) {
 			md5TestFile.delete();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/web/ZipTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/web/ZipTest.java
@@ -39,7 +39,7 @@ public class ZipTest extends AndroidTestCase {
 
 	public void testZipUnzip() throws IOException {
 
-		String pathToTest = Constants.TMP_PATH + "/test1/";
+		String pathToTest = Constants.DEFAULT_TMP_PATH + "/test1/";
 
 		File testfile = new File(pathToTest + "test2/testfile.txt");
 		testfile.getParentFile().mkdirs();
@@ -47,7 +47,7 @@ public class ZipTest extends AndroidTestCase {
 
 		String[] paths = {pathToTest};
 
-		String zipFileName = Constants.TMP_PATH + "/testzip" + Constants.CATROBAT_EXTENSION;
+		String zipFileName = Constants.DEFAULT_TMP_PATH + "/testzip" + Constants.CATROBAT_EXTENSION;
 		File zipFile = new File(zipFileName);
 		if (zipFile.exists()) {
 			zipFile.delete();
@@ -64,7 +64,7 @@ public class ZipTest extends AndroidTestCase {
 		testfile.delete();
 		testfile.getParentFile().delete();
 
-		if (!UtilZip.unZipFile(zipFileName, Constants.TMP_PATH + "/")) {
+		if (!UtilZip.unZipFile(zipFileName, Constants.DEFAULT_TMP_PATH + "/")) {
 			zipFile.delete();
 			assertFalse("unzip failed", true);
 			return;
@@ -76,7 +76,7 @@ public class ZipTest extends AndroidTestCase {
 
 		zipFile.delete();
 
-		File tempDirectory = new File(Constants.TMP_PATH);
+		File tempDirectory = new File(Constants.DEFAULT_TMP_PATH);
 		if (tempDirectory.exists()) {
 			UtilFile.deleteDirectory(tempDirectory);
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -61,15 +61,15 @@ public final class Constants {
 
 	public static final String DEFAULT_ROOT = Environment.getExternalStorageDirectory().getAbsolutePath()
 			+ "/Pocket Code";
-	public static final String TMP_PATH = DEFAULT_ROOT + "/tmp";
-	public static final String TMP_IMAGE_PATH = TMP_PATH + "/PocketPaintImage.tmp";
-	public static final String TEXT_TO_SPEECH_TMP_PATH = TMP_PATH + "/textToSpeech";
+	public static final String TMP_DIRECTORY = "tmp";
+	public static final String DEFAULT_TMP_PATH = DEFAULT_ROOT + "/" + TMP_DIRECTORY;
+	public static final String TMP_IMAGE_PATH = DEFAULT_TMP_PATH + "/PocketPaintImage.tmp";
+	public static final String TEXT_TO_SPEECH_DIRECTORY = "textToSpeech";
 	public static final String IMAGE_DIRECTORY = "images";
 	public static final String SOUND_DIRECTORY = "sounds";
 	public static final String SCENES_DIRECTORY = "scenes";
 	public static final String BACKPACK_DIRECTORY = "backpack";
-	public static final String TMP_LOOKS_PATH = TMP_PATH + "/looks";
-	public static final String TMP_SOUNDS_PATH = TMP_PATH + "/sounds";
+	public static final String LOOKS_DIRECTORY = "looks";
 
 	public static final String BACKPACK_SOUND_DIRECTORY = "backpack_sound";
 	public static final String BACKPACK_IMAGE_DIRECTORY = "backpack_image";

--- a/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
@@ -213,7 +213,7 @@ public class LookData implements Serializable, Cloneable {
 	}
 
 	private String getPathToBackPackImageDirectory() {
-		return Utils.buildPath(Constants.DEFAULT_ROOT, Constants.BACKPACK_DIRECTORY,
+		return Utils.buildPath(StorageHandler.getInstance().getRootDirectory(), Constants.BACKPACK_DIRECTORY,
 				Constants.BACKPACK_IMAGE_DIRECTORY);
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/common/SoundInfo.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/SoundInfo.java
@@ -127,7 +127,7 @@ public class SoundInfo implements Serializable, Comparable<SoundInfo>, Cloneable
 	}
 
 	private String getPathToBackPackSoundDirectory() {
-		return Utils.buildPath(Constants.DEFAULT_ROOT, Constants.BACKPACK_DIRECTORY,
+		return Utils.buildPath(StorageHandler.getInstance().getRootDirectory(), Constants.BACKPACK_DIRECTORY,
 				Constants.BACKPACK_SOUND_DIRECTORY);
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/SpeakAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/SpeakAction.java
@@ -34,6 +34,7 @@ import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
 import org.catrobat.catroid.io.SoundManager;
+import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.stage.PreStageActivity;
 import org.catrobat.catroid.utils.Utils;
 
@@ -83,7 +84,8 @@ public class SpeakAction extends TemporalAction {
 
 		hashText = Utils.md5Checksum(String.valueOf(interpretedText));
 		String fileName = hashText;
-		File pathToSpeechFile = new File(Constants.TEXT_TO_SPEECH_TMP_PATH);
+		File pathToSpeechFile = new File(Utils.buildPath(StorageHandler.getInstance().getTempDirectory(),
+				Constants.TEXT_TO_SPEECH_DIRECTORY));
 		pathToSpeechFile.mkdirs();
 		speechFile = new File(pathToSpeechFile, fileName + Constants.SOUND_STANDARD_EXTENSION);
 		listener = new OnUtteranceCompletedListener() {

--- a/catroid/src/main/java/org/catrobat/catroid/soundrecorder/SoundRecorderActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/soundrecorder/SoundRecorderActivity.java
@@ -35,7 +35,7 @@ import android.view.View.OnClickListener;
 import android.widget.Chronometer;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.ui.BaseActivity;
 import org.catrobat.catroid.utils.ToastUtil;
 import org.catrobat.catroid.utils.Utils;
@@ -94,7 +94,8 @@ public class SoundRecorderActivity extends BaseActivity implements OnClickListen
 			if (soundRecorder != null) {
 				soundRecorder.stop();
 			}
-			String recordPath = Utils.buildPath(Constants.TMP_PATH, getString(R.string.soundrecorder_recorded_filename)
+			String recordPath = Utils.buildPath(StorageHandler.getInstance().getTempDirectory(),
+					getString(R.string.soundrecorder_recorded_filename)
 					+ SoundRecorder.RECORDING_EXTENSION);
 			soundRecorder = new SoundRecorder(recordPath);
 			soundRecorder.start();

--- a/catroid/src/main/java/org/catrobat/catroid/stage/PreStageActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/PreStageActivity.java
@@ -63,6 +63,7 @@ import org.catrobat.catroid.drone.jumpingsumo.JumpingSumoInitializer;
 import org.catrobat.catroid.drone.jumpingsumo.JumpingSumoServiceWrapper;
 import org.catrobat.catroid.facedetection.FaceDetectionHandler;
 import org.catrobat.catroid.formulaeditor.SensorHandler;
+import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.sensing.GatherCollisionInformationTask;
 import org.catrobat.catroid.ui.BaseActivity;
 import org.catrobat.catroid.ui.recyclerview.dialog.NetworkAlertDialog;
@@ -420,7 +421,8 @@ public class PreStageActivity extends BaseActivity implements GatherCollisionInf
 	}
 
 	private static void deleteSpeechFiles() {
-		File pathToSpeechFiles = new File(Constants.TEXT_TO_SPEECH_TMP_PATH);
+		File pathToSpeechFiles = new File(Utils.buildPath(StorageHandler.getInstance().getTempDirectory(),
+				Constants.TEXT_TO_SPEECH_DIRECTORY));
 		if (pathToSpeechFiles.isDirectory()) {
 			for (File file : pathToSpeechFiles.listFiles()) {
 				file.delete();

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/ProjectDownloadService.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/ProjectDownloadService.java
@@ -72,7 +72,7 @@ public class ProjectDownloadService extends IntentService {
 		boolean result = false;
 
 		String projectName = intent.getStringExtra(DOWNLOAD_NAME_TAG);
-		String zipFileString = Utils.buildPath(Constants.TMP_PATH, DOWNLOAD_FILE_NAME);
+		String zipFileString = Utils.buildPath(StorageHandler.getInstance().getTempDirectory(), DOWNLOAD_FILE_NAME);
 		String url = intent.getStringExtra(URL_TAG);
 		Integer notificationId = intent.getIntExtra(ID_TAG, -1);
 

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/ProjectUploadService.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/ProjectUploadService.java
@@ -127,7 +127,7 @@ public class ProjectUploadService extends IntentService {
 				paths[i] = Utils.buildPath(directoryPath.getAbsolutePath(), paths[i]);
 			}
 
-			String zipFileString = Utils.buildPath(Constants.TMP_PATH, UPLOAD_FILE_NAME);
+			String zipFileString = Utils.buildPath(StorageHandler.getInstance().getTempDirectory(), UPLOAD_FILE_NAME);
 			File zipFile = new File(zipFileString);
 			if (!zipFile.exists()) {
 				zipFile.getParentFile().mkdirs();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -139,18 +139,21 @@ public class MainMenuActivity extends BaseCastActivity implements
 			FacebookSdk.sdkInitialize(getApplicationContext());
 			setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
 			getSupportActionBar().setTitle(R.string.app_name);
-		}
 
-		@PermissionChecker.PermissionResult
-		int permissionResult = ContextCompat.checkSelfPermission(this,
-				Manifest.permission.WRITE_EXTERNAL_STORAGE);
-		if (permissionResult == PackageManager.PERMISSION_GRANTED) {
-			onPermissionsGranted();
+			@PermissionChecker.PermissionResult
+			int permissionResult = ContextCompat.checkSelfPermission(this,
+					Manifest.permission.WRITE_EXTERNAL_STORAGE);
+			if (permissionResult == PackageManager.PERMISSION_GRANTED) {
+				onPermissionsGranted();
+			} else {
+				ActivityCompat.requestPermissions(
+						this,
+						new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
+						ACCESS_STORAGE);
+			}
 		} else {
-			ActivityCompat.requestPermissions(
-							this,
-							new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-							ACCESS_STORAGE);
+			setContentView(R.layout.activity_main_menu_splashscreen);
+			prepareStandaloneProject();
 		}
 	}
 
@@ -179,12 +182,6 @@ public class MainMenuActivity extends BaseCastActivity implements
 	}
 
 	private void onPermissionsGranted() {
-		if (BuildConfig.FEATURE_APK_GENERATOR_ENABLED) {
-			setContentView(R.layout.activity_main_menu_splashscreen);
-			prepareStandaloneProject();
-			return;
-		}
-
 		getFragmentManager().beginTransaction()
 				.replace(R.id.fragment_container, new MainMenuFragment(), MainMenuFragment.TAG)
 				.commit();
@@ -306,6 +303,7 @@ public class MainMenuActivity extends BaseCastActivity implements
 	}
 
 	private void prepareStandaloneProject() {
+		StorageHandler.getInstance().setRootDirectory(getFilesDir().getAbsolutePath());
 		try {
 			InputStream inputStream = getAssets().open(BuildConfig.START_PROJECT + ".zip");
 			StorageHandler.copyAndUnzip(inputStream, Utils.buildProjectPath(BuildConfig.PROJECT_NAME));

--- a/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
@@ -48,6 +48,7 @@ import android.webkit.WebViewClient;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.utils.DownloadUtil;
 import org.catrobat.catroid.utils.ToastUtil;
 import org.catrobat.catroid.utils.Utils;
@@ -114,10 +115,12 @@ public class WebViewActivity extends BaseActivity {
 					String tempPath = null;
 					switch (mediaType) {
 						case Constants.MEDIA_TYPE_LOOK:
-							tempPath = Constants.TMP_LOOKS_PATH;
+							tempPath = Utils.buildPath(StorageHandler.getInstance().getTempDirectory(),
+									Constants.LOOKS_DIRECTORY);
 							break;
 						case Constants.MEDIA_TYPE_SOUND:
-							tempPath = Constants.TMP_SOUNDS_PATH;
+							tempPath = Utils.buildPath(StorageHandler.getInstance().getTempDirectory(),
+									Constants.SOUND_DIRECTORY);
 					}
 					String filePath = Utils.buildPath(tempPath, fileName);
 					resultIntent.putExtra(MEDIA_FILE_PATH, filePath);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/LookController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/LookController.java
@@ -40,11 +40,6 @@ import java.util.Set;
 
 public class LookController {
 
-	private static final String BACKPACK_DIRECTORY = Utils.buildPath(
-			Constants.DEFAULT_ROOT,
-			Constants.BACKPACK_DIRECTORY,
-			Constants.BACKPACK_IMAGE_DIRECTORY);
-
 	private UniqueNameProvider uniqueNameProvider = new UniqueNameProvider();
 
 	public LookData copy(LookData lookToCopy, Scene srcScene, Scene dstScene, Sprite dstSprite) throws IOException {
@@ -76,7 +71,7 @@ public class LookController {
 	}
 
 	public void deleteFromBackpack(LookData lookToDelete) throws IOException {
-		StorageHandler.deleteFile(Utils.buildPath(BACKPACK_DIRECTORY, lookToDelete.getFileName()));
+		StorageHandler.deleteFile(Utils.buildPath(getBackpackDirectory(), lookToDelete.getFileName()));
 	}
 
 	public LookData pack(LookData lookToPack, Scene srcScene) throws IOException {
@@ -84,7 +79,7 @@ public class LookController {
 				lookToPack.getName(), getScope(BackPackListManager.getInstance().getBackPackedLooks()));
 
 		String fileName = StorageHandler.copyFile(
-				Utils.buildPath(getImageDirPath(srcScene), lookToPack.getFileName()), BACKPACK_DIRECTORY).getName();
+				Utils.buildPath(getImageDirPath(srcScene), lookToPack.getFileName()), getBackpackDirectory()).getName();
 
 		LookData look = new LookData(name, fileName);
 		look.isBackpackLookData = true;
@@ -97,7 +92,7 @@ public class LookController {
 				return look;
 			}
 		}
-		String fileName = StorageHandler.copyFile(lookToPack.getAbsolutePath(), BACKPACK_DIRECTORY).getName();
+		String fileName = StorageHandler.copyFile(lookToPack.getAbsolutePath(), getBackpackDirectory()).getName();
 		LookData look = new LookData(lookToPack.getName(), fileName);
 		look.isBackpackLookData = true;
 
@@ -134,6 +129,12 @@ public class LookController {
 
 	private String getImageDirPath(Scene scene) {
 		return Utils.buildPath(scene.getPath(), Constants.IMAGE_DIRECTORY);
+	}
+
+	private String getBackpackDirectory() {
+		return Utils.buildPath(StorageHandler.getInstance().getRootDirectory(),
+				Constants.BACKPACK_DIRECTORY,
+				Constants.BACKPACK_IMAGE_DIRECTORY);
 	}
 
 	private boolean compareByChecksum(String filePath1, String filePath2) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SoundController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SoundController.java
@@ -40,11 +40,6 @@ import java.util.Set;
 
 public class SoundController {
 
-	private static final String BACKPACK_DIRECTORY = Utils.buildPath(
-			Constants.DEFAULT_ROOT,
-			Constants.BACKPACK_DIRECTORY,
-			Constants.BACKPACK_SOUND_DIRECTORY);
-
 	private UniqueNameProvider uniqueNameProvider = new UniqueNameProvider();
 
 	public SoundInfo copy(SoundInfo soundToCopy, Scene srcScene, Scene dstScene, Sprite dstSprite) throws IOException {
@@ -76,7 +71,7 @@ public class SoundController {
 	}
 
 	public void deleteFromBackpack(SoundInfo soundToDelete) throws IOException {
-		StorageHandler.deleteFile(Utils.buildPath(BACKPACK_DIRECTORY, soundToDelete.getFileName()));
+		StorageHandler.deleteFile(Utils.buildPath(getBackpackDirectory(), soundToDelete.getFileName()));
 	}
 
 	public SoundInfo pack(SoundInfo soundToPack, Scene srcScene) throws IOException {
@@ -84,7 +79,7 @@ public class SoundController {
 				soundToPack.getName(), getScope(BackPackListManager.getInstance().getBackPackedSounds()));
 
 		String fileName = StorageHandler.copyFile(
-				Utils.buildPath(getSoundDirPath(srcScene), soundToPack.getFileName()), BACKPACK_DIRECTORY).getName();
+				Utils.buildPath(getSoundDirPath(srcScene), soundToPack.getFileName()), getBackpackDirectory()).getName();
 
 		SoundInfo sound = new SoundInfo(name, fileName);
 		sound.isBackpackSoundInfo = true;
@@ -97,7 +92,7 @@ public class SoundController {
 				return sound;
 			}
 		}
-		String fileName = StorageHandler.copyFile(soundToPack.getAbsolutePath(), BACKPACK_DIRECTORY).getName();
+		String fileName = StorageHandler.copyFile(soundToPack.getAbsolutePath(), getBackpackDirectory()).getName();
 		SoundInfo sound = new SoundInfo(soundToPack.getName(), fileName);
 		sound.isBackpackSoundInfo = true;
 
@@ -134,6 +129,12 @@ public class SoundController {
 
 	private String getSoundDirPath(Scene scene) {
 		return Utils.buildPath(scene.getPath(), Constants.SOUND_DIRECTORY);
+	}
+
+	private String getBackpackDirectory() {
+		return Utils.buildPath(StorageHandler.getInstance().getRootDirectory(),
+				Constants.BACKPACK_DIRECTORY,
+				Constants.BACKPACK_SOUND_DIRECTORY);
 	}
 
 	private boolean compareByChecksum(String filePath1, String filePath2) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewLookDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewLookDialogFragment.java
@@ -235,7 +235,7 @@ public class NewLookDialogFragment extends DialogFragment implements View.OnClic
 	}
 
 	private Uri getDefaultLookFromCameraUri(String defLookName) {
-		File pictureFile = new File(Constants.DEFAULT_ROOT, defLookName + ".jpg");
+		File pictureFile = new File(StorageHandler.getInstance().getRootDirectory(), defLookName + ".jpg");
 		return Uri.fromFile(pictureFile);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ProjectListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ProjectListFragment.java
@@ -34,6 +34,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.ProjectData;
 import org.catrobat.catroid.exceptions.ProjectException;
+import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.ui.BottomBar;
 import org.catrobat.catroid.ui.ProjectActivity;
 import org.catrobat.catroid.ui.fragment.ProjectDetailsFragment;
@@ -84,7 +85,7 @@ public class ProjectListFragment extends RecyclerViewFragment<ProjectData> imple
 	}
 
 	private List<ProjectData> getItemList() {
-		File rootDirectory = new File(Constants.DEFAULT_ROOT);
+		File rootDirectory = new File(StorageHandler.getInstance().getRootDirectory());
 		List<ProjectData> items = new ArrayList<>();
 
 		for (String projectName : UtilFile.getProjectNames(rootDirectory)) {

--- a/catroid/src/main/java/org/catrobat/catroid/utils/UtilFile.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/UtilFile.java
@@ -28,6 +28,7 @@ import android.util.Log;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.io.StorageHandler;
 import org.catrobat.catroid.soundrecorder.SoundRecorder;
 
 import java.io.BufferedInputStream;
@@ -196,7 +197,7 @@ public final class UtilFile {
 	}
 
 	public static void createStandardProjectIfRootDirectoryIsEmpty(Context context) {
-		File rootDirectory = new File(Constants.DEFAULT_ROOT);
+		File rootDirectory = new File(StorageHandler.getInstance().getRootDirectory());
 		if (rootDirectory.listFiles() == null || getProjectNames(rootDirectory).size() == 0) {
 			ProjectManager.getInstance().initializeDefaultProject(context);
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
@@ -318,7 +318,8 @@ public final class Utils {
 	}
 
 	public static String buildProjectPath(String projectName) {
-		return buildPath(Constants.DEFAULT_ROOT, UtilFile.encodeSpecialCharsForFileSystem(projectName));
+		return buildPath(StorageHandler.getInstance().getRootDirectory(),
+				UtilFile.encodeSpecialCharsForFileSystem(projectName));
 	}
 
 	public static String buildScenePath(String projectName, String sceneName) {
@@ -326,7 +327,8 @@ public final class Utils {
 	}
 
 	public static String buildBackpackScenePath(String sceneName) {
-		return buildPath(Constants.DEFAULT_ROOT, Constants.BACKPACK_DIRECTORY, Constants.SCENES_DIRECTORY,
+		return buildPath(StorageHandler.getInstance().getRootDirectory(),
+				Constants.BACKPACK_DIRECTORY, Constants.SCENES_DIRECTORY,
 				UtilFile.encodeSpecialCharsForFileSystem(sceneName));
 	}
 
@@ -432,7 +434,7 @@ public final class Utils {
 	public static String getCurrentProjectName(Context context) {
 		if (ProjectManager.getInstance().getCurrentProject() == null) {
 
-			if (UtilFile.getProjectNames(new File(Constants.DEFAULT_ROOT)).size() == 0) {
+			if (UtilFile.getProjectNames(new File(StorageHandler.getInstance().getRootDirectory())).size() == 0) {
 				Log.i(TAG, "Somebody deleted all projects in the file-system");
 				ProjectManager.getInstance().initializeDefaultProject(context);
 			}
@@ -440,7 +442,8 @@ public final class Utils {
 			SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
 			String currentProjectName = sharedPreferences.getString(Constants.PREF_PROJECTNAME_KEY, null);
 			if (currentProjectName == null || !StorageHandler.getInstance().projectExists(currentProjectName)) {
-				currentProjectName = UtilFile.getProjectNames(new File(Constants.DEFAULT_ROOT)).get(0);
+				currentProjectName = UtilFile.getProjectNames(
+						new File(StorageHandler.getInstance().getRootDirectory())).get(0);
 			}
 			return currentProjectName;
 		}


### PR DESCRIPTION
This PR adds additional methods to StorageHandler, such as
getRootDirectory(), setRootDirectory() that allow setting the storage
location at runtime. This is necessary because we cannot obtain the path
to internal storage at compile time.
The application code was modified so that we do not use the root directory
defined in Constants.java directly any more, instead we call the
getRootDirectory() method to get the path.
The directory structure is now not created during initialization of the
StorageHandler, but lazily when we first call getRootDirectory().
This is necessary so that we can change the root directory before first use.

As a result of this change, there is no interference between
standalone apps and the PocketCode application.

NOTE: The test code still uses the Constant DEFAULT_ROOT as the tests basically only target "normal" app mode, not the standalone mode. If I should refactor the test code as well, simply drop a line here and I will update the PR.