### PR TITLE
CAT-2674 BUG regarding undo/redo buttons and discarding the changes.

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/PenBricksTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/PenBricksTest.java
@@ -56,6 +56,7 @@ import static android.support.test.espresso.action.ViewActions.pressBack;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
 import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
@@ -133,6 +134,10 @@ public class PenBricksTest {
 				.perform(swipeLeftSlow());
 		onView(withId(R.id.color_rgb_seekbar_red))
 				.perform(pressBack());
+		onView(withText(R.string.formula_editor_discard_changes_dialog_title))
+				.check(matches(isDisplayed()));
+		onView(withId(android.R.id.button1))
+				.perform(click());
 		onBrickAtPosition(positionPenColorBrick).onFormulaTextField(R.id.brick_set_pen_color_action_red_edit_text)
 				.checkShowsNumber(rgbValueRed);
 
@@ -142,6 +147,11 @@ public class PenBricksTest {
 				.perform(swipeRightSlow());
 		onView(withId(R.id.color_rgb_seekbar_green))
 				.perform(pressBack());
+		onView(withText(R.string.formula_editor_discard_changes_dialog_title))
+				.check(matches(isDisplayed()));
+		onView(withId(android.R.id.button1))
+				.perform(click());
+
 		onBrickAtPosition(positionPenColorBrick).onFormulaTextField(R.id.brick_set_pen_color_action_green_edit_text)
 				.checkShowsNumber(rgbValueGreen);
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/State.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/State.java
@@ -1,0 +1,53 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.formulaeditor;
+
+import org.catrobat.catroid.content.bricks.Brick;
+
+public class State {
+	public final InternFormulaState internFormulaState;
+	public final Brick.BrickField brickField;
+
+	public State(InternFormulaState internFormulaState, Brick.BrickField brickField) {
+		this.brickField = brickField;
+		this.internFormulaState = internFormulaState;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		State state = (State) o;
+		if (state.internFormulaState == this.internFormulaState && state.brickField == this.brickField) {
+			return true;
+		}
+		else {
+			return false;
+		}
+
+	}
+	//TODO read about hashcode
+	@Override
+	public int hashCode() {
+		return 2*internFormulaState.hashCode()+3*brickField.hashCode();
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -62,6 +62,7 @@ import org.catrobat.catroid.formulaeditor.FormulaEditorEditText;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.InternFormulaKeyboardAdapter;
 import org.catrobat.catroid.formulaeditor.InternFormulaParser;
+import org.catrobat.catroid.formulaeditor.InternFormulaState;
 import org.catrobat.catroid.formulaeditor.SensorHandler;
 import org.catrobat.catroid.formulaeditor.UserData;
 import org.catrobat.catroid.formulaeditor.UserList;
@@ -75,6 +76,8 @@ import org.catrobat.catroid.ui.recyclerview.fragment.CategoryListFragment;
 import org.catrobat.catroid.ui.recyclerview.fragment.DataListFragment;
 import org.catrobat.catroid.utils.SnackbarUtil;
 import org.catrobat.catroid.utils.ToastUtil;
+
+import java.util.Map;
 
 import static org.catrobat.catroid.utils.SnackbarUtil.wasHintAlreadyShown;
 
@@ -104,7 +107,6 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	private FormulaBrick clonedFormulaBrick;
 	private static Brick.BrickField currentBrickField;
 	private static Formula currentFormula;
-	private Menu currentMenu;
 	private FormulaElement formulaElementForComputeDialog;
 
 	private long[] confirmSwitchEditTextTimeStamp = {0, 0};
@@ -237,6 +239,7 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		}
 
 		formulaEditorEditText.overwriteCurrentFormula(newFormula.getInternFormulaState());
+		activity.invalidateOptionsMenu();
 	}
 
 	public static void changeInputField(View view, Brick.BrickField brickField) {
@@ -337,7 +340,7 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		}
 	}
 
-	private View getBrickOrCustomView() {
+	public View getBrickOrCustomView() {
 		if (showCustomView) {
 			return clonedFormulaBrick.getCustomView(context, 0, null);
 		} else {
@@ -511,7 +514,6 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 
 	@Override
 	public void onPrepareOptionsMenu(Menu menu) {
-		currentMenu = menu;
 
 		for (int index = 0; index < menu.size(); index++) {
 			menu.getItem(index).setVisible(false);
@@ -584,17 +586,6 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 						return;
 					}
 				}
-				MenuItem undo = currentMenu.findItem(R.id.menu_undo);
-				if (undo != null) {
-					undo.setIcon(R.drawable.icon_undo_disabled);
-					undo.setEnabled(false);
-				}
-
-				MenuItem redo = currentMenu.findItem(R.id.menu_redo);
-				redo.setIcon(R.drawable.icon_redo_disabled);
-				redo.setEnabled(false);
-
-				formulaEditorEditText.endEdit();
 				currentBrickField = brickField;
 				currentFormula = newFormula;
 				formulaEditorEditText.enterNewFormula(newFormula.getInternFormulaState());
@@ -673,15 +664,11 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	}
 
 	public void promptSave() {
-		if (hasFormulaBeenChanged) {
-			ToastUtil.showSuccess(getActivity(), R.string.formula_editor_changes_saved);
-			hasFormulaBeenChanged = false;
-		}
 		exitFormulaEditorFragment();
 	}
 
 	private void exitFormulaEditorFragment() {
-		if (formulaEditorEditText.hasChanges()) {
+		if (hasFormulaBeenChanged || formulaEditorEditText.getHistory().hasUnsavedChanges()) {
 			AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
 			builder.setTitle(R.string.formula_editor_discard_changes_dialog_title)
 					.setMessage(R.string.formula_editor_discard_changes_dialog_message)
@@ -689,9 +676,10 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 
 						@Override
 						public void onClick(DialogInterface dialog, int which) {
-							ToastUtil.showError(getActivity(), R.string.formula_editor_changes_discarded);
-							currentFormula.setDisplayText(null);
-							onUserDismiss();
+								saveInitialStates();
+								ToastUtil.showError(getActivity(), R.string.formula_editor_changes_discarded);
+								currentFormula.setDisplayText(null);
+								onUserDismiss();
 						}
 					})
 					.setPositiveButton(R.string.yes, new OnClickListener() {
@@ -832,6 +820,10 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		return formulaEditorEditText.getSelectedTextFromInternFormula();
 	}
 
+	public Brick.BrickField getCurrentBrickField() {
+		return currentBrickField;
+	}
+
 	public void overrideSelectedText(String string) {
 		formulaEditorEditText.overrideSelectedText(string);
 	}
@@ -857,4 +849,15 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 			backspaceOnKeyboard.setEnabled(true);
 		}
 	}
+
+	private void saveInitialStates() {
+			Map<Brick.BrickField, InternFormulaState> initialStates = formulaEditorEditText.getHistory()
+					.getInitialValues();
+			for (Map.Entry<Brick.BrickField, InternFormulaState> state: initialStates.entrySet()) {
+				changeInputField(getBrickOrCustomView(), state.getKey());
+				formulaEditorEditText.overwriteCurrentFormula(state.getValue());
+				saveFormulaIfPossible();
+			}
+
+		}
 }


### PR DESCRIPTION

CAT-2674 BUG regarding undo/redo buttons and discarding the changes.
Discarding the changes results in  storing false values.
To solve both bugs  changed structure in FormulaEditorHistory and made getBrickorCustomView public to access it from formulaEditorEditText.
In addition created new Class State for storing the State. A state consists of
InternformulaState and Brickfield.
Bug with discarding the changes-> solved it  with pushing the according values on top of stack and consider it as a save.
Changed in PenBricksTest the testPenColorBrick testcase because it is not
testing the right behaviour.

