### PR TITLE
CAT-2729 Replace integer division with float division in PlaySoundAndWaitBrick

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundAndWaitBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundAndWaitBrick.java
@@ -66,7 +66,7 @@ public class PlaySoundAndWaitBrick extends PlaySoundBrick {
 			metadataRetriever.setDataSource(sound.getFile().getAbsolutePath());
 
 			duration = Integer.parseInt(metadataRetriever
-					.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)) / 1000;
+					.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)) / 1000.0f;
 		}
 
 		sequence.addAction(sprite.getActionFactory().createWaitAction(sprite, new Formula(duration)));


### PR DESCRIPTION
With the int division the calculated duration was very inaccurate.