### PR TITLE
[HotFix] Fixed Crash when Unpacking Scene

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
@@ -28,8 +28,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.BroadcastMessageBrick;
-import org.catrobat.catroid.content.bricks.UserListBrick;
-import org.catrobat.catroid.content.bricks.UserVariableBrick;
 import org.catrobat.catroid.formulaeditor.datacontainer.DataContainer;
 import org.catrobat.catroid.io.XStreamFieldKeyOrder;
 import org.catrobat.catroid.physics.PhysicsWorld;
@@ -202,21 +200,5 @@ public class Scene implements Serializable {
 			}
 		}
 		return messagesInUse;
-	}
-
-	public synchronized void correctUserVariableAndListReferences() {
-		for (Sprite sprite : spriteList) {
-			for (Brick brick : sprite.getAllBricks()) {
-				if (brick instanceof UserVariableBrick) {
-					((UserVariableBrick) brick).setUserVariable(dataContainer.getUserVariable(sprite,
-							((UserVariableBrick) brick).getUserVariable().getName()));
-				}
-
-				if (brick instanceof UserListBrick) {
-					((UserListBrick) brick).setUserList(dataContainer.getUserList(sprite,
-							((UserListBrick) brick).getUserList().getName()));
-				}
-			}
-		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/LookController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/LookController.java
@@ -29,6 +29,7 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.io.StorageOperations;
 import org.catrobat.catroid.ui.controller.BackpackListManager;
 import org.catrobat.catroid.ui.recyclerview.util.UniqueNameProvider;
+import org.catrobat.catroid.utils.Utils;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,7 +54,7 @@ public class LookController {
 
 	LookData findOrCopy(LookData lookToCopy, Scene dstScene, Sprite dstSprite) throws IOException {
 		for (LookData look : dstSprite.getLookList()) {
-			if (look.getFile().equals(lookToCopy.getFile())) {
+			if (compareByChecksum(look.getFile(), lookToCopy.getFile())) {
 				return look;
 			}
 		}
@@ -77,7 +78,7 @@ public class LookController {
 
 	LookData packForSprite(LookData lookToPack, Sprite dstSprite) throws IOException {
 		for (LookData look : dstSprite.getLookList()) {
-			if (look.getFile().equals(lookToPack.getFile())) {
+			if (compareByChecksum(look.getFile(), lookToPack.getFile())) {
 				return look;
 			}
 		}
@@ -96,7 +97,7 @@ public class LookController {
 
 	LookData unpackForSprite(LookData lookToUnpack, Scene dstScene, Sprite dstSprite) throws IOException {
 		for (LookData look : dstSprite.getLookList()) {
-			if (look.getFile().equals(lookToUnpack.getFile())) {
+			if (compareByChecksum(look.getFile(), lookToUnpack.getFile())) {
 				return look;
 			}
 		}
@@ -116,5 +117,12 @@ public class LookController {
 
 	private File getImageDir(Scene scene) {
 		return new File(scene.getDirectory(), IMAGE_DIRECTORY_NAME);
+	}
+
+	private boolean compareByChecksum(File file1, File file2) {
+		String checksum1 = Utils.md5Checksum(file1);
+		String checksum2 = Utils.md5Checksum(file2);
+
+		return checksum1.equals(checksum2);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SceneController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SceneController.java
@@ -101,7 +101,6 @@ public class SceneController {
 			scene.getSpriteList().add(spriteController.copy(sprite, sceneToCopy, scene));
 		}
 
-		scene.correctUserVariableAndListReferences();
 		return scene;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/ScriptController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/ScriptController.java
@@ -59,33 +59,33 @@ public class ScriptController {
 		Script script = scriptToCopy.clone();
 
 		for (Brick brick : script.getBrickList()) {
-			if (brick instanceof SetLookBrick) {
+			if (brick instanceof SetLookBrick && ((SetLookBrick) brick).getLook() != null) {
 				((SetLookBrick) brick).setLook(lookController
 						.findOrCopy(((SetLookBrick) brick).getLook(), dstScene, dstSprite));
 			}
 
-			if (brick instanceof WhenBackgroundChangesBrick) {
+			if (brick instanceof WhenBackgroundChangesBrick && ((WhenBackgroundChangesBrick) brick).getLook() != null) {
 				((WhenBackgroundChangesBrick) brick).setLook(lookController
 						.findOrCopy(((WhenBackgroundChangesBrick) brick).getLook(), dstScene, dstSprite));
 			}
 
-			if (brick instanceof PlaySoundBrick) {
+			if (brick instanceof PlaySoundBrick && ((PlaySoundBrick) brick).getSound() != null) {
 				((PlaySoundBrick) brick).setSound(soundController
 						.findOrCopy(((PlaySoundBrick) brick).getSound(), dstScene, dstSprite));
 			}
 
-			if (brick instanceof PlaySoundAndWaitBrick) {
+			if (brick instanceof PlaySoundAndWaitBrick && ((PlaySoundAndWaitBrick) brick).getSound() != null) {
 				((PlaySoundAndWaitBrick) brick).setSound(soundController
 						.findOrCopy(((PlaySoundAndWaitBrick) brick).getSound(), dstScene, dstSprite));
 			}
 
-			if (brick instanceof UserVariableBrick) {
+			if (brick instanceof UserVariableBrick && ((UserVariableBrick) brick).getUserVariable() != null) {
 				UserVariable previousUserVar = ((UserVariableBrick) brick).getUserVariable();
 				((UserVariableBrick) brick).setUserVariable(dstScene.getDataContainer()
 						.getUserVariable(dstSprite, previousUserVar.getName()));
 			}
 
-			if (brick instanceof UserListBrick) {
+			if (brick instanceof UserListBrick && ((UserListBrick) brick).getUserList() != null) {
 				UserList previousUserList = ((UserListBrick) brick).getUserList();
 				((UserListBrick) brick).setUserList(dstScene.getDataContainer()
 						.getUserList(dstSprite, previousUserList.getName()));
@@ -113,22 +113,22 @@ public class ScriptController {
 		Script script = scriptToPack.clone();
 
 		for (Brick brick : script.getBrickList()) {
-			if (brick instanceof SetLookBrick) {
+			if (brick instanceof SetLookBrick && ((SetLookBrick) brick).getLook() != null) {
 				((SetLookBrick) brick).setLook(lookController
 						.packForSprite(((SetLookBrick) brick).getLook(), dstSprite));
 			}
 
-			if (brick instanceof WhenBackgroundChangesBrick) {
+			if (brick instanceof WhenBackgroundChangesBrick && ((WhenBackgroundChangesBrick) brick).getLook() != null) {
 				((WhenBackgroundChangesBrick) brick).setLook(lookController
 						.packForSprite(((WhenBackgroundChangesBrick) brick).getLook(), dstSprite));
 			}
 
-			if (brick instanceof PlaySoundBrick) {
+			if (brick instanceof PlaySoundBrick && ((PlaySoundBrick) brick).getSound() != null) {
 				((PlaySoundBrick) brick).setSound(soundController
 						.packForSprite(((PlaySoundBrick) brick).getSound(), dstSprite));
 			}
 
-			if (brick instanceof PlaySoundAndWaitBrick) {
+			if (brick instanceof PlaySoundAndWaitBrick && ((PlaySoundAndWaitBrick) brick).getSound() != null) {
 				((PlaySoundAndWaitBrick) brick).setSound(soundController
 						.packForSprite(((PlaySoundAndWaitBrick) brick).getSound(), dstSprite));
 			}
@@ -162,36 +162,28 @@ public class ScriptController {
 				return;
 			}
 
-			if (brick instanceof SetLookBrick) {
+			if (brick instanceof SetLookBrick && ((SetLookBrick) brick).getLook() != null) {
 				((SetLookBrick) brick)
 						.setLook(lookController
-								.unpackForSprite(((SetLookBrick) brick).getLook(),
-										dstScene,
-										dstSprite));
+								.unpackForSprite(((SetLookBrick) brick).getLook(), dstScene, dstSprite));
 			}
 
-			if (brick instanceof WhenBackgroundChangesBrick) {
+			if (brick instanceof WhenBackgroundChangesBrick && ((WhenBackgroundChangesBrick) brick).getLook() != null) {
 				((WhenBackgroundChangesBrick) brick)
 						.setLook(lookController
-								.unpackForSprite(((WhenBackgroundChangesBrick) brick).getLook(),
-										dstScene,
-										dstSprite));
+								.unpackForSprite(((WhenBackgroundChangesBrick) brick).getLook(), dstScene, dstSprite));
 			}
 
-			if (brick instanceof PlaySoundBrick) {
+			if (brick instanceof PlaySoundBrick && ((PlaySoundBrick) brick).getSound() != null) {
 				((PlaySoundBrick) brick)
 						.setSound(soundController
-								.unpackForSprite(((PlaySoundBrick) brick).getSound(),
-										dstScene,
-										dstSprite));
+								.unpackForSprite(((PlaySoundBrick) brick).getSound(), dstScene, dstSprite));
 			}
 
-			if (brick instanceof PlaySoundAndWaitBrick) {
+			if (brick instanceof PlaySoundAndWaitBrick && ((PlaySoundAndWaitBrick) brick).getSound() != null) {
 				((PlaySoundAndWaitBrick) brick)
 						.setSound(soundController
-								.unpackForSprite(((PlaySoundAndWaitBrick) brick).getSound(),
-										dstScene,
-										dstSprite));
+								.unpackForSprite(((PlaySoundAndWaitBrick) brick).getSound(), dstScene, dstSprite));
 			}
 		}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SoundController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SoundController.java
@@ -29,6 +29,7 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.io.StorageOperations;
 import org.catrobat.catroid.ui.controller.BackpackListManager;
 import org.catrobat.catroid.ui.recyclerview.util.UniqueNameProvider;
+import org.catrobat.catroid.utils.Utils;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,7 +54,7 @@ public class SoundController {
 
 	SoundInfo findOrCopy(SoundInfo soundToCopy, Scene dstScene, Sprite dstSprite) throws IOException {
 		for (SoundInfo sound : dstSprite.getSoundList()) {
-			if (sound.getFile().equals(soundToCopy.getFile())) {
+			if (compareByChecksum(sound.getFile(), soundToCopy.getFile())) {
 				return sound;
 			}
 		}
@@ -77,7 +78,7 @@ public class SoundController {
 
 	SoundInfo packForSprite(SoundInfo soundToPack, Sprite dstSprite) throws IOException {
 		for (SoundInfo sound : dstSprite.getSoundList()) {
-			if (sound.getFile().equals(soundToPack.getFile())) {
+			if (compareByChecksum(sound.getFile(), soundToPack.getFile())) {
 				return sound;
 			}
 		}
@@ -97,7 +98,7 @@ public class SoundController {
 
 	SoundInfo unpackForSprite(SoundInfo soundToUnpack, Scene dstScene, Sprite dstSprite) throws IOException {
 		for (SoundInfo sound : dstSprite.getSoundList()) {
-			if (sound.getFile().equals(soundToUnpack.getFile())) {
+			if (compareByChecksum(sound.getFile(), soundToUnpack.getFile())) {
 				return sound;
 			}
 		}
@@ -117,5 +118,12 @@ public class SoundController {
 
 	private File getSoundDir(Scene scene) {
 		return new File(scene.getDirectory(), SOUND_DIRECTORY_NAME);
+	}
+
+	private boolean compareByChecksum(File file1, File file2) {
+		String checksum1 = Utils.md5Checksum(file1);
+		String checksum2 = Utils.md5Checksum(file2);
+
+		return checksum1.equals(checksum2);
 	}
 }


### PR DESCRIPTION
 - this also fixes the Backpack in general: i.e.
   comparison of objects with File references were broken, after
   refactoring, this now re-introduces comparison by checksum
   to verify if two images have same content instead of same
   path only.
 - when unpacking a Scene that contains a SpinnerBricks
   a crash occured because the Spinner selection and the Object reference
   are not synchronized.
 - this is ONLY a hotfix. it prevents the crash, but does not correctly
   set up the references. this will be fixed during Spinner refactoring.