### PR TITLE
[HOTFIX] Fixed deserialization of CollisionScript

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/CollisionScript.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/CollisionScript.java
@@ -33,8 +33,6 @@ public class CollisionScript extends Script {
 	private static final long serialVersionUID = 1L;
 	private String spriteToCollideWithName;
 
-	private transient Sprite spriteToCollideWith;
-
 	public CollisionScript(String spriteToCollideWithName) {
 		this.spriteToCollideWithName = spriteToCollideWithName;
 	}
@@ -60,24 +58,11 @@ public class CollisionScript extends Script {
 
 	public void setSpriteToCollideWithName(String spriteToCollideWithName) {
 		this.spriteToCollideWithName = spriteToCollideWithName;
-		updateSpriteToCollideWith();
-	}
-
-	public Sprite getSpriteToCollideWith() {
-		updateSpriteToCollideWith();
-		return spriteToCollideWith;
-	}
-
-	private void updateSpriteToCollideWith() {
-		if (spriteToCollideWithName != null
-				&& (spriteToCollideWith == null || !spriteToCollideWithName.equals(spriteToCollideWith.getName()))) {
-			Scene currentScene = ProjectManager.getInstance().getCurrentlyEditedScene();
-			spriteToCollideWith = currentScene.getSprite(spriteToCollideWithName);
-		}
 	}
 
 	@Override
 	public EventId createEventId(Sprite sprite) {
-		return new CollisionEventId(sprite, spriteToCollideWith);
+		Scene currentlyPlayingScene = ProjectManager.getInstance().getCurrentlyPlayingScene();
+		return new CollisionEventId(sprite, currentlyPlayingScene.getSprite(spriteToCollideWithName));
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/CollisionReceiverBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/CollisionReceiverBrick.java
@@ -136,11 +136,11 @@ public class CollisionReceiverBrick extends BrickBaseType implements ScriptBrick
 	}
 
 	private void setSpinnerSelection(Spinner spinner) {
-		int position = getPositionOfMessageInAdapter(spinner.getContext(), getBroadcastMessage());
+		int position = getPositionOfMessageInAdapter(spinner.getContext(), getSpriteToCollideWithName());
 		spinner.setSelection(position);
 	}
 
-	public int getPositionOfMessageInAdapter(Context context, String message) {
+	private int getPositionOfMessageInAdapter(Context context, String message) {
 		getCollisionObjectAdapter(context);
 		int position = messageAdapter.getPosition(message);
 		if (position == -1) {
@@ -148,13 +148,6 @@ public class CollisionReceiverBrick extends BrickBaseType implements ScriptBrick
 		} else {
 			return position;
 		}
-	}
-
-	public String getBroadcastMessage() {
-		if (collisionScript.getSpriteToCollideWith() == null) {
-			return null;
-		}
-		return collisionScript.getSpriteToCollideWith().getName();
 	}
 
 	@Override


### PR DESCRIPTION
 - removed transient Sprite field that was null
   after serialization.
 - Sprite is now updated every time instead of caching
   spriteToCollideWith in a private field.