### PR TITLE
CAT-FIX retain scroll position of brick list when changing fragments

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ScriptFragment.java
@@ -28,6 +28,7 @@ import android.app.ListFragment;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.support.annotation.IntDef;
 import android.support.v7.app.AlertDialog;
 import android.util.Log;
@@ -97,6 +98,8 @@ public class ScriptFragment extends ListFragment implements OnCategorySelectedLi
 	private Script scriptToEdit;
 
 	private ScriptController scriptController = new ScriptController();
+
+	private Parcelable savedListViewState;
 
 	private ActionMode.Callback callback = new ActionMode.Callback() {
 		@Override
@@ -238,12 +241,18 @@ public class ScriptFragment extends ListFragment implements OnCategorySelectedLi
 		if (adapter != null) {
 			adapter.resetAlphas();
 		}
+
+		if (savedListViewState != null) {
+			listView.onRestoreInstanceState(savedListViewState);
+		}
 	}
 
 	@Override
 	public void onPause() {
 		super.onPause();
 		ProjectManager projectManager = ProjectManager.getInstance();
+
+		savedListViewState = listView.onSaveInstanceState();
 
 		if (projectManager.getCurrentlyEditedScene() != null) {
 			projectManager.saveProject(getActivity().getApplicationContext());


### PR DESCRIPTION
-scroll position of brick list view is retained when
navigating to formula editor and back