### PR TITLE
Failed tests should not fail gradle run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,11 +77,11 @@ pipeline {
 				// wait for emulator startup
 				sh "jenkins_android_emulator_helper -W"
 				// Run Unit and device tests for package: org.catrobat.catroid.test
-				sh "jenkins_android_cmd_wrapper -I ./gradlew test connectedCatroidDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.package=org.catrobat.catroid.test"
+				sh "jenkins_android_cmd_wrapper ./gradlew test connectedCatroidDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.package=org.catrobat.catroid.test"
 				// ensure that the following test run does not overwrite the results
 				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results1"
 				// Run Unit and device tests for class: org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite
-				sh "jenkins_android_cmd_wrapper -I ./gradlew test connectedCatroidDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite"
+				sh "jenkins_android_cmd_wrapper ./gradlew test connectedCatroidDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite"
 				// stop emulator
 				sh "jenkins_android_emulator_helper -K"
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,6 +131,8 @@ pipeline {
 
 	post {
 		always {
+			step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
+
 			// Send notifications with standalone=false
 			script {
 				sendNotifications false

--- a/buildScripts/log_parser_rules
+++ b/buildScripts/log_parser_rules
@@ -1,0 +1,5 @@
+# This file instruments the LogParser-Plugin
+# The initial use-case is to mark builds erroneous on instrumentation failures
+
+error /(?i)Instrumentation run failed due/
+error /(?i)ddmlib.*Exception/

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -301,6 +301,8 @@ android {
                 'GradleCompatible', 'WifiManagerLeak', 'ApplySharedPref', 'DefaultLocale', 'ObsoleteSdkInt',
                 'StaticFieldLeak' , 'AppCompatResource'
 
+        abortOnError false
+
         textReport true
         xmlReport true
         htmlReport true

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -311,6 +311,12 @@ android {
     }
 }
 
+project.gradle.taskGraph.whenReady {
+    connectedCatroidDebugAndroidTest {
+        ignoreFailures = true
+    }
+}
+
 task copyAndroidNatives() {
     file("src/main/jniLibs/armeabi/").mkdirs();
     file("src/main/jniLibs/armeabi-v7a/").mkdirs();

--- a/catroid/gradle/code_quality_tasks.gradle
+++ b/catroid/gradle/code_quality_tasks.gradle
@@ -31,7 +31,7 @@ task checkstyle(type: Checkstyle) {
 
     // needed for console output of warnings/errors
     showViolations true
-    ignoreFailures false
+    ignoreFailures true
 
     reports {
         xml.enabled = true
@@ -47,7 +47,7 @@ task pmd(type: Pmd) {
     include '**/*.java'
     exclude '**/gen/**', '**/build/**', '**/res/**'
 
-    ignoreFailures false
+    ignoreFailures true
 
     reports {
         xml.enabled = true


### PR DESCRIPTION
Currently the static analysis run fails if there are PMD/Checkstyle issues. Therefore the whole build stops after the static analysis. The build should be marked as unstable (already done but superseded by the error) but continue.
The emulator tests should also pass, if an error occurs. As gradle does not differ between failures of a single test or eg an emulator crash the parsing rules got introduces to mark the build erroneous if a problem occurs (needs to be updated if needed).