### PR TITLE
[GSoC18] Moved view inflation of Bricks to BrickBaseType.

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
@@ -27,6 +27,7 @@ import android.support.annotation.NonNull;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.content.bricks.BroadcastMessageBrick;
 import org.catrobat.catroid.content.bricks.UserListBrick;
 import org.catrobat.catroid.content.bricks.UserVariableBrick;
 import org.catrobat.catroid.formulaeditor.datacontainer.DataContainer;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/AddItemToUserListBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/AddItemToUserListBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -66,11 +65,13 @@ public class AddItemToUserListBrick extends UserListBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_add_item_to_userlist, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_add_item_to_userlist;
+	}
 
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView textField = (TextView) view.findViewById(R.id.brick_add_item_to_userlist_edit_text);
 
 		getFormulaWithBrickField(BrickField.LIST_ADD_ITEM).setTextFieldId(R.id.brick_add_item_to_userlist_edit_text);
@@ -95,7 +96,7 @@ public class AddItemToUserListBrick extends UserListBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_add_item_to_userlist, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner userListSpinner = (Spinner) prototypeView.findViewById(R.id.add_item_to_userlist_spinner);
 
 		DataAdapter dataAdapter = ProjectManager.getInstance().getCurrentlyEditedScene().getDataContainer()

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendDigitalValueBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendDigitalValueBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -74,7 +73,7 @@ public class ArduinoSendDigitalValueBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_arduino_send_digital, null);
+		prototypeView = super.getPrototypeView(context);
 
 		TextView textSetPinNumber = (TextView) prototypeView.findViewById(R.id
 				.brick_arduino_set_digital_pin_edit_text);
@@ -87,13 +86,13 @@ public class ArduinoSendDigitalValueBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_arduino_send_digital;
+	}
 
-		view = View.inflate(context, R.layout.brick_arduino_send_digital, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editPinNumber = (TextView) view.findViewById(R.id.brick_arduino_set_digital_pin_edit_text);
 		getFormulaWithBrickField(BrickField.ARDUINO_DIGITAL_PIN_NUMBER).setTextFieldId(R.id.brick_arduino_set_digital_pin_edit_text);
 		getFormulaWithBrickField(BrickField.ARDUINO_DIGITAL_PIN_NUMBER).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendPWMValueBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendPWMValueBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -72,7 +71,7 @@ public class ArduinoSendPWMValueBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_arduino_send_analog, null);
+		prototypeView = super.getPrototypeView(context);
 
 		TextView textSetPinNumber = (TextView) prototypeView.findViewById(R.id.brick_arduino_set_analog_pin_edit_text);
 		textSetPinNumber.setText(formatNumberForPrototypeView(BrickValues.ARDUINO_PWM_INITIAL_PIN_NUMBER));
@@ -83,11 +82,13 @@ public class ArduinoSendPWMValueBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_arduino_send_analog, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_arduino_send_analog;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editPinNumber = (TextView) view.findViewById(R.id.brick_arduino_set_analog_pin_edit_text);
 		getFormulaWithBrickField(BrickField.ARDUINO_ANALOG_PIN_NUMBER).setTextFieldId(R.id.brick_arduino_set_analog_pin_edit_text);
 		getFormulaWithBrickField(BrickField.ARDUINO_ANALOG_PIN_NUMBER).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/AskBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/AskBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -76,12 +75,13 @@ public class AskBrick extends UserVariableBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_ask;
+	}
 
-		view = View.inflate(context, R.layout.brick_ask, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView textField = view.findViewById(R.id.brick_ask_question_edit_text);
 
 		getFormulaWithBrickField(BrickField.ASK_QUESTION).setTextFieldId(R.id.brick_ask_question_edit_text);
@@ -107,7 +107,7 @@ public class AskBrick extends UserVariableBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_ask, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner variableSpinner = prototypeView.findViewById(R.id.brick_ask_spinner);
 
 		DataAdapter dataAdapter = ProjectManager.getInstance().getCurrentlyPlayingScene().getDataContainer()

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/AskSpeechBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/AskSpeechBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -77,12 +76,13 @@ public class AskSpeechBrick extends UserVariableBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_ask_speech;
+	}
 
-		view = View.inflate(context, R.layout.brick_ask_speech, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView textField = (TextView) view.findViewById(R.id.brick_ask_speech_question_edit_text);
 
 		getFormulaWithBrickField(BrickField.ASK_SPEECH_QUESTION).setTextFieldId(R.id.brick_ask_speech_question_edit_text);
@@ -108,7 +108,7 @@ public class AskSpeechBrick extends UserVariableBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_ask_speech, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner variableSpinner = (Spinner) prototypeView.findViewById(R.id.brick_ask_speech_spinner);
 
 		DataAdapter dataAdapter = ProjectManager.getInstance().getCurrentlyPlayingScene().getDataContainer()

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/Brick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/Brick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.CheckBox;
 
 import org.catrobat.catroid.content.Sprite;
@@ -112,7 +111,7 @@ public interface Brick extends Serializable, Cloneable {
 
 	List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence);
 
-	View getView(Context context, BaseAdapter adapter);
+	View getView(Context context);
 
 	View getPrototypeView(Context context);
 
@@ -127,8 +126,6 @@ public interface Brick extends Serializable, Cloneable {
 	boolean isCommentedOut();
 
 	void setCommentedOut(boolean commentedOut);
-
-	void setCheckboxView();
 
 	void setAlpha(int alphaFull);
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/BrickBaseType.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/BrickBaseType.java
@@ -23,8 +23,10 @@
 package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
+import android.support.annotation.CallSuper;
+import android.support.annotation.LayoutRes;
+import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.CheckBox;
 
 import org.catrobat.catroid.R;
@@ -65,30 +67,6 @@ public abstract class BrickBaseType implements Brick {
 	}
 
 	@Override
-	public void setCheckboxView() {
-		int checkboxVisibility = View.GONE;
-		boolean enabled = true;
-		boolean isChecked = false;
-		if (checkbox != null) {
-			checkboxVisibility = checkbox.getVisibility();
-			enabled = checkbox.isEnabled();
-			isChecked = checkbox.isChecked();
-		}
-		checkbox = view.findViewById(R.id.brick_checkbox);
-		checkbox.setChecked(isChecked);
-		checkbox.setVisibility(checkboxVisibility);
-		checkbox.setEnabled(enabled);
-
-		final Brick instance = this;
-		checkbox.setOnClickListener(new View.OnClickListener() {
-			@Override
-			public void onClick(View view) {
-				adapter.handleCheck(instance, ((CheckBox) view).isChecked());
-			}
-		});
-	}
-
-	@Override
 	public Brick clone() throws CloneNotSupportedException {
 		return (Brick) super.clone();
 	}
@@ -103,11 +81,43 @@ public abstract class BrickBaseType implements Brick {
 		return NO_RESOURCES;
 	}
 
-	@Override
-	public abstract View getView(Context context, BaseAdapter adapter);
+	public abstract @LayoutRes int getViewResource();
 
+	@CallSuper
 	@Override
-	public abstract View getPrototypeView(Context context);
+	public View getView(Context context) {
+		view = LayoutInflater.from(context).inflate(getViewResource(), null);
+
+		BrickViewProvider.setAlphaOnView(view, alphaValue);
+
+		int checkboxVisibility = View.GONE;
+		boolean enabled = true;
+		boolean isChecked = false;
+		if (checkbox != null) {
+			checkboxVisibility = checkbox.getVisibility();
+			enabled = checkbox.isEnabled();
+			isChecked = checkbox.isChecked();
+		}
+
+		checkbox = view.findViewById(R.id.brick_checkbox);
+		checkbox.setChecked(isChecked);
+		checkbox.setVisibility(checkboxVisibility);
+		checkbox.setEnabled(enabled);
+		checkbox.setOnClickListener(new View.OnClickListener() {
+			@Override
+			public void onClick(View view) {
+				adapter.handleCheck(BrickBaseType.this, ((CheckBox) view).isChecked());
+			}
+		});
+
+		return view;
+	}
+
+	@CallSuper
+	@Override
+	public View getPrototypeView(Context context) {
+		return LayoutInflater.from(context).inflate(getViewResource(), null);
+	}
 
 	@Override
 	public abstract List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/BrickViewProvider.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/BrickViewProvider.java
@@ -22,7 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
 import android.graphics.ColorMatrix;
 import android.graphics.ColorMatrixColorFilter;
 import android.graphics.drawable.Drawable;
@@ -32,24 +31,10 @@ import android.widget.Spinner;
 
 public final class BrickViewProvider {
 
-	private BrickViewProvider() {
-	}
-
 	public static final int ALPHA_FULL = 255;
 	public static final int ALPHA_GREYED = 100;
 
-	public static View createView(Context context, int layout) {
-		View view = View.inflate(context, layout, null);
-		//TODO: - SetCheckboxView()
-		//      - EnableSpinners()
-		//      - SetOnclickListeners()
-		return view;
-	}
-
-	public static View createPrototypeView(Context context, int layout) {
-		View prototypeView = View.inflate(context, layout, null);
-
-		return prototypeView;
+	private BrickViewProvider() {
 	}
 
 	public static void setAlphaForBrick(Brick brick, int alphaValue) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/BroadcastBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/BroadcastBrick.java
@@ -23,7 +23,6 @@
 package org.catrobat.catroid.content.bricks;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.BroadcastMessageBrick;
 import org.catrobat.catroid.content.EventWrapper;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/BroadcastMessageBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/BroadcastMessageBrick.java
@@ -20,24 +20,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.catroid.content;
+package org.catrobat.catroid.content.bricks;
 
 import android.app.Activity;
 import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.bricks.BrickBaseType;
-import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.ui.adapter.BroadcastSpinnerAdapter;
 import org.catrobat.catroid.ui.recyclerview.dialog.NewBroadcastMessageDialog;
 
 public abstract class BroadcastMessageBrick extends BrickBaseType implements NewBroadcastMessageDialog.NewBroadcastMessageInterface {
-	protected transient BroadcastSpinnerAdapter messageAdapter;
-	protected transient int viewId;
+
+	transient BroadcastSpinnerAdapter messageAdapter;
+	transient int viewId;
 	private transient int spinnerId = R.id.brick_broadcast_spinner;
 
 	protected Object readResolve() {
@@ -66,9 +64,9 @@ public abstract class BroadcastMessageBrick extends BrickBaseType implements New
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, viewId, null);
-		Spinner broadcastSpinner = prototypeView.findViewById(spinnerId);
+		View prototypeView = super.getPrototypeView(context);
 
+		Spinner broadcastSpinner = prototypeView.findViewById(spinnerId);
 		BroadcastSpinnerAdapter broadcastSpinnerAdapter = getMessageAdapter(context);
 		if (context.getString(R.string.new_broadcast_message).equals(getBroadcastMessage())) {
 			setBroadcastMessage(broadcastSpinnerAdapter.getItem(1));
@@ -79,18 +77,21 @@ public abstract class BroadcastMessageBrick extends BrickBaseType implements New
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, viewId, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-		final Spinner broadcastSpinner = view.findViewById(spinnerId);
+	public int getViewResource() {
+		return viewId;
+	}
 
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
+		Spinner broadcastSpinner = view.findViewById(spinnerId);
 		broadcastSpinner.setAdapter(getMessageAdapter(context));
+
 		if (getBroadcastMessage().equals(context.getString(R.string.new_broadcast_message))) {
 			setBroadcastMessage(messageAdapter.getItem(1));
 		}
-		setOnItemSelectedListener(broadcastSpinner, context);
 
+		setOnItemSelectedListener(broadcastSpinner, context);
 		setSpinnerSelection(broadcastSpinner);
 		return view;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/BroadcastReceiverBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/BroadcastReceiverBrick.java
@@ -23,7 +23,6 @@
 package org.catrobat.catroid.content.bricks;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.BroadcastMessageBrick;
 import org.catrobat.catroid.content.BroadcastScript;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/CameraBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/CameraBrick.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.R;
@@ -55,11 +54,13 @@ public class CameraBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_video, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_video;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		Spinner videoSpinner = (Spinner) view.findViewById(R.id.brick_video_spinner);
 
 		ArrayAdapter<String> spinnerAdapter = createArrayAdapter(context);
@@ -85,7 +86,7 @@ public class CameraBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_video, null);
+		prototypeView = super.getPrototypeView(context);
 
 		Spinner setVideoSpinner = (Spinner) prototypeView.findViewById(R.id.brick_video_spinner);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeBrightnessByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeBrightnessByNBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,12 +63,13 @@ public class ChangeBrightnessByNBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_change_brightness;
+	}
 
-		view = View.inflate(context, R.layout.brick_change_brightness, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editX = (TextView) view.findViewById(R.id.brick_change_brightness_edit_text);
 		getFormulaWithBrickField(BrickField.BRIGHTNESS_CHANGE).setTextFieldId(R.id.brick_change_brightness_edit_text);
 		getFormulaWithBrickField(BrickField.BRIGHTNESS_CHANGE).refreshTextField(view);
@@ -80,7 +80,7 @@ public class ChangeBrightnessByNBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_change_brightness, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textChangeBrightness = (TextView) prototypeView
 				.findViewById(R.id.brick_change_brightness_edit_text);
 		textChangeBrightness.setText(formatNumberForPrototypeView(BrickValues.CHANGE_BRITHNESS_BY));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeColorByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeColorByNBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,12 +63,13 @@ public class ChangeColorByNBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_change_color_by;
+	}
 
-		view = View.inflate(context, R.layout.brick_change_color_by, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editX = (TextView) view.findViewById(R.id.brick_change_color_by_edit_text);
 		getFormulaWithBrickField(BrickField.COLOR_CHANGE).setTextFieldId(R.id.brick_change_color_by_edit_text);
 		getFormulaWithBrickField(BrickField.COLOR_CHANGE).refreshTextField(view);
@@ -80,7 +80,7 @@ public class ChangeColorByNBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_change_color_by, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textChangeColor = (TextView) prototypeView
 				.findViewById(R.id.brick_change_color_by_edit_text);
 		textChangeColor.setText(formatNumberForPrototypeView(BrickValues.CHANGE_COLOR_BY));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeSizeByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeSizeByNBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,12 +63,13 @@ public class ChangeSizeByNBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_change_size_by_n;
+	}
 
-		view = View.inflate(context, R.layout.brick_change_size_by_n, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView edit = (TextView) view.findViewById(R.id.brick_change_size_by_edit_text);
 		getFormulaWithBrickField(BrickField.SIZE_CHANGE).setTextFieldId(R.id.brick_change_size_by_edit_text);
 		getFormulaWithBrickField(BrickField.SIZE_CHANGE).refreshTextField(view);
@@ -80,7 +80,7 @@ public class ChangeSizeByNBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_change_size_by_n, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textChangeSizeBy = (TextView) prototypeView
 				.findViewById(R.id.brick_change_size_by_edit_text);
 		textChangeSizeBy.setText(formatNumberForPrototypeView(BrickValues.CHANGE_SIZE_BY));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeTransparencyByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeTransparencyByNBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -65,12 +64,13 @@ public class ChangeTransparencyByNBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_change_transparency;
+	}
 
-		view = View.inflate(context, R.layout.brick_change_transparency, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editX = (TextView) view.findViewById(R.id.brick_change_transparency_edit_text);
 		getFormulaWithBrickField(BrickField.TRANSPARENCY_CHANGE)
 				.setTextFieldId(R.id.brick_change_transparency_edit_text);
@@ -82,7 +82,7 @@ public class ChangeTransparencyByNBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_change_transparency, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textChangeGhostEffect = (TextView) prototypeView
 				.findViewById(R.id.brick_change_transparency_edit_text);
 		textChangeGhostEffect.setText(formatNumberForPrototypeView(BrickValues.CHANGE_TRANSPARENCY_EFFECT));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeVariableBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeVariableBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -73,11 +72,13 @@ public class ChangeVariableBrick extends UserVariableBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_change_variable_by;
+	}
 
-		view = View.inflate(context, R.layout.brick_change_variable_by, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView textField = (TextView) view.findViewById(R.id.brick_change_variable_edit_text);
 		getFormulaWithBrickField(BrickField.VARIABLE_CHANGE).setTextFieldId(R.id.brick_change_variable_edit_text);
 		getFormulaWithBrickField(BrickField.VARIABLE_CHANGE).refreshTextField(view);
@@ -102,7 +103,7 @@ public class ChangeVariableBrick extends UserVariableBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_change_variable_by, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner variableSpinner = (Spinner) prototypeView.findViewById(R.id.change_variable_spinner);
 
 		DataAdapter dataAdapter = ProjectManager.getInstance().getCurrentlyEditedScene()

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeVolumeByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeVolumeByNBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -65,12 +64,13 @@ public class ChangeVolumeByNBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_change_volume_by;
+	}
 
-		view = View.inflate(context, R.layout.brick_change_volume_by, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView edit = (TextView) view.findViewById(R.id.brick_change_volume_by_edit_text);
 		getFormulaWithBrickField(BrickField.VOLUME_CHANGE).setTextFieldId(R.id.brick_change_volume_by_edit_text);
 		getFormulaWithBrickField(BrickField.VOLUME_CHANGE).refreshTextField(view);
@@ -81,7 +81,7 @@ public class ChangeVolumeByNBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_change_volume_by, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSetVolumenTo = (TextView) prototypeView
 				.findViewById(R.id.brick_change_volume_by_edit_text);
 		textSetVolumenTo.setText(formatNumberForPrototypeView(BrickValues.CHANGE_VOLUME_BY));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeXByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeXByNBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,12 +63,13 @@ public class ChangeXByNBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_change_x;
+	}
 
-		view = View.inflate(context, R.layout.brick_change_x, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editX = (TextView) view.findViewById(R.id.brick_change_x_edit_text);
 		getFormulaWithBrickField(BrickField.X_POSITION_CHANGE).setTextFieldId(R.id.brick_change_x_edit_text);
 		getFormulaWithBrickField(BrickField.X_POSITION_CHANGE).refreshTextField(view);
@@ -80,7 +80,7 @@ public class ChangeXByNBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_change_x, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textXMovement = (TextView) prototypeView.findViewById(R.id.brick_change_x_edit_text);
 		textXMovement.setText(formatNumberForPrototypeView(BrickValues.CHANGE_X_BY));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeYByNBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChangeYByNBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,12 +63,13 @@ public class ChangeYByNBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_change_y, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_change_y;
+	}
 
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editY = (TextView) view.findViewById(R.id.brick_change_y_edit_text);
 		getFormulaWithBrickField(BrickField.Y_POSITION_CHANGE).setTextFieldId(R.id.brick_change_y_edit_text);
 		getFormulaWithBrickField(BrickField.Y_POSITION_CHANGE).refreshTextField(view);
@@ -80,7 +80,7 @@ public class ChangeYByNBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_change_y, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textYMovement = (TextView) prototypeView.findViewById(R.id.brick_change_y_edit_text);
 		textYMovement.setText(formatNumberForPrototypeView(BrickValues.CHANGE_Y_BY));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChooseCameraBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ChooseCameraBrick.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.R;
@@ -53,11 +52,13 @@ public class ChooseCameraBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_choose_camera, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_choose_camera;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		Spinner videoSpinner = (Spinner) view.findViewById(R.id.brick_choose_camera_spinner);
 
 		ArrayAdapter<String> spinnerAdapter = createArrayAdapter(context);
@@ -83,7 +84,7 @@ public class ChooseCameraBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_choose_camera, null);
+		prototypeView = super.getPrototypeView(context);
 
 		Spinner setVideoSpinner = (Spinner) prototypeView.findViewById(R.id.brick_choose_camera_spinner);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ClearBackgroundBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ClearBackgroundBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -41,7 +40,7 @@ public class ClearBackgroundBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = View.inflate(context, R.layout.brick_clear_background, null);
+		View view = super.getPrototypeView(context);
 
 		return view;
 	}
@@ -52,11 +51,13 @@ public class ClearBackgroundBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_clear_background, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_clear_background;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ClearGraphicEffectBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ClearGraphicEffectBrick.java
@@ -22,10 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
-import android.view.View;
-import android.widget.BaseAdapter;
-
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
@@ -39,17 +35,8 @@ public class ClearGraphicEffectBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_clear_graphic_effect, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-		return view;
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_clear_graphic_effect, null);
+	public int getViewResource() {
+		return R.layout.brick_clear_graphic_effect;
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/CloneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/CloneBrick.java
@@ -26,7 +26,6 @@ import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.ProjectManager;
@@ -51,19 +50,20 @@ public class CloneBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_clone;
+	}
 
-		view = View.inflate(context, R.layout.brick_clone, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		setupValueSpinner(context);
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = View.inflate(context, R.layout.brick_clone, null);
+		View view = super.getPrototypeView(context);
 		Spinner cloneSpinner = (Spinner) view.findViewById(R.id.brick_clone_spinner);
 
 		cloneSpinner.setAdapter(getSpinnerArrayAdapter(context));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ComeToFrontBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ComeToFrontBrick.java
@@ -22,10 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
-import android.view.View;
-import android.widget.BaseAdapter;
-
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
@@ -39,23 +35,13 @@ public class ComeToFrontBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-
-		view = View.inflate(context, R.layout.brick_go_to_front, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_go_to_front;
 	}
 
 	@Override
 	public Brick clone() {
 		return new ComeToFrontBrick();
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_go_to_front, null);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DeleteItemOfUserListBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DeleteItemOfUserListBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -71,11 +70,13 @@ public class DeleteItemOfUserListBrick extends UserListBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_delete_item_of_userlist;
+	}
 
-		view = View.inflate(context, R.layout.brick_delete_item_of_userlist, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView textField = (TextView) view.findViewById(R.id.brick_delete_item_of_userlist_edit_text);
 		getFormulaWithBrickField(BrickField.LIST_DELETE_ITEM).setTextFieldId(R.id.brick_delete_item_of_userlist_edit_text);
 		getFormulaWithBrickField(BrickField.LIST_DELETE_ITEM).refreshTextField(view);
@@ -99,7 +100,7 @@ public class DeleteItemOfUserListBrick extends UserListBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_delete_item_of_userlist, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner userListSpinner = (Spinner) prototypeView.findViewById(R.id.delete_item_of_userlist_spinner);
 
 		DataAdapter dataAdapter = ProjectManager.getInstance().getCurrentlyEditedScene().getDataContainer()

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DeleteThisCloneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DeleteThisCloneBrick.java
@@ -22,10 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
-import android.view.View;
-import android.widget.BaseAdapter;
-
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
@@ -40,22 +36,13 @@ public class DeleteThisCloneBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_delete_this_clone, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_delete_this_clone;
 	}
 
 	@Override
 	public Brick clone() {
 		return new DeleteThisCloneBrick();
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_delete_this_clone, null);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneBasicControlBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneBasicControlBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -32,11 +31,13 @@ import org.catrobat.catroid.R;
 public abstract class DroneBasicControlBrick extends BrickBaseType {
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_drone_control, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_drone_control;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView label = (TextView) view.findViewById(R.id.ValueTextViewControl);
 		label.setText(getBrickLabel(view));
 
@@ -45,7 +46,7 @@ public abstract class DroneBasicControlBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_control, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		TextView label = (TextView) prototypeView.findViewById(R.id.ValueTextViewControl);
 		label.setText(getBrickLabel(prototypeView));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneEmergencyBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneEmergencyBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -36,19 +35,19 @@ public class DroneEmergencyBrick extends BrickBaseType {
 	private static final long serialVersionUID = 1L;
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_emergency;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_emergency, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_emergency, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		return prototypeView;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneFlipBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneFlipBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -36,19 +35,19 @@ public class DroneFlipBrick extends BrickBaseType{
 	private static final long serialVersionUID = 1L;
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_flip;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_flip, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_flip, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		return prototypeView;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveBackwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveBackwardBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -72,13 +71,13 @@ public class DroneMoveBackwardBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter adapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_move_backward;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_move_backward, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_drone_move_backward_text_second, R.id
 				.brick_drone_move_backward_edit_text_second, BrickField
 				.DRONE_TIME_TO_FLY_IN_SECONDS);
@@ -100,7 +99,7 @@ public class DroneMoveBackwardBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_move_backward, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_drone_move_backward_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveDownBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveDownBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -71,13 +70,13 @@ public class DroneMoveDownBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter adapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_move_down;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_move_down, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_drone_move_down_text_second, R.id
 				.brick_drone_move_down_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
 
@@ -98,7 +97,7 @@ public class DroneMoveDownBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_move_down, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_drone_move_down_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveForwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveForwardBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -71,12 +70,13 @@ public class DroneMoveForwardBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter adapter) {
-		view = View.inflate(context, R.layout.brick_drone_move_forward, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_drone_move_forward;
+	}
 
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_drone_move_forward_text_second, R.id
 				.brick_drone_move_forward_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
 
@@ -97,7 +97,7 @@ public class DroneMoveForwardBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_move_forward, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_drone_move_forward_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveLeftBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveLeftBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -71,13 +70,13 @@ public class DroneMoveLeftBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter adapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_move_left;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_move_left, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_drone_move_left_text_second, R.id.brick_drone_move_left_edit_text_second, BrickField
 				.DRONE_TIME_TO_FLY_IN_SECONDS);
 
@@ -98,7 +97,7 @@ public class DroneMoveLeftBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_move_left, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_drone_move_left_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveRightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveRightBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -71,13 +70,13 @@ public class DroneMoveRightBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter adapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_move_right;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_move_right, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_drone_move_right_text_second, R.id
 				.brick_drone_move_right_edit_text_second, BrickField
 				.DRONE_TIME_TO_FLY_IN_SECONDS);
@@ -99,7 +98,7 @@ public class DroneMoveRightBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_move_right, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_drone_move_right_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveUpBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveUpBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -71,13 +70,13 @@ public class DroneMoveUpBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter adapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_move_up;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_move_up, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_drone_move_up_text_second, R.id.brick_drone_move_up_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
 
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_move_up_edit_text_second);
@@ -97,7 +96,7 @@ public class DroneMoveUpBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_move_up, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_drone_move_up_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DronePlayLedAnimationBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DronePlayLedAnimationBrick.java
@@ -26,7 +26,6 @@ import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import com.parrot.freeflight.drone.DroneProxy.ARDRONE_LED_ANIMATION;
@@ -58,7 +57,7 @@ public class DronePlayLedAnimationBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_drone_play_led_animation, null);
+		prototypeView = super.getPrototypeView(context);
 
 		Spinner dronePlayLedAnimationSpinner = (Spinner) prototypeView.findViewById(R.id
 				.brick_drone_play_led_animation_spinner);
