### PR TITLE
[GSoC18] Remove MIPS

### DIFF
--- a/buildScripts/jenkins-android-helper/jenkins_android_sdk.py
+++ b/buildScripts/jenkins-android-helper/jenkins_android_sdk.py
@@ -95,7 +95,7 @@ class AndroidSDK:
 
     ### ndk versions and properties contents
     #### Currently catroid can only be build with Android NDK r16, manual install that version
-    ANDROID_NDK_WORKAROUND_KEEP_R16 = True
+    ANDROID_NDK_WORKAROUND_KEEP_R16 = False
     ANDROID_NDK_PROP_VAL_PKG_REV = "16.1.4479499"
     ANDROID_NDK_PROP_VAL_PKG_PATH = None
     ANDROID_NDK_PROP_VAL_PKG_DESC = "Android NDK"

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -81,6 +81,7 @@ android {
         exclude 'META-INF/maven/com.google.guava/guava/pom.xml'
         exclude 'META-INF/INDEX.LIST'  //compile problem with parrot arsdk
         exclude 'lib/arm64-v8a/*' // exclude all arm64-v8a libs as we don't have all libs for that architecture
+        exclude 'lib/mips/*'      // Mips devices are deprecated
     }
 
     buildTypes {


### PR DESCRIPTION
* Exclude MIPS architecture binary files from builds
  - MIPS support has been removed from NDK >= 17, builds will fail if you have NDK installed as it tries to strip the MIPS binaries
---
* ~~Remove some unused files (eclipse configuration files, outdated gradle files in a wrong folder)~~
  - Moved to #2913
* ~~Migrate the build.gradle file to gradle >= 3.0.0 according to this guideline: https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration~~
  - Moved to #2914