### PR TITLE
CAT-2738 Fix PenActor concurrency issues for release

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/PenActor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/PenActor.java
@@ -114,14 +114,17 @@ public class PenActor extends Actor {
 		pen.previousPoint.y = y;
 	}
 
-	public void dispose() {
-		if (buffer != null) {
-			buffer.dispose();
-			buffer = null;
+	@Override
+	public boolean remove() {
+		boolean hadParent = super.remove();
+		if (hadParent) {
+			if (buffer != null) {
+				buffer.dispose();
+			}
+			if (bufferBatch != null) {
+				bufferBatch.dispose();
+			}
 		}
-		if (bufferBatch != null) {
-			bufferBatch.dispose();
-			bufferBatch = null;
-		}
+		return hadParent;
 	}
 }


### PR DESCRIPTION
Synchronize on StageListener instance during rendering/execution and for stopping/reloading a project.

This way the PenActor can only be removed before/after rendering/execution.
The "remove" libgdx lifecycle method removes it from the queue for rendering/execution.