@@ -77,12 +76,13 @@ public class DronePlayLedAnimationBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_play_led_animation;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_play_led_animation, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		ArrayAdapter<CharSequence> animationAdapter = ArrayAdapter.createFromResource(context,
 				R.array.brick_drone_play_led_animation_spinner, android.R.layout.simple_spinner_item);
 		animationAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneSpinnerBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneSpinnerBrick.java
@@ -27,7 +27,6 @@ import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -43,10 +42,13 @@ public abstract class DroneSpinnerBrick extends BrickBaseType {
 	protected int spinnerPosition = 0;
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_drone_spinner, null);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_drone_spinner;
+	}
 
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		Spinner spinner = (Spinner) view.findViewById(R.id.brick_drone_spinner_ID);
 		spinner.setFocusableInTouchMode(false);
 		spinner.setFocusable(false);
@@ -82,7 +84,7 @@ public abstract class DroneSpinnerBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_spinner, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		Spinner spinner = (Spinner) prototypeView.findViewById(R.id.brick_drone_spinner_ID);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneSwitchCameraBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneSwitchCameraBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -36,19 +35,19 @@ public class DroneSwitchCameraBrick extends BrickBaseType {
 	private static final long serialVersionUID = 1L;
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_switch_camera;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_switch_camera, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_switch_camera, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		return prototypeView;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTakeOffLandBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTakeOffLandBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -36,19 +35,19 @@ public class DroneTakeOffLandBrick extends BrickBaseType{
 	private static final long serialVersionUID = 1L;
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_takeoff_land;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_takeoff_land, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_takeoff_land, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		return prototypeView;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -71,13 +70,13 @@ public class DroneTurnLeftBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter adapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_turn_left;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_turn_left, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_drone_turn_left_text_second, R.id.brick_drone_turn_left_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
 
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_turn_left_edit_text_second);
@@ -97,7 +96,7 @@ public class DroneTurnLeftBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_turn_left, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_drone_turn_left_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftMagnetoBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftMagnetoBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -71,12 +70,13 @@ public class DroneTurnLeftMagnetoBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter adapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_turn_left_magneto;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_turn_left_magneto, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_drone_turn_left_magneto_text_second, R.id.brick_drone_turn_left_magneto_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
 
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_turn_left_magneto_edit_text_second);
@@ -96,7 +96,7 @@ public class DroneTurnLeftMagnetoBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_turn_left_magneto, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_drone_turn_left_magneto_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -71,13 +70,13 @@ public class DroneTurnRightBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter adapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_turn_right;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_turn_right, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_drone_turn_right_text_second, R.id.brick_drone_turn_right_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
 
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_turn_right_edit_text_second);
@@ -97,7 +96,7 @@ public class DroneTurnRightBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_turn_right, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_drone_turn_right_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightMagnetoBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightMagnetoBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -71,13 +70,13 @@ public class DroneTurnRightMagnetoBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter adapter) {
+	public int getViewResource() {
+		return R.layout.brick_drone_turn_right_magneto;
+	}
 
-		view = View.inflate(context, R.layout.brick_drone_turn_right_magneto, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_drone_turn_right_magneto_text_second, R.id.brick_drone_turn_right_magneto_edit_text_second, BrickField.DRONE_TIME_TO_FLY_IN_SECONDS);
 
 		TextView editTime = (TextView) view.findViewById(R.id.brick_drone_turn_right_magneto_edit_text_second);
@@ -97,7 +96,7 @@ public class DroneTurnRightMagnetoBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_drone_turn_right_magneto, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_drone_turn_right_magneto_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/FlashBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/FlashBrick.java
@@ -26,7 +26,6 @@ import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.R;
@@ -53,11 +52,13 @@ public class FlashBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_flash, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_flash;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		Spinner flashSpinner = (Spinner) view.findViewById(R.id.brick_flash_spinner);
 
 		ArrayAdapter<String> spinnerAdapter = createArrayAdapter(context);
@@ -83,7 +84,7 @@ public class FlashBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_flash, null);
+		prototypeView = super.getPrototypeView(context);
 
 		Spinner setFlashSpinner = (Spinner) prototypeView.findViewById(R.id.brick_flash_spinner);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ForeverBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ForeverBrick.java
@@ -22,10 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
-import android.view.View;
-import android.widget.BaseAdapter;
-
 import com.badlogic.gdx.scenes.scene2d.Action;
 
 import org.catrobat.catroid.R;
@@ -54,17 +50,8 @@ public class ForeverBrick extends BrickBaseType implements LoopBeginBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_forever, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-		return view;
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_forever, null);
+	public int getViewResource() {
+		return R.layout.brick_forever;
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/GlideToBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/GlideToBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.util.Log;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.ProjectManager;
@@ -84,12 +83,14 @@ public class GlideToBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_glide_to, null);
+	public int getViewResource() {
+		return R.layout.brick_glide_to;
+	}
+
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
 		TextView editX = (TextView) view.findViewById(R.id.brick_glide_to_edit_text_x);
 		getFormulaWithBrickField(BrickField.X_DESTINATION).setTextFieldId(R.id.brick_glide_to_edit_text_x);
 		getFormulaWithBrickField(BrickField.X_DESTINATION).refreshTextField(view);
@@ -129,7 +130,7 @@ public class GlideToBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_glide_to, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textX = (TextView) prototypeView.findViewById(R.id.brick_glide_to_edit_text_x);
 		TextView textY = (TextView) prototypeView.findViewById(R.id.brick_glide_to_edit_text_y);
 		TextView textDuration = (TextView) prototypeView.findViewById(R.id.brick_glide_to_edit_text_duration);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/GoNStepsBackBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/GoNStepsBackBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.util.Log;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.ProjectManager;
@@ -68,12 +67,13 @@ public class GoNStepsBackBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_go_back, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_go_back;
+	}
 
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView edit = (TextView) view.findViewById(R.id.brick_go_back_edit_text);
 
 		getFormulaWithBrickField(BrickField.STEPS).setTextFieldId(R.id.brick_go_back_edit_text);
@@ -105,7 +105,7 @@ public class GoNStepsBackBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_go_back, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSteps = (TextView) prototypeView.findViewById(R.id.brick_go_back_edit_text);
 		TextView times = (TextView) prototypeView.findViewById(R.id.brick_go_back_layers_text_view);
 		textSteps.setText(formatNumberForPrototypeView(BrickValues.GO_BACK));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/GoToBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/GoToBrick.java
@@ -30,7 +30,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
 
@@ -66,13 +65,13 @@ public class GoToBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_go_to;
+	}
 
-		view = View.inflate(context, R.layout.brick_go_to, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		final Spinner goToSpinner = (Spinner) view.findViewById(R.id.brick_go_to_spinner);
 
 		final ArrayAdapter<String> spinnerAdapter = createArrayAdapter(context);
@@ -117,7 +116,7 @@ public class GoToBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_go_to, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		Spinner goToSpinner = (Spinner) prototypeView.findViewById(R.id.brick_go_to_spinner);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/HideBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/HideBrick.java
@@ -22,10 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
-import android.view.View;
-import android.widget.BaseAdapter;
-
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
@@ -40,22 +36,13 @@ public class HideBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_hide, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_hide;
 	}
 
 	@Override
 	public Brick clone() {
 		return new HideBrick();
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_hide, null);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/HideTextBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/HideTextBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.ProjectManager;
@@ -57,11 +56,13 @@ public class HideTextBrick extends UserVariableBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_hide_variable, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_hide_variable;
+	}
 
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		Spinner variableSpinner = (Spinner) view.findViewById(R.id.hide_variable_spinner);
 
 		DataAdapter dataAdapter = ProjectManager.getInstance().getCurrentlyEditedScene().getDataContainer()
@@ -81,7 +82,7 @@ public class HideTextBrick extends UserVariableBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_hide_variable, null);
+		prototypeView = super.getPrototypeView(context);
 
 		Spinner variableSpinner = (Spinner) prototypeView.findViewById(R.id.hide_variable_spinner);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfLogicBeginBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfLogicBeginBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.util.Log;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
