### PR TITLE
CATROID-37 crashes when restoring fragments after activity was destroyed

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaySoundBrick.java
@@ -32,6 +32,7 @@ import android.widget.Spinner;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.SoundInfo;
+import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
 import org.catrobat.catroid.content.bricks.brickspinner.SpinnerAdapterWithNewOption;
@@ -124,16 +125,10 @@ public class PlaySoundBrick extends BrickBaseType implements
 	@Override
 	public boolean onNewOptionInDropDownClicked(View v) {
 		spinnerSelectionBuffer = spinner.getSelectedItemPosition();
-		new NewSoundDialogFragment(this,
+		new NewSoundFromBrickSpinnerDialogFragment(this,
 				ProjectManager.getInstance().getCurrentlyEditedScene(),
-				ProjectManager.getInstance().getCurrentSprite()) {
-
-			@Override
-			public void onCancel(DialogInterface dialog) {
-				super.onCancel(dialog);
-				spinner.setSelection(spinnerSelectionBuffer);
-			}
-		}.show(((Activity) v.getContext()).getFragmentManager(), NewSoundDialogFragment.TAG);
+				ProjectManager.getInstance().getCurrentSprite())
+				.show(((Activity) v.getContext()).getFragmentManager(), NewSoundDialogFragment.TAG);
 		return false;
 	}
 
@@ -149,7 +144,7 @@ public class PlaySoundBrick extends BrickBaseType implements
 	public View getPrototypeView(Context context) {
 		View view = super.getPrototypeView(context);
 		onPrototypeViewCreated(view);
-		spinner = view.findViewById(R.id.brick_play_sound_spinner);
+		spinner = (Spinner) view.findViewById(R.id.brick_play_sound_spinner);
 		spinnerAdapter = new SpinnerAdapterWithNewOption(context, getSoundNames());
 		spinner.setAdapter(spinnerAdapter);
 		spinner.setSelection(spinnerAdapter.getPosition(sound != null ? sound.getName() : null));
@@ -163,5 +158,24 @@ public class PlaySoundBrick extends BrickBaseType implements
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createPlaySoundAction(sprite, sound));
 		return null;
