### PR TITLE
[JENKINS-194] Add Dockerfile for building to repository

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,16 @@
 
 pipeline {
 	agent {
-		docker {
-			image 'redeamer/jenkins-android-helper:latest'
+		dockerfile {
+			filename 'Dockerfile.jenkins'
+			// 'docker build' would normally copy the whole build-dir to the container, changing the
+			// docker build directory avoids that overhead
+			dir 'docker'
+			// Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
+			// corresponding user can be added. This is needed to provide the jenkins user inside
+			// the container for the ssh-agent to work.
+			// Another way would be to simply map the passwd file, but would spoil additional information
+			additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
 			args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings -v /var/local/container_shared/analytics.settings:/analytics.settings"
 		}
 	}

--- a/docker/Dockerfile.jenkins
+++ b/docker/Dockerfile.jenkins
@@ -1,0 +1,16 @@
+FROM openjdk:8-jdk
+
+LABEL maintainer="contact@catrobat.org"
+
+## Default values for the arguments to be passed from the Jenkinsfile.
+## Those contain the uid and gid of the Jenkins user, and are used to
+## create this user inside of the container, needed for eg ssh-agent to work
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		lsof \
+		python3 \
+	&& rm -rf /var/lib/apt/lists/*
+## add the 'Jenkins' user
+RUN groupadd -g $GROUP_ID user && useradd -M -u $USER_ID -g $GROUP_ID -d / -s /usr/sbin/nologin user


### PR DESCRIPTION
This removes external dependencies and the need of an own docker-hub account.
As all the build-scripts are now reside inside of the repository, the Dockerfile is simply the jdk-8 image with python and lsof installed for the buildScripts and a hook that the Jenkins-User is added to avoid problems with programs which rely on an existing user (eg ssh-agent).