### PR TITLE
CAT-FIX Handle google login 'in progress' status code

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/transfers/GooglePlusLoginHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/GooglePlusLoginHandler.java
@@ -57,6 +57,7 @@ public class GooglePlusLoginHandler implements GoogleApiClient.ConnectionCallbac
 	private Activity activity;
 	public static final int GPLUS_REQUEST_CODE_SIGN_IN = 0;
 	public static final int REQUEST_CODE_GOOGLE_PLUS_SIGNIN = 100;
+	public static final int STATUS_CODE_SIGN_IN_CURRENTLY_IN_PROGRESS = 12502;
 	private GoogleApiClient googleApiClient;
 	private static final String GOOGLE_PLUS_CATROWEB_SERVER_CLIENT_ID = "427226922034-r016ige5kb30q9vflqbt1h0i3arng8u1.apps.googleusercontent.com";
 
@@ -94,8 +95,14 @@ public class GooglePlusLoginHandler implements GoogleApiClient.ConnectionCallbac
 			GoogleSignInAccount account = result.getSignInAccount();
 			onGoogleLogInComplete(account);
 		} else {
-			ToastUtil.showError(activity, activity.getString(R.string.error_google_plus_sign_in,
-					result.getStatus().getStatusMessage()));
+			switch (result.getStatus().getStatusCode()) {
+				case STATUS_CODE_SIGN_IN_CURRENTLY_IN_PROGRESS:
+					break;
+
+				default:
+					ToastUtil.showError(activity, activity.getString(R.string.error_google_plus_sign_in,
+							Integer.toString(result.getStatus().getStatusCode())));
+			}
 		}
 	}
 


### PR DESCRIPTION
-prevent status code SIGN_IN_CURRENTLY_IN_PROGRESS from showing
error message