@@ -45,8 +44,8 @@ public class IfLogicBeginBrick extends FormulaBrick implements NestingBrick {
 
 	private static final long serialVersionUID = 1L;
 	private static final String TAG = IfLogicBeginBrick.class.getSimpleName();
-	protected transient IfLogicElseBrick ifElseBrick;
-	protected transient IfLogicEndBrick ifEndBrick;
+	transient IfLogicElseBrick ifElseBrick;
+	transient IfLogicEndBrick ifEndBrick;
 
 	public IfLogicBeginBrick() {
 		addAllowedBrickField(BrickField.IF_CONDITION);
@@ -74,12 +73,12 @@ public class IfLogicBeginBrick extends FormulaBrick implements NestingBrick {
 		return ifElseBrick;
 	}
 
-	public IfLogicEndBrick getIfEndBrick() {
-		return ifEndBrick;
-	}
-
 	public void setIfElseBrick(IfLogicElseBrick elseBrick) {
 		this.ifElseBrick = elseBrick;
+	}
+
+	public IfLogicEndBrick getIfEndBrick() {
+		return ifEndBrick;
 	}
 
 	public void setIfEndBrick(IfLogicEndBrick ifEndBrick) {
@@ -97,29 +96,29 @@ public class IfLogicBeginBrick extends FormulaBrick implements NestingBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_if_begin_if;
+	}
 
-		view = View.inflate(context, R.layout.brick_if_begin_if, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
-		TextView ifBeginTextView = (TextView) view.findViewById(R.id.brick_if_begin_edit_text);
-
-		getFormulaWithBrickField(BrickField.IF_CONDITION).setTextFieldId(R.id.brick_if_begin_edit_text);
-		getFormulaWithBrickField(BrickField.IF_CONDITION).refreshTextField(view);
-
-		ifBeginTextView.setOnClickListener(this);
-
-		removePrototypeElseTextViews(view);
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
+		onViewCreated(view);
 		return view;
 	}
 
+	protected void onViewCreated(View view) {
+		TextView ifBeginTextView = view.findViewById(R.id.brick_if_begin_edit_text);
+		getFormulaWithBrickField(BrickField.IF_CONDITION).setTextFieldId(R.id.brick_if_begin_edit_text);
+		getFormulaWithBrickField(BrickField.IF_CONDITION).refreshTextField(view);
+		ifBeginTextView.setOnClickListener(this);
+		removePrototypeElseTextViews(view);
+	}
+
 	protected void removePrototypeElseTextViews(View view) {
-		TextView prototypeTextPunctuation = (TextView) view.findViewById(R.id.if_else_prototype_punctuation);
-		TextView prototypeTextElse = (TextView) view.findViewById(R.id.if_prototype_else);
-		TextView prototypeTextPunctuation2 = (TextView) view.findViewById(R.id.if_else_prototype_punctuation2);
+		TextView prototypeTextPunctuation = view.findViewById(R.id.if_else_prototype_punctuation);
+		TextView prototypeTextElse = view.findViewById(R.id.if_prototype_else);
+		TextView prototypeTextPunctuation2 = view.findViewById(R.id.if_else_prototype_punctuation2);
 		prototypeTextPunctuation.setVisibility(View.GONE);
 		prototypeTextElse.setVisibility(View.GONE);
 		prototypeTextPunctuation2.setVisibility(View.GONE);
@@ -127,10 +126,14 @@ public class IfLogicBeginBrick extends FormulaBrick implements NestingBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_if_begin_if, null);
-		TextView textIfBegin = (TextView) prototypeView.findViewById(R.id.brick_if_begin_edit_text);
-		textIfBegin.setText(BrickValues.IF_CONDITION);
+		View prototypeView = super.getPrototypeView(context);
+		onPrototypeViewCreated(prototypeView);
 		return prototypeView;
+	}
+
+	protected void onPrototypeViewCreated(View prototypeView) {
+		TextView textIfBegin = prototypeView.findViewById(R.id.brick_if_begin_edit_text);
+		textIfBegin.setText(BrickValues.IF_CONDITION);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfLogicElseBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfLogicElseBrick.java
@@ -22,10 +22,7 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
 import android.util.Log;
-import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -47,13 +44,8 @@ public class IfLogicElseBrick extends BrickBaseType implements NestingBrick, All
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_if_else, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_if_else;
 	}
 
 	@Override
@@ -61,25 +53,20 @@ public class IfLogicElseBrick extends BrickBaseType implements NestingBrick, All
 		return new IfLogicElseBrick(ifBeginBrick);
 	}
 
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_if_else, null);
-	}
-
-	public void setIfEndBrick(IfLogicEndBrick ifEndBrick) {
-		this.ifEndBrick = ifEndBrick;
+	public IfLogicBeginBrick getIfBeginBrick() {
+		return ifBeginBrick;
 	}
 
 	public void setIfBeginBrick(IfLogicBeginBrick ifBeginBrick) {
 		this.ifBeginBrick = ifBeginBrick;
 	}
 
-	public IfLogicBeginBrick getIfBeginBrick() {
-		return ifBeginBrick;
-	}
-
 	public IfLogicEndBrick getIfEndBrick() {
 		return ifEndBrick;
+	}
+
+	public void setIfEndBrick(IfLogicEndBrick ifEndBrick) {
+		this.ifEndBrick = ifEndBrick;
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfLogicEndBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfLogicEndBrick.java
@@ -22,10 +22,7 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
 import android.util.Log;
-import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -52,12 +49,12 @@ public class IfLogicEndBrick extends BrickBaseType implements NestingBrick, Allo
 		return ifElseBrick;
 	}
 
-	public IfLogicBeginBrick getIfBeginBrick() {
-		return ifBeginBrick;
-	}
-
 	public void setIfElseBrick(IfLogicElseBrick ifElseBrick) {
 		this.ifElseBrick = ifElseBrick;
+	}
+
+	public IfLogicBeginBrick getIfBeginBrick() {
+		return ifBeginBrick;
 	}
 
 	public void setIfBeginBrick(IfLogicBeginBrick ifBeginBrick) {
@@ -65,23 +62,13 @@ public class IfLogicEndBrick extends BrickBaseType implements NestingBrick, Allo
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-
-		view = View.inflate(context, R.layout.brick_if_end_if, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_if_end_if;
 	}
 
 	@Override
 	public Brick clone() {
 		return new IfLogicEndBrick(ifElseBrick, ifBeginBrick);
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_if_end_if, null);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfOnEdgeBounceBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfOnEdgeBounceBrick.java
@@ -22,10 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
-import android.view.View;
-import android.widget.BaseAdapter;
-
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
@@ -40,22 +36,13 @@ public class IfOnEdgeBounceBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_if_on_edge_bounce, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_if_on_edge_bounce;
 	}
 
 	@Override
 	public Brick clone() {
 		return new IfOnEdgeBounceBrick();
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_if_on_edge_bounce, null);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfThenLogicEndBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfThenLogicEndBrick.java
@@ -22,10 +22,7 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
 import android.util.Log;
-import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -51,22 +48,13 @@ public class IfThenLogicEndBrick extends BrickBaseType implements NestingBrick, 
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_if_end_if, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_if_end_if;
 	}
 
 	@Override
 	public Brick clone() {
 		return new IfThenLogicEndBrick(ifBeginBrick);
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_if_end_if, null);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/InsertItemIntoUserListBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/InsertItemIntoUserListBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -71,11 +70,13 @@ public class InsertItemIntoUserListBrick extends UserListBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_insert_item_into_userlist, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_insert_item_into_userlist;
+	}
 
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView textFieldValue = (TextView) view.findViewById(R.id.brick_insert_item_into_userlist_value_edit_text);
 
 		getFormulaWithBrickField(BrickField.INSERT_ITEM_INTO_USERLIST_VALUE).setTextFieldId(R.id.brick_insert_item_into_userlist_value_edit_text);
@@ -105,7 +106,7 @@ public class InsertItemIntoUserListBrick extends UserListBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_insert_item_into_userlist, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner userListSpinner = (Spinner) prototypeView.findViewById(R.id.insert_item_into_userlist_spinner);
 
 		DataAdapter dataAdapter = ProjectManager.getInstance().getCurrentlyEditedScene().getDataContainer()

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoAnimationsBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoAnimationsBrick.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.R;
@@ -67,7 +66,7 @@ public class JumpingSumoAnimationsBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_jumping_sumo_animations, null);
+		prototypeView = super.getPrototypeView(context);
 
 		Spinner jsAnimationSpinner = (Spinner) prototypeView.findViewById(R.id.brick_jumping_sumo_animation_spinner);
 		jsAnimationSpinner.setFocusableInTouchMode(false);
@@ -85,12 +84,13 @@ public class JumpingSumoAnimationsBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_jumping_sumo_animations;
+	}
 
-		view = View.inflate(context, R.layout.brick_jumping_sumo_animations, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		ArrayAdapter<CharSequence> animationAdapter = ArrayAdapter.createFromResource(context, R.array.brick_jumping_sumo_select_animation_spinner,
 				android.R.layout.simple_spinner_item);
 		animationAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoJumpHighBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoJumpHighBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -36,19 +35,19 @@ public class JumpingSumoJumpHighBrick extends BrickBaseType {
 	private static final long serialVersionUID = 1L;
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_jumping_sumo_jump_high;
+	}
 
-		view = View.inflate(context, R.layout.brick_jumping_sumo_jump_high, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_jumping_sumo_jump_high, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		return prototypeView;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoJumpLongBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoJumpLongBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -36,19 +35,19 @@ public class JumpingSumoJumpLongBrick extends BrickBaseType {
 	private static final long serialVersionUID = 1L;
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_jumping_sumo_jump_long;
+	}
 
-		view = View.inflate(context, R.layout.brick_jumping_sumo_jump_long, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_jumping_sumo_jump_long, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		return prototypeView;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveBackwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveBackwardBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -71,13 +70,13 @@ public class JumpingSumoMoveBackwardBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_jumping_sumo_move_backward;
+	}
 
-		view = View.inflate(context, R.layout.brick_jumping_sumo_move_backward, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_jumping_sumo_move_backward_text_second, R.id.brick_jumping_sumo_move_backward_edit_text_second, BrickField.JUMPING_SUMO_TIME_TO_DRIVE_IN_SECONDS);
 
 		TextView editTime = (TextView) view.findViewById(R.id.brick_jumping_sumo_move_backward_edit_text_second);
@@ -97,7 +96,7 @@ public class JumpingSumoMoveBackwardBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_jumping_sumo_move_backward, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_jumping_sumo_move_backward_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveForwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveForwardBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.util.Log;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -74,13 +73,13 @@ public class JumpingSumoMoveForwardBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_jumping_sumo_move_forward;
+	}
 
-		view = View.inflate(context, R.layout.brick_jumping_sumo_move_forward, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_jumping_sumo_move_forward_text_second, R.id
 				.brick_jumping_sumo_move_forward_edit_text_second, BrickField.JUMPING_SUMO_TIME_TO_DRIVE_IN_SECONDS);
 
@@ -101,7 +100,7 @@ public class JumpingSumoMoveForwardBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_jumping_sumo_move_forward, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textTime = (TextView) prototypeView.findViewById(R.id
 				.brick_jumping_sumo_move_forward_edit_text_second);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoNoSoundBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoNoSoundBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -36,19 +35,19 @@ public class JumpingSumoNoSoundBrick extends BrickBaseType {
 	private static final long serialVersionUID = 1L;
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_jumping_sumo_nosound;
+	}
 
-		view = View.inflate(context, R.layout.brick_jumping_sumo_nosound, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_jumping_sumo_nosound, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		return prototypeView;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoRotateLeftBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoRotateLeftBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -61,13 +60,13 @@ public class JumpingSumoRotateLeftBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_jumping_sumo_rotate_left;
+	}
 
-		view = View.inflate(context, R.layout.brick_jumping_sumo_rotate_left, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editDegree = (TextView) view.findViewById(R.id.brick_jumping_sumo_change_left_variable_edit_text);
 		getFormulaWithBrickField(BrickField.JUMPING_SUMO_ROTATE)
 				.setTextFieldId(R.id.brick_jumping_sumo_change_left_variable_edit_text);
@@ -79,7 +78,7 @@ public class JumpingSumoRotateLeftBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_jumping_sumo_rotate_left, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textDegree = (TextView) prototypeView.findViewById(R.id
 				.brick_jumping_sumo_change_left_variable_edit_text);
 		textDegree.setText(formatNumberForPrototypeView(BrickValues.JUMPING_SUMO_ROTATE_DEFAULT_DEGREE));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoRotateRightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoRotateRightBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -62,13 +61,13 @@ public class JumpingSumoRotateRightBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_jumping_sumo_rotate_right;
+	}
 
-		view = View.inflate(context, R.layout.brick_jumping_sumo_rotate_right, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editDegree = (TextView) view.findViewById(R.id.brick_jumping_sumo_change_right_variable_edit_text);
 		getFormulaWithBrickField(BrickField.JUMPING_SUMO_ROTATE)
 				.setTextFieldId(R.id.brick_jumping_sumo_change_right_variable_edit_text);
@@ -80,7 +79,7 @@ public class JumpingSumoRotateRightBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_jumping_sumo_rotate_right, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textDegree = (TextView) prototypeView.findViewById(R.id
 				.brick_jumping_sumo_change_right_variable_edit_text);
 		textDegree.setText(formatNumberForPrototypeView(BrickValues.JUMPING_SUMO_ROTATE_DEFAULT_DEGREE));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoSoundBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoSoundBrick.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -84,7 +83,7 @@ public class JumpingSumoSoundBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_jumping_sumo_sound, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView editVolume = (TextView) prototypeView.findViewById(R.id.brick_jumping_sumo_sound_edit_text);
 		editVolume.setText(formatNumberForPrototypeView(BrickValues.JUMPING_SUMO_SOUND_BRICK_DEFAULT_VOLUME_PERCENT));
 
@@ -104,12 +103,13 @@ public class JumpingSumoSoundBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_jumping_sumo_sound;
+	}
 
-		view = View.inflate(context, R.layout.brick_jumping_sumo_sound, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		editVolume = (TextView) view.findViewById(R.id.brick_jumping_sumo_sound_edit_text);
 		getFormulaWithBrickField(BrickField.JUMPING_SUMO_VOLUME).setTextFieldId(R.id.brick_jumping_sumo_sound_edit_text);
 		getFormulaWithBrickField(BrickField.JUMPING_SUMO_VOLUME).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoTakingPictureBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoTakingPictureBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -36,19 +35,19 @@ public class JumpingSumoTakingPictureBrick extends BrickBaseType {
 	private static final long serialVersionUID = 1L;
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_jumping_sumo_taking_picture;
+	}
 
-		view = View.inflate(context, R.layout.brick_jumping_sumo_taking_picture, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_jumping_sumo_taking_picture, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		return prototypeView;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoTurnBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoTurnBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -36,19 +35,19 @@ public class JumpingSumoTurnBrick extends BrickBaseType {
 	private static final long serialVersionUID = 1L;
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_jumping_sumo_turn;
+	}
 
-		view = View.inflate(context, R.layout.brick_jumping_sumo_turn, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_jumping_sumo_turn, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		return prototypeView;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorMoveBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorMoveBrick.java
@@ -26,7 +26,6 @@ import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -87,7 +86,7 @@ public class LegoEv3MotorMoveBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_ev3_motor_move, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSpeed = (TextView) prototypeView.findViewById(R.id.ev3_motor_move_speed_edit_text);
 		textSpeed.setText(formatNumberForPrototypeView(BrickValues.LEGO_SPEED));
 
@@ -110,11 +109,13 @@ public class LegoEv3MotorMoveBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_ev3_motor_move, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_ev3_motor_move;
+	}
 
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		editSpeed = (TextView) view.findViewById(R.id.ev3_motor_move_speed_edit_text);
 		getFormulaWithBrickField(BrickField.LEGO_EV3_SPEED).setTextFieldId(R.id.ev3_motor_move_speed_edit_text);
 		getFormulaWithBrickField(BrickField.LEGO_EV3_SPEED).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorStopBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorStopBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.R;
@@ -64,7 +63,7 @@ public class LegoEv3MotorStopBrick extends BrickBaseType implements OnItemSelect
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_ev3_motor_stop, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner legoSpinner = (Spinner) prototypeView.findViewById(R.id.ev3_stop_motor_spinner);
 		legoSpinner.setFocusableInTouchMode(false);
 		legoSpinner.setFocusable(false);
@@ -79,12 +78,13 @@ public class LegoEv3MotorStopBrick extends BrickBaseType implements OnItemSelect
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_ev3_motor_stop, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_ev3_motor_stop;
+	}
 
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		ArrayAdapter<CharSequence> motorAdapter = ArrayAdapter.createFromResource(context,
 				R.array.ev3_stop_motor_chooser, android.R.layout.simple_spinner_item);
 		motorAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorTurnAngleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3MotorTurnAngleBrick.java
@@ -26,7 +26,6 @@ import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -82,7 +81,7 @@ public class LegoEv3MotorTurnAngleBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_ev3_motor_turn_angle, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textX = (TextView) prototypeView.findViewById(R.id.ev3_motor_turn_angle_edit_text);
 		textX.setText(formatNumberForPrototypeView(BrickValues.LEGO_ANGLE));
 
@@ -106,12 +105,13 @@ public class LegoEv3MotorTurnAngleBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_ev3_motor_turn_angle, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_ev3_motor_turn_angle;
+	}
 
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		editSpeed = (TextView) view.findViewById(R.id.ev3_motor_turn_angle_edit_text);
 		getFormulaWithBrickField(BrickField.LEGO_EV3_DEGREES).setTextFieldId(R.id.ev3_motor_turn_angle_edit_text);
 		getFormulaWithBrickField(BrickField.LEGO_EV3_DEGREES).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3PlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3PlayToneBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -75,7 +74,7 @@ public class LegoEv3PlayToneBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_ev3_play_tone, null);
+		prototypeView = super.getPrototypeView(context);
 
 		TextView textDuration = (TextView) prototypeView.findViewById(R.id.brick_ev3_tone_duration_edit_text);
 
@@ -96,12 +95,13 @@ public class LegoEv3PlayToneBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_ev3_play_tone, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_ev3_play_tone;
+	}
 
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_ev3_tone_seconds, R.id.brick_ev3_tone_duration_edit_text, BrickField.LEGO_EV3_DURATION_IN_SECONDS);
 
 		TextView editFreq = (TextView) view.findViewById(R.id.brick_ev3_tone_freq_edit_text);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3SetLedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3SetLedBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.R;
@@ -66,7 +65,7 @@ public class LegoEv3SetLedBrick extends BrickBaseType implements OnItemSelectedL
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_ev3_set_led, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		Spinner ledStatusSpinner = (Spinner) prototypeView.findViewById(R.id.brick_ev3_set_led_spinner);
 		ledStatusSpinner.setFocusableInTouchMode(false);
@@ -82,12 +81,13 @@ public class LegoEv3SetLedBrick extends BrickBaseType implements OnItemSelectedL
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_ev3_set_led, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_ev3_set_led;
+	}
 
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		ArrayAdapter<CharSequence> ledStatusAdapter = ArrayAdapter.createFromResource(context,
 				R.array.ev3_led_status_chooser, android.R.layout.simple_spinner_item);
 		ledStatusAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorMoveBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorMoveBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -88,7 +87,7 @@ public class LegoNxtMotorMoveBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_nxt_motor_action, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSpeed = (TextView) prototypeView.findViewById(R.id.motor_action_speed_edit_text);
 		textSpeed.setText(formatNumberForPrototypeView(BrickValues.LEGO_SPEED));
 
@@ -109,12 +108,13 @@ public class LegoNxtMotorMoveBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_nxt_motor_action;
+	}
 
