### PR TITLE
CAT-2673 none sense error message while registration 

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/transfers/CheckEmailAvailableTaskThroughRegistration.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/CheckEmailAvailableTaskThroughRegistration.java
@@ -1,0 +1,73 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.transfers;
+
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.catrobat.catroid.web.ServerCalls;
+import org.catrobat.catroid.web.WebconnectionException;
+
+public class CheckEmailAvailableTaskThroughRegistration extends AsyncTask<String, Void, Boolean> {
+	private static final String TAG = CheckEmailAvailableTask.class.getSimpleName();
+
+	private String email;
+	private String provider;
+
+	private Boolean emailAvailable;
+
+	private OnCheckEmailAvailableCompleteListener onCheckEmailAvailableCompleteListener;
+
+	public CheckEmailAvailableTaskThroughRegistration(String email, String provider) {
+		this.email = email;
+		this.provider = provider;
+	}
+
+	public void setOnCheckEmailAvailableCompleteListener(OnCheckEmailAvailableCompleteListener listener) {
+		onCheckEmailAvailableCompleteListener = listener;
+	}
+
+	@Override
+	protected Boolean doInBackground(String... params) {
+		try {
+			emailAvailable = ServerCalls.getInstance().checkEMailAvailable(email);
+			return true;
+		} catch (WebconnectionException webconnectionException) {
+			Log.e(TAG, Log.getStackTraceString(webconnectionException));
+		}
+		return false;
+	}
+
+	@Override
+	protected void onPostExecute(Boolean success) {
+		super.onPostExecute(success);
+
+		if (onCheckEmailAvailableCompleteListener != null) {
+			onCheckEmailAvailableCompleteListener.onCheckEmailAvailableComplete(emailAvailable, provider);
+		}
+	}
+
+	public interface OnCheckEmailAvailableCompleteListener {
+		void onCheckEmailAvailableComplete(Boolean emailAvailable, String provider);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/CheckUserNameAvailableTaskThroughRegistration.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/CheckUserNameAvailableTaskThroughRegistration.java
@@ -1,0 +1,71 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.transfers;
+
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.catrobat.catroid.web.ServerCalls;
+import org.catrobat.catroid.web.WebconnectionException;
+
+public class CheckUserNameAvailableTaskThroughRegistration extends AsyncTask<Void, Void, Boolean> {
+	private static final String TAG = CheckUserNameAvailableTask.class.getSimpleName();
+	private String username;
+
+	private Boolean userNameAvailable;
+
+	private OnCheckUserNameAvailableCompleteListener onCheckUserNameAvailableCompleteListener;
+
+	public CheckUserNameAvailableTaskThroughRegistration(String username) {
+		this.username = username;
+	}
+
+	public void setOnCheckUserNameAvailableCompleteListener(OnCheckUserNameAvailableCompleteListener listener) {
+		onCheckUserNameAvailableCompleteListener = listener;
+	}
+
+	@Override
+	protected Boolean doInBackground(Void... params) {
+		try {
+
+			userNameAvailable = ServerCalls.getInstance().checkUserNameAvailable(username);
+			return true;
+		} catch (WebconnectionException webconnectionException) {
+			Log.e(TAG, Log.getStackTraceString(webconnectionException));
+		}
+		return false;
+	}
+
+	@Override
+	protected void onPostExecute(Boolean success) {
+		super.onPostExecute(success);
+
+		if (onCheckUserNameAvailableCompleteListener != null) {
+			onCheckUserNameAvailableCompleteListener.onCheckUserNameAvailableComplete(userNameAvailable, username);
+		}
+	}
+
+	public interface OnCheckUserNameAvailableCompleteListener {
+		void onCheckUserNameAvailableComplete(Boolean userNameAvailable, String username);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
@@ -28,6 +28,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
@@ -95,7 +96,11 @@ public final class Utils {
 	public static boolean isNetworkAvailable(Context context) {
 		ConnectivityManager connectivityManager = (ConnectivityManager) context
 				.getSystemService(Context.CONNECTIVITY_SERVICE);
-		return connectivityManager != null && connectivityManager.getActiveNetworkInfo().isConnected();
+		NetworkInfo activeNetworkInfo = null;
+		if (connectivityManager != null) {
+			activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
+		}
+		return activeNetworkInfo != null && activeNetworkInfo.isConnected();
 	}
 
 	public static boolean checkForNetworkError(boolean success, WebconnectionException exception) {

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -901,12 +901,22 @@
     <string name="signin_choose_username_hint">The username should not be your real name.</string>
     <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
     <string name="show_password">Show Password</string>
-    <string name="register_password_mismatch">Passwords do not match</string>
     <string name="sign_in_error">Error during Sign-In</string>
     <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
     <string name="error_facebook_session_expired">Session expired, please log in.</string>
     <string name="sign_in_with_facebook">Sign in with Facebook</string>
     <string name="sign_in_with_google">Sign in with Google</string>
+    <string name="error_register_empty_username">Empty username</string>
+    <string name="error_register_username_as_email">E-mail address can not be used as username</string>
+    <string name="error_register_invalid_username">Username can contain only Latin–letters (a–z), numbers (0–9), dashes (-), underscores (_), and periods (.).</string>
+    <string name="error_register_username_start_with">Username can not start with dashes (-), underscores (_), and periods (.).</string>
+    <string name="error_register_invalid_email_format">Invalid E-mail format</string>
+    <string name="error_register_empty_password">Empty Password</string>
+    <string name="error_register_password_at_least_6_characters">Password should be at least 6 characters</string>
+    <string name="error_register_passwords_mismatch">Passwords mismatch</string>
+    <string name="error_register_empty_confirm_password">Empty confirm password</string>
+    <string name="error_register_username_already_exists">Username already exists</string>
+    <string name="error_register_email_exists">Email Address already exists</string>
     <!--  -->
 
 


### PR DESCRIPTION
* Sets an error message that will be displayed below the TextInputLayouts 
(Username/E-mail/Password/confirm Password ) instead of showing AlertDialogs
* Check E-mail and Username availability in background
* Username should start with Latin character or number and contains no "@" - to block using email as username
* Check if the the provided Email_address matches Patterns.EMAIL_ADDRESS
* Password should be at least 6 characters 
* Check if Password and Confirm Password are matched
**have a look at the [video](https://drive.google.com/open?id=1rVOdzGVHA-_MGbm_fFbrdLzWaUw2OdqB
)**
* it still remains one problem which is : 
change the language of the App to Deutsch
try to register --> server error " Invalid country"
_need to be fixed with the web team " I've tried to arrange a meeting with them but No answer yet"_