### PR TITLE
CAT-2732: Testing: Disable animations via emulator

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,11 +77,11 @@ pipeline {
 				// wait for emulator startup
 				sh "jenkins_android_emulator_helper -W"
 				// Run Unit and device tests for package: org.catrobat.catroid.test
-				sh "jenkins_android_cmd_wrapper ./gradlew test connectedCatroidDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.package=org.catrobat.catroid.test"
+				sh "jenkins_android_cmd_wrapper ./gradlew adbDisableAnimationsGlobally test connectedCatroidDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.package=org.catrobat.catroid.test"
 				// ensure that the following test run does not overwrite the results
 				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results1"
 				// Run Unit and device tests for class: org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite
-				sh "jenkins_android_cmd_wrapper ./gradlew test connectedCatroidDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite"
+				sh "jenkins_android_cmd_wrapper ./gradlew adbDisableAnimationsGlobally test connectedCatroidDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite"
 				// stop emulator
 				sh "jenkins_android_emulator_helper -K"
 			}

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -54,6 +54,7 @@ apply plugin: 'pmd'
 apply from: 'gradle/code_quality_tasks.gradle'
 apply from: 'gradle/intellij_config_tasks.gradle'
 apply from: 'gradle/standalone_apk_tasks.gradle'
+apply from: 'gradle/android_tasks.gradle'
 
 check.dependsOn 'checkstyle'
 check.dependsOn 'pmd'

