### PR TITLE
CAT-2673 none sense error message when register

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/transfers/CheckEmailAvailableTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/CheckEmailAvailableTask.java
@@ -22,33 +22,23 @@
  */
 package org.catrobat.catroid.transfers;
 
-import android.app.Activity;
-import android.app.ProgressDialog;
 import android.os.AsyncTask;
-import android.support.v7.app.AlertDialog;
 import android.util.Log;
 
-import org.catrobat.catroid.R;
-import org.catrobat.catroid.utils.Utils;
 import org.catrobat.catroid.web.ServerCalls;
 import org.catrobat.catroid.web.WebconnectionException;
 
 public class CheckEmailAvailableTask extends AsyncTask<String, Void, Boolean> {
 	private static final String TAG = CheckEmailAvailableTask.class.getSimpleName();
 
-	private Activity activity;
-	private ProgressDialog progressDialog;
 	private String email;
 	private String provider;
 
 	private Boolean emailAvailable;
 
-	private WebconnectionException exception;
-
 	private OnCheckEmailAvailableCompleteListener onCheckEmailAvailableCompleteListener;
 
-	public CheckEmailAvailableTask(Activity activity, String email, String provider) {
-		this.activity = activity;
+	public CheckEmailAvailableTask(String email, String provider) {
 		this.email = email;
 		this.provider = provider;
 	}
@@ -58,29 +48,12 @@ public class CheckEmailAvailableTask extends AsyncTask<String, Void, Boolean> {
 	}
 
 	@Override
-	protected void onPreExecute() {
-		super.onPreExecute();
-		if (activity == null) {
-			return;
-		}
-		String title = activity.getString(R.string.please_wait);
-		String message = activity.getString(R.string.loading_check_email);
-		progressDialog = ProgressDialog.show(activity, title, message);
-	}
-
-	@Override
 	protected Boolean doInBackground(String... params) {
 		try {
-			if (!Utils.isNetworkAvailable(activity)) {
-				exception = new WebconnectionException(WebconnectionException.ERROR_NETWORK, "Network not available!");
-				return false;
-			}
-
 			emailAvailable = ServerCalls.getInstance().checkEMailAvailable(email);
 			return true;
 		} catch (WebconnectionException webconnectionException) {
 			Log.e(TAG, Log.getStackTraceString(webconnectionException));
-			exception = webconnectionException;
 		}
 		return false;
 	}
@@ -89,35 +62,8 @@ public class CheckEmailAvailableTask extends AsyncTask<String, Void, Boolean> {
 	protected void onPostExecute(Boolean success) {
 		super.onPostExecute(success);
 
-		if (progressDialog != null && progressDialog.isShowing()) {
-			progressDialog.dismiss();
-		}
-
-		if (Utils.checkForNetworkError(exception)) {
-			showDialog(R.string.error_internet_connection);
-			return;
-		}
-
-		if (!success && exception != null) {
-			showDialog(R.string.sign_in_error);
-			return;
-		}
-
 		if (onCheckEmailAvailableCompleteListener != null) {
 			onCheckEmailAvailableCompleteListener.onCheckEmailAvailableComplete(emailAvailable, provider);
-		}
-	}
-
-	private void showDialog(int messageId) {
-		if (activity == null) {
-			return;
-		}
-		if (exception.getMessage() == null) {
-			new AlertDialog.Builder(activity).setMessage(messageId).setPositiveButton(R.string.ok, null)
-					.show();
-		} else {
-			new AlertDialog.Builder(activity).setMessage(exception.getMessage())
-					.setPositiveButton(R.string.ok, null).show();
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/CheckUserNameAvailableTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/CheckUserNameAvailableTask.java
@@ -22,32 +22,21 @@
  */
 package org.catrobat.catroid.transfers;
 
-import android.app.Activity;
-import android.app.ProgressDialog;
 import android.os.AsyncTask;
-import android.support.v7.app.AlertDialog;
 import android.util.Log;
 
-import org.catrobat.catroid.R;
-import org.catrobat.catroid.utils.Utils;
 import org.catrobat.catroid.web.ServerCalls;
 import org.catrobat.catroid.web.WebconnectionException;
 
 public class CheckUserNameAvailableTask extends AsyncTask<Void, Void, Boolean> {
 	private static final String TAG = CheckUserNameAvailableTask.class.getSimpleName();
-
-	private Activity activity;
-	private ProgressDialog progressDialog;
 	private String username;
 
 	private Boolean userNameAvailable;
 
-	private WebconnectionException exception;
-
 	private OnCheckUserNameAvailableCompleteListener onCheckUserNameAvailableCompleteListener;
 
-	public CheckUserNameAvailableTask(Activity activity, String username) {
-		this.activity = activity;
+	public CheckUserNameAvailableTask(String username) {
 		this.username = username;
 	}
 
@@ -56,29 +45,12 @@ public class CheckUserNameAvailableTask extends AsyncTask<Void, Void, Boolean> {
 	}
 
 	@Override
-	protected void onPreExecute() {
-		super.onPreExecute();
-		if (activity == null) {
-			return;
-		}
-		String title = activity.getString(R.string.please_wait);
-		String message = activity.getString(R.string.loading_check_oauth_username);
-		progressDialog = ProgressDialog.show(activity, title, message);
-	}
-
-	@Override
 	protected Boolean doInBackground(Void... params) {
 		try {
-			if (!Utils.isNetworkAvailable(activity)) {
-				exception = new WebconnectionException(WebconnectionException.ERROR_NETWORK, "Network not available!");
-				return false;
-			}
-
 			userNameAvailable = ServerCalls.getInstance().checkUserNameAvailable(username);
 			return true;
 		} catch (WebconnectionException webconnectionException) {
 			Log.e(TAG, Log.getStackTraceString(webconnectionException));
-			exception = webconnectionException;
 		}
 		return false;
 	}
@@ -87,35 +59,8 @@ public class CheckUserNameAvailableTask extends AsyncTask<Void, Void, Boolean> {
 	protected void onPostExecute(Boolean success) {
 		super.onPostExecute(success);
 
-		if (progressDialog != null && progressDialog.isShowing()) {
-			progressDialog.dismiss();
-		}
-
-		if (Utils.checkForNetworkError(success, exception)) {
-			showDialog(R.string.error_internet_connection);
-			return;
-		}
-
-		if (!success && exception != null) {
-			showDialog(R.string.sign_in_error);
-			return;
-		}
-
 		if (onCheckUserNameAvailableCompleteListener != null) {
 			onCheckUserNameAvailableCompleteListener.onCheckUserNameAvailableComplete(userNameAvailable, username);
-		}
-	}
-
-	private void showDialog(int messageId) {
-		if (activity == null) {
-			return;
-		}
-		if (exception != null && exception.getMessage() == null) {
-			new AlertDialog.Builder(activity).setMessage(messageId).setPositiveButton(R.string.ok, null)
-					.show();
-		} else {
-			new AlertDialog.Builder(activity).setMessage(exception.getMessage())
-					.setPositiveButton(R.string.ok, null).show();
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/FacebookLoginHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/FacebookLoginHandler.java
@@ -112,8 +112,7 @@ public class FacebookLoginHandler implements FacebookCallback<LoginResult>,
 			facebookLogInTask.setOnFacebookLogInCompleteListener(this);
 			facebookLogInTask.execute();
 		} else {
-			CheckEmailAvailableTask checkEmailAvailableTask = new CheckEmailAvailableTask(activity,
-					sharedPreferences.getString(Constants.FACEBOOK_EMAIL, Constants.NO_FACEBOOK_EMAIL), Constants.FACEBOOK);
+			CheckEmailAvailableTask checkEmailAvailableTask = new CheckEmailAvailableTask(sharedPreferences.getString(Constants.FACEBOOK_EMAIL, Constants.NO_FACEBOOK_EMAIL), Constants.FACEBOOK);
 			checkEmailAvailableTask.setOnCheckEmailAvailableCompleteListener(this);
 			checkEmailAvailableTask.execute();
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/GooglePlusLoginHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/GooglePlusLoginHandler.java
@@ -168,8 +168,7 @@ public class GooglePlusLoginHandler implements GoogleApiClient.ConnectionCallbac
 			googleLogInTask.execute();
 		} else {
 			String email = sharedPreferences.getString(Constants.GOOGLE_EMAIL, Constants.NO_GOOGLE_EMAIL);
-			CheckEmailAvailableTask checkEmailAvailableTask = new CheckEmailAvailableTask(activity,
-					email, Constants.GOOGLE_PLUS);
+			CheckEmailAvailableTask checkEmailAvailableTask = new CheckEmailAvailableTask(email, Constants.GOOGLE_PLUS);
 			checkEmailAvailableTask.setOnCheckEmailAvailableCompleteListener(this);
 			checkEmailAvailableTask.execute();
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/LoginTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/LoginTask.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.preference.PreferenceManager;
-import android.support.v7.app.AlertDialog;
 import android.util.Log;
 
 import org.catrobat.catroid.R;
@@ -49,7 +48,7 @@ public class LoginTask extends AsyncTask<Void, Void, Boolean> {
 	private String message;
 	private boolean userLoggedIn;
 
-	private OnLoginCompleteListener onLoginCompleteListener;
+	private OnLoginListener onLoginListener;
 	private WebconnectionException exception;
 
 	public LoginTask(Context activity, String username, String password) {
@@ -58,8 +57,8 @@ public class LoginTask extends AsyncTask<Void, Void, Boolean> {
 		this.password = password;
 	}
 
-	public void setOnLoginCompleteListener(OnLoginCompleteListener listener) {
-		onLoginCompleteListener = listener;
+	public void setOnLoginListener(OnLoginListener listener) {
+		onLoginListener = listener;
 	}
 
 	@Override
@@ -76,11 +75,6 @@ public class LoginTask extends AsyncTask<Void, Void, Boolean> {
 	@Override
 	protected Boolean doInBackground(Void... arg0) {
 		try {
-			if (!Utils.isNetworkAvailable(context)) {
-				exception = new WebconnectionException(WebconnectionException.ERROR_NETWORK, "Network not available!");
-				return false;
-			}
-
 			SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
 			String token = sharedPreferences.getString(Constants.TOKEN, Constants.NO_TOKEN);
 			Log.d(TAG, token);
@@ -90,6 +84,7 @@ public class LoginTask extends AsyncTask<Void, Void, Boolean> {
 			return true;
 		} catch (WebconnectionException webconnectionException) {
 			Log.e(TAG, Log.getStackTraceString(webconnectionException));
+			exception = webconnectionException;
 			message = webconnectionException.getMessage();
 		}
 		return false;
@@ -104,12 +99,16 @@ public class LoginTask extends AsyncTask<Void, Void, Boolean> {
 		}
 
 		if (Utils.checkForNetworkError(exception)) {
-			showDialog(R.string.error_internet_connection);
+			ToastUtil.showError(context, R.string.error_internet_connection);
 			return;
 		}
 
 		if (Utils.checkForSignInError(success, exception, context, userLoggedIn)) {
-			showDialog(R.string.sign_in_error);
+			if (message == null) {
+				message = context.getString(R.string.sign_in_error);
+			}
+			onLoginListener.onLoginFailed(message);
+			Log.e(TAG, message);
 			return;
 		}
 
@@ -117,26 +116,15 @@ public class LoginTask extends AsyncTask<Void, Void, Boolean> {
 			ToastUtil.showSuccess(context, R.string.user_logged_in);
 		}
 
-		if (onLoginCompleteListener != null) {
-			onLoginCompleteListener.onLoginComplete();
+		if (onLoginListener != null) {
+			onLoginListener.onLoginComplete();
 		}
 	}
 
-	private void showDialog(int messageId) {
-		if (context == null) {
-			return;
-		}
-		if (message == null) {
-			new AlertDialog.Builder(context).setTitle(R.string.register_error).setMessage(messageId)
-					.setPositiveButton(R.string.ok, null).show();
-		} else {
-			new AlertDialog.Builder(context).setTitle(R.string.register_error).setMessage(message)
-					.setPositiveButton(R.string.ok, null).show();
-		}
-	}
-
-	public interface OnLoginCompleteListener {
+	public interface OnLoginListener {
 
 		void onLoginComplete();
+
+		void onLoginFailed(String msg);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/RegistrationTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/RegistrationTask.java
@@ -27,7 +27,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.preference.PreferenceManager;
-import android.support.v7.app.AlertDialog;
 import android.util.Log;
 
 import org.catrobat.catroid.R;
@@ -51,7 +50,7 @@ public class RegistrationTask extends AsyncTask<Void, Void, Boolean> {
 	private String message;
 	private boolean userRegistered;
 
-	private OnRegistrationCompleteListener onRegistrationCompleteListener;
+	private OnRegistrationListener onRegistrationListener;
 	private WebconnectionException exception;
 
 	public RegistrationTask(Context activity, String username, String password, String email) {
@@ -61,8 +60,8 @@ public class RegistrationTask extends AsyncTask<Void, Void, Boolean> {
 		this.email = email;
 	}
 
-	public void setOnRegistrationCompleteListener(OnRegistrationCompleteListener listener) {
-		onRegistrationCompleteListener = listener;
+	public void setOnRegistrationListener(OnRegistrationListener listener) {
+		onRegistrationListener = listener;
 	}
 
 	@Override
@@ -109,12 +108,16 @@ public class RegistrationTask extends AsyncTask<Void, Void, Boolean> {
 		}
 
 		if (Utils.checkForNetworkError(exception)) {
-			showDialog(R.string.error_internet_connection);
+			ToastUtil.showError(context, R.string.error_internet_connection);
 			return;
 		}
 
 		if (Utils.checkForSignInError(success, exception, context, userRegistered)) {
-			showDialog(R.string.sign_in_error);
+			if (message == null) {
+				message = context.getString(R.string.register_error);
+			}
+			onRegistrationListener.onRegistrationFailed(message);
+			Log.e(TAG, message);
 			return;
 		}
 
@@ -122,26 +125,15 @@ public class RegistrationTask extends AsyncTask<Void, Void, Boolean> {
 			ToastUtil.showSuccess(context, R.string.new_user_registered);
 		}
 
-		if (onRegistrationCompleteListener != null) {
-			onRegistrationCompleteListener.onRegistrationComplete();
+		if (onRegistrationListener != null) {
+			onRegistrationListener.onRegistrationComplete();
 		}
 	}
 
-	private void showDialog(int messageId) {
-		if (context == null) {
-			return;
-		}
-		if (message == null) {
-			new AlertDialog.Builder(context).setTitle(R.string.register_error).setMessage(messageId)
-					.setPositiveButton(R.string.ok, null).show();
-		} else {
-			new AlertDialog.Builder(context).setTitle(R.string.register_error).setMessage(message)
-					.setPositiveButton(R.string.ok, null).show();
-		}
-	}
-
-	public interface OnRegistrationCompleteListener {
+	public interface OnRegistrationListener {
 
 		void onRegistrationComplete();
+
+		void onRegistrationFailed(String msg);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/OAuthUsernameDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/OAuthUsernameDialogFragment.java
@@ -106,7 +106,7 @@ public class OAuthUsernameDialogFragment extends DialogFragment implements
 		if (username.isEmpty()) {
 			inputLayout.setError(getString(R.string.signin_choose_username_empty));
 		} else {
-			CheckUserNameAvailableTask checkUserNameAvailableTask = new CheckUserNameAvailableTask(getActivity(), username);
+			CheckUserNameAvailableTask checkUserNameAvailableTask = new CheckUserNameAvailableTask(username);
 			checkUserNameAvailableTask.setOnCheckUserNameAvailableCompleteListener(this);
 			checkUserNameAvailableTask.execute();
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/RegistrationDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/RegistrationDialogFragment.java
@@ -29,18 +29,26 @@ import android.content.DialogInterface.OnShowListener;
 import android.os.Bundle;
 import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.AlertDialog;
+import android.text.Editable;
 import android.text.InputType;
+import android.text.TextWatcher;
+import android.util.Patterns;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
+import android.widget.EditText;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.transfers.CheckEmailAvailableTask;
+import org.catrobat.catroid.transfers.CheckUserNameAvailableTask;
 import org.catrobat.catroid.transfers.RegistrationTask;
-import org.catrobat.catroid.transfers.RegistrationTask.OnRegistrationCompleteListener;
+import org.catrobat.catroid.transfers.RegistrationTask.OnRegistrationListener;
+import org.catrobat.catroid.utils.ToastUtil;
 import org.catrobat.catroid.utils.UtilDeviceInfo;
+import org.catrobat.catroid.utils.Utils;
 
-public class RegistrationDialogFragment extends DialogFragment implements OnRegistrationCompleteListener {
+public class RegistrationDialogFragment extends DialogFragment implements OnRegistrationListener {
 
 	public static final String TAG = RegistrationDialogFragment.class.getSimpleName();
 
@@ -48,6 +56,11 @@ public class RegistrationDialogFragment extends DialogFragment implements OnRegi
 	private TextInputLayout emailInputLayout;
 	private TextInputLayout passwordInputLayout;
 	private TextInputLayout confirmPasswordInputLayout;
+	private EditText userNameEditText;
+	private EditText emailAddressEditText;
+	private EditText passwordEditText;
+	private EditText confirmPasswordEditText;
+	private AlertDialog alertDialog;
 
 	private SignInCompleteListener signInCompleteListener;
 
@@ -64,36 +77,169 @@ public class RegistrationDialogFragment extends DialogFragment implements OnRegi
 		passwordInputLayout = view.findViewById(R.id.dialog_register_password);
 		confirmPasswordInputLayout = view.findViewById(R.id.dialog_register_password_confirm);
 
+		alertDialog = new AlertDialog.Builder(getActivity())
+				.setTitle(R.string.register)
+				.setView(view)
+				.setPositiveButton(R.string.register, null)
+				.create();
+
+		userNameEditText = usernameInputLayout.getEditText();
+		emailAddressEditText = emailInputLayout.getEditText();
+		passwordEditText = passwordInputLayout.getEditText();
+		confirmPasswordEditText = confirmPasswordInputLayout.getEditText();
+
+		userNameEditText.addTextChangedListener(new TextWatcher() {
+			@Override
+			public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+			}
+
+			@Override
+			public void onTextChanged(CharSequence s, int start, int before, int count) {
+			}
+
+			@Override
+			public void afterTextChanged(final Editable s) {
+				if (s.toString().trim().isEmpty()) {
+					usernameInputLayout.setError(getString(R.string.error_register_empty_username));
+				} else if (s.toString().trim().contains("@")) {
+					usernameInputLayout.setError(getString(R.string.error_register_username_as_email));
+				} else if (!s.toString().trim().matches("^[a-zA-Z0-9-_.]*$")) {
+					usernameInputLayout.setError(getString(R.string.error_register_invalid_username));
+				} else if (s.toString().trim().startsWith("-") || s.toString().startsWith("_") || s.toString().startsWith(".")) {
+					usernameInputLayout.setError(getString(R.string.error_register_username_start_with));
+				} else {
+					usernameInputLayout.setErrorEnabled(false);
+				}
+
+				if (!usernameInputLayout.isErrorEnabled()) {
+					CheckUserNameAvailableTask checkUserNameAvailableTask = new CheckUserNameAvailableTask(s.toString());
+					checkUserNameAvailableTask.setOnCheckUserNameAvailableCompleteListener(new CheckUserNameAvailableTask.OnCheckUserNameAvailableCompleteListener() {
+						@Override
+						public void onCheckUserNameAvailableComplete(Boolean userNameAvailable, String username) {
+							if (userNameAvailable == null) {
+								ToastUtil.showError(getActivity(), R.string.error_internet_connection);
+							} else if (userNameAvailable) {
+								usernameInputLayout.setError(getString(R.string.error_register_username_already_exists));
+							}
+						}
+					});
+					checkUserNameAvailableTask.execute();
+				}
+				handleRegisterBtnStatus();
+			}
+		});
+
+		emailAddressEditText.addTextChangedListener(new TextWatcher() {
+			@Override
+			public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+			}
+
+			@Override
+			public void onTextChanged(CharSequence s, int start, int before, int count) {
+			}
+
+			@Override
+			public void afterTextChanged(final Editable s) {
+				if (!Patterns.EMAIL_ADDRESS.matcher(s.toString()).matches() || s.toString().isEmpty()) {
+					emailInputLayout.setError(getString(R.string.error_register_invalid_email_format));
+				} else {
+					emailInputLayout.setErrorEnabled(false);
+				}
+				if (!emailInputLayout.isErrorEnabled()) {
+					CheckEmailAvailableTask checkEmailAvailableTask = new
+							CheckEmailAvailableTask(s.toString(), Constants
+							.NO_OAUTH_PROVIDER);
+					checkEmailAvailableTask.setOnCheckEmailAvailableCompleteListener(new CheckEmailAvailableTask.OnCheckEmailAvailableCompleteListener() {
+						@Override
+						public void onCheckEmailAvailableComplete(Boolean emailAvailable, String provider) {
+							if (emailAvailable == null) {
+								ToastUtil.showError(getActivity(), R.string.error_internet_connection);
+							} else if (emailAvailable) {
+								emailInputLayout.setError(getString(R.string.error_register_email_exists));
+							}
+						}
+					});
+					checkEmailAvailableTask.execute();
+				}
+				handleRegisterBtnStatus();
+			}
+		});
+
+		passwordEditText.addTextChangedListener(new TextWatcher() {
+			@Override
+			public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+			}
+
+			@Override
+			public void onTextChanged(CharSequence s, int start, int before, int count) {
+			}
+
+			@Override
+			public void afterTextChanged(Editable s) {
+				if (s.toString().isEmpty()) {
+					passwordInputLayout.setError(getString(R.string.error_register_empty_password));
+				} else if (s.toString().length() < 6) {
+					passwordInputLayout.setError(getString(R.string.error_register_password_at_least_6_characters));
+				} else if (!s.toString().equals(confirmPasswordEditText.getText().toString())) {
+					confirmPasswordInputLayout.setError(getString(R.string.error_register_passwords_mismatch));
+					passwordInputLayout.setErrorEnabled(false);
+				} else {
+					passwordInputLayout.setErrorEnabled(false);
+					confirmPasswordInputLayout.setErrorEnabled(false);
+				}
+				handleRegisterBtnStatus();
+			}
+		});
+
+		confirmPasswordEditText.addTextChangedListener(new TextWatcher() {
+			@Override
+			public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+			}
+
+			@Override
+			public void onTextChanged(CharSequence s, int start, int before, int count) {
+			}
+
+			@Override
+			public void afterTextChanged(Editable s) {
+				if (s.toString().isEmpty()) {
+					confirmPasswordInputLayout.setError(getString(R.string.error_register_empty_confirm_password));
+				} else if (s.toString().length() < 6) {
+					confirmPasswordInputLayout.setError(getString(R.string.error_register_password_at_least_6_characters));
+				} else if (!s.toString().equals(passwordEditText.getText().toString())) {
+					confirmPasswordInputLayout.setError(getString(R.string.error_register_passwords_mismatch));
+				} else {
+					confirmPasswordInputLayout.setErrorEnabled(false);
+					passwordInputLayout.setErrorEnabled(false);
+				}
+				handleRegisterBtnStatus();
+			}
+		});
+
 		CheckBox showPasswordCheckBox = view.findViewById(R.id.show_password);
 		showPasswordCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
 			@Override
 			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
 				if (isChecked) {
-					passwordInputLayout.getEditText().setInputType(InputType.TYPE_CLASS_TEXT);
-					confirmPasswordInputLayout.getEditText().setInputType(InputType.TYPE_CLASS_TEXT);
+					passwordEditText.setInputType(InputType.TYPE_CLASS_TEXT);
+					confirmPasswordEditText.setInputType(InputType.TYPE_CLASS_TEXT);
 				} else {
-					passwordInputLayout.getEditText()
-							.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-					confirmPasswordInputLayout.getEditText()
-							.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+					passwordEditText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+					confirmPasswordEditText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
 				}
 			}
 		});
 
 		String eMail = UtilDeviceInfo.getUserEmail(getActivity());
 		if (eMail != null) {
-			emailInputLayout.getEditText().setText(eMail);
+			emailAddressEditText.setText(eMail);
+			emailInputLayout.setErrorEnabled(false);
 		}
-
-		final AlertDialog alertDialog = new AlertDialog.Builder(getActivity())
-				.setTitle(R.string.register)
-				.setView(view)
-				.setPositiveButton(R.string.register, null)
-				.create();
 
 		alertDialog.setOnShowListener(new OnShowListener() {
 			@Override
 			public void onShow(DialogInterface dialog) {
+				alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
 				alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
 					@Override
 					public void onClick(View view) {
@@ -102,7 +248,6 @@ public class RegistrationDialogFragment extends DialogFragment implements OnRegi
 				});
 			}
 		});
-
 		return alertDialog;
 	}
 
@@ -119,22 +264,30 @@ public class RegistrationDialogFragment extends DialogFragment implements OnRegi
 		dismiss();
 	}
 
-	private void onRegisterButtonClick() {
-		String username = usernameInputLayout.getEditText().getText().toString().trim();
-		String password = passwordInputLayout.getEditText().getText().toString();
-		String passwordConfirmation = confirmPasswordInputLayout.getEditText().getText().toString();
-		String email = emailInputLayout.getEditText().getText().toString();
+	@Override
+	public void onRegistrationFailed(String msg) {
+		confirmPasswordEditText.setError(msg);
+		alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+	}
 
-		if (password.equals(passwordConfirmation)) {
-			RegistrationTask registrationTask = new RegistrationTask(getActivity(), username, password, email);
-			registrationTask.setOnRegistrationCompleteListener(this);
-			registrationTask.execute();
-		} else {
-			new AlertDialog.Builder(getActivity())
-					.setTitle(R.string.register_error)
-					.setMessage(R.string.register_password_mismatch)
-					.setPositiveButton(R.string.ok, null)
-					.show();
+	private void onRegisterButtonClick() {
+		String username = userNameEditText.getText().toString().trim();
+		String password = passwordEditText.getText().toString();
+		String email = emailAddressEditText.getText().toString();
+
+		RegistrationTask registrationTask = new RegistrationTask(getActivity(), username, password, email);
+		registrationTask.setOnRegistrationListener(this);
+		registrationTask.execute();
+	}
+
+	private void handleRegisterBtnStatus() {
+		if (alertDialog.getButton(AlertDialog.BUTTON_POSITIVE) != null) {
+			if (!usernameInputLayout.isErrorEnabled() && !emailInputLayout.isErrorEnabled() && !passwordInputLayout
+					.isErrorEnabled() && !confirmPasswordInputLayout.isErrorEnabled() && Utils.isNetworkAvailable(getActivity())) {
+				alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+			} else {
+				alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+			}
 		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
@@ -28,6 +28,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
@@ -95,9 +96,11 @@ public final class Utils {
 	public static boolean isNetworkAvailable(Context context) {
 		ConnectivityManager connectivityManager = (ConnectivityManager) context
 				.getSystemService(Context.CONNECTIVITY_SERVICE);
-		return connectivityManager != null
-				&& connectivityManager.getActiveNetworkInfo() != null
-				&& connectivityManager.getActiveNetworkInfo().isConnected();
+		NetworkInfo activeNetworkInfo = null;
+		if (connectivityManager != null) {
+			activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
+		}
+		return activeNetworkInfo != null && activeNetworkInfo.isConnected();
 	}
 
 	public static boolean checkForNetworkError(boolean success, WebconnectionException exception) {

--- a/catroid/src/main/res/values-ar/strings.xml
+++ b/catroid/src/main/res/values-ar/strings.xml
@@ -53,7 +53,6 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">استرداد بيانات فيس بوك&#8230;</string>
-  <string name="loading_check_email">التحقق ما إذا كان البريد الإلكتروني متوفراً&#8230;</string>
   <string name="loading_check_oauth_token">التحقق من بيانات تسجيل الدخول&#8230;</string>
   <string name="loading_check_facebook_token_validity">التحقق من بيانات الفيس بوك&#8230;</string>
   <string name="loading_check_oauth_username">التحقق ما إذا كان البريد الإلكتروني متوفراً&#8230;</string>
@@ -1043,8 +1042,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">لا يوجد اتصال بالشبكة</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">انت بحاجة الى اتصال نشط بالإنترنت لاستخدام \"بوكت كوود\". من فضلك قم بتشغيل بيانات الهاتف او قم بالاتصال بشبكة لاسلكية في الاعدادات.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="zero">The following bricks need a network connection:</item>
@@ -1103,7 +1100,6 @@
   <string name="signin_choose_username_hint">يجب أن لا يكون اسم المستخدم هو اسمك الحقيقي.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">إظهار كلمة المرور</string>
-  <string name="register_password_mismatch">كلمات المرور لا تتطابق</string>
   <string name="sign_in_error">حدث خطأ أثناء تسجيل الدخول</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-az/strings.xml
+++ b/catroid/src/main/res/values-az/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-bg/strings.xml
+++ b/catroid/src/main/res/values-bg/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-bs/strings.xml
+++ b/catroid/src/main/res/values-bs/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -852,8 +850,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -910,7 +906,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-ca/strings.xml
+++ b/catroid/src/main/res/values-ca/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-cs/strings.xml
+++ b/catroid/src/main/res/values-cs/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -919,8 +917,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">Žádná síť</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">Potřebujete připojení k síti  aby jste mohl/a používat tento Pocket Code program. Prosím zapněte mobilní sít nebo k Wi-Fi v nastavení.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="one">The following brick needs a network connection:</item>
@@ -977,7 +973,6 @@
   <string name="signin_choose_username_hint">Uživatelské jméno by nemělo být vaše skutečné jméno.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Zobrazit heslo</string>
-  <string name="register_password_mismatch">Hesla se neshodují</string>
   <string name="sign_in_error">Chyba při přihlášení</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-da/strings.xml
+++ b/catroid/src/main/res/values-da/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-de/strings.xml
+++ b/catroid/src/main/res/values-de/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -780,8 +778,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">Keine Netzwerkverbindung</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">Du benötigst eine Netzwerkverbindung um dieses Programm verwenden zu können. Schalte dein mobiles Netz ein oder ändere die WLAN Einstellungen.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="one">The following brick needs a network connection:</item>
@@ -836,7 +832,6 @@
   <string name="signin_choose_username_hint">Der Benutzername sollte nicht dein richtiger Name sein.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Passwort anzeigen</string>
-  <string name="register_password_mismatch">Passwörter stimmen nicht überein</string>
   <string name="sign_in_error">Fehler beim Anmelden</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-el/strings.xml
+++ b/catroid/src/main/res/values-el/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -777,8 +775,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -834,7 +830,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Εμφάνιση κωδικού πρόσβασης</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-en-rAU/strings.xml
+++ b/catroid/src/main/res/values-en-rAU/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-en-rCA/strings.xml
+++ b/catroid/src/main/res/values-en-rCA/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-en-rGB/strings.xml
+++ b/catroid/src/main/res/values-en-rGB/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-es/strings.xml
+++ b/catroid/src/main/res/values-es/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -778,8 +776,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No hay red</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">Necesitas una conexión de red para utilizar el Pocket Code. Por favor activa la red móvil o Wi-Fi en ajustes.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="one">The following brick needs a network connection:</item>
@@ -834,7 +830,6 @@
   <string name="signin_choose_username_hint">El nombre de usuario no debe ser su nombre real.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Mostrar Contraseña</string>
-  <string name="register_password_mismatch">Las contraseñas no coinciden</string>
   <string name="sign_in_error">Error durante el Registro</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-fa/strings.xml
+++ b/catroid/src/main/res/values-fa/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -710,8 +708,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -766,7 +762,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-fr/strings.xml
+++ b/catroid/src/main/res/values-fr/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -777,8 +775,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">Pas de réseau</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">Tu as besoin d’une connexion réseau pour utiliser ce programme Pocket Code. Merci d\'activer le réseau mobile ou le Wi-Fi dans les paramètres.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="one">The following brick needs a network connection:</item>
@@ -833,7 +829,6 @@
   <string name="signin_choose_username_hint">Le nom d\'utilisateur ne doit pas être ton vrai nom.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Afficher le mot de passe</string>
-  <string name="register_password_mismatch">Les mots de passes ne correspondent pas</string>
   <string name="sign_in_error">Erreur pendant la connexion</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-gl/strings.xml
+++ b/catroid/src/main/res/values-gl/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Mostrar contrasinal</string>
-  <string name="register_password_mismatch">Os contrasinais non coinciden</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-gu/strings.xml
+++ b/catroid/src/main/res/values-gu/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-hi/strings.xml
+++ b/catroid/src/main/res/values-hi/strings.xml
@@ -55,10 +55,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -783,8 +781,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -840,7 +836,6 @@
   <string name="signin_choose_username_hint">उपयोगकर्ता का नाम आपका असली नाम नहीं होना चाहिए ।</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">पासवर्ड दिखाएँ</string>
-  <string name="register_password_mismatch">पासवर्ड्स समान नहीं हैं</string>
   <string name="sign_in_error">साइन-इन के दौरान त्रुटि</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-hr/strings.xml
+++ b/catroid/src/main/res/values-hr/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -852,8 +850,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -910,7 +906,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-hu/strings.xml
+++ b/catroid/src/main/res/values-hu/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-in/strings.xml
+++ b/catroid/src/main/res/values-in/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -710,8 +708,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">Tidak ada jaringan</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">Anda memerlukan koneksi jaringan untuk menggunakan program ini. Aktifkan
          jaringan seluler atau Wi-Fi di setelan.</string>
   <plurals name="bricks_using_network_headline">
@@ -766,7 +762,6 @@
   <string name="signin_choose_username_hint">Nama pengguna tidak boleh nama asli Anda.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Tampilkan kata sandi</string>
-  <string name="register_password_mismatch">Sandi tidak cocok</string>
   <string name="sign_in_error">Terjadi kesalahan saat Masuk</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-it/strings.xml
+++ b/catroid/src/main/res/values-it/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Recupero dati da Facebook&#8230;</string>
-  <string name="loading_check_email">Verifico se l\'e-mail è disponibile&#8230;</string>
   <string name="loading_check_oauth_token">Verifica dati di login&#8230;</string>
   <string name="loading_check_facebook_token_validity">Controllo dei dati da Facebook&#8230;</string>
-  <string name="loading_check_oauth_username">Verifico se il nome utente è disponibile&#8230;</string>
   <string name="loading_facebook_exchange_token">Scambio dati da Facebook&#8230;</string>
   <string name="loading_facebook_login">Login completo con i dati da Facebook&#8230;</string>
   <string name="loading_google_exchange_code">Scambio dati con Google+&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">Nessuna Rete</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">Hai bisogno di una connessione di rete per utilizzare questo programma di Pocket Code. Attiva una rete Wi-Fi o altre rete nelle impostazioni di sistema.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="one">The following brick needs a network connection:</item>
@@ -837,7 +833,6 @@
   <string name="signin_choose_username_hint">Il nome utente non dovrebbe essere il tuo vero nome.</string>
   <string name="oauth_username_taken">Nome già usato. Scegli uno diverso!</string>
   <string name="show_password">Mostra Password</string>
-  <string name="register_password_mismatch">Le password non corrispondono</string>
   <string name="sign_in_error">Errore durante l\'accesso</string>
   <string name="error_google_plus_sign_in">Errore di login su Google. Stato: %s</string>
   <string name="error_facebook_session_expired">Sessione scaduta, effettua nuovamente il login.</string>

--- a/catroid/src/main/res/values-iw/strings.xml
+++ b/catroid/src/main/res/values-iw/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -923,8 +921,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -982,7 +978,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-ja/strings.xml
+++ b/catroid/src/main/res/values-ja/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -706,8 +704,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">ネットワーク接続がありません</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">このポケットコードのプログラムを使用するには、ネットワーク接続が必要です。
 携帯電話ネットワークまたは Wi-Fi 設定をオンにしてください。</string>
   <plurals name="bricks_using_network_headline">
@@ -762,7 +758,6 @@
   <string name="signin_choose_username_hint">ユーザー名は、あなたの本当の名前にする必要はありません。</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">パスワードを表示</string>
-  <string name="register_password_mismatch">パスワードが一致しません</string>
   <string name="sign_in_error">サインイン時にエラー</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-kk/strings.xml
+++ b/catroid/src/main/res/values-kk/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-kn/strings.xml
+++ b/catroid/src/main/res/values-kn/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-ko/strings.xml
+++ b/catroid/src/main/res/values-ko/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -706,8 +704,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">네트워크 연결 불가</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">이 포켓 코드 프로그램을 사용 하 여 네트워크 연결을 해야 합니다. 모바일 네트워크 또는 Wi-fi 설정에서 설정하십시오.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="other">The following bricks need a network connection:</item>
@@ -761,7 +757,6 @@
   <string name="signin_choose_username_hint">사용자 이름은 당신의 진짜 이름을 사용할 수 없습니다.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">비밀 번호 표시</string>
-  <string name="register_password_mismatch">비밀번호가 일치하지 않습니다</string>
   <string name="sign_in_error">로그인 중 오류가 발생했습니다</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-lt/strings.xml
+++ b/catroid/src/main/res/values-lt/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -923,8 +921,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -982,7 +978,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-mk/strings.xml
+++ b/catroid/src/main/res/values-mk/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">Вашето корисничко име не треба да се совпаѓа со вашето вистинското име.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-ml/strings.xml
+++ b/catroid/src/main/res/values-ml/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-ms/strings.xml
+++ b/catroid/src/main/res/values-ms/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -710,8 +708,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -766,7 +762,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-nl/strings.xml
+++ b/catroid/src/main/res/values-nl/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-no/strings.xml
+++ b/catroid/src/main/res/values-no/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -777,8 +775,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">Ingen nettverk</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">Du trenger en nettverkstilkobling forvå kunne bruke dette Pocket Code programmet. Vennligst slå på mobilnettverk eller Wi-Fi i innstillingene.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="one">The following brick needs a network connection:</item>
@@ -833,7 +829,6 @@
   <string name="signin_choose_username_hint">Brukernavnet bør ikke være ditt virkelige navn.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Vis passord</string>
-  <string name="register_password_mismatch">Passordene samsvarer ikke</string>
   <string name="sign_in_error">Feil under pålogging</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-pl/strings.xml
+++ b/catroid/src/main/res/values-pl/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Pobieranie danych Facebooka&#8230;</string>
-  <string name="loading_check_email">Sprawdzenie, czy e-mail jest dostępny&#8230;</string>
   <string name="loading_check_oauth_token">Sprawdzanie danych logowania&#8230;</string>
   <string name="loading_check_facebook_token_validity">Sprawdzanie danych Facebooka&#8230;</string>
-  <string name="loading_check_oauth_username">Sprawdzenie, czy nazwa użytkownika jest dostępna&#8230;</string>
   <string name="loading_facebook_exchange_token">Wymiana danych z Facebooka&#8230;</string>
   <string name="loading_facebook_login">Logowanie do Facebooka na naszym serwerze zostało zakończone&#8230;</string>
   <string name="loading_google_exchange_code">Wymiana danych z Google+&#8230;</string>
@@ -887,8 +885,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">Brak sieci</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">Potrzebujesz połączenia sieciowego, aby korzystać z tego programu Pocket Code. Włącz sieć komórkową lub Wi-Fi w ustawieniach.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="one">Następujący bloczek wymaga połączenia sieciowego:</item>
@@ -945,7 +941,6 @@
   <string name="signin_choose_username_hint">Nazwa użytkownika nie powinna być Twoim prawdziwym nazwiskiem.</string>
   <string name="oauth_username_taken">Ktoś już używa tej nazwy. Proszę wybrać inną!</string>
   <string name="show_password">Pokaż hasło</string>
-  <string name="register_password_mismatch">Hasła nie pasują</string>
   <string name="sign_in_error">Wystąpił błąd podczas logowania</string>
   <string name="error_google_plus_sign_in">Błąd logowania Google. Status: %s</string>
   <string name="error_facebook_session_expired">Twoja sesja wygasła, zaloguj się ponownie.</string>

--- a/catroid/src/main/res/values-ps/strings.xml
+++ b/catroid/src/main/res/values-ps/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-pt-rBR/strings.xml
+++ b/catroid/src/main/res/values-pt-rBR/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -778,8 +776,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -835,7 +831,6 @@
   <string name="signin_choose_username_hint">O nome de usuário não deve ser seu nome verdadeiro.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Mostrar palavra-passe</string>
-  <string name="register_password_mismatch">As senhas não coincidem</string>
   <string name="sign_in_error">Erro durante a inscrição</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-pt/strings.xml
+++ b/catroid/src/main/res/values-pt/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -778,8 +776,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -835,7 +831,6 @@
   <string name="signin_choose_username_hint">O nome de utilizador não deve ser seu nome verdadeiro.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Mostrar palavra-passe</string>
-  <string name="register_password_mismatch">As senhas não coincidem</string>
   <string name="sign_in_error">Erro durante a inscrição</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-ro/strings.xml
+++ b/catroid/src/main/res/values-ro/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -852,8 +850,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -910,7 +906,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-ru/strings.xml
+++ b/catroid/src/main/res/values-ru/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -921,8 +919,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">Нет сети</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">Для использования этой программы Pocket Code необходим доступ к Интернету. Пожалуйста, включите мобильную сеть или Wi-Fi в настройках.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="one">The following brick needs a network connection:</item>
@@ -979,7 +975,6 @@
   <string name="signin_choose_username_hint">Имя пользователя не должно совпадать с вашим настоящим именем.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Показать пароль</string>
-  <string name="register_password_mismatch">Пароли не совпадают</string>
   <string name="sign_in_error">Ошибка во время входа</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-sd/strings.xml
+++ b/catroid/src/main/res/values-sd/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">پاسورڊ ڏسو</string>
-  <string name="register_password_mismatch">پاسورڊ صحيح نه آهي</string>
   <string name="sign_in_error">سايئن ان ۾ مثئلو پيو اچي</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-sk/strings.xml
+++ b/catroid/src/main/res/values-sk/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -919,8 +917,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -978,7 +974,6 @@
   <string name="signin_choose_username_hint">Užívateľské meno by nemalo byť Vaše skutočné meno.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Zobraziť heslo</string>
-  <string name="register_password_mismatch">Heslá sa nezhodujú</string>
   <string name="sign_in_error">Chyba pri prihlásení</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-sl/strings.xml
+++ b/catroid/src/main/res/values-sl/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -923,8 +921,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -982,7 +978,6 @@
   <string name="signin_choose_username_hint">Uporabniško ime ne sme biti vaše pravo ime.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-sq/strings.xml
+++ b/catroid/src/main/res/values-sq/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">Emri përdoruesit nuk duhet të jetë emri juaj i vërtetë.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-sr-rCS/strings.xml
+++ b/catroid/src/main/res/values-sr-rCS/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -852,8 +850,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -910,7 +906,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-sr-rSP/strings.xml
+++ b/catroid/src/main/res/values-sr-rSP/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -852,8 +850,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -910,7 +906,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-sv/strings.xml
+++ b/catroid/src/main/res/values-sv/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">Inget nätverk</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Visa lösenord</string>
-  <string name="register_password_mismatch">Lösenorden matchar ej</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-sw/strings.xml
+++ b/catroid/src/main/res/values-sw/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -777,8 +775,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">Mtandao haupatikani</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">Unahitaji muungano wa mtandao ili kutumia programu hii. Tafadhali washa mtandao wa simu au WiFi kwenye mpangilio.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="one">The following brick needs a network connection:</item>
@@ -833,7 +829,6 @@
   <string name="signin_choose_username_hint">Jina la mtumiaji si lazima jina lako halisi.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Onyesha nenosiri</string>
-  <string name="register_password_mismatch">Manenosiri hayafanani</string>
   <string name="sign_in_error">Kosa wakati wa kuingia</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-ta/strings.xml
+++ b/catroid/src/main/res/values-ta/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-te/strings.xml
+++ b/catroid/src/main/res/values-te/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-th/strings.xml
+++ b/catroid/src/main/res/values-th/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -710,8 +708,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -766,7 +762,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-tr/strings.xml
+++ b/catroid/src/main/res/values-tr/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -785,8 +783,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">Bağlantı yok</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">Bu programı kullanmak için ağa bağlanmanız gerekir. Lütfen ayarları mobil ağı veya Kablosuz özelliğini açın.</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="one">The following brick needs a network connection:</item>
@@ -841,7 +837,6 @@
   <string name="signin_choose_username_hint">Kullanıcı adınız gerçek adınız olmamalıdır.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Parolayı göster</string>
-  <string name="register_password_mismatch">Parolalar uyuşmuyor</string>
   <string name="sign_in_error">Oturum açma sırasında bir hata oluştu</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-uk/strings.xml
+++ b/catroid/src/main/res/values-uk/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -923,8 +921,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -982,7 +978,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-ur/strings.xml
+++ b/catroid/src/main/res/values-ur/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -781,8 +779,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -838,7 +834,6 @@
   <string name="signin_choose_username_hint">یوزر نیم آپکا اصلی نام نہیں ہونا چاہیے.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-vi/strings.xml
+++ b/catroid/src/main/res/values-vi/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -710,8 +708,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -766,7 +762,6 @@
   <string name="signin_choose_username_hint">Tên người dùng không nên là tên thật của bạn.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-zh-rCN/strings.xml
+++ b/catroid/src/main/res/values-zh-rCN/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -706,8 +704,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">没有网络</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">您需要网络连接才能使用此程序。请在设置中启用移动网络或无线网络。</string>
   <plurals name="bricks_using_network_headline">
     <item quantity="other">The following bricks need a network connection:</item>
@@ -761,7 +757,6 @@
   <string name="signin_choose_username_hint">用户名不建议使用您的真实姓名。</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">显示密码</string>
-  <string name="register_password_mismatch">密码不匹配</string>
   <string name="sign_in_error">登录时出错</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values-zh-rTW/strings.xml
+++ b/catroid/src/main/res/values-zh-rTW/strings.xml
@@ -53,10 +53,8 @@
   <string name="share_website_text">www.pocketcode.org</string>
   <!-- Login/Logout Mechanism -->
   <string name="loading_check_facebook_data">Retrieving Facebook data&#8230;</string>
-  <string name="loading_check_email">Checking if the e-mail is available&#8230;</string>
   <string name="loading_check_oauth_token">Checking login data&#8230;</string>
   <string name="loading_check_facebook_token_validity">Checking Facebook data&#8230;</string>
-  <string name="loading_check_oauth_username">Checking if the username is available&#8230;</string>
   <string name="loading_facebook_exchange_token">Exchanging Facebook data&#8230;</string>
   <string name="loading_facebook_login">Facebook login on our server is complete&#8230;</string>
   <string name="loading_google_exchange_code">Exchanging Google+ data&#8230;</string>
@@ -710,8 +708,6 @@
   <!--  -->
   <!-- NetworkAlertDialog -->
   <string name="error_no_network_title">No Network</string>
-  <string name="error_no_network_one_brick">Following brick will use the network:</string>
-  <string name="error_no_network_multiple_bricks">Following brick will use the networks:</string>
   <string name="error_no_network">You need a network connection to use this program. Please turn on the
         mobile network or the Wi-Fi in the settings.</string>
   <plurals name="bricks_using_network_headline">
@@ -766,7 +762,6 @@
   <string name="signin_choose_username_hint">The username should not be your real name.</string>
   <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
   <string name="show_password">Show Password</string>
-  <string name="register_password_mismatch">Passwords do not match</string>
   <string name="sign_in_error">Error during Sign-In</string>
   <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
   <string name="error_facebook_session_expired">Session expired, please log in.</string>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -64,10 +64,8 @@
 
     <!-- Login/Logout Mechanism -->
     <string name="loading_check_facebook_data">Retrieving Facebook data…</string>
-    <string name="loading_check_email">Checking if the e-mail is available…</string>
     <string name="loading_check_oauth_token">Checking login data…</string>
     <string name="loading_check_facebook_token_validity">Checking Facebook data…</string>
-    <string name="loading_check_oauth_username">Checking if the username is available…</string>
     <string name="loading_facebook_exchange_token">Exchanging Facebook data…</string>
     <string name="loading_facebook_login">Facebook login on our server is complete…</string>
     <string name="loading_google_exchange_code">Exchanging Google+ data…</string>
@@ -930,12 +928,22 @@
     <string name="signin_choose_username_hint">The username should not be your real name.</string>
     <string name="oauth_username_taken">Someone else already uses this name. Please choose a different one!</string>
     <string name="show_password">Show Password</string>
-    <string name="register_password_mismatch">Passwords do not match</string>
     <string name="sign_in_error">Error during Sign-In</string>
     <string name="error_google_plus_sign_in">Google Sign-In error. Status: %s</string>
     <string name="error_facebook_session_expired">Session expired, please log in.</string>
     <string name="sign_in_with_facebook">Sign in with Facebook</string>
     <string name="sign_in_with_google">Sign in with Google</string>
+    <string name="error_register_empty_username">Empty username</string>
+    <string name="error_register_username_as_email">E-mail address can not be used as username</string>
+    <string name="error_register_invalid_username">Username can contain only Latin–letters (a–z), numbers (0–9), dashes (-), underscores (_), and periods (.).</string>
+    <string name="error_register_username_start_with">Username can not start with dashes (-), underscores (_), and periods (.).</string>
+    <string name="error_register_invalid_email_format">Invalid E-mail format</string>
+    <string name="error_register_empty_password">Empty Password</string>
+    <string name="error_register_password_at_least_6_characters">Password should be at least 6 characters</string>
+    <string name="error_register_passwords_mismatch">Passwords mismatch</string>
+    <string name="error_register_empty_confirm_password">Empty confirm password</string>
+    <string name="error_register_username_already_exists">Username already exists</string>
+    <string name="error_register_email_exists">Email Address already exists</string>
     <!--  -->
 
 
@@ -1877,7 +1885,6 @@
     <string name="formula_editor_sensor_face_y_position">face_y_position</string>
     <string name="formula_editor_function_number_of_items">number_of_items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
-
     <string name="formula_editor_intro_title_formula_editor">Formula editor</string>
     <string name="formula_editor_intro_summary_formula_editor">With the  formula editor you can create mathematical and
         logical formulas that you can use in your bricks.\n\nYou can continue through this little intro by tapping


### PR DESCRIPTION
Comments from original PR

- removing unused Strings
- Sets an error message that will be displayed below the TextInputLayouts
- (Username/E-mail/Password/confirm Password ) instead of showing AlertDialogs
- Check E-mail and Username availability in background
- Username should start with Latin character or number and contains no "@" - to block using email as username
- Check if the the provided Email_address matches Patterns.EMAIL_ADDRESS
- Password should be at least 6 characters
- Check if Password and Confirm Password are matched