### PR TITLE
CAT-2730 Refactor WhenStartedBrick, WhenClonedBrick, WhenNfcBrick and WhenGamepadButtonBrick to use the new event system

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/EventActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/EventActionTest.java
@@ -37,6 +37,7 @@ import org.catrobat.catroid.content.bricks.BroadcastWaitBrick;
 import org.catrobat.catroid.content.bricks.ChangeXByNBrick;
 import org.catrobat.catroid.content.bricks.SetXBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,7 +79,7 @@ public class EventActionTest {
 		startScript.addBrick(new BroadcastBrick(MESSAGE1));
 		broadcastScript1.addBrick(new SetXBrick(testPosition));
 
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		executeAllActions();
 
@@ -95,7 +96,7 @@ public class EventActionTest {
 		broadcastScript1.addBrick(new WaitBrick(500));
 		broadcastScript1.addBrick(new SetXBrick(setTestPosition));
 
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		executeAllActions();
 
@@ -111,7 +112,7 @@ public class EventActionTest {
 		broadcastScript1.addBrick(new BroadcastBrick(MESSAGE1));
 		broadcastScript1.addBrick(new WaitBrick(5));
 
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		executeAllActionsOrTimeoutAfter(20);
 
@@ -132,7 +133,7 @@ public class EventActionTest {
 		broadcastScript2.addBrick(new BroadcastWaitBrick(MESSAGE1));
 		sprite.addScript(broadcastScript2);
 
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		executeAllActionsOrTimeoutAfter(20);
 
@@ -154,7 +155,7 @@ public class EventActionTest {
 		startScript2.addBrick(new SetXBrick(xPosition));
 		sprite.addScript(startScript2);
 
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		executeAllActionsOrTimeoutAfter(20);
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ForeverActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/ForeverActionTest.java
@@ -30,6 +30,7 @@ import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.ChangeYByNBrick;
 import org.catrobat.catroid.content.bricks.ForeverBrick;
 import org.catrobat.catroid.content.bricks.LoopEndBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 
 public class ForeverActionTest extends InstrumentationTestCase {
 
@@ -51,7 +52,7 @@ public class ForeverActionTest extends InstrumentationTestCase {
 		testScript.addBrick(loopEndBrick);
 
 		testSprite.addScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 
 		/*
 		 * This is only to document that a delay of 20ms is by contract. See Issue 28 in Google Code

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/IfLogicActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/IfLogicActionTest.java
@@ -38,6 +38,7 @@ import org.catrobat.catroid.content.bricks.IfLogicEndBrick;
 import org.catrobat.catroid.content.bricks.LoopEndBrick;
 import org.catrobat.catroid.content.bricks.RepeatBrick;
 import org.catrobat.catroid.content.bricks.SetVariableBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
@@ -109,7 +110,7 @@ public class IfLogicActionTest extends AndroidTestCase {
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
 
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1f);
 		}
@@ -141,7 +142,7 @@ public class IfLogicActionTest extends AndroidTestCase {
 		project.getDefaultScene().addSprite(testSprite);
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 		testSprite.look.act(100f);
 
 		userVariable = ProjectManager.getInstance().getCurrentScene().getDataContainer()
@@ -171,7 +172,7 @@ public class IfLogicActionTest extends AndroidTestCase {
 		project.getDefaultScene().addSprite(testSprite);
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 		testSprite.look.act(100f);
 
 		userVariable = ProjectManager.getInstance().getCurrentScene().getDataContainer()
@@ -226,7 +227,7 @@ public class IfLogicActionTest extends AndroidTestCase {
 		project.getDefaultScene().addSprite(testSprite);
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 		testSprite.look.act(1f);
 		userVariable = ProjectManager.getInstance().getCurrentScene().getDataContainer()
 				.getUserVariable(null, TEST_USERVARIABLE);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/RepeatActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/RepeatActionTest.java
@@ -35,6 +35,7 @@ import org.catrobat.catroid.content.actions.RepeatAction;
 import org.catrobat.catroid.content.bricks.ChangeYByNBrick;
 import org.catrobat.catroid.content.bricks.LoopEndBrick;
 import org.catrobat.catroid.content.bricks.RepeatBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
@@ -70,7 +71,7 @@ public class RepeatActionTest extends InstrumentationTestCase {
 		testScript.addBrick(new ChangeYByNBrick(150));
 
 		testSprite.addScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 
 		// http://code.google.com/p/catroid/issues/detail?id=28
 		for (int index = 0; index < REPEAT_TIMES; index++) {
@@ -97,7 +98,7 @@ public class RepeatActionTest extends InstrumentationTestCase {
 		testScript.addBrick(loopEndBrick);
 
 		testSprite.addScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1.0f);
@@ -124,7 +125,7 @@ public class RepeatActionTest extends InstrumentationTestCase {
 		testScript.addBrick(loopEndBrick);
 
 		testSprite.addScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1.0f);
@@ -154,7 +155,7 @@ public class RepeatActionTest extends InstrumentationTestCase {
 		testScript.addBrick(loopEndBrick);
 
 		testSprite.addScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 
 		float timePerActCycle = 0.5f;
 
@@ -233,7 +234,7 @@ public class RepeatActionTest extends InstrumentationTestCase {
 		testScript.addBrick(new ChangeYByNBrick(delta));
 		testScript.addBrick(loopEndBrick);
 		testSprite.addScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1.0f);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/RepeatUntilActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/RepeatUntilActionTest.java
@@ -38,6 +38,7 @@ import org.catrobat.catroid.content.bricks.ChangeYByNBrick;
 import org.catrobat.catroid.content.bricks.LoopEndBrick;
 import org.catrobat.catroid.content.bricks.RepeatUntilBrick;
 import org.catrobat.catroid.content.bricks.SetVariableBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
@@ -110,7 +111,7 @@ public class RepeatUntilActionTest extends InstrumentationTestCase {
 		testScript.addBrick(loopEndBrick);
 
 		testSprite.addScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1.0f);
@@ -159,7 +160,7 @@ public class RepeatUntilActionTest extends InstrumentationTestCase {
 		testScript.addBrick(new ChangeYByNBrick(delta));
 		testScript.addBrick(loopEndBrick);
 		testSprite.addScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1.0f);
@@ -184,7 +185,7 @@ public class RepeatUntilActionTest extends InstrumentationTestCase {
 		testScript.addBrick(loopEndBrick);
 
 		testSprite.addScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1.0f);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/StopScriptActionsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/StopScriptActionsTest.java
@@ -37,6 +37,7 @@ import org.catrobat.catroid.content.bricks.SetVariableBrick;
 import org.catrobat.catroid.content.bricks.SetXBrick;
 import org.catrobat.catroid.content.bricks.StopScriptBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.io.XstreamSerializer;
@@ -74,7 +75,7 @@ public class StopScriptActionsTest extends InstrumentationTestCase {
 
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 		ProjectManager.getInstance().setCurrentScript(script);
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		for (int i = 0; i < 100; i++) {
 			sprite.look.act(1.0f);
@@ -111,7 +112,7 @@ public class StopScriptActionsTest extends InstrumentationTestCase {
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 		ProjectManager.getInstance().setCurrentScript(script2);
 
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		for (int i = 0; i < 50; i++) {
 			sprite.look.act(10.0f);
@@ -151,7 +152,7 @@ public class StopScriptActionsTest extends InstrumentationTestCase {
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 		ProjectManager.getInstance().setCurrentScript(script2);
 
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		for (int i = 0; i < 100; i++) {
 			sprite.look.act(1.0f);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/WaitUntilActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/WaitUntilActionTest.java
@@ -31,6 +31,7 @@ import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.WaitUntilBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.Operators;
@@ -83,7 +84,7 @@ public class WaitUntilActionTest extends AndroidTestCase {
 		project.getDefaultScene().addSprite(testSprite);
 		ProjectManager.getInstance().setCurrentSprite(testSprite);
 		ProjectManager.getInstance().setCurrentScript(testScript);
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 
 		testSprite.look.act(100f);
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/StartScriptTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/StartScriptTest.java
@@ -30,6 +30,7 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.HideBrick;
 import org.catrobat.catroid.content.bricks.SetSizeToBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 
 public class StartScriptTest extends AndroidTestCase {
 
@@ -44,7 +45,7 @@ public class StartScriptTest extends AndroidTestCase {
 		testScript.addBrick(setSizeToBrick);
 		testSprite.addScript(testScript);
 
-		testSprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		testSprite.initializeActions(EventId.START);
 
 		while (!testSprite.look.getAllActionsAreFinished()) {
 			testSprite.look.act(1.0f);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/WhenBackgroundChangesScriptTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/WhenBackgroundChangesScriptTest.java
@@ -38,6 +38,7 @@ import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.WhenBackgroundChangesScript;
 import org.catrobat.catroid.content.bricks.SetBackgroundBrick;
 import org.catrobat.catroid.content.bricks.SetXBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -100,7 +101,7 @@ public class WhenBackgroundChangesScriptTest {
 		setBackgroundBrick.setLook(bg2);
 		startScript.addBrick(setBackgroundBrick);
 		whenBgChangesScript.addBrick(new SetXBrick(position));
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		while (!sprite.look.getAllActionsAreFinished()) {
 			sprite.look.act(1.0f);
@@ -116,7 +117,7 @@ public class WhenBackgroundChangesScriptTest {
 		setBackgroundBrick.setLook(bg1);
 		startScript.addBrick(setBackgroundBrick);
 		whenBgChangesScript.addBrick(new SetXBrick(position));
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		while (!sprite.look.getAllActionsAreFinished()) {
 			sprite.look.act(1.0f);
@@ -136,7 +137,7 @@ public class WhenBackgroundChangesScriptTest {
 		startScript.addBrick(setBackgroundBrick1);
 		startScript.addBrick(setBackgroundBrick2);
 		whenBgChangesScript.addBrick(new SetXBrick(position));
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		while (!sprite.look.getAllActionsAreFinished()) {
 			sprite.look.act(1.0f);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/WhenConditionScriptTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/WhenConditionScriptTest.java
@@ -34,6 +34,7 @@ import org.catrobat.catroid.content.WhenConditionScript;
 import org.catrobat.catroid.content.bricks.ChangeXByNBrick;
 import org.catrobat.catroid.content.bricks.StopScriptBrick;
 import org.catrobat.catroid.content.bricks.WhenConditionBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
 import org.junit.Before;
@@ -74,7 +75,7 @@ public class WhenConditionScriptTest {
 	public void executeWhenConditionScriptOnce() throws InterpretationException {
 		when(formula.interpretBoolean(any(Sprite.class))).thenReturn(true);
 		conditionScript.addBrick(new ChangeXByNBrick(POSITION_DELTA));
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 		sprite.initConditionScriptTiggers();
 
 		sprite.look.act(1.0f);
@@ -89,7 +90,7 @@ public class WhenConditionScriptTest {
 	public void executeWhenConditionScriptMultipleTimes() throws InterpretationException {
 		when(formula.interpretBoolean(any(Sprite.class))).thenReturn(true, true, false, true);
 		conditionScript.addBrick(new ChangeXByNBrick(POSITION_DELTA));
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 		sprite.initConditionScriptTiggers();
 
 		for (int i = 0; i < 10; i++) {
@@ -104,7 +105,7 @@ public class WhenConditionScriptTest {
 		when(formula.interpretBoolean(any(Sprite.class))).thenReturn(true, true, false, true);
 		conditionScript.addBrick(new ChangeXByNBrick(POSITION_DELTA));
 		conditionScript.addBrick(new StopScriptBrick(0));
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 		sprite.initConditionScriptTiggers();
 
 		for (int i = 0; i < 10; i++) {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/WhenScriptTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/WhenScriptTest.java
@@ -37,6 +37,7 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.WhenScript;
 import org.catrobat.catroid.content.bricks.ChangeXByNBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.catrobat.catroid.test.utils.TestUtils;
 import org.catrobat.catroid.utils.TouchUtil;
 import org.junit.Before;
@@ -88,7 +89,7 @@ public class WhenScriptTest {
 	@Test
 	public void basicWhenScriptTest() {
 		whenScript.addBrick(new ChangeXByNBrick(10));
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		tapSprite();
 		while (!sprite.look.getAllActionsAreFinished()) {
@@ -106,7 +107,7 @@ public class WhenScriptTest {
 	public void whenScriptRestartTest() {
 		whenScript.addBrick(new WaitBrick(50));
 		whenScript.addBrick(new ChangeXByNBrick(10));
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		tapSprite();
 		tapSprite();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/WhenTouchDownScriptTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/script/WhenTouchDownScriptTest.java
@@ -34,6 +34,7 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.WhenTouchDownScript;
 import org.catrobat.catroid.content.bricks.ChangeXByNBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.catrobat.catroid.utils.TouchUtil;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,7 +62,7 @@ public class WhenTouchDownScriptTest {
 	public void basicTouchDownScriptTest() {
 		touchDownScript.addBrick(new ChangeXByNBrick(10));
 
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		TouchUtil.touchDown(0, 0, 1);
 
@@ -77,7 +78,7 @@ public class WhenTouchDownScriptTest {
 		touchDownScript.addBrick(new WaitBrick(50));
 		touchDownScript.addBrick(new ChangeXByNBrick(10));
 
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		TouchUtil.touchDown(0, 0, 1);
 		TouchUtil.touchUp(1);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionBetweenTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/PhysicsCollisionBetweenTest.java
@@ -32,6 +32,7 @@ import org.catrobat.catroid.content.CollisionScript;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.PlaceAtBrick;
 import org.catrobat.catroid.content.eventids.CollisionEventId;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.catrobat.catroid.physics.PhysicsCollision;
 import org.catrobat.catroid.physics.PhysicsCollisionBroadcast;
 import org.catrobat.catroid.physics.PhysicsObject;
@@ -109,7 +110,7 @@ public class PhysicsCollisionBetweenTest extends PhysicsCollisionBaseTest {
 		secondSpriteCollisionScript.addBrick(testBrick);
 		sprite2.addScript(secondSpriteCollisionScript);
 
-		sprite2.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite2.initializeActions(EventId.START);
 
 		simulateFullCollision();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/actions/IfOnEdgeBouncePhysicsActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/actions/IfOnEdgeBouncePhysicsActionTest.java
@@ -31,6 +31,7 @@ import org.catrobat.catroid.content.ActionFactory;
 import org.catrobat.catroid.content.CollisionScript;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.PlaceAtBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 import org.catrobat.catroid.physics.PhysicsObject;
 import org.catrobat.catroid.physics.PhysicsWorld;
 import org.catrobat.catroid.physics.content.actions.IfOnEdgeBouncePhysicsAction;
@@ -179,7 +180,7 @@ public class IfOnEdgeBouncePhysicsActionTest extends PhysicsBaseTest {
 		spriteCollisionScript.addBrick(testBrick);
 		sprite.addScript(spriteCollisionScript);
 
-		sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		sprite.initializeActions(EventId.START);
 
 		PhysicsObject physicsObject = physicsWorld.getPhysicsObject(sprite);
 		physicsObject.setType(PhysicsObject.Type.DYNAMIC);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/WhenGamepadButtonBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/WhenGamepadButtonBrickTest.java
@@ -28,6 +28,7 @@ import android.support.test.runner.AndroidJUnit4;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.WhenGamepadButtonScript;
 import org.catrobat.catroid.content.bricks.WhenGamepadButtonBrick;
+import org.catrobat.catroid.formulaeditor.Sensors;
 import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.annotations.Flaky;
 import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
@@ -57,7 +58,7 @@ public class WhenGamepadButtonBrickTest {
 	public void setUp() throws Exception {
 		brickPosition = 1;
 		BrickTestUtils.createProjectAndGetStartScript("WhenGamepadButtonBrickTest")
-				.addBrick(new WhenGamepadButtonBrick(new WhenGamepadButtonScript()));
+				.addBrick(new WhenGamepadButtonBrick(new WhenGamepadButtonScript(Sensors.GAMEPAD_A_PRESSED.name())));
 		baseActivityTestRule.launchActivity();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/cast/CastManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/cast/CastManager.java
@@ -68,7 +68,6 @@ import java.util.EnumMap;
 import static org.catrobat.catroid.common.Constants.CAST_IDLE_BACKGROUND_COLOR;
 
 public final class CastManager {
-
 	private static final CastManager INSTANCE = new CastManager();
 	private final ArrayList<MediaRouter.RouteInfo> routeInfos = new ArrayList<MediaRouter.RouteInfo>();
 	StageActivity gamepadActivity;
@@ -233,38 +232,40 @@ public final class CastManager {
 		}
 
 		boolean isActionDown = (event.getAction() == MotionEvent.ACTION_DOWN);
-		String buttonPressedName;
 
+		Sensors buttonPressed;
+		String buttonPressedName;
 		switch (button.getId()) {
 			case R.id.gamepadButtonA:
-				buttonPressedName = gamepadActivity.getString(R.string.cast_gamepad_A);
 				button.setImageResource(isActionDown ? R.drawable.gamepad_button_a_pressed : R.drawable.gamepad_button_a);
-				setButtonPress(Sensors.GAMEPAD_A_PRESSED, isActionDown);
+				buttonPressedName = gamepadActivity.getString(R.string.cast_gamepad_A);
+				buttonPressed = Sensors.GAMEPAD_A_PRESSED;
 				break;
 			case R.id.gamepadButtonB:
-				buttonPressedName = gamepadActivity.getString(R.string.cast_gamepad_B);
 				button.setImageResource(isActionDown ? R.drawable.gamepad_button_b_pressed : R.drawable.gamepad_button_b);
-				setButtonPress(Sensors.GAMEPAD_B_PRESSED, isActionDown);
+				buttonPressedName = gamepadActivity.getString(R.string.cast_gamepad_B);
+				buttonPressed = Sensors.GAMEPAD_B_PRESSED;
 				break;
 			case R.id.gamepadButtonUp:
 				buttonPressedName = gamepadActivity.getString(R.string.cast_gamepad_up);
-				setButtonPress(Sensors.GAMEPAD_UP_PRESSED, isActionDown);
+				buttonPressed = Sensors.GAMEPAD_UP_PRESSED;
 				break;
 			case R.id.gamepadButtonDown:
 				buttonPressedName = gamepadActivity.getString(R.string.cast_gamepad_down);
-				setButtonPress(Sensors.GAMEPAD_DOWN_PRESSED, isActionDown);
+				buttonPressed = Sensors.GAMEPAD_DOWN_PRESSED;
 				break;
 			case R.id.gamepadButtonLeft:
 				buttonPressedName = gamepadActivity.getString(R.string.cast_gamepad_left);
-				setButtonPress(Sensors.GAMEPAD_LEFT_PRESSED, isActionDown);
+				buttonPressed = Sensors.GAMEPAD_LEFT_PRESSED;
 				break;
 			case R.id.gamepadButtonRight:
 				buttonPressedName = gamepadActivity.getString(R.string.cast_gamepad_right);
-				setButtonPress(Sensors.GAMEPAD_RIGHT_PRESSED, isActionDown);
+				buttonPressed = Sensors.GAMEPAD_RIGHT_PRESSED;
 				break;
 			default:
 				throw new IllegalArgumentException("Unknown button pressed");
 		}
+		setButtonPress(buttonPressed, isActionDown);
 
 		if (isActionDown) {
 			((StageListener) gamepadActivity.getApplicationListener()).gamepadPressed(buttonPressedName);
@@ -364,7 +365,7 @@ public final class CastManager {
 				}
 				routeInfos.add(info);
 				castButton.setVisible(mediaRouter.isRouteAvailable(mediaRouteSelector, MediaRouter
-							.AVAILABILITY_FLAG_REQUIRE_MATCH));
+						.AVAILABILITY_FLAG_REQUIRE_MATCH));
 				deviceAdapter.notifyDataSetChanged();
 			}
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/common/ActionScheduler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/ActionScheduler.java
@@ -96,6 +96,11 @@ public class ActionScheduler {
 		}
 	}
 
+	public void stopAllActions() {
+		actionsToBeRemoved.addAll(actor.getActions());
+		actionsToBeStarted.clear();
+	}
+
 	public boolean getAllActionsFinished() {
 		return actionsToBeStarted.size + actor.getActions().size == 0;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -196,6 +196,12 @@ public class Look extends Image {
 		}
 	}
 
+	public void stopAllActions() {
+		if (scheduler != null) {
+			scheduler.stopAllActions();
+		}
+	}
+
 	void stopActionWithScript(Script script) {
 		if (scheduler != null) {
 			scheduler.stopActionsWithScript(script);
@@ -525,10 +531,6 @@ public class Look extends Image {
 	protected float convertStageAngleToCatroidAngle(float stageAngle) {
 		float catroidAngle = -stageAngle + DEGREE_UI_OFFSET;
 		return breakDownCatroidAngle(catroidAngle);
-	}
-
-	public void createAndAddActionsWithoutStartActions() {
-		sprite.createAndAddActions(Sprite.EXCLUDE_START_ACTIONS);
 	}
 
 	private class BrightnessContrastHueShader extends ShaderProgram {

--- a/catroid/src/main/java/org/catrobat/catroid/content/StartScript.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/StartScript.java
@@ -24,8 +24,9 @@ package org.catrobat.catroid.content;
 
 import org.catrobat.catroid.content.bricks.ScriptBrick;
 import org.catrobat.catroid.content.bricks.WhenStartedBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 
-public class StartScript extends Script {
+public class StartScript extends Script implements EventScript {
 
 	private static final long serialVersionUID = 1L;
 	private boolean isUserScript;
@@ -62,5 +63,10 @@ public class StartScript extends Script {
 		Script clone = new StartScript(isUserScript);
 		clone.getBrickList().addAll(cloneBrickList());
 		return clone;
+	}
+
+	@Override
+	public EventId createEventId(Sprite sprite) {
+		return new EventId(EventId.START);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/WhenClonedScript.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/WhenClonedScript.java
@@ -24,18 +24,11 @@ package org.catrobat.catroid.content;
 
 import org.catrobat.catroid.content.bricks.ScriptBrick;
 import org.catrobat.catroid.content.bricks.WhenClonedBrick;
+import org.catrobat.catroid.content.eventids.EventId;
 
-public class WhenClonedScript extends Script {
+public class WhenClonedScript extends Script implements EventScript {
 
 	private static final long serialVersionUID = 1L;
-
-	public WhenClonedScript() {
-		super();
-	}
-
-	public WhenClonedScript(WhenClonedBrick brick) {
-		this.brick = brick;
-	}
 
 	@Override
 	protected Object readResolve() {
@@ -57,5 +50,10 @@ public class WhenClonedScript extends Script {
 		WhenClonedScript clone = new WhenClonedScript();
 		clone.getBrickList().addAll(cloneBrickList());
 		return clone;
+	}
+
+	@Override
+	public EventId createEventId(Sprite sprite) {
+		return new EventId(EventId.START_AS_CLONE);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/WhenGamepadButtonScript.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/WhenGamepadButtonScript.java
@@ -22,28 +22,18 @@
  */
 package org.catrobat.catroid.content;
 
-import org.catrobat.catroid.CatroidApplication;
-import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.ScriptBrick;
 import org.catrobat.catroid.content.bricks.WhenGamepadButtonBrick;
+import org.catrobat.catroid.content.eventids.EventId;
+import org.catrobat.catroid.content.eventids.GamepadEventId;
 
-public class WhenGamepadButtonScript extends Script {
+public class WhenGamepadButtonScript extends Script implements EventScript {
 
 	private static final long serialVersionUID = 1L;
 	private String action;
 
-	public WhenGamepadButtonScript() {
-		super();
-		this.action = CatroidApplication.getAppContext().getString(R.string.cast_gamepad_A);
-	}
-
-	public WhenGamepadButtonScript(WhenGamepadButtonBrick brick) {
-		this.brick = brick;
-	}
-
 	public WhenGamepadButtonScript(String action) {
-		super();
 		this.action = action;
 	}
 
@@ -66,7 +56,6 @@ public class WhenGamepadButtonScript extends Script {
 		if (brick == null) {
 			brick = new WhenGamepadButtonBrick(this);
 		}
-
 		return brick;
 	}
 
@@ -77,8 +66,13 @@ public class WhenGamepadButtonScript extends Script {
 
 	@Override
 	public Script clone() throws CloneNotSupportedException {
-		WhenGamepadButtonScript clone = new WhenGamepadButtonScript();
+		WhenGamepadButtonScript clone = new WhenGamepadButtonScript(action);
 		clone.getBrickList().addAll(cloneBrickList());
 		return clone;
+	}
+
+	@Override
+	public EventId createEventId(Sprite sprite) {
+		return new GamepadEventId(action);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/WhenNfcScript.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/WhenNfcScript.java
@@ -26,25 +26,26 @@ import org.catrobat.catroid.common.NfcTagData;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.ScriptBrick;
 import org.catrobat.catroid.content.bricks.WhenNfcBrick;
+import org.catrobat.catroid.content.eventids.EventId;
+import org.catrobat.catroid.content.eventids.NfcEventId;
 
 import java.util.ArrayList;
 
-public class WhenNfcScript extends Script {
+public class WhenNfcScript extends Script implements EventScript {
 
 	private static final long serialVersionUID = 1L;
 
 	private NfcTagData nfcTag;
 	private boolean matchAll = true;
 
-	public WhenNfcScript() {
-		nfcTag = null;
-	}
-
 	@Override
 	public Script clone() throws CloneNotSupportedException {
 		WhenNfcScript clone = new WhenNfcScript(nfcTag);
 		clone.getBrickList().addAll(cloneBrickList());
 		return clone;
+	}
+
+	public WhenNfcScript() {
 	}
 
 	public WhenNfcScript(NfcTagData nfcTag) {
@@ -74,15 +75,21 @@ public class WhenNfcScript extends Script {
 		this.matchAll = matchAll;
 	}
 
-	public boolean isMatchAll() {
-		return matchAll;
-	}
-
 	public NfcTagData getNfcTag() {
 		return nfcTag;
 	}
 
 	public void setNfcTag(NfcTagData nfcTag) {
 		this.nfcTag = nfcTag;
+	}
+
+	@Override
+	public EventId createEventId(Sprite sprite) {
+		if (matchAll) {
+			return new NfcEventId(null);
+		} else if (nfcTag != null) {
+			return new NfcEventId(nfcTag.getNfcTagUid());
+		}
+		throw new RuntimeException("We want to identify a specific NfcTag, but null is given.");
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/StopAllScriptsAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/StopAllScriptsAction.java
@@ -23,7 +23,6 @@
 
 package org.catrobat.catroid.content.actions;
 
-import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 import com.badlogic.gdx.utils.Array;
@@ -37,13 +36,9 @@ public class StopAllScriptsAction extends TemporalAction {
 	protected void update(float percent) {
 		Array<Actor> stageActors = StageActivity.stageListener.getStage().getActors();
 		for (Actor actor : stageActors) {
-			for (Action action : actor.getActions()) {
-				action.reset();
-			}
-			actor.getActions().clear();
 			if (actor instanceof Look) {
 				Look look = (Look) actor;
-				look.createAndAddActionsWithoutStartActions();
+				look.stopAllActions();
 			}
 		}
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenGamepadButtonBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenGamepadButtonBrick.java
@@ -23,6 +23,7 @@
 package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -37,29 +38,16 @@ import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.WhenGamepadButtonScript;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class WhenGamepadButtonBrick extends BrickBaseType implements ScriptBrick {
-
-	protected WhenGamepadButtonScript whenGamepadButtonScript;
-	protected transient boolean checked = false;
 	private static final long serialVersionUID = 1L;
-	private String[] actions;
-	private String action;
-	private int position;
+	private WhenGamepadButtonScript whenGamepadButtonScript;
+	private List<String> actions = Arrays.asList(CatroidApplication.getAppContext().getResources().getStringArray(R.array.gamepad_buttons_array));
 
-	public WhenGamepadButtonBrick(WhenGamepadButtonScript whenGamepadButtonScript) {
+	public WhenGamepadButtonBrick(@NonNull WhenGamepadButtonScript whenGamepadButtonScript) {
 		this.whenGamepadButtonScript = whenGamepadButtonScript;
-		actions = CatroidApplication.getAppContext().getResources().getStringArray(R.array.gamepad_buttons_array);
-		if (whenGamepadButtonScript != null) {
-			action = whenGamepadButtonScript.getAction();
-			for (int i = 0; i < actions.length; i++) {
-				if (actions[i].equals(action)) {
-					position = i;
-					break;
-				}
-			}
-		}
 	}
 
 	@Override
@@ -91,21 +79,14 @@ public class WhenGamepadButtonBrick extends BrickBaseType implements ScriptBrick
 			@Override
 			public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
 				String actionChosen = actionSpinner.getSelectedItem().toString();
-				action = actionChosen;
-				WhenGamepadButtonBrick.this.position = position;
-				if (whenGamepadButtonScript == null) {
-					whenGamepadButtonScript = new WhenGamepadButtonScript(actionChosen);
-				} else {
-					whenGamepadButtonScript.setAction(actionChosen);
-				}
+				whenGamepadButtonScript.setAction(actionChosen);
 			}
 
 			@Override
 			public void onNothingSelected(AdapterView<?> parent) {
 			}
 		});
-
-		actionSpinner.setSelection(position);
+		actionSpinner.setSelection(actions.indexOf(whenGamepadButtonScript.getAction()));
 		return view;
 	}
 
@@ -116,15 +97,12 @@ public class WhenGamepadButtonBrick extends BrickBaseType implements ScriptBrick
 
 	@Override
 	public Brick clone() {
-		return new WhenGamepadButtonBrick(null);
+		WhenGamepadButtonScript clonedScript = new WhenGamepadButtonScript(whenGamepadButtonScript.getAction());
+		return new WhenGamepadButtonBrick(clonedScript);
 	}
 
 	@Override
 	public Script getScriptSafe() {
-		if (whenGamepadButtonScript == null) {
-			whenGamepadButtonScript = new WhenGamepadButtonScript();
-		}
-
 		return whenGamepadButtonScript;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenNfcBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenNfcBrick.java
@@ -61,15 +61,6 @@ public class WhenNfcBrick extends BrickBaseType implements ScriptBrick {
 		this.whenNfcScript.setMatchAll(true);
 	}
 
-	public WhenNfcBrick(String tagName, String tagUid) {
-		this.oldSelectedNfcTag = null;
-		this.nfcTag = new NfcTagData();
-		this.nfcTag.setNfcTagName(tagName);
-		this.nfcTag.setNfcTagUid(tagUid);
-		this.whenNfcScript = new WhenNfcScript(nfcTag);
-		this.whenNfcScript.setMatchAll(false);
-	}
-
 	public WhenNfcBrick(WhenNfcScript script) {
 		this.oldSelectedNfcTag = null;
 		this.nfcTag = script.getNfcTag();
@@ -304,14 +295,6 @@ public class WhenNfcBrick extends BrickBaseType implements ScriptBrick {
 
 	public NfcTagData getNfcTag() {
 		return nfcTag;
-	}
-
-	public void setNfcTag(NfcTagData nfcTagData) {
-		this.nfcTag = nfcTagData;
-	}
-
-	public WhenNfcScript getWhenNfcScript() {
-		return whenNfcScript;
 	}
 
 	public void setWhenNfcScript(WhenNfcScript whenNfcScript) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/eventids/GamepadEventId.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/eventids/GamepadEventId.java
@@ -20,34 +20,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.catrobat.catroid.content.eventids;
 
-import android.support.annotation.IntDef;
+import com.google.common.base.Objects;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+public class GamepadEventId extends EventId {
+	final String buttonPressed;
 
-public class EventId {
-	@Retention(RetentionPolicy.SOURCE)
-	@IntDef({TAP, TAP_BACKGROUND, START, START_AS_CLONE, OTHER})
-	public @interface EventType {
-	}
-
-	public static final int OTHER = 0;
-	public static final int TAP = 1;
-	public static final int TAP_BACKGROUND = 2;
-	public static final int START = 3;
-	public static final int START_AS_CLONE = 4;
-
-	@EventType
-	private final int type;
-
-	public EventId(@EventType int type) {
-		this.type = type;
-	}
-
-	protected EventId() {
-		this.type = OTHER;
+	public GamepadEventId(String buttonPressed) {
+		this.buttonPressed = buttonPressed;
 	}
 
 	@Override
@@ -55,17 +37,18 @@ public class EventId {
 		if (this == o) {
 			return true;
 		}
-		if (!(o instanceof EventId)) {
+		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
-
-		EventId eventId = (EventId) o;
-
-		return type == eventId.type;
+		if (!super.equals(o)) {
+			return false;
+		}
+		GamepadEventId that = (GamepadEventId) o;
+		return Objects.equal(buttonPressed, that.buttonPressed);
 	}
 
 	@Override
 	public int hashCode() {
-		return type;
+		return Objects.hashCode(super.hashCode(), buttonPressed);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/eventids/NfcEventId.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/eventids/NfcEventId.java
@@ -20,34 +20,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.catrobat.catroid.content.eventids;
 
-import android.support.annotation.IntDef;
+import com.google.common.base.Objects;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+public class NfcEventId extends EventId {
+	final String tag;
 
-public class EventId {
-	@Retention(RetentionPolicy.SOURCE)
-	@IntDef({TAP, TAP_BACKGROUND, START, START_AS_CLONE, OTHER})
-	public @interface EventType {
-	}
-
-	public static final int OTHER = 0;
-	public static final int TAP = 1;
-	public static final int TAP_BACKGROUND = 2;
-	public static final int START = 3;
-	public static final int START_AS_CLONE = 4;
-
-	@EventType
-	private final int type;
-
-	public EventId(@EventType int type) {
-		this.type = type;
-	}
-
-	protected EventId() {
-		this.type = OTHER;
+	public NfcEventId(String tag) {
+		this.tag = tag;
 	}
 
 	@Override
@@ -55,17 +37,18 @@ public class EventId {
 		if (this == o) {
 			return true;
 		}
-		if (!(o instanceof EventId)) {
+		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
-
-		EventId eventId = (EventId) o;
-
-		return type == eventId.type;
+		if (!super.equals(o)) {
+			return false;
+		}
+		NfcEventId that = (NfcEventId) o;
+		return tag == null || that.tag == null || Objects.equal(tag, that.tag);
 	}
 
 	@Override
 	public int hashCode() {
-		return type;
+		return Objects.hashCode(super.hashCode(), tag);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/nfc/NfcHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/nfc/NfcHandler.java
@@ -35,12 +35,13 @@ import android.util.Log;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.BrickValues;
-import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.EventWrapper;
+import org.catrobat.catroid.content.eventids.EventId;
+import org.catrobat.catroid.content.eventids.NfcEventId;
 import org.catrobat.catroid.formulaeditor.InterpretationException;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.List;
 
 public final class NfcHandler {
 	private static final String TAG = NfcHandler.class.getSimpleName();
@@ -60,11 +61,9 @@ public final class NfcHandler {
 		setLastNfcTagId(uid);
 		setLastNfcTagMessage(getMessageFromIntent(intent));
 
-		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentProject().getSpriteListWithClones();
-
-		for (Sprite sprite : spriteList) {
-			sprite.createWhenNfcScriptAction(uid);
-		}
+		EventId eventId = new NfcEventId(uid);
+		EventWrapper nfcEvent = new EventWrapper(eventId, EventWrapper.NO_WAIT);
+		ProjectManager.getInstance().getCurrentProject().fireToAllSprites(nfcEvent);
 	}
 
 	public static String getTagIdFromIntent(Intent intent) {

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -60,12 +60,13 @@ import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.ScreenModes;
 import org.catrobat.catroid.common.ScreenValues;
+import org.catrobat.catroid.content.EventWrapper;
 import org.catrobat.catroid.content.Look;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
-import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
-import org.catrobat.catroid.content.WhenGamepadButtonScript;
+import org.catrobat.catroid.content.eventids.EventId;
+import org.catrobat.catroid.content.eventids.GamepadEventId;
 import org.catrobat.catroid.facedetection.FaceDetectionHandler;
 import org.catrobat.catroid.formulaeditor.datacontainer.DataContainer;
 import org.catrobat.catroid.io.SoundManager;
@@ -252,7 +253,7 @@ public class StageListener implements ApplicationListener {
 		if (!copy.getLookList().isEmpty()) {
 			copy.look.setLookData(copy.getLookList().get(0));
 		}
-		copy.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+		copy.initializeActions(EventId.START_AS_CLONE);
 	}
 
 	public boolean removeClonedSpriteFromStage(Sprite sprite) {
@@ -478,7 +479,7 @@ public class StageListener implements ApplicationListener {
 			int spriteSize = sprites.size();
 			for (int currentSprite = 0; currentSprite < spriteSize; currentSprite++) {
 				Sprite sprite = sprites.get(currentSprite);
-				sprite.createAndAddActions(Sprite.INCLUDE_START_ACTIONS);
+				sprite.initializeActions(EventId.START);
 				sprite.initConditionScriptTiggers();
 				if (!sprite.getLookList().isEmpty()) {
 					sprite.look.setLookData(sprite.getLookList().get(0));
@@ -738,22 +739,9 @@ public class StageListener implements ApplicationListener {
 	}
 
 	public void gamepadPressed(String buttonType) {
-
-		for (Sprite sprite : sprites) {
-			if (hasSpriteGamepadScript(sprite)) {
-				sprite.createWhengamepadButtonScriptActionSequence(buttonType);
-			}
-		}
-	}
-
-	public static boolean hasSpriteGamepadScript(Sprite sprite) {
-
-		for (Script script : sprite.getScriptList()) {
-			if (script instanceof WhenGamepadButtonScript) {
-				return true;
-			}
-		}
-		return false;
+		EventId eventId = new GamepadEventId(buttonType);
+		EventWrapper gamepadEvent = new EventWrapper(eventId, EventWrapper.NO_WAIT);
+		project.fireToAllSprites(gamepadEvent);
 	}
 
 	public void addActor(Actor actor) {


### PR DESCRIPTION
- Let StartScript, WhenClonedScript, WhenGamepadButtonScript and
WhenNfcScript implement EventScript and create corresponding EventIds
- Fire Start event at the beginning of the stage
- Fire Clone event when cloning of a sprite is done
- Fire Nfc event and GamepadEvent at the appropriate places
- Refactor WhenGamepadButtonBrick and CastManager (minor)
- Remove old methods for action creation from Sprite