--- a/catroid/gradle/android_tasks.gradle
+++ b/catroid/gradle/android_tasks.gradle
@@ -1,0 +1,68 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+def getAndroidDevices() {
+    def deviceIds = []
+    [ android.getAdbExecutable().absolutePath, 'devices' ].execute().text.eachLine { line ->
+        def matcher = line =~ /^(.*)\tdevice/
+        if (matcher) {
+            deviceIds << matcher[0][1]
+        }
+    }
+    deviceIds
+}
+
+def getAndroidSerial() {
+    def availableDevices = getAndroidDevices()
+    def androidSerial = System.getenv('ANDROID_SERIAL')
+
+    if (androidSerial?.trim() && !availableDevices.contains(androidSerial)) {
+        throw new IllegalStateException("Device ${androidSerial} not found")
+    } else if (availableDevices.size() == 0) {
+        throw new IllegalStateException("No connected devices!")
+    } else {
+        androidSerial = availableDevices.first()
+    }
+
+    return androidSerial.toString().trim()
+}
+
+task adbDisableAnimationsGlobally {
+    description 'Disables android animations globally on the connected device'
+    group 'android'
+
+    doLast {
+        logger.lifecycle(description)
+
+        def androidSerial = getAndroidSerial()
+        exec {
+            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'put', 'global', 'window_animation_scale', '0.0'
+        }
+        exec {
+            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'put', 'global', 'transition_animation_scale', '0.0'
+        }
+        exec {
+            commandLine android.getAdbExecutable().absolutePath, '-s', androidSerial, 'shell', 'settings', 'put', 'global', 'animator_duration_scale', '0.0'
+        }
+    }
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/pocketmusic/PocketMusicActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/pocketmusic/PocketMusicActivityTest.java
@@ -23,6 +23,7 @@
 package org.catrobat.catroid.uiespresso.pocketmusic;
 
 import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.UiController;
 import android.support.test.espresso.ViewAction;
 import android.support.test.espresso.contrib.RecyclerViewActions;
@@ -37,11 +38,14 @@ import org.catrobat.catroid.pocketmusic.PocketMusicActivity;
 import org.catrobat.catroid.pocketmusic.ui.TactScrollRecyclerView;
 import org.catrobat.catroid.pocketmusic.ui.TrackRowView;
 import org.catrobat.catroid.pocketmusic.ui.TrackView;
+import org.catrobat.catroid.uiespresso.util.SystemAnimations;
 import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -69,6 +73,25 @@ public class PocketMusicActivityTest {
 	@Rule
 	public BaseActivityInstrumentationRule<PocketMusicActivity> pocketMusicActivityRule =
 			new BaseActivityInstrumentationRule<>(PocketMusicActivity.class, true, false);
+
+	// For testing all Animations are disabled, this causes troubles, because the PocketMusic
+	// functionality is highly coupled with the Animation-Framework. To avoid rewrites of
+	// PocketMusic simply activate the animations for that single Test-Class.
+	// See setUp()- and tearDown()-methods.
+	private static SystemAnimations systemAnimations = null;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		systemAnimations = new SystemAnimations(InstrumentationRegistry.getInstrumentation());
+		systemAnimations.storeCurrentSettings();
+		systemAnimations.enableAll();
+	}
+
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		systemAnimations.resetToStoredSettings();
+		systemAnimations = null;
+	}
 
 	public static ViewAction toggleNoteViewAtPositionInTact(final int position) {
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/AboutDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/AboutDialogTest.java
@@ -28,7 +28,6 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.ui.MainMenuActivity;
-import org.catrobat.catroid.uiespresso.annotations.Flaky;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
 import org.catrobat.catroid.uiespresso.util.rules.DontGenerateDefaultProjectActivityInstrumentationRule;
@@ -79,7 +78,6 @@ public class AboutDialogTest {
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
-	@Flaky
 	@Test
 	public void aboutDialogTest() {
 		openActionBarOverflowOrOptionsMenu(baseActivityTestRule.getActivity());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/SystemAnimations.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/SystemAnimations.java
@@ -23,60 +23,114 @@
 
 package org.catrobat.catroid.uiespresso.util;
 
-import android.content.Context;
-import android.content.pm.PackageManager;
-import android.os.IBinder;
-import android.util.Log;
+import android.app.Instrumentation;
+import android.os.ParcelFileDescriptor;
 
-import java.lang.reflect.Method;
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-// Taken from https://gist.github.com/xrigau/11284124
 public class SystemAnimations {
-	private static final String TAG = SystemAnimations.class.getSimpleName();
 
-	private static final String ANIMATION_PERMISSION = "android.permission.SET_ANIMATION_SCALE";
-	private static final float DISABLED = 0.0f;
-	private static final float DEFAULT = 1.0f;
-
-	private final Context context;
-
-	public SystemAnimations(Context context) {
-		this.context = context;
+	private static final List<String> ANIMATION_PROPERTIES;
+	static {
+		ANIMATION_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+				"window_animation_scale", "transition_animation_scale",
+						"animator_duration_scale"));
 	}
 
-	public void disableAll() {
-		int permStatus = context.checkCallingOrSelfPermission(ANIMATION_PERMISSION);
-		if (permStatus == PackageManager.PERMISSION_GRANTED) {
-			setSystemAnimationsScale(DISABLED);
-		}
+	//DISABLED would be 0.0
+	private static final String DEFAULT = "1.0";
+	private static final String UNSET = "null";
+
+	private final Instrumentation instrumentation;
+
+	private Map<String, String> storedAnimationSettings = new HashMap<>();
+
+	public SystemAnimations(final Instrumentation instrumentation) {
+		this.instrumentation = instrumentation;
 	}
 
-	public void enableAll() {
-		int permStatus = context.checkCallingOrSelfPermission(ANIMATION_PERMISSION);
-		if (permStatus == PackageManager.PERMISSION_GRANTED) {
-			setSystemAnimationsScale(DEFAULT);
-		}
+	public void enableAll() throws IOException {
+		setSystemAnimationsScale(DEFAULT);
 	}
 
-	private void setSystemAnimationsScale(float animationScale) {
-		try {
-			Class<?> windowManagerStubClazz = Class.forName("android.view.IWindowManager$Stub");
-			Method asInterface = windowManagerStubClazz.getDeclaredMethod("asInterface", IBinder.class);
-			Class<?> serviceManagerClazz = Class.forName("android.os.ServiceManager");
-			Method getService = serviceManagerClazz.getDeclaredMethod("getService", String.class);
-			Class<?> windowManagerClazz = Class.forName("android.view.IWindowManager");
-			Method setAnimationScales = windowManagerClazz.getDeclaredMethod("setAnimationScales", float[].class);
-			Method getAnimationScales = windowManagerClazz.getDeclaredMethod("getAnimationScales");
-
-			IBinder windowManagerBinder = (IBinder) getService.invoke(null, "window");
-			Object windowManagerObj = asInterface.invoke(null, windowManagerBinder);
-			float[] currentScales = (float[]) getAnimationScales.invoke(windowManagerObj);
-			for (int i = 0; i < currentScales.length; i++) {
-				currentScales[i] = animationScale;
+	public void storeCurrentSettings() throws IOException {
+		storedAnimationSettings.clear();
+		for (String property : ANIMATION_PROPERTIES) {
+			final String val = getGlobalSetting(property);
+			if (isFloat(val) || UNSET.equals(val)) {
+				storedAnimationSettings.put(property, val);
 			}
-			setAnimationScales.invoke(windowManagerObj, new Object[] {currentScales});
-		} catch (Exception e) {
-			Log.e(TAG, "Could not change animation scale to " + animationScale + " :'(");
 		}
+	}
+
+	public void resetToStoredSettings() throws IOException {
+		for (String property : ANIMATION_PROPERTIES) {
+			final String value = storedAnimationSettings.get(property);
+			if (UNSET.equals(value)) {
+				deleteGlobalSetting(property);
+			} else if (value != null) {
+				setGlobalSetting(property, value);
+			}
+		}
+	}
+
+	private void setSystemAnimationsScale(String animationScale) throws IOException {
+		for (String property : ANIMATION_PROPERTIES) {
+			setGlobalSetting(property, animationScale);
+		}
+	}
+
+	private String getGlobalSetting(final String key) throws IOException {
+		return executeShellCommand("settings get global " + key).trim();
+	}
+
+	private void setGlobalSetting(final String key, final String value) throws IOException {
+		executeShellCommand("settings put global " + key + " " + value);
+	}
+
+	private void deleteGlobalSetting(final String key) throws IOException {
+		executeShellCommand("settings delete global " + key);
+	}
+
+	/**
+	 * Executes a shell command via the UIAutomator.
+	 * @param command the command to execute
+	 * @return the STDOUT of the command as String
+	 * @throws IOException if the command can't be executed or the output could not be parsed
+	 */
+	private String executeShellCommand(final String command) throws IOException {
+		StringBuilder cmdOutput = new StringBuilder();
+
+		try (ParcelFileDescriptor pfd = instrumentation.getUiAutomation()
+				.executeShellCommand(command);
+				BufferedReader reader = new BufferedReader(new InputStreamReader(
+						new FileInputStream(pfd.getFileDescriptor())))) {
+
+			final String line = reader.readLine();
+			if (line != null) {
+				cmdOutput.append(line);
+			}
+		}
+
+		return cmdOutput.toString();
+	}
+
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	private boolean isFloat(final String valueToCheck) {
+		boolean isFloat = true;
+		try {
+			Float.parseFloat(valueToCheck);
+		} catch (NumberFormatException nfe) {
+			isFloat = false;
+		}
+		return isFloat;
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/rules/BaseActivityInstrumentationRule.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/rules/BaseActivityInstrumentationRule.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.uiespresso.util.rules;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Environment;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.ActivityTestRule;
 import android.util.Log;
 
@@ -34,7 +33,6 @@ import org.catrobat.catroid.io.StorageOperations;
 import org.catrobat.catroid.stage.StageListener;
 import org.catrobat.catroid.test.utils.Reflection;
 import org.catrobat.catroid.uiespresso.annotations.Flaky;
-import org.catrobat.catroid.uiespresso.util.SystemAnimations;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
@@ -45,7 +43,6 @@ import static org.catrobat.catroid.common.Constants.DEFAULT_ROOT_DIRECTORY;
 
 public class BaseActivityInstrumentationRule<T extends Activity> extends ActivityTestRule<T> {
 
-	private SystemAnimations systemAnimations;
 	private static final String TAG = BaseActivityInstrumentationRule.class.getSimpleName();
 	private Intent launchIntent = null;
 
@@ -72,19 +69,6 @@ public class BaseActivityInstrumentationRule<T extends Activity> extends Activit
 
 	public void launchActivity() {
 		super.launchActivity(launchIntent);
-	}
-
-	@Override
-	protected void afterActivityLaunched() {
-		systemAnimations = new SystemAnimations(InstrumentationRegistry.getTargetContext());
-		systemAnimations.disableAll();
-		super.afterActivityLaunched();
-	}
-
-	@Override
-	protected void afterActivityFinished() {
-		systemAnimations.enableAll();
-		super.afterActivityFinished();
 	}
 
 	void setUpTestProjectFolder() {

--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -75,9 +75,6 @@
         android:required="false" />
     <uses-permission android:name="android.permission.NFC" />
 
-    <!-- For testing purposes, this is automatically removed in live builds, but not in jenkins builds -->
-    <uses-permission android:name="android.permission.SET_ANIMATION_SCALE" />
-
     <!-- Prevent manifest merger from automatically added phone permission -->
     <uses-permission android:name="android.permission.READ_PHONE_STATE"
         tools:node="remove"/>


### PR DESCRIPTION
For UI-Tests the animations shall be disabled, currently this was done programmatically, but the approach was broken.
For now the animations are disabled on emulator startup and are programmatically switched on again for PocketMusicActivityTest, because it highly depends on animations.
In the future (for Oreo and later and when PocketMusicActivityTest does not need animations for the tests) this can be done via testOptions.disableAnimations and all other code can be removed.