-		view = View.inflate(context, R.layout.brick_nxt_motor_action, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		editSpeed = (TextView) view.findViewById(R.id.motor_action_speed_edit_text);
 		getFormulaWithBrickField(BrickField.LEGO_NXT_SPEED).setTextFieldId(R.id.motor_action_speed_edit_text);
 		getFormulaWithBrickField(BrickField.LEGO_NXT_SPEED).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorStopBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorStopBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.R;
@@ -64,7 +63,7 @@ public class LegoNxtMotorStopBrick extends BrickBaseType implements OnItemSelect
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_nxt_motor_stop, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner legoSpinner = (Spinner) prototypeView.findViewById(R.id.stop_motor_spinner);
 
 		ArrayAdapter<CharSequence> motorAdapter = ArrayAdapter.createFromResource(context,
@@ -77,12 +76,13 @@ public class LegoNxtMotorStopBrick extends BrickBaseType implements OnItemSelect
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_nxt_motor_stop;
+	}
 
-		view = View.inflate(context, R.layout.brick_nxt_motor_stop, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		ArrayAdapter<CharSequence> motorAdapter = ArrayAdapter.createFromResource(context,
 				R.array.nxt_stop_motor_chooser, android.R.layout.simple_spinner_item);
 		motorAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorTurnAngleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtMotorTurnAngleBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -87,7 +86,7 @@ public class LegoNxtMotorTurnAngleBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_nxt_motor_turn_angle, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textX = (TextView) prototypeView.findViewById(R.id.motor_turn_angle_edit_text);
 		textX.setText(formatNumberForPrototypeView(BrickValues.LEGO_ANGLE));
 
@@ -108,13 +107,13 @@ public class LegoNxtMotorTurnAngleBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_nxt_motor_turn_angle;
+	}
 
-		view = View.inflate(context, R.layout.brick_nxt_motor_turn_angle, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		editSpeed = (TextView) view.findViewById(R.id.motor_turn_angle_edit_text);
 		getFormulaWithBrickField(BrickField.LEGO_NXT_DEGREES).setTextFieldId(R.id.motor_turn_angle_edit_text);
 		getFormulaWithBrickField(BrickField.LEGO_NXT_DEGREES).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtPlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtPlayToneBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -72,7 +71,7 @@ public class LegoNxtPlayToneBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_nxt_play_tone, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textDuration = (TextView) prototypeView.findViewById(R.id.nxt_tone_duration_edit_text);
 
 		NumberFormat nf = NumberFormat.getInstance(context.getResources().getConfiguration().locale);
@@ -88,12 +87,13 @@ public class LegoNxtPlayToneBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_nxt_play_tone, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_nxt_play_tone;
+	}
 
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_nxt_play_tone_seconds, R.id.nxt_tone_duration_edit_text, BrickField.LEGO_NXT_DURATION_IN_SECONDS);
 
 		editFreq = (TextView) view.findViewById(R.id.nxt_tone_freq_edit_text);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LoopEndBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LoopEndBrick.java
@@ -22,10 +22,7 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
 import android.util.Log;
