### PR TITLE
[Under discussion] Hotfix for CollisionScript references not set correctly

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -32,6 +32,7 @@ import org.catrobat.catroid.common.DefaultProjectHandler;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.ScreenModes;
 import org.catrobat.catroid.common.SoundInfo;
+import org.catrobat.catroid.content.CollisionScript;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Script;
@@ -169,6 +170,7 @@ public final class ProjectManager {
 
 		makeShallowCopiesDeepAgain(project);
 		checkNestingBrickReferences(true, false);
+		updateCollisionScriptsSpriteReference(project);
 
 		if (project.getCatrobatLanguageVersion() == Constants.CURRENT_CATROBAT_LANGUAGE_VERSION) {
 			localizeBackgroundSprite(context);
@@ -620,6 +622,19 @@ public final class ProjectManager {
 
 		for (Brick brick : bricksWithInvalidReferences) {
 			script.removeBrick(brick);
+		}
+	}
+
+	private void updateCollisionScriptsSpriteReference(Project project) {
+		for (Scene scene : project.getSceneList()) {
+			for (Sprite sprite : scene.getSpriteList()) {
+				for (Script script : sprite.getScriptList()) {
+					if (script instanceof CollisionScript) {
+						CollisionScript collisionScript = (CollisionScript) script;
+						collisionScript.updateSpriteToCollideWith(scene);
+					}
+				}
+			}
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/CollisionScript.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/CollisionScript.java
@@ -60,19 +60,22 @@ public class CollisionScript extends Script {
 
 	public void setSpriteToCollideWithName(String spriteToCollideWithName) {
 		this.spriteToCollideWithName = spriteToCollideWithName;
-		updateSpriteToCollideWith();
+		updateSpriteToCollideWith(ProjectManager.getInstance().getCurrentlyEditedScene());
 	}
 
 	public Sprite getSpriteToCollideWith() {
-		updateSpriteToCollideWith();
+		updateSpriteToCollideWith(ProjectManager.getInstance().getCurrentlyEditedScene());
 		return spriteToCollideWith;
 	}
 
-	private void updateSpriteToCollideWith() {
-		if (spriteToCollideWithName != null
-				&& (spriteToCollideWith == null || !spriteToCollideWithName.equals(spriteToCollideWith.getName()))) {
-			Scene currentScene = ProjectManager.getInstance().getCurrentlyEditedScene();
-			spriteToCollideWith = currentScene.getSprite(spriteToCollideWithName);
+	public void updateSpriteToCollideWith(Scene scene) {
+		if (spriteToCollideWithName == null) {
+			spriteToCollideWith = null;
+		} else {
+			spriteToCollideWith = scene.getSprite(spriteToCollideWithName);
+			if (spriteToCollideWith == null) {
+				spriteToCollideWithName = null;
+			}
 		}
 	}
 


### PR DESCRIPTION
How to reproduce the error

* Download https://share.catrob.at/pocketcode/program/28126
* Open and immediately press run (don't go in any script view)
* Press the ball. You can move the Players by touch down and move them.
--
* Instead of normally bouncing of, the ball moves around and behind the player.

The problem is, [`CollisionScript`](https://github.com/Catrobat/Catroid/blob/develop/catroid/src/main/java/org/catrobat/catroid/content/CollisionScript.java) has two members
```java
private String spriteToCollideWithName;
private transient Sprite spriteToCollideWith;
```
where only the name is serialized. When deserializing, only the name is deserialized and the Sprite itself will remain null which is equal to 'collide with anything'. When opening the Sprites Script View (maybe scroll to the collision bricks), the program will work as expected though.

The problem will be fixed in a hotfix release. I haven't fully tested it nor added tests (yet, hopefully this testrun will be green :crossed_fingers:).
Feedback is highly appreciated, a better fix even more. Just keep in mind that it will be a hotfix release.