### PR TITLE
JENKINS-221: Do not run Unit-test multiple times

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,11 +84,17 @@ pipeline {
 
 		stage('Unit and Device tests') {
 			steps {
-				// Run Unit and device tests for package: org.catrobat.catroid.test
+				// Run local unit tests
+				sh "./buildScripts/build_step_run_unit_tests__all_tests"
+				// ensure that the following test run does not overwrite the results
+				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build ${env.GRADLE_PROJECT_MODULE_NAME}/build-unittest"
+
+				// Run device tests for package: org.catrobat.catroid.test
 				sh "./buildScripts/build_step_run_tests_on_emulator__test_pkg"
 				// ensure that the following test run does not overwrite the results
-				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results1"
-				// Run Unit and device tests for class: org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite
+				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build ${env.GRADLE_PROJECT_MODULE_NAME}/build-test-test-pkg"
+
+				// Run device tests for class: org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite
 				sh "./buildScripts/build_step_run_tests_on_emulator__pr_test_suite"
 			}
 

--- a/Jenkinsfile.PullRequest
+++ b/Jenkinsfile.PullRequest
@@ -84,7 +84,12 @@ pipeline {
 
 		stage('Unit and Device tests') {
 			steps {
-				// Run Unit and device tests for package: org.catrobat.catroid.test
+				// Run local unit tests
+				sh "./buildScripts/build_step_run_unit_tests__all_tests"
+				// ensure that the following test run does not overwrite the results
+				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build ${env.GRADLE_PROJECT_MODULE_NAME}/build-unittest"
+
+				// Run device tests for package: org.catrobat.catroid.test
 				sh "./buildScripts/build_step_run_tests_on_emulator__test_pkg"
 			}
 

--- a/buildScripts/build_helper_run_tests_on_emulator
+++ b/buildScripts/build_helper_run_tests_on_emulator
@@ -51,7 +51,7 @@ print("Calling: " + " ".join(disable_cmd))
 return_code = subprocess.run( disable_cmd, cwd=os.environ['REPO_DIR'] ).returncode
 
 ## RUN tests
-test_runner_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_cmd_wrapper') + [ '-I', build_helper_functions.get_relative_gradle_name(), 'clean', 'adbDisableAnimationsGlobally', 'test', 'connectedCatroidDebugAndroidTest' ]
+test_runner_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_cmd_wrapper') + [ '-I', build_helper_functions.get_relative_gradle_name(), 'clean', 'adbDisableAnimationsGlobally', 'connectedCatroidDebugAndroidTest' ]
 if test_runner_arg is not None and test_runner_arg != "":
     test_runner_cmd = test_runner_cmd + [ test_runner_arg ]
 

--- a/buildScripts/build_helper_run_unit_tests
+++ b/buildScripts/build_helper_run_unit_tests
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+os.environ['SCRIPT_DIR'] = os.path.dirname(os.path.realpath(__file__))
+os.environ['REPO_DIR'] = os.path.realpath(os.path.join(os.environ['SCRIPT_DIR'], ".."))
+
+import build_helper_functions
+
+def usage():
+    print(sys.argv[0] + """ <test_filter>
+
+This scripts runs all the local unit tests for the debug flavor.
+A filter can be passed as single argument which is then passed as
+'--tests <filter>' parameter.
+See: https://docs.gradle.org/current/userguide/java_testing.html#test_filtering
+
+The environment variable ANDROID_SDK_ROOT needs to be set.""")
+
+build_helper_functions.check_number_of_parameters(valid_param_count_min=0, valid_param_count_max=1, usage_func=usage)
+
+## RUN tests
+test_runner_cmd = [ build_helper_functions.get_relative_gradle_name(), 'clean', 'testCatroidDebug' ]
+## pass filter if argument is given
+if len(sys.argv) > 1:
+    test_runner_cmd = test_runner_cmd + [ '--tests', sys.argv[1] ]
+
+print("Calling: " + " ".join(test_runner_cmd))
+return_code = subprocess.run( test_runner_cmd, cwd=os.environ['REPO_DIR'] ).returncode
+sys.exit(return_code)

--- a/buildScripts/build_step_run_unit_tests__all_tests
+++ b/buildScripts/build_step_run_unit_tests__all_tests
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+os.environ['SCRIPT_DIR'] = os.path.dirname(os.path.realpath(__file__))
+os.environ['REPO_DIR'] = os.path.realpath(os.path.join(os.environ['SCRIPT_DIR'], ".."))
+
+import build_helper_functions
+
+def usage():
+    print(sys.argv[0] + """
+
+This script is a simple wrapper for the build_helper_run_unit_tests which
+allows to add a test-filter, but currently all tests are run.
+
+The environment variable ANDROID_SDK_ROOT needs to be set.""")
+
+build_helper_functions.check_number_of_parameters(valid_param_count=0, usage_func=usage)
+
+# Run Unit and device tests for all tests
+test_runner_cmd = build_helper_functions.get_build_scripts_executable('build_helper_run_unit_tests')
+
+print("Calling: " + " ".join(test_runner_cmd))
+return_code = subprocess.run( test_runner_cmd ).returncode
+sys.exit(return_code)


### PR DESCRIPTION
Currently the unit-tests automatically started when device/emulator tests are running. As for a PR two different device tests are started (different sets of classes), the unit tests would also run multiple times.
Therefore move the local unit test call to a separate build step.
Additionally call the tests only for the catroid debug suite. To avoid even more duplications of the unit test results.