-import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -57,25 +54,13 @@ public class LoopEndBrick extends BrickBaseType implements NestingBrick, Allowed
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-
-		if (view == null) {
-			view = View.inflate(context, R.layout.brick_loop_end, null);
-			view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-			setCheckboxView();
-		}
-
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_loop_end;
 	}
 
 	@Override
 	public Brick clone() {
 		return new LoopEndBrick();
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_loop_end, null);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LoopEndlessBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LoopEndlessBrick.java
@@ -22,10 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
-import android.view.View;
-import android.widget.BaseAdapter;
-
 import org.catrobat.catroid.R;
 
 public class LoopEndlessBrick extends LoopEndBrick implements DeadEndBrick {
@@ -40,13 +36,8 @@ public class LoopEndlessBrick extends LoopEndBrick implements DeadEndBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		if (view == null) {
-			view = View.inflate(context, R.layout.brick_loop_endless, null);
-			view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-			setCheckboxView();
-		}
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_loop_endless;
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/MoveNStepsBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/MoveNStepsBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.util.Log;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.ProjectManager;
@@ -69,11 +68,13 @@ public class MoveNStepsBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_move_n_steps, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_move_n_steps;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView edit = (TextView) view.findViewById(R.id.brick_move_n_steps_edit_text);
 
 		getFormulaWithBrickField(BrickField.STEPS).setTextFieldId(R.id.brick_move_n_steps_edit_text);
@@ -105,7 +106,7 @@ public class MoveNStepsBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_move_n_steps, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSteps = (TextView) prototypeView.findViewById(R.id.brick_move_n_steps_edit_text);
 		textSteps.setText(formatNumberForPrototypeView(BrickValues.MOVE_STEPS));
 		TextView times = (TextView) prototypeView.findViewById(R.id.brick_move_n_steps_step_text_view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/NextLookBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/NextLookBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.ProjectManager;
@@ -43,7 +42,7 @@ public class NextLookBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = View.inflate(context, R.layout.brick_next_look, null);
+		View view = super.getPrototypeView(context);
 
 		if (ProjectManager.getInstance().getCurrentSprite().getName().equals(context.getString(R.string.background))) {
 			TextView textField = (TextView) view.findViewById(R.id.brick_next_look_text_view);
@@ -58,11 +57,13 @@ public class NextLookBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_next_look, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_next_look;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		if (ProjectManager.getInstance().getCurrentSprite().getName().equals(context.getString(R.string.background))) {
 			TextView textField = (TextView) view.findViewById(R.id.brick_next_look_text_view);
 			textField.setText(R.string.brick_next_background);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/NoteBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/NoteBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -58,12 +57,13 @@ public class NoteBrick extends FormulaBrick implements OnClickListener {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_note;
+	}
 
-		view = View.inflate(context, R.layout.brick_note, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView textField = (TextView) view.findViewById(R.id.brick_note_edit_text);
 		getFormulaWithBrickField(BrickField.NOTE).setTextFieldId(R.id.brick_note_edit_text);
 		getFormulaWithBrickField(BrickField.NOTE).refreshTextField(view);
@@ -75,7 +75,7 @@ public class NoteBrick extends FormulaBrick implements OnClickListener {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_note, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSpeak = (TextView) prototypeView.findViewById(R.id.brick_note_edit_text);
 		textSpeak.setText(context.getString(R.string.brick_note_default_value));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PenDownBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PenDownBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -41,7 +40,7 @@ public class PenDownBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = View.inflate(context, R.layout.brick_pen_down, null);
+		View view = super.getPrototypeView(context);
 		return view;
 	}
 
@@ -51,11 +50,13 @@ public class PenDownBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_pen_down, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_pen_down;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PenUpBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PenUpBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -41,7 +40,7 @@ public class PenUpBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = View.inflate(context, R.layout.brick_pen_up, null);
+		View view = super.getPrototypeView(context);
 
 		return view;
 	}
@@ -52,11 +51,13 @@ public class PenUpBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_pen_up, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_pen_up;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroIfLogicBeginBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroIfLogicBeginBrick.java
@@ -22,12 +22,10 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
@@ -44,8 +42,6 @@ import java.util.List;
 public class PhiroIfLogicBeginBrick extends IfLogicBeginBrick implements OnItemSelectedListener {
 
 	private static final long serialVersionUID = 1L;
-	protected transient IfLogicElseBrick ifElseBrick;
-	protected transient IfLogicEndBrick ifEndBrick;
 	private int sensorSpinnerPosition = 0;
 
 	public PhiroIfLogicBeginBrick() {
@@ -61,12 +57,12 @@ public class PhiroIfLogicBeginBrick extends IfLogicBeginBrick implements OnItemS
 		return ifElseBrick;
 	}
 
-	public IfLogicEndBrick getIfEndBrick() {
-		return ifEndBrick;
-	}
-
 	public void setIfElseBrick(IfLogicElseBrick elseBrick) {
 		this.ifElseBrick = elseBrick;
+	}
+
+	public IfLogicEndBrick getIfEndBrick() {
+		return ifEndBrick;
 	}
 
 	public void setIfEndBrick(IfLogicEndBrick ifEndBrick) {
@@ -83,17 +79,18 @@ public class PhiroIfLogicBeginBrick extends IfLogicBeginBrick implements OnItemS
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_phiro_if_sensor;
+	}
 
-		view = View.inflate(context, R.layout.brick_phiro_if_sensor, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	@Override
+	protected void onViewCreated(View view) {
+		Spinner phiroProSensorSpinner = view.findViewById(R.id.brick_phiro_sensor_action_spinner);
 
-		setCheckboxView();
+		ArrayAdapter<CharSequence> phiroProSensorAdapter = ArrayAdapter.createFromResource(view.getContext(),
+				R.array.brick_phiro_select_sensor_spinner,
+				android.R.layout.simple_spinner_item);
 
-		Spinner phiroProSensorSpinner = (Spinner) view.findViewById(R.id.brick_phiro_sensor_action_spinner);
-
-		ArrayAdapter<CharSequence> phiroProSensorAdapter = ArrayAdapter.createFromResource(context,
-				R.array.brick_phiro_select_sensor_spinner, android.R.layout.simple_spinner_item);
 		phiroProSensorAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 
 		phiroProSensorSpinner.setAdapter(phiroProSensorAdapter);
@@ -110,8 +107,6 @@ public class PhiroIfLogicBeginBrick extends IfLogicBeginBrick implements OnItemS
 			public void onNothingSelected(AdapterView<?> arg0) {
 			}
 		});
-
-		return view;
 	}
 
 	@Override
@@ -123,19 +118,17 @@ public class PhiroIfLogicBeginBrick extends IfLogicBeginBrick implements OnItemS
 	}
 
 	@Override
-	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_phiro_if_sensor, null);
+	protected void onPrototypeViewCreated(View prototypeView) {
+		Spinner phiroProSensorSpinner = prototypeView.findViewById(R.id.brick_phiro_sensor_action_spinner);
 
-		Spinner phiroProSensorSpinner = (Spinner) prototypeView.findViewById(R.id.brick_phiro_sensor_action_spinner);
+		ArrayAdapter<CharSequence> phiroProSensorSpinnerAdapter = ArrayAdapter
+				.createFromResource(prototypeView.getContext(),
+						R.array.brick_phiro_select_sensor_spinner,
+						android.R.layout.simple_spinner_item);
 
-		ArrayAdapter<CharSequence> phiroProSensorSpinnerAdapter = ArrayAdapter.createFromResource(context,
-				R.array.brick_phiro_select_sensor_spinner, android.R.layout.simple_spinner_item);
 		phiroProSensorSpinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-
 		phiroProSensorSpinner.setAdapter(phiroProSensorSpinnerAdapter);
 		phiroProSensorSpinner.setSelection(sensorSpinnerPosition);
-
-		return prototypeView;
 	}
 
 	@Override
@@ -151,7 +144,6 @@ public class PhiroIfLogicBeginBrick extends IfLogicBeginBrick implements OnItemS
 
 	@Override
 	public List<NestingBrick> getAllNestingBrickParts(boolean sorted) {
-		//TODO: handle sorting
 		List<NestingBrick> nestingBrickList = new ArrayList<NestingBrick>();
 		if (sorted) {
 			nestingBrickList.add(this);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorMoveBackwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorMoveBackwardBrick.java
@@ -96,7 +96,7 @@ public class PhiroMotorMoveBackwardBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_phiro_motor_backward, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSpeed = (TextView) prototypeView.findViewById(R.id.brick_phiro_motor_backward_action_speed_edit_text);
 		textSpeed.setText(formatNumberForPrototypeView(BrickValues.PHIRO_SPEED));
 
@@ -124,12 +124,13 @@ public class PhiroMotorMoveBackwardBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_phiro_motor_backward;
+	}
 
-		view = View.inflate(context, R.layout.brick_phiro_motor_backward, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		editSpeed = (TextView) view.findViewById(R.id.brick_phiro_motor_backward_action_speed_edit_text);
 		getFormulaWithBrickField(BrickField.PHIRO_SPEED).setTextFieldId(R.id.brick_phiro_motor_backward_action_speed_edit_text);
 		getFormulaWithBrickField(BrickField.PHIRO_SPEED).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorMoveForwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorMoveForwardBrick.java
@@ -98,7 +98,7 @@ public class PhiroMotorMoveForwardBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_phiro_motor_forward, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSpeed = (TextView) prototypeView.findViewById(R.id.brick_phiro_motor_forward_action_speed_edit_text);
 		textSpeed.setText(formatNumberForPrototypeView(BrickValues.PHIRO_SPEED));
 
@@ -135,12 +135,13 @@ public class PhiroMotorMoveForwardBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_phiro_motor_forward;
+	}
 
-		view = View.inflate(context, R.layout.brick_phiro_motor_forward, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		editSpeed = (TextView) view.findViewById(R.id.brick_phiro_motor_forward_action_speed_edit_text);
 		getFormulaWithBrickField(BrickField.PHIRO_SPEED).setTextFieldId(R.id.brick_phiro_motor_forward_action_speed_edit_text);
 		getFormulaWithBrickField(BrickField.PHIRO_SPEED).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorStopBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorStopBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.R;
@@ -64,7 +63,7 @@ public class PhiroMotorStopBrick extends BrickBaseType implements OnItemSelected
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_phiro_motor_stop, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner phiroProSpinner = (Spinner) prototypeView.findViewById(R.id.brick_phiro_stop_motor_spinner);
 
 		ArrayAdapter<CharSequence> motorAdapter = ArrayAdapter.createFromResource(context,
@@ -77,12 +76,13 @@ public class PhiroMotorStopBrick extends BrickBaseType implements OnItemSelected
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_phiro_motor_stop;
+	}
 
-		view = View.inflate(context, R.layout.brick_phiro_motor_stop, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		ArrayAdapter<CharSequence> motorAdapter = ArrayAdapter.createFromResource(context,
 				R.array.brick_phiro_stop_motor_spinner, android.R.layout.simple_spinner_item);
 		motorAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroPlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroPlayToneBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -89,7 +88,7 @@ public class PhiroPlayToneBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_phiro_play_tone, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textDuration = (TextView) prototypeView.findViewById(R.id.brick_phiro_play_tone_duration_edit_text);
 		textDuration.setText(formatNumberForPrototypeView(BrickValues.PHIRO_DURATION));
 		TextView times = (TextView) prototypeView.findViewById(R.id.brick_phiro_play_tone_seconds_text_view);
@@ -108,12 +107,13 @@ public class PhiroPlayToneBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_phiro_play_tone;
+	}
 
-		view = View.inflate(context, R.layout.brick_phiro_play_tone, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setSecondText(view, R.id.brick_phiro_play_tone_seconds_text_view, R.id.brick_phiro_play_tone_duration_edit_text, BrickField.PHIRO_DURATION_IN_SECONDS);
 
 		ArrayAdapter<CharSequence> toneAdapter = ArrayAdapter.createFromResource(context, R.array.brick_phiro_select_tone_spinner,

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroRGBLightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroRGBLightBrick.java
@@ -108,7 +108,7 @@ public class PhiroRGBLightBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_phiro_rgb_light, null);
+		prototypeView = super.getPrototypeView(context);
 
 		TextView textValueRed = (TextView) prototypeView.findViewById(R.id.brick_phiro_rgb_led_action_red_edit_text);
 		textValueRed.setText(formatNumberForPrototypeView(BrickValues.PHIRO_VALUE_RED));
@@ -145,10 +145,13 @@ public class PhiroRGBLightBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_phiro_rgb_light;
+	}
 
-		view = View.inflate(context, R.layout.brick_phiro_rgb_light, null);
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		editRedValue = (TextView) view.findViewById(R.id.brick_phiro_rgb_led_action_red_edit_text);
 		getFormulaWithBrickField(BrickField.PHIRO_LIGHT_RED).setTextFieldId(R.id.brick_phiro_rgb_led_action_red_edit_text);
 		getFormulaWithBrickField(BrickField.PHIRO_LIGHT_RED).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaceAtBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaceAtBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -75,12 +74,13 @@ public class PlaceAtBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_place_at;
+	}
 
-		view = View.inflate(context, R.layout.brick_place_at, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editX = (TextView) view.findViewById(R.id.brick_place_at_edit_text_x);
 		getFormulaWithBrickField(BrickField.X_POSITION).setTextFieldId(R.id.brick_place_at_edit_text_x);
 		getFormulaWithBrickField(BrickField.X_POSITION).refreshTextField(view);
@@ -96,7 +96,7 @@ public class PlaceAtBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_place_at, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textX = (TextView) prototypeView.findViewById(R.id.brick_place_at_edit_text_x);
 		textX.setText(formatNumberForPrototypeView(BrickValues.X_POSITION));
 		TextView textY = (TextView) prototypeView.findViewById(R.id.brick_place_at_edit_text_y);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundAndWaitBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundAndWaitBrick.java
@@ -22,7 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
 import android.media.MediaMetadataRetriever;
 import android.view.View;
 import android.widget.TextView;
@@ -48,10 +47,16 @@ public class PlaySoundAndWaitBrick extends PlaySoundBrick {
 		return clone;
 	}
 
-	protected View prepareView(Context context) {
-		View view = View.inflate(context, R.layout.brick_play_sound, null);
-		((TextView) view.findViewById(R.id.brick_play_sound_text_view)).setText(R.string.brick_play_sound_and_wait);
-		return view;
+	@Override
+	protected void onViewCreated(View prototypeView) {
+		((TextView) view.findViewById(R.id.brick_play_sound_text_view))
+				.setText(R.string.brick_play_sound_and_wait);
+	}
+
+	@Override
+	protected void onPrototypeViewCreated(View prototypeView) {
+		((TextView) prototypeView.findViewById(R.id.brick_play_sound_text_view))
+				.setText(R.string.brick_play_sound_and_wait);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.view.View;
 import android.widget.AdapterView;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.ProjectManager;
@@ -72,21 +71,16 @@ public class PlaySoundBrick extends BrickBaseType implements
 		return clone;
 	}
 
-	protected View prepareView(Context context) {
-		return View.inflate(context, R.layout.brick_play_sound, null);
-	}
-
-	protected Spinner findSpinner(View view) {
-		return view.findViewById(R.id.brick_play_sound_spinner);
+	@Override
+	public int getViewResource() {
+		return R.layout.brick_play_sound;
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
-		view = prepareView(context);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
-		spinner = findSpinner(view);
+	public View getView(Context context) {
+		super.getView(context);
+		onViewCreated(view);
+		spinner = view.findViewById(R.id.brick_play_sound_spinner);
 		spinnerAdapter = new SpinnerAdapterWithNewOption(context, getSoundNames());
 		spinnerAdapter.setOnDropDownItemClickListener(this);
 
@@ -105,6 +99,9 @@ public class PlaySoundBrick extends BrickBaseType implements
 		});
 		spinner.setSelection(spinnerAdapter.getPosition(sound != null ? sound.getName() : null));
 		return view;
+	}
+
+	protected void onViewCreated(View view) {
 	}
 
 	private SoundInfo getSoundByName(String name) {
@@ -150,12 +147,16 @@ public class PlaySoundBrick extends BrickBaseType implements
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = prepareView(context);
-		spinner = findSpinner(view);
+		View view = super.getPrototypeView(context);
+		onPrototypeViewCreated(view);
+		spinner = view.findViewById(R.id.brick_play_sound_spinner);
 		spinnerAdapter = new SpinnerAdapterWithNewOption(context, getSoundNames());
 		spinner.setAdapter(spinnerAdapter);
 		spinner.setSelection(spinnerAdapter.getPosition(sound != null ? sound.getName() : null));
 		return view;
+	}
+
+	protected void onPrototypeViewCreated(View prototypeView) {
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PointInDirectionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PointInDirectionBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -83,10 +82,13 @@ public class PointInDirectionBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_point_in_direction, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_point_in_direction;
+	}
+
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView setAngleTextField = (TextView) view.findViewById(R.id.brick_point_in_direction_edit_text);
 
 		getFormulaWithBrickField(BrickField.DEGREES).setTextFieldId(R.id.brick_point_in_direction_edit_text);
@@ -98,7 +100,7 @@ public class PointInDirectionBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_point_in_direction, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView setAngleTextView = (TextView) prototypeView
 				.findViewById(R.id.brick_point_in_direction_edit_text);
 		setAngleTextView.setText(formatNumberForPrototypeView(BrickValues.POINT_IN_DIRECTION));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PointToBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PointToBrick.java
@@ -26,7 +26,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.ProjectManager;
@@ -64,12 +63,13 @@ public class PointToBrick extends BrickBaseType implements
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_point_to;
+	}
 
-		view = View.inflate(context, R.layout.brick_point_to, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		spinner = view.findViewById(R.id.brick_point_to_spinner);
 		spinnerAdapter = new SpinnerAdapterWithNewOption(context, getSpriteNames());
 		spinnerAdapter.setOnDropDownItemClickListener(this);
@@ -125,7 +125,7 @@ public class PointToBrick extends BrickBaseType implements
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = View.inflate(context, R.layout.brick_point_to, null);
+		View view = super.getPrototypeView(context);
 		spinner = view.findViewById(R.id.brick_point_to_spinner);
 
 		spinnerAdapter = new SpinnerAdapterWithNewOption(context, getSpriteNames());

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PreviousLookBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PreviousLookBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.ProjectManager;
@@ -43,7 +42,7 @@ public class PreviousLookBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = View.inflate(context, R.layout.brick_previous_look, null);
+		View view = super.getPrototypeView(context);
 
 		if (ProjectManager.getInstance().getCurrentSprite().getName().equals(context.getString(R.string.background))) {
 			TextView textField = (TextView) view.findViewById(R.id.brick_previous_look_text_view);
@@ -58,11 +57,13 @@ public class PreviousLookBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_previous_look, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_previous_look;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		if (ProjectManager.getInstance().getCurrentSprite().getName().equals(context.getString(R.string.background))) {
 			TextView textField = (TextView) view.findViewById(R.id.brick_previous_look_text_view);
 			textField.setText(R.string.brick_previous_background);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiIfLogicBeginBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiIfLogicBeginBrick.java
@@ -22,15 +22,14 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
+import org.catrobat.catroid.content.ActionFactory;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
 import org.catrobat.catroid.formulaeditor.Formula;
@@ -39,6 +38,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class RaspiIfLogicBeginBrick extends IfLogicBeginBrick {
+
 	private static final long serialVersionUID = 1L;
 
 	public RaspiIfLogicBeginBrick() {
@@ -64,36 +64,32 @@ public class RaspiIfLogicBeginBrick extends IfLogicBeginBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_raspi_if_begin_if, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
-		TextView ifBeginTextView = (TextView) view.findViewById(R.id.brick_raspi_if_begin_edit_text);
-
-		getFormulaWithBrickField(BrickField.IF_CONDITION).setTextFieldId(R.id.brick_raspi_if_begin_edit_text);
-		getFormulaWithBrickField(BrickField.IF_CONDITION).refreshTextField(view);
-
-		ifBeginTextView.setOnClickListener(this);
-
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_raspi_if_begin_if;
 	}
 
 	@Override
-	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_raspi_if_begin_if, null);
-		TextView textIfBegin = (TextView) prototypeView.findViewById(R.id.brick_raspi_if_begin_edit_text);
+	public void onViewCreated(View view) {
+		TextView ifBeginTextView = view.findViewById(R.id.brick_raspi_if_begin_edit_text);
+		getFormulaWithBrickField(BrickField.IF_CONDITION).setTextFieldId(R.id.brick_raspi_if_begin_edit_text);
+		getFormulaWithBrickField(BrickField.IF_CONDITION).refreshTextField(view);
+		ifBeginTextView.setOnClickListener(this);
+	}
+
+	@Override
+	public void onPrototypeViewCreated(View prototypeView) {
+		TextView textIfBegin = prototypeView.findViewById(R.id.brick_raspi_if_begin_edit_text);
 		textIfBegin.setText(formatNumberForPrototypeView(BrickValues.RASPI_DIGITAL_INITIAL_PIN_NUMBER));
-		return prototypeView;
 	}
 
 	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
-		ScriptSequenceAction ifAction = (ScriptSequenceAction) sprite.getActionFactory().eventSequence(sequence.getScript());
-		ScriptSequenceAction elseAction = (ScriptSequenceAction) sprite.getActionFactory().eventSequence(sequence.getScript());
-		Action action = sprite.getActionFactory().createRaspiIfLogicActionAction(sprite, getFormulaWithBrickField(BrickField.IF_CONDITION), ifAction,
-				elseAction);
+		ScriptSequenceAction ifAction = (ScriptSequenceAction) ActionFactory.eventSequence(sequence.getScript());
+		ScriptSequenceAction elseAction = (ScriptSequenceAction) ActionFactory.eventSequence(sequence.getScript());
+
+		Action action = sprite.getActionFactory().createRaspiIfLogicActionAction(sprite,
+				getFormulaWithBrickField(BrickField.IF_CONDITION), ifAction, elseAction);
+
 		sequence.addAction(action);
 
 		LinkedList<ScriptSequenceAction> returnActionList = new LinkedList<>();

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiPwmBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiPwmBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -65,7 +64,7 @@ public class RaspiPwmBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_raspi_pwm, null);
+		prototypeView = super.getPrototypeView(context);
 
 		TextView textPinNumber = (TextView) prototypeView.findViewById(R.id.brick_raspi_pwm_pin_edit_text);
 		textPinNumber.setText(formatNumberForPrototypeView(BrickValues.RASPI_DIGITAL_INITIAL_PIN_NUMBER));
@@ -82,11 +81,13 @@ public class RaspiPwmBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_raspi_pwm, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_raspi_pwm;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editPinNumber = (TextView) view.findViewById(R.id.brick_raspi_pwm_pin_edit_text);
 		getFormulaWithBrickField(BrickField.RASPI_DIGITAL_PIN_NUMBER).setTextFieldId(R.id.brick_raspi_pwm_pin_edit_text);
 		getFormulaWithBrickField(BrickField.RASPI_DIGITAL_PIN_NUMBER).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiSendDigitalValueBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiSendDigitalValueBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -74,7 +73,7 @@ public class RaspiSendDigitalValueBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_raspi_send_digital, null);
+		prototypeView = super.getPrototypeView(context);
 
 		TextView textSetPinNumber = (TextView) prototypeView.findViewById(R.id.brick_raspi_set_digital_pin_edit_text);
 		textSetPinNumber.setText(formatNumberForPrototypeView(BrickValues.RASPI_DIGITAL_INITIAL_PIN_NUMBER));
@@ -85,11 +84,13 @@ public class RaspiSendDigitalValueBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_raspi_send_digital, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_raspi_send_digital;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editPinNumber = (TextView) view.findViewById(R.id.brick_raspi_set_digital_pin_edit_text);
 		getFormulaWithBrickField(BrickField.RASPI_DIGITAL_PIN_NUMBER).setTextFieldId(R.id.brick_raspi_set_digital_pin_edit_text);
 		getFormulaWithBrickField(BrickField.RASPI_DIGITAL_PIN_NUMBER).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.util.Log;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
@@ -85,13 +84,13 @@ public class RepeatBrick extends FormulaBrick implements LoopBeginBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_repeat;
+	}
 
-		view = View.inflate(context, R.layout.brick_repeat, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView edit = (TextView) view.findViewById(R.id.brick_repeat_edit_text);
 		getFormulaWithBrickField(BrickField.TIMES_TO_REPEAT).setTextFieldId(R.id.brick_repeat_edit_text);
 		getFormulaWithBrickField(BrickField.TIMES_TO_REPEAT).refreshTextField(view);
@@ -122,7 +121,7 @@ public class RepeatBrick extends FormulaBrick implements LoopBeginBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_repeat, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textRepeat = (TextView) prototypeView.findViewById(R.id.brick_repeat_edit_text);
 		TextView times = (TextView) prototypeView.findViewById(R.id.brick_repeat_time_text_view);
 		textRepeat.setText(formatNumberForPrototypeView(BrickValues.REPEAT));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatUntilBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatUntilBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
@@ -77,13 +76,13 @@ public class RepeatUntilBrick extends FormulaBrick implements LoopBeginBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_repeat_until;
+	}
 
-		view = View.inflate(context, R.layout.brick_repeat_until, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView edit = (TextView) view.findViewById(R.id.brick_repeat_until_edit_text);
 		getFormulaWithBrickField(BrickField.REPEAT_UNTIL_CONDITION).setTextFieldId(R.id.brick_repeat_until_edit_text);
 		getFormulaWithBrickField(BrickField.REPEAT_UNTIL_CONDITION).refreshTextField(view);
@@ -94,7 +93,7 @@ public class RepeatUntilBrick extends FormulaBrick implements LoopBeginBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_repeat_until, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textRepeat = (TextView) prototypeView.findViewById(R.id.brick_repeat_until_edit_text);
 		textRepeat.setText(BrickValues.IF_CONDITION);
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ReplaceItemInUserListBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ReplaceItemInUserListBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -70,11 +69,13 @@ public class ReplaceItemInUserListBrick extends UserListBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_replace_item_in_userlist;
+	}
 
-		view = View.inflate(context, R.layout.brick_replace_item_in_userlist, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView textFieldValue = (TextView) view.findViewById(R.id.brick_replace_item_in_userlist_value_edit_text);
 		getFormulaWithBrickField(BrickField.REPLACE_ITEM_IN_USERLIST_VALUE).setTextFieldId(R.id.brick_replace_item_in_userlist_value_edit_text);
 		getFormulaWithBrickField(BrickField.REPLACE_ITEM_IN_USERLIST_VALUE).refreshTextField(view);
@@ -102,7 +103,7 @@ public class ReplaceItemInUserListBrick extends UserListBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_replace_item_in_userlist, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner userListSpinner = (Spinner) prototypeView.findViewById(R.id.replace_item_in_userlist_spinner);
 
 		DataAdapter dataAdapter = ProjectManager.getInstance().getCurrentlyEditedScene().getDataContainer()

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneStartBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneStartBrick.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.view.View;
 import android.widget.AdapterView;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.ProjectManager;
@@ -71,12 +70,13 @@ public class SceneStartBrick extends BrickBaseType implements
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_scene_start;
+	}
 
-		view = View.inflate(context, R.layout.brick_scene_start, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		spinner = view.findViewById(R.id.brick_scene_start_spinner);
 		spinnerAdapter = new SpinnerAdapterWithNewOption(context,
 				ProjectManager.getInstance().getCurrentProject().getSceneNames());
@@ -123,7 +123,7 @@ public class SceneStartBrick extends BrickBaseType implements
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = View.inflate(context, R.layout.brick_scene_start, null);
+		View view = super.getPrototypeView(context);
 		spinner = view.findViewById(R.id.brick_scene_start_spinner);
 
 		spinnerAdapter = new SpinnerAdapterWithNewOption(context,

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneTransitionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneTransitionBrick.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.view.View;
 import android.widget.AdapterView;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.ProjectManager;
@@ -71,12 +70,13 @@ public class SceneTransitionBrick extends BrickBaseType implements
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_scene_transition;
+	}
 
-		view = View.inflate(context, R.layout.brick_scene_transition, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		spinner = view.findViewById(R.id.brick_scene_transition_spinner);
 
 		List<String> sceneNames = ProjectManager.getInstance().getCurrentProject().getSceneNames();
@@ -126,7 +126,7 @@ public class SceneTransitionBrick extends BrickBaseType implements
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = View.inflate(context, R.layout.brick_scene_transition, null);
+		View view = super.getPrototypeView(context);
 		spinner = view.findViewById(R.id.brick_scene_transition_spinner);
 
 		List<String> sceneNames = ProjectManager.getInstance().getCurrentProject().getSceneNames();

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetBackgroundAndWaitBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetBackgroundAndWaitBrick.java
@@ -23,7 +23,6 @@
 
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
 import android.view.View;
 import android.widget.TextView;
 
@@ -48,11 +47,13 @@ public class SetBackgroundAndWaitBrick extends SetBackgroundBrick {
 	}
 
 	@Override
-	protected View prepareView(Context context) {
-		View view = View.inflate(context, R.layout.brick_set_look, null);
-		((TextView) view.findViewById(R.id.brick_set_look_text_view))
-				.setText(R.string.brick_set_background_and_wait);
-		return view;
+	protected void onViewCreated(View view) {
+		((TextView) view.findViewById(R.id.brick_set_look_text_view)).setText(R.string.brick_set_background_and_wait);
+	}
+
+	@Override
+	protected void onPrototypeViewCreated(View view) {
+		((TextView) view.findViewById(R.id.brick_set_look_text_view)).setText(R.string.brick_set_background_and_wait);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetBackgroundBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetBackgroundBrick.java
@@ -23,7 +23,6 @@
 
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
 import android.view.View;
 import android.widget.TextView;
 
@@ -49,11 +48,13 @@ public class SetBackgroundBrick extends SetLookBrick {
 	}
 
 	@Override
-	protected View prepareView(Context context) {
-		View view = View.inflate(context, R.layout.brick_set_look, null);
-		((TextView) view.findViewById(R.id.brick_set_look_text_view))
-				.setText(R.string.brick_set_background);
-		return view;
+	protected void onViewCreated(View view) {
+		((TextView) view.findViewById(R.id.brick_set_look_text_view)).setText(R.string.brick_set_background);
+	}
+
+	@Override
+	protected void onPrototypeViewCreated(View view) {
+		((TextView) view.findViewById(R.id.brick_set_look_text_view)).setText(R.string.brick_set_background);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetBrightnessBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetBrightnessBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,12 +63,13 @@ public class SetBrightnessBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_set_brightness;
+	}
 
-		view = View.inflate(context, R.layout.brick_set_brightness, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editX = (TextView) view.findViewById(R.id.brick_set_brightness_edit_text);
 		getFormulaWithBrickField(BrickField.BRIGHTNESS).setTextFieldId(R.id.brick_set_brightness_edit_text);
 		getFormulaWithBrickField(BrickField.BRIGHTNESS).refreshTextField(view);
@@ -80,7 +80,7 @@ public class SetBrightnessBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_set_brightness, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSetBrightness = (TextView) prototypeView
 				.findViewById(R.id.brick_set_brightness_edit_text);
 		textSetBrightness.setText(formatNumberForPrototypeView(BrickValues.SET_BRIGHTNESS_TO));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetColorBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetColorBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -66,13 +65,13 @@ public class SetColorBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_set_color_to;
+	}
 
-		view = View.inflate(context, R.layout.brick_set_color_to, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView edit = (TextView) view.findViewById(R.id.brick_set_color_edit_text);
 		getFormulaWithBrickField(BrickField.COLOR).setTextFieldId(R.id.brick_set_color_edit_text);
 		getFormulaWithBrickField(BrickField.COLOR).refreshTextField(view);
@@ -83,7 +82,7 @@ public class SetColorBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_set_color_to, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSetSizeTo = (TextView) prototypeView.findViewById(R.id.brick_set_color_edit_text);
 		textSetSizeTo.setText(formatNumberForPrototypeView(BrickValues.SET_COLOR_TO));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetLookBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetLookBrick.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.view.View;
 import android.widget.AdapterView;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -74,29 +73,21 @@ public class SetLookBrick extends BrickBaseType implements
 		return clone;
 	}
 
-	protected View prepareView(Context context) {
-		View view = View.inflate(context, R.layout.brick_set_look, null);
-
-		if (getSprite().isBackgroundSprite()) {
-			((TextView) view.findViewById(R.id.brick_set_look_text_view))
-					.setText(R.string.brick_set_background);
-		}
-
-		return view;
-	}
-
 	protected Spinner findSpinner(View view) {
 		return view.findViewById(R.id.brick_set_look_spinner);
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
-		view = prepareView(context);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_set_look;
+	}
 
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
+		onViewCreated(view);
 		spinner = findSpinner(view);
-		spinnerAdapter = new SpinnerAdapterWithNewOption(context, getLookNames());
+		spinnerAdapter = new SpinnerAdapterWithNewOption(view.getContext(), getLookNames());
 		spinnerAdapter.setOnDropDownItemClickListener(this);
 
 		spinner.setAdapter(spinnerAdapter);
@@ -114,6 +105,12 @@ public class SetLookBrick extends BrickBaseType implements
 		});
 		spinner.setSelection(spinnerAdapter.getPosition(look != null ? look.getName() : null));
 		return view;
+	}
+
+	protected void onViewCreated(View view) {
+		if (getSprite().isBackgroundSprite()) {
+			((TextView) view.findViewById(R.id.brick_set_look_text_view)).setText(R.string.brick_set_background);
+		}
 	}
 
 	private LookData getLookByName(String name) {
@@ -159,12 +156,19 @@ public class SetLookBrick extends BrickBaseType implements
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = prepareView(context);
+		View view = super.getPrototypeView(context);
+		onPrototypeViewCreated(view);
 		spinner = findSpinner(view);
-		spinnerAdapter = new SpinnerAdapterWithNewOption(context, getLookNames());
+		spinnerAdapter = new SpinnerAdapterWithNewOption(view.getContext(), getLookNames());
 		spinner.setAdapter(spinnerAdapter);
 		spinner.setSelection(spinnerAdapter.getPosition(look != null ? look.getName() : null));
 		return view;
+	}
+
+	protected void onPrototypeViewCreated(View view) {
+		if (getSprite().isBackgroundSprite()) {
+			((TextView) view.findViewById(R.id.brick_set_look_text_view)).setText(R.string.brick_set_background);
+		}
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetLookByIndexBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetLookByIndexBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.ProjectManager;
@@ -71,17 +70,15 @@ public class SetLookByIndexBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return wait == EventWrapper.WAIT
+				? R.layout.brick_set_look_by_index_and_wait
+				: R.layout.brick_set_look_by_index;
+	}
 
-		if (wait == EventWrapper.WAIT) {
-			view = View.inflate(context, R.layout.brick_set_look_by_index_and_wait, null);
-		} else {
-			view = View.inflate(context, R.layout.brick_set_look_by_index, null);
-		}
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		if (getSprite().getName().equals(context.getString(R.string.background))) {
 			TextView textField = (TextView) view.findViewById(R.id.brick_set_look_by_index_label);
 			textField.setText(R.string.brick_set_background_by_index);
@@ -98,9 +95,9 @@ public class SetLookByIndexBrick extends FormulaBrick {
 	@Override
 	public View getPrototypeView(Context context) {
 		if (wait == EventWrapper.WAIT) {
-			prototypeView = View.inflate(context, R.layout.brick_set_look_by_index_and_wait, null);
+			prototypeView = super.getPrototypeView(context);
 		} else {
-			prototypeView = View.inflate(context, R.layout.brick_set_look_by_index, null);
+			prototypeView = super.getPrototypeView(context);
 		}
 
 		if (getSprite().getName().equals(context.getString(R.string.background))) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetNfcTagBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetNfcTagBrick.java
@@ -29,7 +29,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
 import android.widget.TextView;
@@ -74,11 +73,13 @@ public class SetNfcTagBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_set_nfc_tag, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_set_nfc_tag;
+	}
 
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		spinner = (Spinner) view.findViewById(R.id.brick_set_nfc_tag_ndef_record_spinner);
 
 		final ArrayAdapter<String> spinnerAdapter = createArrayAdapter(context);
@@ -124,7 +125,7 @@ public class SetNfcTagBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_set_nfc_tag, null);
+		prototypeView = super.getPrototypeView(context);
 
 		spinner = (Spinner) prototypeView.findViewById(R.id.brick_set_nfc_tag_ndef_record_spinner);
 		SpinnerAdapter setLookSpinnerAdapter = createArrayAdapter(context);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenColorBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenColorBrick.java
@@ -79,7 +79,7 @@ public class SetPenColorBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_set_pen_color, null);
+		prototypeView = super.getPrototypeView(context);
 
 		TextView textValueRed = (TextView) prototypeView.findViewById(R.id.brick_set_pen_color_action_red_edit_text);
 		textValueRed.setText(formatNumberForPrototypeView(BrickValues.PEN_COLOR.r * 255));
@@ -106,9 +106,13 @@ public class SetPenColorBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_set_pen_color, null);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_set_pen_color;
+	}
+
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		editRedValue = (TextView) view.findViewById(R.id.brick_set_pen_color_action_red_edit_text);
 		getFormulaWithBrickField(BrickField.PEN_COLOR_RED).setTextFieldId(R.id.brick_set_pen_color_action_red_edit_text);
 		getFormulaWithBrickField(BrickField.PEN_COLOR_RED).refreshTextField(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenSizeBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenSizeBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,13 +63,13 @@ public class SetPenSizeBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_set_pen_size;
+	}
 
-		view = View.inflate(context, R.layout.brick_set_pen_size, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView penSizeEdit = (TextView) view.findViewById(R.id.brick_set_pen_size_edit_text);
 
 		getFormulaWithBrickField(BrickField.PEN_SIZE).setTextFieldId(R.id.brick_set_pen_size_edit_text);
@@ -83,7 +82,7 @@ public class SetPenSizeBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_set_pen_size, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView penSizeText = (TextView) prototypeView.findViewById(R.id.brick_set_pen_size_edit_text);
 		penSizeText.setText(formatNumberForPrototypeView(BrickValues.PEN_SIZE));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetRotationStyleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetRotationStyleBrick.java
@@ -29,7 +29,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
 
@@ -50,11 +49,14 @@ public class SetRotationStyleBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_set_rotation_style, null);
-		BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_set_rotation_style;
+	}
 
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
+		BrickViewProvider.setAlphaOnView(view, alphaValue);
 		spinner = (Spinner) view.findViewById(R.id.brick_set_rotation_style_spinner);
 
 		final ArrayAdapter<String> spinnerAdapter = createSpinnerAdapter(context);
@@ -87,7 +89,7 @@ public class SetRotationStyleBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_set_rotation_style, null);
+		prototypeView = super.getPrototypeView(context);
 
 		spinner = (Spinner) prototypeView.findViewById(R.id.brick_set_rotation_style_spinner);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetSizeToBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetSizeToBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,13 +63,13 @@ public class SetSizeToBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_set_size_to;
+	}
 
-		view = View.inflate(context, R.layout.brick_set_size_to, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView edit = (TextView) view.findViewById(R.id.brick_set_size_to_edit_text);
 		getFormulaWithBrickField(BrickField.SIZE).setTextFieldId(R.id.brick_set_size_to_edit_text);
 		getFormulaWithBrickField(BrickField.SIZE).refreshTextField(view);
@@ -80,7 +79,7 @@ public class SetSizeToBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_set_size_to, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSetSizeTo = (TextView) prototypeView.findViewById(R.id.brick_set_size_to_edit_text);
 		textSetSizeTo.setText(formatNumberForPrototypeView(BrickValues.SET_SIZE_TO));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetTextBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetTextBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -86,12 +85,13 @@ public class SetTextBrick extends FormulaBrick implements View.OnClickListener {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_drone_set_text, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_drone_set_text;
+	}
 
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editX = (TextView) view.findViewById(R.id.brick_set_text_edit_text_x);
 		TextView editY = (TextView) view.findViewById(R.id.brick_set_text_edit_text_y);
 
@@ -114,7 +114,7 @@ public class SetTextBrick extends FormulaBrick implements View.OnClickListener {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_drone_set_text, null);
+		prototypeView = super.getPrototypeView(context);
 
 		TextView posX = (TextView) prototypeView.findViewById(R.id.brick_set_text_edit_text_x);
 		TextView posY = (TextView) prototypeView.findViewById(R.id.brick_set_text_edit_text_y);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetTransparencyBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetTransparencyBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -65,12 +64,13 @@ public class SetTransparencyBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_set_transparency;
+	}
 
-		view = View.inflate(context, R.layout.brick_set_transparency, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editX = (TextView) view.findViewById(R.id.brick_set_transparency_to_edit_text);
 		getFormulaWithBrickField(BrickField.TRANSPARENCY).setTextFieldId(R.id.brick_set_transparency_to_edit_text);
 		getFormulaWithBrickField(BrickField.TRANSPARENCY).refreshTextField(view);
@@ -81,7 +81,7 @@ public class SetTransparencyBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_set_transparency, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSetTransparency = (TextView) prototypeView
 				.findViewById(R.id.brick_set_transparency_to_edit_text);
 		textSetTransparency.setText(formatNumberForPrototypeView(BrickValues.SET_TRANSPARENCY));

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetVariableBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetVariableBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -97,10 +96,13 @@ public class SetVariableBrick extends UserVariableBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_set_variable, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_set_variable;
+	}
+
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView textField = (TextView) view.findViewById(R.id.brick_set_variable_edit_text);
 		getFormulaWithBrickField(BrickField.VARIABLE).setTextFieldId(R.id.brick_set_variable_edit_text);
 		getFormulaWithBrickField(BrickField.VARIABLE).refreshTextField(view);
@@ -125,7 +127,7 @@ public class SetVariableBrick extends UserVariableBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_set_variable, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner variableSpinner = (Spinner) prototypeView.findViewById(R.id.set_variable_spinner);
 
 		DataAdapter dataAdapter = ProjectManager.getInstance().getCurrentlyEditedScene().getDataContainer()

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetVolumeToBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetVolumeToBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,11 +63,13 @@ public class SetVolumeToBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_set_volume_to, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_set_volume_to;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView edit = (TextView) view.findViewById(R.id.brick_set_volume_to_edit_text);
 		getFormulaWithBrickField(BrickField.VOLUME).setTextFieldId(R.id.brick_set_volume_to_edit_text);
 		getFormulaWithBrickField(BrickField.VOLUME).refreshTextField(view);
@@ -79,7 +80,7 @@ public class SetVolumeToBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_set_volume_to, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSetVolumeTo = (TextView) prototypeView.findViewById(R.id.brick_set_volume_to_edit_text);
 		textSetVolumeTo.setText(formatNumberForPrototypeView(BrickValues.SET_VOLUME_TO));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetXBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetXBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,13 +63,13 @@ public class SetXBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_set_x;
+	}
 