+	}
+
+	public static class NewSoundFromBrickSpinnerDialogFragment extends NewSoundDialogFragment {
+
+		private PlaySoundBrick playSoundBrick;
+
+		public NewSoundFromBrickSpinnerDialogFragment() {
+		}
+
+		public NewSoundFromBrickSpinnerDialogFragment(PlaySoundBrick playSoundBrick, Scene dstScene, Sprite dstSprite) {
+			super(playSoundBrick, dstScene, dstSprite);
+			this.playSoundBrick = playSoundBrick;
+		}
+
+		@Override
+		public void onCancel(DialogInterface dialog) {
+			super.onCancel(dialog);
+			playSoundBrick.spinner.setSelection(playSoundBrick.spinnerSelectionBuffer);
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneStartBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneStartBrick.java
@@ -31,6 +31,7 @@ import android.widget.Spinner;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
@@ -102,14 +103,8 @@ public class SceneStartBrick extends BrickBaseType implements
 	@Override
 	public boolean onNewOptionInDropDownClicked(View v) {
 		spinnerSelectionBuffer = spinner.getSelectedItemPosition();
-		new NewSceneDialogFragment(this, ProjectManager.getInstance().getCurrentProject()) {
-
-			@Override
-			public void onCancel(DialogInterface dialog) {
-				super.onCancel(dialog);
-				spinner.setSelection(spinnerSelectionBuffer);
-			}
-		}.show(((Activity) v.getContext()).getFragmentManager(), NewSceneDialogFragment.TAG);
+		new NewSceneFromBrickDialogFragment(this, ProjectManager.getInstance().getCurrentProject())
+				.show(((Activity) v.getContext()).getFragmentManager(), NewSceneDialogFragment.TAG);
 		return false;
 	}
 
@@ -137,5 +132,25 @@ public class SceneStartBrick extends BrickBaseType implements
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createSceneStartAction(sceneToStart));
 		return null;
+	}
+
+	public static class NewSceneFromBrickDialogFragment extends NewSceneDialogFragment {
+
+		private SceneStartBrick sceneStartBrick;
+
+		public NewSceneFromBrickDialogFragment(SceneStartBrick sceneStartBrick, Project dstProject) {
+			super(sceneStartBrick, dstProject);
+			this.sceneStartBrick = sceneStartBrick;
+		}
+
+		public NewSceneFromBrickDialogFragment() {
+			super();
+		}
+
+		@Override
+		public void onCancel(DialogInterface dialog) {
+			super.onCancel(dialog);
+			sceneStartBrick.spinner.setSelection(sceneStartBrick.spinnerSelectionBuffer);
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneTransitionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SceneTransitionBrick.java
@@ -31,6 +31,7 @@ import android.widget.Spinner;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
@@ -105,14 +106,8 @@ public class SceneTransitionBrick extends BrickBaseType implements
 	@Override
 	public boolean onNewOptionInDropDownClicked(View v) {
 		spinnerSelectionBuffer = spinner.getSelectedItemPosition();
-		new NewSceneDialogFragment(this, ProjectManager.getInstance().getCurrentProject()) {
-
-			@Override
-			public void onCancel(DialogInterface dialog) {
-				super.onCancel(dialog);
-				spinner.setSelection(spinnerSelectionBuffer);
-			}
-		}.show(((Activity) v.getContext()).getFragmentManager(), NewSceneDialogFragment.TAG);
+		new NewSceneFromBrickDialogFragment(this, ProjectManager.getInstance().getCurrentProject())
+				.show(((Activity) v.getContext()).getFragmentManager(), NewSceneDialogFragment.TAG);
 		return false;
 	}
 
@@ -142,5 +137,25 @@ public class SceneTransitionBrick extends BrickBaseType implements
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createSceneTransitionAction(sceneForTransition));
 		return null;
+	}
+
+	public static class NewSceneFromBrickDialogFragment extends NewSceneDialogFragment {
+
+		private SceneTransitionBrick sceneTransitionBrick;
+
+		public NewSceneFromBrickDialogFragment() {
+			super();
+		}
+
+		public NewSceneFromBrickDialogFragment(SceneTransitionBrick sceneTransitionBrick, Project dstProject) {
+			super(sceneTransitionBrick, dstProject);
+			this.sceneTransitionBrick = sceneTransitionBrick;
+		}
+
+		@Override
+		public void onCancel(DialogInterface dialog) {
+			super.onCancel(dialog);
+			sceneTransitionBrick.spinner.setSelection(sceneTransitionBrick.spinnerSelectionBuffer);
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetLookBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetLookBrick.java
@@ -34,6 +34,7 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.content.EventWrapper;
+import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
 import org.catrobat.catroid.content.bricks.brickspinner.SpinnerAdapterWithNewOption;
@@ -133,16 +134,10 @@ public class SetLookBrick extends BrickBaseType implements
 	@Override
 	public boolean onNewOptionInDropDownClicked(View v) {
 		spinnerSelectionBuffer = spinner.getSelectedItemPosition();
-		new NewLookDialogFragment(this,
+		new NewLookFromBrickDialogFragment(this,
 				ProjectManager.getInstance().getCurrentlyEditedScene(),
-				getSprite()) {
-
-			@Override
-			public void onCancel(DialogInterface dialog) {
-				super.onCancel(dialog);
-				spinner.setSelection(spinnerSelectionBuffer);
-			}
-		}.show(((Activity) v.getContext()).getFragmentManager(), NewLookDialogFragment.TAG);
+				getSprite())
+				.show(((Activity) v.getContext()).getFragmentManager(), NewLookDialogFragment.TAG);
 		return false;
 	}
 
@@ -179,5 +174,24 @@ public class SetLookBrick extends BrickBaseType implements
 
 	protected Sprite getSprite() {
 		return ProjectManager.getInstance().getCurrentSprite();
+	}
+
+	public static class NewLookFromBrickDialogFragment extends NewLookDialogFragment {
+
+		private SetLookBrick setLookBrick;
+
+		public NewLookFromBrickDialogFragment() {
+		}
+
+		public NewLookFromBrickDialogFragment(SetLookBrick setLookBrick, Scene dstScene, Sprite dstSprite) {
+			super(setLookBrick, dstScene, dstSprite);
+			this.setLookBrick = setLookBrick;
+		}
+
+		@Override
+		public void onCancel(DialogInterface dialog) {
+			super.onCancel(dialog);
+			setLookBrick.spinner.setSelection(setLookBrick.spinnerSelectionBuffer);
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBackgroundChangesBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBackgroundChangesBrick.java
@@ -32,6 +32,7 @@ import android.widget.Spinner;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.WhenBackgroundChangesScript;
@@ -139,17 +140,10 @@ public class WhenBackgroundChangesBrick extends BrickBaseType implements
 	@Override
 	public boolean onNewOptionInDropDownClicked(View v) {
 		previouslySelectedLook = getLook();
-		new NewLookDialogFragment(this,
+		new NewLookFromBrickDialogFragment(this,
 				ProjectManager.getInstance().getCurrentlyEditedScene(),
-				ProjectManager.getInstance().getCurrentSprite()) {
-
-			@Override
-			public void onCancel(DialogInterface dialog) {
-				super.onCancel(dialog);
-				setLook(previouslySelectedLook);
-				spinner.setSelection(spinnerAdapter.getPosition(getLook() != null ? getLook().getName() : null));
-			}
-		}.show(((Activity) v.getContext()).getFragmentManager(), NewLookDialogFragment.TAG);
+				ProjectManager.getInstance().getCurrentSprite())
+				.show(((Activity) v.getContext()).getFragmentManager(), NewLookDialogFragment.TAG);
 		return false;
 	}
 
@@ -176,5 +170,25 @@ public class WhenBackgroundChangesBrick extends BrickBaseType implements
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createSetLookAction(sprite, getLook()));
 		return null;
+	}
+
+	public static class NewLookFromBrickDialogFragment extends NewLookDialogFragment {
+
+		private WhenBackgroundChangesBrick whenBackgroundChangesBrick;
+
+		public NewLookFromBrickDialogFragment() {
+		}
+
+		public NewLookFromBrickDialogFragment(WhenBackgroundChangesBrick whenBackgroundChangesBrick, Scene dstScene, Sprite dstSprite) {
+			super(whenBackgroundChangesBrick, dstScene, dstSprite);
+			this.whenBackgroundChangesBrick = whenBackgroundChangesBrick;
+		}
+
+		@Override
+		public void onCancel(DialogInterface dialog) {
+			super.onCancel(dialog);
+			whenBackgroundChangesBrick.setLook(whenBackgroundChangesBrick.previouslySelectedLook);
+			whenBackgroundChangesBrick.spinner.setSelection(whenBackgroundChangesBrick.spinnerAdapter.getPosition(whenBackgroundChangesBrick.getLook() != null ? whenBackgroundChangesBrick.getLook().getName() : null));
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/BrickTextDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/BrickTextDialog.java
@@ -26,6 +26,9 @@ import org.catrobat.catroid.ui.recyclerview.dialog.TextInputDialogFragment;
 
 public class BrickTextDialog extends TextInputDialogFragment {
 
+	public BrickTextDialog() {
+	}
+
 	public BrickTextDialog(int title, int label, String previousText) {
 		super(title, label, previousText, false);
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/LegoSensorConfigInfoDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/LegoSensorConfigInfoDialog.java
@@ -47,8 +47,20 @@ public class LegoSensorConfigInfoDialog extends DialogFragment {
 
 	private @LegoSensorType int legoSensorType;
 
+	public LegoSensorConfigInfoDialog() {
+	}
+
 	public LegoSensorConfigInfoDialog(@LegoSensorType int legoSensorType) {
 		this.legoSensorType = legoSensorType;
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/LegoSensorPortConfigDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/LegoSensorPortConfigDialog.java
@@ -87,6 +87,9 @@ public class LegoSensorPortConfigDialog extends DialogFragment {
 					new SensorInfo(R.string.ev3_sensor_nxt_temperature_f, EV3Sensor.Sensor.NXT_TEMPERATURE_F))
 			.build();
 
+	public LegoSensorPortConfigDialog() {
+	}
+
 	public LegoSensorPortConfigDialog(OnSetSensorListener listener, int clickedResItem, @LegoSensorType int type) {
 		this.listener = listener;
 		sensorInfo = getSensorInfo(clickedResItem, type);
@@ -94,6 +97,15 @@ public class LegoSensorPortConfigDialog extends DialogFragment {
 
 		if (type != Constants.NXT && type != Constants.EV3) {
 			throw new IllegalArgumentException("LegoSensorPortConfigDialog: Unknown LegoSensorType");
+		}
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/SelectCastDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/SelectCastDialog.java
@@ -47,10 +47,22 @@ public class SelectCastDialog extends DialogFragment {
 	private Activity activity;
 	private AlertDialog dialog;
 
+	public SelectCastDialog() {
+	}
+
 	public SelectCastDialog(ArrayAdapter<MediaRouter.RouteInfo> adapter, Activity activity) {
 		this.deviceAdapter = adapter;
 		this.activity = activity;
 		CastManager.getInstance().setCallback(MediaRouter.CALLBACK_FLAG_PERFORM_ACTIVE_SCAN);
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
 	}
 
 	public void openDialog() {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/SelectTagsDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/SelectTagsDialogFragment.java
@@ -48,6 +48,18 @@ public class SelectTagsDialogFragment extends DialogFragment {
 		this.tags = tags;
 	}
 
+	public SelectTagsDialogFragment() {
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
+	}
+
 	@Override
 	public Dialog onCreateDialog(final Bundle bundle) {
 		final List<String> checkedTags = new ArrayList<>();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UserBrickEditElementDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/UserBrickEditElementDialog.java
@@ -59,9 +59,21 @@ public class UserBrickEditElementDialog extends DialogFragment {
 	private View fragmentView;
 	private UserBrickElementEditorFragment userBrickElementEditorFragment;
 
+	public UserBrickEditElementDialog() {
+	}
+
 	public UserBrickEditElementDialog(View fragmentView) {
 		super();
 		this.fragmentView = fragmentView;
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
 	}
 
 	public interface DialogListener {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddBrickFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddBrickFragment.java
@@ -28,6 +28,7 @@ import android.app.ListFragment;
 import android.content.Context;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -118,7 +119,11 @@ public class AddBrickFragment extends ListFragment {
 
 	@Override
 	public void onDestroy() {
-		((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(previousActionBarTitle);
+		ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
+		boolean isRestoringPreviouslyDestroyedActivity = actionBar == null;
+		if (!isRestoringPreviouslyDestroyedActivity) {
+			actionBar.setTitle(previousActionBarTitle);
+		}
 		super.onDestroy();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/BrickCategoryFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/BrickCategoryFragment.java
@@ -22,9 +22,11 @@
  */
 package org.catrobat.catroid.ui.fragment;
 
+import android.app.FragmentManager;
 import android.app.ListFragment;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -76,6 +78,11 @@ public class BrickCategoryFragment extends ListFragment {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			getFragmentManager().popBackStack(BRICK_CATEGORY_FRAGMENT_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+			return;
+		}
 		setHasOptionsMenu(true);
 	}
 
@@ -125,10 +132,15 @@ public class BrickCategoryFragment extends ListFragment {
 
 	@Override
 	public void onDestroy() {
-		resetActionBar();
 		super.onDestroy();
-		BottomBar.showBottomBar(getActivity());
-		BottomBar.showPlayButton(getActivity());
+		ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
+		boolean isRestoringPreviouslyDestroyedActivity = actionBar == null;
+		if (!isRestoringPreviouslyDestroyedActivity) {
+			actionBar.setDisplayShowTitleEnabled(true);
+			actionBar.setTitle(this.previousActionBarTitle);
+			BottomBar.showBottomBar(getActivity());
+			BottomBar.showPlayButton(getActivity());
+		}
 	}
 
 	@Override
@@ -144,11 +156,6 @@ public class BrickCategoryFragment extends ListFragment {
 		((AppCompatActivity) getActivity()).getSupportActionBar().setDisplayShowTitleEnabled(true);
 		previousActionBarTitle = ((AppCompatActivity) getActivity()).getSupportActionBar().getTitle();
 		((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(R.string.categories);
-	}
-
-	private void resetActionBar() {
-		((AppCompatActivity) getActivity()).getSupportActionBar().setDisplayShowTitleEnabled(true);
-		((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(this.previousActionBarTitle);
 	}
 
 	private void setupBrickCategories() {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.ui.fragment;
 
 import android.app.Activity;
 import android.app.Fragment;
+import android.app.FragmentManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
@@ -117,11 +118,14 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		setHasOptionsMenu(!ViewConfiguration.get(getActivity()).hasPermanentMenuKey());
 
-		ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
-		previousActionBarTitle = actionBar.getTitle().toString();
-		actionBar.setTitle(R.string.formula_editor_title);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			getFragmentManager().popBackStack(FORMULA_EDITOR_FRAGMENT_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+			return;
+		}
+
+		setHasOptionsMenu(!ViewConfiguration.get(getActivity()).hasPermanentMenuKey());
 
 		onFormulaChangedListener = (OnFormulaChangedListener) getFragmentManager()
 				.findFragmentByTag(ScriptFragment.TAG);
@@ -135,6 +139,11 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	@Override
 	public void onActivityCreated(Bundle savedInstanceState) {
 		super.onActivityCreated(savedInstanceState);
+
+		ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
+		previousActionBarTitle = actionBar.getTitle().toString();
+		actionBar.setTitle(R.string.formula_editor_title);
+
 		setHasOptionsMenu(true);
 	}
 
@@ -839,9 +848,13 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	@Override
 	public void onHiddenChanged(boolean hidden) {
 		if (!hidden) {
-			((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(R.string.formula_editor_title);
-			BottomBar.hideBottomBar(getActivity());
-			updateButtonsOnKeyboardAndInvalidateOptionsMenu();
+			ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
+			boolean isRestoringPreviouslyDestroyedActivity = actionBar == null;
+			if (!isRestoringPreviouslyDestroyedActivity) {
+				actionBar.setTitle(R.string.formula_editor_title);
+				BottomBar.hideBottomBar(getActivity());
+				updateButtonsOnKeyboardAndInvalidateOptionsMenu();
+			}
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewBroadcastMessageDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewBroadcastMessageDialog.java
@@ -35,6 +35,9 @@ public class NewBroadcastMessageDialog extends BrickTextDialog {
 	NewBroadcastMessageInterface newBroadcastMessageInterface;
 	String newString;
 
+	public NewBroadcastMessageDialog() {
+	}
+
 	public NewBroadcastMessageDialog(NewBroadcastMessageInterface newBroadcastMessageInterface, String newString) {
 		super(R.string.dialog_new_broadcast_message_title, R.string.dialog_new_broadcast_message_name, newString);
 		this.newBroadcastMessageInterface = newBroadcastMessageInterface;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewDataDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewDataDialogFragment.java
@@ -58,6 +58,15 @@ public class NewDataDialogFragment extends DialogFragment {
 	}
 
 	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
+	}
+
+	@Override
 	public Dialog onCreateDialog(Bundle bundle) {
 		View view = View.inflate(getActivity(), R.layout.dialog_new_user_data, null);
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewGroupDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewGroupDialogFragment.java
@@ -39,6 +39,9 @@ public class NewGroupDialogFragment extends TextInputDialogFragment {
 	private NewItemInterface<Sprite> newItemInterface;
 	private Scene dstScene;
 
+	public NewGroupDialogFragment() {
+	}
+
 	public NewGroupDialogFragment(NewItemInterface<Sprite> newItemInterface, Scene dstScene) {
 		super(R.string.new_group, R.string.sprite_group_name_label, null, false);
 		this.newItemInterface = newItemInterface;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewLookDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewLookDialogFragment.java
@@ -75,6 +75,18 @@ public class NewLookDialogFragment extends DialogFragment implements View.OnClic
 	private UniqueNameProvider uniqueNameProvider = new UniqueNameProvider();
 	private Uri uri;
 
+	public NewLookDialogFragment() {
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
+	}
+
 	public NewLookDialogFragment(NewItemInterface<LookData> newItemInterface, Scene dstScene, Sprite dstSprite) {
 		this.newItemInterface = newItemInterface;
 		this.dstScene = dstScene;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSceneDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSceneDialogFragment.java
@@ -44,6 +44,9 @@ public class NewSceneDialogFragment extends TextInputDialogFragment {
 	private NewItemInterface<Scene> newItemInterface;
 	private Project dstProject;
 
+	public NewSceneDialogFragment() {
+	}
+
 	public NewSceneDialogFragment(NewItemInterface<Scene> newItemInterface, Project dstProject) {
 		super(R.string.new_scene_dialog, R.string.scene_name, null, false);
 		this.newItemInterface = newItemInterface;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewScriptGroupDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewScriptGroupDialog.java
@@ -34,6 +34,9 @@ public class NewScriptGroupDialog extends TextInputDialogFragment {
 
 	private BackpackScriptInterface backpackInterface;
 
+	public NewScriptGroupDialog() {
+	}
+
 	public NewScriptGroupDialog(BackpackScriptInterface backpackInterface) {
 		super(R.string.new_group, R.string.script_group_label, null, false);
 		this.backpackInterface = backpackInterface;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSoundDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSoundDialogFragment.java
@@ -65,6 +65,18 @@ public class NewSoundDialogFragment extends DialogFragment implements View.OnCli
 
 	private UniqueNameProvider uniqueNameProvider = new UniqueNameProvider();
 
+	public NewSoundDialogFragment() {
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
+	}
+
 	public NewSoundDialogFragment(NewItemInterface<SoundInfo> newItemInterface, Scene dstScene, Sprite dstSprite) {
 		this.newItemInterface = newItemInterface;
 		this.dstScene = dstScene;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSpriteDialogWrapper.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSpriteDialogWrapper.java
@@ -59,14 +59,7 @@ public class NewSpriteDialogWrapper implements NewItemInterface<LookData> {
 	public void showDialog(FragmentManager manager) {
 		fragmentManager = manager;
 		sprite = new Sprite();
-		NewLookDialogFragment dialog = new NewLookDialogFragment(this, dstScene, sprite) {
-
-			@Override
-			public void onCancel(DialogInterface dialog) {
-				super.onCancel(dialog);
-				onWorkflowCanceled();
-			}
-		};
+		NewLookDialogFragment dialog = new NewLookForNewSpriteDialogFragment(this, dstScene, sprite);
 		dialog.show(fragmentManager, NewLookDialogFragment.TAG);
 	}
 
@@ -135,6 +128,25 @@ public class NewSpriteDialogWrapper implements NewItemInterface<LookData> {
 			} catch (IOException e) {
 				Log.e(TAG, Log.getStackTraceString(e));
 			}
+		}
+	}
+
+	public static class NewLookForNewSpriteDialogFragment extends NewLookDialogFragment {
+		private NewSpriteDialogWrapper dialogWrapper;
+
+		public NewLookForNewSpriteDialogFragment(NewSpriteDialogWrapper dialogWrapper, Scene dstScene, Sprite dstSprite) {
+			super(dialogWrapper, dstScene, dstSprite);
+			this.dialogWrapper = dialogWrapper;
+		}
+
+		public NewLookForNewSpriteDialogFragment() {
+			super();
+		}
+
+		@Override
+		public void onCancel(DialogInterface dialog) {
+			super.onCancel(dialog);
+			dialogWrapper.onWorkflowCanceled();
 		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewStringDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewStringDialogFragment.java
@@ -33,6 +33,9 @@ public class NewStringDialogFragment extends TextInputDialogFragment {
 
 	private NewItemInterface<String> newItemInterface;
 
+	public NewStringDialogFragment() {
+	}
+
 	public NewStringDialogFragment(@Nullable String previousString, NewItemInterface<String> newItemInterface) {
 		super(R.string.formula_editor_new_string_name, R.string.string_label, previousString, true);
 		if (previousString != null) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewVariableDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewVariableDialogFragment.java
@@ -38,6 +38,18 @@ public class NewVariableDialogFragment extends NewDataDialogFragment {
 		this.newVariableInterface = newVariableInterface;
 	}
 
+	public NewVariableDialogFragment() {
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
+	}
+
 	@Override
 	public Dialog onCreateDialog(Bundle bundle) {
 		Dialog dialog = super.onCreateDialog(bundle);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/OrientationDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/OrientationDialogFragment.java
@@ -48,9 +48,21 @@ public class OrientationDialogFragment extends DialogFragment {
 	private boolean createEmptyProject;
 	private RadioGroup radioGroup;
 
+	public OrientationDialogFragment() {
+	}
+
 	public OrientationDialogFragment(String name, boolean createEmptyProject) {
 		this.name = name;
 		this.createEmptyProject = createEmptyProject;
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/PlaySceneDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/PlaySceneDialogFragment.java
@@ -41,8 +41,20 @@ public class PlaySceneDialogFragment extends DialogFragment {
 	private PlaySceneInterface playSceneInterface;
 	private RadioGroup radioGroup;
 
+	public PlaySceneDialogFragment() {
+	}
+
 	public PlaySceneDialogFragment(PlaySceneInterface playSceneInterface) {
 		this.playSceneInterface = playSceneInterface;
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/RenameDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/RenameDialogFragment.java
@@ -31,6 +31,9 @@ public class RenameDialogFragment extends TextInputDialogFragment {
 
 	private RenameInterface renameInterface;
 
+	public RenameDialogFragment() {
+	}
+
 	public RenameDialogFragment(int title, int hint, String text, RenameInterface renameInterface) {
 		super(title, hint, text, false);
 		this.renameInterface = renameInterface;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/SelectSpriteDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/SelectSpriteDialogFragment.java
@@ -46,9 +46,21 @@ public class SelectSpriteDialogFragment extends DialogFragment {
 	private List<Sprite> selectableSprites;
 	private Spinner spinner;
 
+	public SelectSpriteDialogFragment() {
+	}
+
 	public SelectSpriteDialogFragment(SelectSpriteListener listener, List<Sprite> selectableSprites) {
 		this.listener = listener;
 		this.selectableSprites = selectableSprites;
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/SetDescriptionDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/SetDescriptionDialogFragment.java
@@ -30,6 +30,9 @@ public class SetDescriptionDialogFragment extends TextInputDialogFragment {
 
 	private ChangeDescriptionInterface descriptionInterface;
 
+	public SetDescriptionDialogFragment() {
+	}
+
 	public SetDescriptionDialogFragment(String text, ChangeDescriptionInterface descriptionInterface) {
 		super(R.string.set_description, R.string.description, text, true);
 		this.descriptionInterface = descriptionInterface;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/TextInputDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/TextInputDialogFragment.java
@@ -43,6 +43,18 @@ public abstract class TextInputDialogFragment extends DialogFragment {
 	protected String text;
 	protected boolean allowEmptyInput;
 
+	public TextInputDialogFragment() {
+	}
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		boolean isRestoringPreviouslyDestroyedActivity = savedInstanceState != null;
+		if (isRestoringPreviouslyDestroyedActivity) {
+			dismiss();
+		}
+	}
+
 	public TextInputDialogFragment(int title, int hint, @Nullable String text, boolean allowEmptyInput) {
 		this.title = title;
 		this.hint = hint;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/RecyclerViewFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/RecyclerViewFragment.java
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.ui.recyclerview.fragment;
 
 import android.app.Fragment;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -249,12 +250,17 @@ public abstract class RecyclerViewFragment<T> extends Fragment implements
 	@Override
 	public void onPrepareOptionsMenu(Menu menu) {
 		super.onPrepareOptionsMenu(menu);
-		adapter.showDetails = PreferenceManager.getDefaultSharedPreferences(
-				getActivity()).getBoolean(sharedPreferenceDetailsKey, false);
+		Context context = getActivity();
+		// necessary because of cast! blows up when activity is restored (CATROID-37)
+		// see BaseCastActivity
+		if (context != null) {
+			adapter.showDetails = PreferenceManager.getDefaultSharedPreferences(
+					context).getBoolean(sharedPreferenceDetailsKey, false);
 
-		menu.findItem(R.id.show_details).setTitle(adapter.showDetails
-				? R.string.hide_details
-				: R.string.show_details);
+			menu.findItem(R.id.show_details).setTitle(adapter.showDetails
+					? R.string.hide_details
+					: R.string.show_details);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Can be reproduced by setting Don't keep activities in developer options.
Problem is that some fragments have listeners or members that link back to
its activity or other views. This isnt recoverable when activity is killed
due to low memory or long inactivity. When app is left in this state it
will crash badly on reopening.
To fix this for now this PR prevents those fragments to be restored when
activity is recovering from such a killed state. (eg. formula editor open
- activity killed by OS - reopen activity is back in script view)