### PR TITLE
[FIX] Invalidated outdated thumbnails for LookData after edits with

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
@@ -200,6 +200,10 @@ public class LookData implements Serializable, Cloneable {
 		return thumbnailBitmap;
 	}
 
+	public void invalidateThumbnailBitmap() {
+		thumbnailBitmap = null;
+	}
+
 	public int[] getMeasure() {
 		BitmapFactory.Options options = new BitmapFactory.Options();
 		options.inJustDecodeBounds = true;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
@@ -229,6 +229,8 @@ public class LookListFragment extends RecyclerViewFragment<LookData> {
 			return;
 		}
 
+		item.invalidateThumbnailBitmap();
+
 		Intent intent = new Intent("android.intent.action.MAIN");
 		intent.setComponent(new ComponentName(POCKET_PAINT_PACKAGE_NAME,
 				Constants.POCKET_PAINT_INTENT_ACTIVITY_NAME));
@@ -260,8 +262,8 @@ public class LookListFragment extends RecyclerViewFragment<LookData> {
 				getActivity().unregisterReceiver(this);
 
 				if (PocketPaintExchangeHandler.isPocketPaintInstalled(getActivity(), paintroidIntent)) {
-					ActivityManager activityManager = (ActivityManager) getActivity().getSystemService(Context
-							.ACTIVITY_SERVICE);
+					ActivityManager activityManager = (ActivityManager) getActivity()
+							.getSystemService(Context.ACTIVITY_SERVICE);
 					activityManager.moveTaskToFront(getActivity().getTaskId(), 0);
 					startActivityForResult(paintroidIntent, requestCode);
 				}


### PR DESCRIPTION
paint.

- whenever the user edited a look via pocket paint the thumbnail was not
refreshed, because the Bitmap was cached in the LookData.
+ now image data is invalidated (set to null) before the intent to
pocket paint is called -> this causes some unnecesary recalculations of
the bitmap (e.g whenever pocket paint is called and exited without
changes) but it still is a minimally invasive fix.