-		view = View.inflate(context, R.layout.brick_set_x, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editX = (TextView) view.findViewById(R.id.brick_set_x_edit_text);
 
 		getFormulaWithBrickField(BrickField.X_POSITION).setTextFieldId(R.id.brick_set_x_edit_text);
@@ -83,7 +82,7 @@ public class SetXBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_set_x, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textXPosition = (TextView) prototypeView.findViewById(R.id.brick_set_x_edit_text);
 		textXPosition.setText(formatNumberForPrototypeView(BrickValues.X_POSITION));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetYBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetYBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,11 +63,13 @@ public class SetYBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_set_y, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_set_y;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editY = (TextView) view.findViewById(R.id.brick_set_y_edit_text);
 		getFormulaWithBrickField(BrickField.Y_POSITION).setTextFieldId(R.id.brick_set_y_edit_text);
 		getFormulaWithBrickField(BrickField.Y_POSITION).refreshTextField(view);
@@ -78,7 +79,7 @@ public class SetYBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_set_y, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textYPosition = (TextView) prototypeView.findViewById(R.id.brick_set_y_edit_text);
 		textYPosition.setText(formatNumberForPrototypeView(BrickValues.Y_POSITION));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowBrick.java
@@ -22,10 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
-import android.view.View;
-import android.widget.BaseAdapter;
-
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
@@ -39,17 +35,8 @@ public class ShowBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_show, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
-		return view;
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_show, null);
+	public int getViewResource() {
+		return R.layout.brick_show;
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -100,13 +99,13 @@ public class ShowTextBrick extends UserVariableBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_show_variable;
+	}
 
-		view = View.inflate(context, R.layout.brick_show_variable, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView editTextX = (TextView) view.findViewById(R.id.brick_show_variable_edit_text_x);
 		getFormulaWithBrickField(BrickField.X_POSITION).setTextFieldId(R.id.brick_show_variable_edit_text_x);
 		getFormulaWithBrickField(BrickField.X_POSITION).refreshTextField(view);
@@ -138,7 +137,7 @@ public class ShowTextBrick extends UserVariableBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_show_variable, null);
+		prototypeView = super.getPrototypeView(context);
 
 		Spinner variableSpinner = (Spinner) prototypeView.findViewById(R.id.show_variable_spinner);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SpeakAndWaitBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SpeakAndWaitBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -69,12 +68,13 @@ public class SpeakAndWaitBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(final Context context, final BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_speak_and_wait;
+	}
 
