### PR TITLE
CAT-FIX Fix crash when not connected to a network

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/SignInActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SignInActivity.java
@@ -23,9 +23,7 @@
 
 package org.catrobat.catroid.ui;
 
-import android.content.Context;
 import android.content.Intent;
-import android.net.ConnectivityManager;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.text.Html;
@@ -46,6 +44,7 @@ import org.catrobat.catroid.ui.recyclerview.dialog.login.LoginDialogFragment;
 import org.catrobat.catroid.ui.recyclerview.dialog.login.RegistrationDialogFragment;
 import org.catrobat.catroid.ui.recyclerview.dialog.login.SignInCompleteListener;
 import org.catrobat.catroid.utils.ToastUtil;
+import org.catrobat.catroid.utils.Utils;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -95,11 +94,7 @@ public class SignInActivity extends BaseActivity implements SignInCompleteListen
 	}
 
 	public void onButtonClick(final View view) {
-		ConnectivityManager connectivityManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-		boolean isNetworkAvailable = connectivityManager != null
-				&& connectivityManager.getActiveNetworkInfo().isConnected();
-
-		if (!isNetworkAvailable) {
+		if (!Utils.isNetworkAvailable(this)) {
 			ToastUtil.showError(this, R.string.error_internet_connection);
 			return;
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
@@ -31,8 +31,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -213,12 +211,8 @@ public class WebViewActivity extends BaseActivity {
 
 		@Override
 		public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
-			ConnectivityManager cm = (ConnectivityManager) getBaseContext().getSystemService(Context.CONNECTIVITY_SERVICE);
-			NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
-			boolean isConnected = activeNetwork != null && activeNetwork.isConnectedOrConnecting();
-
 			int errorMessage;
-			if (!isConnected) {
+			if (!Utils.isNetworkAvailable(WebViewActivity.this)) {
 				errorMessage = R.string.error_internet_connection;
 			} else {
 				errorMessage = R.string.error_unknown_error;

--- a/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
@@ -95,7 +95,9 @@ public final class Utils {
 	public static boolean isNetworkAvailable(Context context) {
 		ConnectivityManager connectivityManager = (ConnectivityManager) context
 				.getSystemService(Context.CONNECTIVITY_SERVICE);
-		return connectivityManager != null && connectivityManager.getActiveNetworkInfo().isConnected();
+		return connectivityManager != null
+				&& connectivityManager.getActiveNetworkInfo() != null
+				&& connectivityManager.getActiveNetworkInfo().isConnected();
 	}
 
 	public static boolean checkForNetworkError(boolean success, WebconnectionException exception) {


### PR DESCRIPTION
When the device is not connected to a network,
ConnectivityManager.getActiveNetworkInfo will return null which will
result in a NullPointerException. Added null checks to prevent this
crash.

There is a small behavior change when an error occurs in the WebView.
Previously, the additional info '…Check your Internet connection.' was
only shown if the device is not connected to a network. Now the info is
also shown if the device is connecting to a network. IMO and in this
case, the difference is almost non-existent. Also, if the device is
connecting to a network, it doesn't mean it will get a connection. So
showing the additional info in both cases is fine.