### PR TITLE
CAT-2106 Do not allow email addresses as user names

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/RegistrationDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/RegistrationDialogFragment.java
@@ -125,16 +125,22 @@ public class RegistrationDialogFragment extends DialogFragment implements OnRegi
 		String passwordConfirmation = confirmPasswordInputLayout.getEditText().getText().toString();
 		String email = emailInputLayout.getEditText().getText().toString();
 
-		if (password.equals(passwordConfirmation)) {
+		if (username.contains("@")) {
+			showErrorAlertDialog(R.string.register_email_as_username_error);
+		} else if (!password.equals(passwordConfirmation)) {
+			showErrorAlertDialog(R.string.register_password_mismatch);
+		} else {
 			RegistrationTask registrationTask = new RegistrationTask(getActivity(), username, password, email);
 			registrationTask.setOnRegistrationCompleteListener(this);
 			registrationTask.execute();
-		} else {
-			new AlertDialog.Builder(getActivity())
-					.setTitle(R.string.register_error)
-					.setMessage(R.string.register_password_mismatch)
-					.setPositiveButton(R.string.ok, null)
-					.show();
 		}
+	}
+
+	private void showErrorAlertDialog(int messageId) {
+		new AlertDialog.Builder(getActivity())
+				.setTitle(R.string.register_error)
+				.setMessage(messageId)
+				.setPositiveButton(R.string.ok, null)
+				.show();
 	}
 }

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -902,6 +902,7 @@
     <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
     <string name="show_password">Show Password</string>
     <string name="register_password_mismatch">Passwords do not match</string>
+    <string name="register_email_as_username_error">Email address can not be used as username</string>
     <string name="sign_in_error">Error during Sign-In</string>
     <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
     <!--  -->


### PR DESCRIPTION
easy way to fix this by preventing user from using "@" in the username field
cause Z.B `example@gmail` is understandable AS E-Mail address as well