-		view = View.inflate(context, R.layout.brick_speak_and_wait, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView textField = (TextView) view.findViewById(R.id.brick_speak_and_wait_edit_text);
 		getFormulaWithBrickField(BrickField.SPEAK).setTextFieldId(R.id.brick_speak_and_wait_edit_text);
 		getFormulaWithBrickField(BrickField.SPEAK).refreshTextField(view);
@@ -85,7 +85,7 @@ public class SpeakAndWaitBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_speak_and_wait, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSpeak = (TextView) prototypeView.findViewById(R.id.brick_speak_and_wait_edit_text);
 		textSpeak.setText(context.getString(R.string.brick_speak_default_value));
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SpeakBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SpeakBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -63,11 +62,13 @@ public class SpeakBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(final Context context, final BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_speak, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_speak;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		TextView textField = (TextView) view.findViewById(R.id.brick_speak_edit_text);
 		getFormulaWithBrickField(BrickField.SPEAK).setTextFieldId(R.id.brick_speak_edit_text);
 		getFormulaWithBrickField(BrickField.SPEAK).refreshTextField(view);
@@ -78,7 +79,7 @@ public class SpeakBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_speak, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textSpeak = (TextView) prototypeView.findViewById(R.id.brick_speak_edit_text);
 		textSpeak.setText(context.getString(R.string.brick_speak_default_value));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/StampBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/StampBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
@@ -41,7 +40,7 @@ public class StampBrick extends BrickBaseType {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = View.inflate(context, R.layout.brick_stamp, null);
+		View view = super.getPrototypeView(context);
 
 		return view;
 	}
@@ -52,11 +51,13 @@ public class StampBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_stamp, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_stamp;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		return view;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/StopAllSoundsBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/StopAllSoundsBrick.java
@@ -22,10 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
-import android.view.View;
-import android.widget.BaseAdapter;
-
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
@@ -39,22 +35,13 @@ public class StopAllSoundsBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_stop_all_sounds, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_stop_all_sounds;
 	}
 
 	@Override
 	public Brick clone() {
 		return new StopAllSoundsBrick();
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_stop_all_sounds, null);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/StopScriptBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/StopScriptBrick.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.R;
@@ -51,12 +50,13 @@ public class StopScriptBrick extends BrickBaseType {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_stop_script;
+	}
 
-		view = View.inflate(context, R.layout.brick_stop_script, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		Spinner stopScriptSpinner = (Spinner) view.findViewById(R.id.brick_stop_script_spinner);
 
 		ArrayAdapter<String> spinnerAdapter = createArrayAdapter(context);
@@ -81,7 +81,7 @@ public class StopScriptBrick extends BrickBaseType {
 	@Override
 	public View getPrototypeView(Context context) {
 
-		View prototypeView = View.inflate(context, R.layout.brick_stop_script, null);
+		View prototypeView = super.getPrototypeView(context);
 
 		Spinner stopSctiptSpinner = (Spinner) prototypeView.findViewById(R.id.brick_stop_script_spinner);
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkBubbleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkBubbleBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -38,9 +37,9 @@ import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import java.util.List;
 
 public class ThinkBubbleBrick extends FormulaBrick implements OnClickListener {
+
 	private static final long serialVersionUID = 1L;
 	protected int type = Constants.THINK_BRICK;
-	private transient View prototypeView;
 
 	public ThinkBubbleBrick() {
 		addAllowedBrickField(BrickField.STRING);
@@ -57,15 +56,17 @@ public class ThinkBubbleBrick extends FormulaBrick implements OnClickListener {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return type == Constants.SAY_BRICK
+				? R.layout.brick_say_bubble
+				: R.layout.brick_think_bubble;
+	}
 
-		int layoutId = type == Constants.SAY_BRICK ? R.layout.brick_say_bubble : R.layout.brick_think_bubble;
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
+
 		int editTextId = type == Constants.SAY_BRICK ? R.id.brick_say_bubble_edit_text : R.id.brick_think_bubble_edit_text;
-
-		view = View.inflate(context, layoutId, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
 
 		TextView textField = (TextView) view.findViewById(editTextId);
 		getFormulaWithBrickField(BrickField.STRING).setTextFieldId(editTextId);
@@ -78,12 +79,11 @@ public class ThinkBubbleBrick extends FormulaBrick implements OnClickListener {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		int layoutId = type == Constants.SAY_BRICK ? R.layout.brick_say_bubble : R.layout.brick_think_bubble;
+		View prototypeView = super.getPrototypeView(context);
 		int stringId = type == Constants.SAY_BRICK ? R.string.brick_say_bubble_default_value : R.string.brick_think_bubble_default_value;
-		int prototypeTextViewId = type == Constants.SAY_BRICK ? R.id.brick_say_bubble_edit_text : R.id
-				.brick_think_bubble_edit_text;
+		int prototypeTextViewId = type == Constants.SAY_BRICK
+				? R.id.brick_say_bubble_edit_text : R.id.brick_think_bubble_edit_text;
 
-		prototypeView = View.inflate(context, layoutId, null);
 		TextView textSpeak = (TextView) prototypeView.findViewById(prototypeTextViewId);
 		textSpeak.setText(context.getString(stringId));
 		return prototypeView;
@@ -91,8 +91,8 @@ public class ThinkBubbleBrick extends FormulaBrick implements OnClickListener {
 
 	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
-		sequence.addAction(sprite.getActionFactory().createThinkSayBubbleAction(sprite, getFormulaWithBrickField(BrickField
-				.STRING), type));
+		sequence.addAction(sprite.getActionFactory().createThinkSayBubbleAction(sprite,
+				getFormulaWithBrickField(BrickField.STRING), type));
 		return null;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkForBubbleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkForBubbleBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.util.Log;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.ProjectManager;
@@ -42,9 +41,9 @@ import org.catrobat.catroid.utils.Utils;
 import java.util.List;
 
 public class ThinkForBubbleBrick extends FormulaBrick {
+
 	private static final long serialVersionUID = 1L;
 	protected int type = Constants.THINK_BRICK;
-	private transient View prototypeView;
 
 	public ThinkForBubbleBrick() {
 		addAllowedBrickField(BrickField.STRING);
@@ -79,20 +78,22 @@ public class ThinkForBubbleBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return type == Constants.SAY_BRICK
+				? R.layout.brick_say_for_bubble
+				: R.layout.brick_think_for_bubble;
+	}
 
-		int layoutId = type == Constants.SAY_BRICK ? R.layout.brick_say_for_bubble : R.layout.brick_think_for_bubble;
-		int editTextId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_edit_text_text : R.id
-				.brick_think_for_bubble_edit_text_text;
-		int editDurationId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_edit_text_duration : R.id
-				.brick_think_for_bubble_edit_text_duration;
-		int thinkSaySecondsLabelId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_seconds_label : R.id
-				.brick_think_for_bubble_seconds_label;
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 
-		view = View.inflate(context, layoutId, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
+		int editTextId = type == Constants.SAY_BRICK
+				? R.id.brick_say_for_bubble_edit_text_text : R.id.brick_think_for_bubble_edit_text_text;
+		int editDurationId = type == Constants.SAY_BRICK
+				? R.id.brick_say_for_bubble_edit_text_duration : R.id.brick_think_for_bubble_edit_text_duration;
+		int thinkSaySecondsLabelId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_seconds_label
+				: R.id.brick_think_for_bubble_seconds_label;
 
 		TextView editText = (TextView) view.findViewById(editTextId);
 		getFormulaWithBrickField(BrickField.STRING).setTextFieldId(editTextId);
@@ -115,7 +116,6 @@ public class ThinkForBubbleBrick extends FormulaBrick {
 				Log.d(getClass().getSimpleName(), "Couldn't interpret Formula.", interpretationException);
 			}
 		} else {
-
 			// Random Number to get into the "other" keyword for values like 0.99 or 2.001 seconds or degrees
 			// in hopefully all possible languages
 			seconds.setText(view.getResources().getQuantityString(R.plurals.second_plural,
@@ -128,16 +128,17 @@ public class ThinkForBubbleBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		int layoutId = type == Constants.SAY_BRICK ? R.layout.brick_say_for_bubble : R.layout.brick_think_for_bubble;
-		int textTextId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_edit_text_text : R.id
-				.brick_think_for_bubble_edit_text_text;
-		int textDurationId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_edit_text_duration : R
-				.id.brick_think_for_bubble_edit_text_duration;
+		View prototypeView = super.getPrototypeView(context);
+
+		int textTextId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_edit_text_text
+				: R.id.brick_think_for_bubble_edit_text_text;
+		int textDurationId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_edit_text_duration
+				: R.id.brick_think_for_bubble_edit_text_duration;
 		int defaultStringId = type == Constants.SAY_BRICK ? R.string.brick_say_bubble_default_value : R.string
 				.brick_think_bubble_default_value;
-		int thinkSaySecondsLabelId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_seconds_label : R.id
-				.brick_think_for_bubble_seconds_label;
-		prototypeView = View.inflate(context, layoutId, null);
+		int thinkSaySecondsLabelId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_seconds_label
+				: R.id.brick_think_for_bubble_seconds_label;
+
 		TextView textText = (TextView) prototypeView.findViewById(textTextId);
 		TextView textDuration = (TextView) prototypeView.findViewById(textDurationId);
 		TextView seconds = (TextView) prototypeView.findViewById(thinkSaySecondsLabelId);
@@ -150,15 +151,16 @@ public class ThinkForBubbleBrick extends FormulaBrick {
 
 	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
-		sequence.addAction(sprite.getActionFactory().createThinkSayForBubbleAction(sprite, getFormulaWithBrickField(BrickField
-				.STRING), type));
-		sequence.addAction(sprite.getActionFactory().createWaitForBubbleBrickAction(sprite, getFormulaWithBrickField(BrickField.DURATION_IN_SECONDS)));
+		sequence.addAction(sprite.getActionFactory().createThinkSayForBubbleAction(sprite,
+				getFormulaWithBrickField(BrickField.STRING), type));
+		sequence.addAction(sprite.getActionFactory().createWaitForBubbleBrickAction(sprite,
+				getFormulaWithBrickField(BrickField.DURATION_IN_SECONDS)));
 		return null;
 	}
 
 	public void showFormulaEditorToEditFormula(View view) {
-		int editTextId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_edit_text_text : R.id
-				.brick_think_for_bubble_edit_text_text;
+		int editTextId = type == Constants.SAY_BRICK ? R.id.brick_say_for_bubble_edit_text_text
+				: R.id.brick_think_for_bubble_edit_text_text;
 
 		if (view.getId() == editTextId) {
 			FormulaEditorFragment.showFragment(view, this, BrickField.STRING);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/TurnLeftBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/TurnLeftBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -65,11 +64,13 @@ public class TurnLeftBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_turn_left, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_turn_left;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editDegrees = (TextView) view.findViewById(R.id.brick_turn_left_edit_text);
 		getFormulaWithBrickField(BrickField.TURN_LEFT_DEGREES).setTextFieldId(R.id.brick_turn_left_edit_text);
 		getFormulaWithBrickField(BrickField.TURN_LEFT_DEGREES).refreshTextField(view);
@@ -80,7 +81,7 @@ public class TurnLeftBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_turn_left, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textDegrees = (TextView) prototypeView.findViewById(R.id.brick_turn_left_edit_text);
 		textDegrees.setText(formatNumberForPrototypeView(BrickValues.TURN_DEGREES));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/TurnRightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/TurnRightBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -64,13 +63,13 @@ public class TurnRightBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_turn_right;
+	}
 
-		view = View.inflate(context, R.layout.brick_turn_right, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editDegrees = (TextView) view.findViewById(R.id.brick_turn_right_edit_text);
 		getFormulaWithBrickField(BrickField.TURN_RIGHT_DEGREES).setTextFieldId(R.id.brick_turn_right_edit_text);
 		getFormulaWithBrickField(BrickField.TURN_RIGHT_DEGREES).refreshTextField(view);
@@ -81,7 +80,7 @@ public class TurnRightBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_turn_right, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textDegrees = (TextView) prototypeView.findViewById(R.id.brick_turn_right_edit_text);
 		textDegrees.setText(formatNumberForPrototypeView(BrickValues.TURN_DEGREES));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserBrick.java
@@ -26,7 +26,6 @@ import android.content.Context;
 import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.widget.BaseAdapter;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -187,20 +186,16 @@ public class UserBrick extends BrickBaseType implements OnClickListener {
 		return formulaList;
 	}
 
-	public void appendBrickToScript(Brick brick) {
-		definitionBrick.appendBrickToScript(brick);
+	@Override
+	public int getViewResource() {
+		return R.layout.brick_user;
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public View getView(Context context) {
+		super.getView(context);
 		setUserBrickParametersParent();
-
-		view = View.inflate(context, R.layout.brick_user, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
 		onLayoutChanged(view);
-
 		return view;
 	}
 
@@ -214,7 +209,7 @@ public class UserBrick extends BrickBaseType implements OnClickListener {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_user, null);
+		prototypeView = super.getPrototypeView(context);
 		onLayoutChanged(prototypeView);
 		return prototypeView;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserBrickParameter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserBrickParameter.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.ProjectManager;
@@ -74,13 +73,14 @@ public class UserBrickParameter extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter adapter) {
-		return parent.getView(context, adapter);
+	public int getViewResource() {
+		return parent.getViewResource();
 	}
 
 	@Override
-	public View getPrototypeView(Context context) {
-		return null;
+	public View getView(Context context) {
+		super.getView(context);
+		return parent.getView(context);
 	}
 
 	@Override
@@ -98,35 +98,35 @@ public class UserBrickParameter extends FormulaBrick {
 		FormulaEditorFragment.showFragment(view, this, BrickField.USER_BRICK);
 	}
 
-	public void setParent(UserBrick parent) {
-		this.parent = parent;
-	}
-
 	public TextView getTextView() {
 		return textView;
-	}
-
-	public TextView getPrototypeView() {
-		return prototypeView;
-	}
-
-	public UserScriptDefinitionBrickElement getElement() {
-		return element;
 	}
 
 	public void setTextView(TextView textView) {
 		this.textView = textView;
 	}
 
+	public TextView getPrototypeView() {
+		return prototypeView;
+	}
+
 	public void setPrototypeView(TextView prototypeView) {
 		this.prototypeView = prototypeView;
+	}
+
+	public UserScriptDefinitionBrickElement getElement() {
+		return element;
+	}
+
+	public void setElement(UserScriptDefinitionBrickElement element) {
+		this.element = element;
 	}
 
 	public UserBrick getParent() {
 		return parent;
 	}
 
-	public void setElement(UserScriptDefinitionBrickElement element) {
-		this.element = element;
+	public void setParent(UserBrick parent) {
+		this.parent = parent;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserScriptDefinitionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserScriptDefinitionBrick.java
@@ -31,7 +31,6 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.View.MeasureSpec;
 import android.view.View.OnClickListener;
-import android.widget.BaseAdapter;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -118,34 +117,20 @@ public class UserScriptDefinitionBrick extends BrickBaseType implements ScriptBr
 		return resources;
 	}
 
-	public void appendBrickToScript(Brick brick) {
-		this.getScriptSafe().addBrick(brick);
-	}
-
 	@Override
 	public CheckBox getCheckBox() {
 		return null;
 	}
 
-	public List<UserScriptDefinitionBrickElement> cloneDefinitionBrickElements() {
-		List<UserScriptDefinitionBrickElement> cloneList = new ArrayList<>();
-		for (UserScriptDefinitionBrickElement originalUserBrickElement : userScriptDefinitionBrickElements) {
-			UserScriptDefinitionBrickElement clonedUserBrickElement = new UserScriptDefinitionBrickElement();
-			clonedUserBrickElement.setText(originalUserBrickElement.getText());
-			clonedUserBrickElement.setElementType(originalUserBrickElement.getElementType());
-			clonedUserBrickElement.setNewLineHint(originalUserBrickElement.isNewLineHint());
-			cloneList.add(clonedUserBrickElement);
-		}
-		return cloneList;
+	@Override
+	public int getViewResource() {
+		return R.layout.brick_user_definition;
 	}
 
 	@Override
-	public View getView(final Context context, final BaseAdapter baseAdapter) {
-
-		view = View.inflate(context, R.layout.brick_user_definition, null);
-		setCheckboxView();
+	public View getView(final Context context) {
+		super.getView(context);
 		onLayoutChanged();
-
 		return view;
 	}
 
@@ -189,7 +174,7 @@ public class UserScriptDefinitionBrick extends BrickBaseType implements ScriptBr
 	}
 
 	private View getUserBrickPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_user, null);
+		View prototypeView = super.getPrototypeView(context);
 		BrickLayout layout = (BrickLayout) prototypeView.findViewById(R.id.brick_user_flow_layout);
 		if (layout.getChildCount() > 0) {
 			layout.removeAllViews();
@@ -293,11 +278,6 @@ public class UserScriptDefinitionBrick extends BrickBaseType implements ScriptBr
 		canvas.drawBitmap(bitmap, radius, radius, paint);
 
 		return toReturn;
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return getView(context, null);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/VibrationBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/VibrationBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.util.Log;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.ProjectManager;
@@ -68,13 +67,13 @@ public class VibrationBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_vibration;
+	}
 
-		view = View.inflate(context, R.layout.brick_vibration, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView editVibrate = (TextView) view.findViewById(R.id.brick_vibration_edit_text);
 		TextView secondTextVibrate = (TextView) view.findViewById(R.id.brick_vibration_second_label);
 
@@ -102,7 +101,7 @@ public class VibrationBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_vibration, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textVibrate = (TextView) prototypeView.findViewById(R.id.brick_vibration_edit_text);
 		textVibrate.setText(formatNumberForPrototypeView(BrickValues.VIBRATE_SECONDS));
 		TextView secondTextVibrate = (TextView) prototypeView.findViewById(R.id.brick_vibration_second_label);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WaitBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WaitBrick.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.util.Log;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.ProjectManager;
@@ -41,9 +40,8 @@ import org.catrobat.catroid.utils.Utils;
 import java.util.List;
 
 public class WaitBrick extends FormulaBrick {
-	private static final long serialVersionUID = 1L;
 
-	private transient View prototypeView;
+	private static final long serialVersionUID = 1L;
 
 	public WaitBrick() {
 		addAllowedBrickField(BrickField.TIME_TO_WAIT_IN_SECONDS);
@@ -76,17 +74,23 @@ public class WaitBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_wait;
+	}
 
-		view = View.inflate(context, R.layout.brick_wait, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
+		onViewCreated(view);
+		return view;
+	}
 
-		setCheckboxView();
-		TextView edit = (TextView) view.findViewById(R.id.brick_wait_edit_text);
+	protected void onViewCreated(View view) {
+		TextView edit = view.findViewById(R.id.brick_wait_edit_text);
 		getFormulaWithBrickField(BrickField.TIME_TO_WAIT_IN_SECONDS).setTextFieldId(R.id.brick_wait_edit_text);
 		getFormulaWithBrickField(BrickField.TIME_TO_WAIT_IN_SECONDS).refreshTextField(view);
 
-		TextView times = (TextView) view.findViewById(R.id.brick_wait_second_text_view);
+		TextView times = view.findViewById(R.id.brick_wait_second_text_view);
 
 		if (getFormulaWithBrickField(BrickField.TIME_TO_WAIT_IN_SECONDS).isSingleNumberFormula()) {
 			try {
@@ -107,18 +111,21 @@ public class WaitBrick extends FormulaBrick {
 		}
 
 		edit.setOnClickListener(this);
-		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_wait, null);
-		TextView textWait = (TextView) prototypeView.findViewById(R.id.brick_wait_edit_text);
-		textWait.setText(formatNumberForPrototypeView(BrickValues.WAIT / 1000));
-		TextView times = (TextView) prototypeView.findViewById(R.id.brick_wait_second_text_view);
-		times.setText(context.getResources().getQuantityString(R.plurals.second_plural,
-				Utils.convertDoubleToPluralInteger(BrickValues.WAIT / 1000)));
+		View prototypeView = super.getPrototypeView(context);
+		onPrototypeViewCreated(prototypeView);
 		return prototypeView;
+	}
+
+	protected void onPrototypeViewCreated(View prototypeView) {
+		TextView textWait = prototypeView.findViewById(R.id.brick_wait_edit_text);
+		textWait.setText(formatNumberForPrototypeView(BrickValues.WAIT / 1000));
+		TextView times = prototypeView.findViewById(R.id.brick_wait_second_text_view);
+		times.setText(prototypeView.getContext().getResources().getQuantityString(R.plurals.second_plural,
+				Utils.convertDoubleToPluralInteger(BrickValues.WAIT / 1000)));
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WaitUntilBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WaitUntilBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -49,12 +48,13 @@ public class WaitUntilBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_wait_until, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_wait_until;
+	}
 
-		setCheckboxView();
-
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		TextView ifBeginTextView = (TextView) view.findViewById(R.id.brick_wait_until_edit_text);
 
 		getFormulaWithBrickField(BrickField.IF_CONDITION).setTextFieldId(R.id.brick_wait_until_edit_text);
@@ -67,7 +67,7 @@ public class WaitUntilBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_wait_until, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textIfBegin = (TextView) prototypeView.findViewById(R.id.brick_wait_until_edit_text);
 		textIfBegin.setText(BrickValues.IF_CONDITION);
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBackgroundChangesBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBackgroundChangesBrick.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.view.View;
 import android.widget.AdapterView;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.ProjectManager;
@@ -92,12 +91,13 @@ public class WhenBackgroundChangesBrick extends BrickBaseType implements
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_when_background_changes_to;
+	}
 
-		view = View.inflate(context, R.layout.brick_when_background_changes_to, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		spinner = view.findViewById(R.id.brick_when_background_spinner);
 		spinnerAdapter = new SpinnerAdapterWithNewOption(context, getLookNames());
 		spinnerAdapter.setOnDropDownItemClickListener(this);
@@ -163,7 +163,7 @@ public class WhenBackgroundChangesBrick extends BrickBaseType implements
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View view = View.inflate(context, R.layout.brick_when_background_changes_to, null);
+		View view = super.getPrototypeView(context);
 		spinner = view.findViewById(R.id.brick_when_background_spinner);
 
 		spinnerAdapter = new SpinnerAdapterWithNewOption(context, getLookNames());

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
@@ -51,17 +50,14 @@ public class WhenBrick extends BrickBaseType implements ScriptBrick {
 	}
 
 	@Override
-	public View getView(final Context context, final BaseAdapter baseAdapter) {
-
-		view = View.inflate(context, R.layout.brick_when, null);
-
-		setCheckboxView();
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_when;
 	}
 
 	@Override
-	public View getPrototypeView(Context context) {
-		return getView(context, null);
+	public View getView(final Context context) {
+		super.getView(context);
+		return view;
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenClonedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenClonedBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
@@ -48,18 +47,14 @@ public class WhenClonedBrick extends BrickBaseType implements ScriptBrick {
 	}
 
 	@Override
-	public View getView(final Context context, final BaseAdapter baseAdapter) {
-
-		view = View.inflate(context, R.layout.brick_when_cloned, null);
-
-		setCheckboxView();
-
-		return view;
+	public int getViewResource() {
+		return R.layout.brick_when_cloned;
 	}
 
 	@Override
-	public View getPrototypeView(Context context) {
-		return getView(context, null);
+	public View getView(final Context context) {
+		super.getView(context);
+		return view;
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenConditionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenConditionBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -73,13 +72,14 @@ public class WhenConditionBrick extends FormulaBrick implements ScriptBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_when_condition_true;
+	}
 
-		view = View.inflate(context, R.layout.brick_when_condition_true, null);
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
 		TextView conditionEditText = (TextView) view.findViewById(R.id.brick_when_condition_edit_text);
 
 		getFormulaWithBrickField(BrickField.IF_CONDITION).setTextFieldId(R.id.brick_when_condition_edit_text);
@@ -96,7 +96,7 @@ public class WhenConditionBrick extends FormulaBrick implements ScriptBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_when_condition_true, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textView = (TextView) prototypeView.findViewById(R.id.brick_when_condition_edit_text);
 		textView.setText(BrickValues.IF_CONDITION);
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenGamepadButtonBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenGamepadButtonBrick.java
@@ -27,7 +27,6 @@ import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.CatroidApplication;
@@ -55,13 +54,13 @@ public class WhenGamepadButtonBrick extends BrickBaseType implements ScriptBrick
 	}
 
 	@Override
-	public View getView(final Context context, final BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_when_gamepad_button;
+	}
 
-		view = View.inflate(context, R.layout.brick_when_gamepad_button, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		final Spinner actionSpinner = (Spinner) view.findViewById(R.id.brick_when_gamepad_button_spinner);
 
 		ArrayAdapter<CharSequence> arrayAdapter = ArrayAdapter.createFromResource(context,
@@ -84,11 +83,6 @@ public class WhenGamepadButtonBrick extends BrickBaseType implements ScriptBrick
 		});
 		actionSpinner.setSelection(actions.indexOf(whenGamepadButtonScript.getAction()));
 		return view;
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return getView(context, null);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenNfcBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenNfcBrick.java
@@ -31,7 +31,6 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
 
@@ -84,15 +83,16 @@ public class WhenNfcBrick extends BrickBaseType implements ScriptBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_when_nfc;
+	}
+
+	@Override
+	public View getView(final Context context) {
 		if (whenNfcScript == null) {
 			whenNfcScript = new WhenNfcScript(nfcTag);
 		}
-
-		view = View.inflate(context, R.layout.brick_when_nfc, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+		super.getView(context);
 		final Spinner nfcSpinner = (Spinner) view.findViewById(R.id.brick_when_nfc_spinner);
 
 		final ArrayAdapter<NfcTagData> spinnerAdapter = createNfcTagAdapter(context);
@@ -179,7 +179,7 @@ public class WhenNfcBrick extends BrickBaseType implements ScriptBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_when_nfc, null);
+		prototypeView = super.getPrototypeView(context);
 		Spinner nfcSpinner = (Spinner) prototypeView.findViewById(R.id.brick_when_nfc_spinner);
 
 		SpinnerAdapter nfcSpinnerAdapter = createNfcTagAdapter(context); //NfcTagContainer.getMessageAdapter(context);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenRaspiPinChangedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenRaspiPinChangedBrick.java
@@ -26,7 +26,6 @@ import android.content.Context;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 
 import org.catrobat.catroid.R;
@@ -41,6 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class WhenRaspiPinChangedBrick extends BrickBaseType implements ScriptBrick {
+
 	private static final long serialVersionUID = 1L;
 
 	private RaspiInterruptScript script;
@@ -53,40 +53,40 @@ public class WhenRaspiPinChangedBrick extends BrickBaseType implements ScriptBri
 	}
 
 	@Override
-	public View getView(final Context context, final BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_raspi_pin_changed, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
+	public int getViewResource() {
+		return R.layout.brick_raspi_pin_changed;
+	}
 
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 		setupValueSpinner(context);
 		setupPinSpinner(context);
-
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_raspi_pin_changed, null);
+		View prototypeView = super.getPrototypeView(context);
 
-		Spinner pinSpinner = (Spinner) prototypeView.findViewById(R.id.brick_raspi_when_pinspinner);
+		Spinner pinSpinner = prototypeView.findViewById(R.id.brick_raspi_when_pinspinner);
 
-		ArrayAdapter<String> messageAdapter = new ArrayAdapter<String>(context, android.R.layout.simple_spinner_item);
+		ArrayAdapter<String> messageAdapter = new ArrayAdapter<>(context, android.R.layout.simple_spinner_item);
 		messageAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 		messageAdapter.add(script.getPin());
 		pinSpinner.setAdapter(messageAdapter);
 
-		Spinner valueSpinner = (Spinner) prototypeView.findViewById(R.id.brick_raspi_when_valuespinner);
-
+		Spinner valueSpinner = prototypeView.findViewById(R.id.brick_raspi_when_valuespinner);
 		valueSpinner.setAdapter(getValueSpinnerArrayAdapter(context));
 		return prototypeView;
 	}
 
 	private void setupPinSpinner(Context context) {
-		final Spinner pinSpinner = (Spinner) view.findViewById(R.id.brick_raspi_when_pinspinner);
+		final Spinner pinSpinner = view.findViewById(R.id.brick_raspi_when_pinspinner);
 
 		String revision = SettingsFragment.getRaspiRevision(context);
 		ArrayList<Integer> availableGPIOs = RaspberryPiService.getInstance().getGpioList(revision);
-		ArrayAdapter<String> messageAdapter2 = new ArrayAdapter<String>(context, android.R.layout.simple_spinner_item);
+		ArrayAdapter<String> messageAdapter2 = new ArrayAdapter<>(context, android.R.layout.simple_spinner_item);
 		messageAdapter2.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 		for (Integer gpio : availableGPIOs) {
 			messageAdapter2.add(gpio.toString());
@@ -110,7 +110,7 @@ public class WhenRaspiPinChangedBrick extends BrickBaseType implements ScriptBri
 
 	private void setupValueSpinner(final Context context) {
 
-		final Spinner valueSpinner = (Spinner) view.findViewById(R.id.brick_raspi_when_valuespinner);
+		final Spinner valueSpinner = view.findViewById(R.id.brick_raspi_when_valuespinner);
 
 		ArrayAdapter<String> valueAdapter = getValueSpinnerArrayAdapter(context);
 		valueSpinner.setAdapter(valueAdapter);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenStartedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenStartedBrick.java
@@ -22,10 +22,6 @@
  */
 package org.catrobat.catroid.content.bricks;
 
-import android.content.Context;
-import android.view.View;
-import android.widget.BaseAdapter;
-
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
@@ -51,16 +47,8 @@ public class WhenStartedBrick extends BrickBaseType implements ScriptBrick {
 	}
 
 	@Override
-	public View getView(Context context, final BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_when_started, null);
-
-		setCheckboxView();
-		return view;
-	}
-
-	@Override
-	public View getPrototypeView(Context context) {
-		return View.inflate(context, R.layout.brick_when_started, null);
+	public int getViewResource() {
+		return R.layout.brick_when_started;
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenTouchDownBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenTouchDownBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
@@ -65,18 +64,19 @@ public class WhenTouchDownBrick extends BrickBaseType implements ScriptBrick {
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_screen_touched;
+	}
 
-		view = View.inflate(context, R.layout.brick_screen_touched, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
-
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
 		return view;
 	}
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_screen_touched, null);
+		prototypeView = super.getPrototypeView(context);
 		return prototypeView;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/CollisionReceiverBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/CollisionReceiverBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
 
@@ -39,15 +38,14 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.BrickBaseType;
-import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.ScriptBrick;
 
 import java.util.List;
 
 public class CollisionReceiverBrick extends BrickBaseType implements ScriptBrick, Cloneable {
-	private static final long serialVersionUID = 1L;
-	public static final String ANYTHING_ESCAPE_CHAR = "\0";
 
+	public static final String ANYTHING_ESCAPE_CHAR = "\0";
+	private static final long serialVersionUID = 1L;
 	private CollisionScript collisionScript;
 	private transient ArrayAdapter<String> messageAdapter;
 
@@ -68,14 +66,17 @@ public class CollisionReceiverBrick extends BrickBaseType implements ScriptBrick
 	}
 
 	@Override
-	public View getView(final Context context, BaseAdapter baseAdapter) {
+	public int getViewResource() {
+		return R.layout.brick_physics_collision_receive;
+	}
+
+	@Override
+	public View getView(final Context context) {
+		super.getView(context);
+
 		if (collisionScript == null) {
 			collisionScript = new CollisionScript(getSpriteToCollideWithName());
 		}
-
-		view = View.inflate(context, R.layout.brick_physics_collision_receive, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
-		setCheckboxView();
 
 		final Spinner broadcastSpinner = (Spinner) view.findViewById(R.id.brick_collision_receive_spinner);
 
@@ -102,7 +103,7 @@ public class CollisionReceiverBrick extends BrickBaseType implements ScriptBrick
 
 	@Override
 	public View getPrototypeView(Context context) {
-		View prototypeView = View.inflate(context, R.layout.brick_physics_collision_receive, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner broadcastReceiverSpinner = (Spinner) prototypeView.findViewById(R.id.brick_collision_receive_spinner);
 
 		SpinnerAdapter collisionReceiverSpinnerAdapter = getCollisionObjectAdapter(context);

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetBounceBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetBounceBrick.java
@@ -24,14 +24,12 @@ package org.catrobat.catroid.physics.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
-import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -39,9 +37,8 @@ import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import java.util.List;
 
 public class SetBounceBrick extends FormulaBrick {
-	private static final long serialVersionUID = 1L;
 
-	private transient View prototypeView;
+	private static final long serialVersionUID = 1L;
 
 	public SetBounceBrick() {
 		addAllowedBrickField(BrickField.PHYSICS_BOUNCE_FACTOR);
@@ -66,11 +63,13 @@ public class SetBounceBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_physics_set_bounce_factor, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_physics_set_bounce_factor;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 
 		TextView edit = (TextView) view.findViewById(R.id.brick_set_bounce_factor_edit_text);
 
@@ -84,7 +83,7 @@ public class SetBounceBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_physics_set_bounce_factor, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textBounceFactor = (TextView) prototypeView.findViewById(R.id.brick_set_bounce_factor_edit_text);
 		textBounceFactor.setText(formatNumberForPrototypeView(BrickValues.PHYSIC_BOUNCE_FACTOR * 100));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetFrictionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetFrictionBrick.java
@@ -24,14 +24,12 @@ package org.catrobat.catroid.physics.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
-import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -39,9 +37,8 @@ import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import java.util.List;
 
 public class SetFrictionBrick extends FormulaBrick {
-	private static final long serialVersionUID = 1L;
 
-	private transient View prototypeView;
+	private static final long serialVersionUID = 1L;
 
 	public SetFrictionBrick() {
 		addAllowedBrickField(BrickField.PHYSICS_FRICTION);
@@ -66,11 +63,13 @@ public class SetFrictionBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_physics_set_friction, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_physics_set_friction;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 
 		TextView edit = (TextView) view.findViewById(R.id.brick_set_friction_edit_text);
 
@@ -84,7 +83,7 @@ public class SetFrictionBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_physics_set_friction, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textFriction = (TextView) prototypeView.findViewById(R.id.brick_set_friction_edit_text);
 		textFriction.setText(formatNumberForPrototypeView(BrickValues.PHYSIC_FRICTION * 100));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetGravityBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetGravityBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.physics.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.badlogic.gdx.math.Vector2;
@@ -33,7 +32,6 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
-import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -41,9 +39,8 @@ import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import java.util.List;
 
 public class SetGravityBrick extends FormulaBrick {
-	private static final long serialVersionUID = 1L;
 
-	private transient View prototypeView;
+	private static final long serialVersionUID = 1L;
 
 	public SetGravityBrick() {
 		addAllowedBrickField(BrickField.PHYSICS_GRAVITY_X);
@@ -71,11 +68,13 @@ public class SetGravityBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_physics_set_gravity, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_physics_set_gravity;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 
 		TextView editX = (TextView) view.findViewById(R.id.brick_set_gravity_edit_text_x);
 		getFormulaWithBrickField(BrickField.PHYSICS_GRAVITY_X).setTextFieldId(R.id.brick_set_gravity_edit_text_x);
@@ -93,7 +92,7 @@ public class SetGravityBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_physics_set_gravity, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textGravityX = (TextView) prototypeView.findViewById(R.id.brick_set_gravity_edit_text_x);
 		textGravityX.setText(formatNumberForPrototypeView(BrickValues.PHYSIC_GRAVITY.x));
 		TextView textGravityY = (TextView) prototypeView.findViewById(R.id.brick_set_gravity_edit_text_y);

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetMassBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetMassBrick.java
@@ -24,14 +24,12 @@ package org.catrobat.catroid.physics.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
-import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -39,9 +37,8 @@ import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import java.util.List;
 
 public class SetMassBrick extends FormulaBrick {
-	private static final long serialVersionUID = 1L;
 
-	private transient View prototypeView;
+	private static final long serialVersionUID = 1L;
 
 	public SetMassBrick() {
 		addAllowedBrickField(BrickField.PHYSICS_MASS);
@@ -66,11 +63,13 @@ public class SetMassBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_physics_set_mass, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_physics_set_mass;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 
 		TextView edit = (TextView) view.findViewById(R.id.brick_set_mass_edit_text);
 
@@ -84,7 +83,7 @@ public class SetMassBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_physics_set_mass, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textMass = (TextView) prototypeView.findViewById(R.id.brick_set_mass_edit_text);
 		textMass.setText(formatNumberForPrototypeView(BrickValues.PHYSIC_MASS));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetPhysicsObjectTypeBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetPhysicsObjectTypeBrick.java
@@ -27,7 +27,6 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
 
@@ -36,17 +35,15 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.BrickBaseType;
-import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.physics.PhysicsObject;
 
 import java.util.List;
 
 public class SetPhysicsObjectTypeBrick extends BrickBaseType implements Cloneable {
+
 	private static final long serialVersionUID = 1L;
 
 	private PhysicsObject.Type type = PhysicsObject.Type.NONE;
-
-	private transient View prototypeView;
 
 	public SetPhysicsObjectTypeBrick() {
 	}
@@ -66,11 +63,13 @@ public class SetPhysicsObjectTypeBrick extends BrickBaseType implements Cloneabl
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_physics_set_physics_object_type, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_physics_set_physics_object_type;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 
 		final Spinner spinner = (Spinner) view.findViewById(R.id.brick_set_physics_object_type_spinner);
 		spinner.setAdapter(createAdapter(context));
@@ -106,7 +105,7 @@ public class SetPhysicsObjectTypeBrick extends BrickBaseType implements Cloneabl
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_physics_set_physics_object_type, null);
+		View prototypeView = super.getPrototypeView(context);
 		Spinner pointToSpinner = (Spinner) prototypeView.findViewById(R.id.brick_set_physics_object_type_spinner);
 		SpinnerAdapter objectTypeSpinnerAdapter = createAdapter(context);
 		pointToSpinner.setAdapter(objectTypeSpinnerAdapter);

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetVelocityBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetVelocityBrick.java
@@ -24,7 +24,6 @@ package org.catrobat.catroid.physics.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.badlogic.gdx.math.Vector2;
@@ -33,7 +32,6 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
-import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -41,9 +39,8 @@ import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import java.util.List;
 
 public class SetVelocityBrick extends FormulaBrick {
-	private static final long serialVersionUID = 1L;
 
-	private transient View prototypeView;
+	private static final long serialVersionUID = 1L;
 
 	public SetVelocityBrick() {
 		addAllowedBrickField(BrickField.PHYSICS_VELOCITY_X);
@@ -71,11 +68,14 @@ public class SetVelocityBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_physics_set_velocity, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_physics_set_velocity;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
+
 		TextView editX = (TextView) view.findViewById(R.id.brick_set_velocity_edit_text_x);
 		getFormulaWithBrickField(BrickField.PHYSICS_VELOCITY_X).setTextFieldId(R.id.brick_set_velocity_edit_text_x);
 		getFormulaWithBrickField(BrickField.PHYSICS_VELOCITY_X).refreshTextField(view);
@@ -92,7 +92,7 @@ public class SetVelocityBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_physics_set_velocity, null);
+		View prototypeView = super.getPrototypeView(context);
 		TextView textVelocityX = (TextView) prototypeView.findViewById(R.id.brick_set_velocity_edit_text_x);
 		textVelocityX.setText(formatNumberForPrototypeView(BrickValues.PHYSIC_VELOCITY.x));
 		TextView textVelocityY = (TextView) prototypeView.findViewById(R.id.brick_set_velocity_edit_text_y);

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/TurnLeftSpeedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/TurnLeftSpeedBrick.java
@@ -24,14 +24,12 @@ package org.catrobat.catroid.physics.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
-import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -66,11 +64,13 @@ public class TurnLeftSpeedBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_physics_turn_left_speed, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_physics_turn_left_speed;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 
 		TextView edit = (TextView) view.findViewById(R.id.brick_turn_left_speed_edit_text);
 
@@ -84,7 +84,7 @@ public class TurnLeftSpeedBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_physics_turn_left_speed, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textTurnLeftSpeed = (TextView) prototypeView.findViewById(R.id.brick_turn_left_speed_edit_text);
 		textTurnLeftSpeed.setText(formatNumberForPrototypeView(BrickValues.PHYSIC_TURN_DEGREES));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/TurnRightSpeedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/TurnRightSpeedBrick.java
@@ -24,14 +24,12 @@ package org.catrobat.catroid.physics.content.bricks;
 
 import android.content.Context;
 import android.view.View;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
-import org.catrobat.catroid.content.bricks.BrickViewProvider;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -66,11 +64,13 @@ public class TurnRightSpeedBrick extends FormulaBrick {
 	}
 
 	@Override
-	public View getView(Context context, BaseAdapter baseAdapter) {
-		view = View.inflate(context, R.layout.brick_physics_turn_right_speed, null);
-		view = BrickViewProvider.setAlphaOnView(view, alphaValue);
+	public int getViewResource() {
+		return R.layout.brick_physics_turn_right_speed;
+	}
 
-		setCheckboxView();
+	@Override
+	public View getView(Context context) {
+		super.getView(context);
 
 		TextView edit = (TextView) view.findViewById(R.id.brick_turn_right_speed_edit_text);
 
@@ -84,7 +84,7 @@ public class TurnRightSpeedBrick extends FormulaBrick {
 
 	@Override
 	public View getPrototypeView(Context context) {
-		prototypeView = View.inflate(context, R.layout.brick_physics_turn_right_speed, null);
+		prototypeView = super.getPrototypeView(context);
 		TextView textTurnRightSpeed = (TextView) prototypeView.findViewById(R.id.brick_turn_right_speed_edit_text);
 		textTurnRightSpeed.setText(formatNumberForPrototypeView(BrickValues.PHYSIC_TURN_DEGREES));
 		return prototypeView;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/adapter/BrickAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/adapter/BrickAdapter.java
@@ -866,7 +866,7 @@ public class BrickAdapter extends BrickBaseAdapter implements DragAndDropListene
 
 		BrickBaseType brick = (BrickBaseType) getItem(position);
 
-		View currentBrickView = brick.getView(context, this);
+		View currentBrickView = brick.getView(context);
 		BrickViewProvider.setSaturationOnView(currentBrickView, brick.isCommentedOut());
 		currentBrickView.setOnClickListener(this);
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -341,7 +341,7 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		if (showCustomView) {
 			return clonedFormulaBrick.getCustomView(context, 0, null);
 		} else {
-			return clonedFormulaBrick.getView(context, null);
+			return clonedFormulaBrick.getView(context);
 		}
 	}
 


### PR DESCRIPTION
- all ~150 bricks are now inflated from a single point.
- brick now only need to provide LayoutRes through one method.
- prototype view and ScriptFragmentView are now inflated by the
base type, overrides still initialse the TextViews.
- bricks are still inflated newly on every getView(..) call,
anything else wouldn't have worked anyway (at least we know that now).
- many Bricks have become very minimal now.
- many things could still be improved -> e.g. alpha handling.