### PR TITLE
CAT-2736 Convert test for FlakyTest-annotation to non-flaky itself

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/annotations/FlakyTestTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/annotations/FlakyTestTest.java
@@ -30,13 +30,12 @@ import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.Random;
-
-import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.assertEquals;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
 
@@ -47,6 +46,14 @@ public class FlakyTestTest {
 	public BaseActivityInstrumentationRule<SpriteActivity> baseActivityTestRule = new
 			BaseActivityInstrumentationRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION,
 			SpriteActivity.FRAGMENT_SCRIPTS);
+
+	private static int flakyTestCounter;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		flakyTestCounter = 0;
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		BrickTestUtils.createProjectAndGetStartScript("flakyTestTest");
@@ -57,9 +64,7 @@ public class FlakyTestTest {
 	@Flaky(5)
 	public void flakyTestTest() {
 		onBrickAtPosition(0).checkShowsText(R.string.brick_when_started);
-
-		Random randomGenerator = new Random();
-		int randomNumber = randomGenerator.nextInt(100);
-		assertTrue(randomNumber < 50);
+		flakyTestCounter++;
+		assertEquals(5, flakyTestCounter);
 	}
 }


### PR DESCRIPTION
Convert test for FlakyTest-annotation to non-flaky itself by not relying on a random number.
Instead use a simple static variable and let the test fail for the defined number of times.
With the random number it can still be the case, that the test fails.