### PR TITLE
[GSoC18] Fix espresso core dependency

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -256,7 +256,7 @@ dependencies {
         exclude group: 'com.android.support'
     }
 
-    implementation ('com.android.support.test.espresso:espresso-core:3.0.1') {
+    implementation ('com.android.support.test.espresso:espresso-idling-resource:3.0.1') {
         exclude group: 'com.android.support'
     }
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBackgroundChangesBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBackgroundChangesBrick.java
@@ -25,6 +25,8 @@ package org.catrobat.catroid.content.bricks;
 import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.View;
 
 import org.catrobat.catroid.ProjectManager;
@@ -43,9 +45,6 @@ import org.catrobat.catroid.ui.recyclerview.dialog.dialoginterface.NewItemInterf
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 public class WhenBackgroundChangesBrick extends BrickBaseType implements ScriptBrick, NewItemInterface<LookData>,
 		BrickSpinner.OnItemSelectedListener<LookData> {
 
@@ -59,7 +58,7 @@ public class WhenBackgroundChangesBrick extends BrickBaseType implements ScriptB
 		this(new WhenBackgroundChangesScript());
 	}
 
-	public WhenBackgroundChangesBrick(@Nonnull WhenBackgroundChangesScript script) {
+	public WhenBackgroundChangesBrick(@NonNull WhenBackgroundChangesScript script) {
 		script.setScriptBrick(this);
 		commentedOut = script.isCommentedOut();
 		this.script = script;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBrick.java
@@ -22,6 +22,8 @@
  */
 package org.catrobat.catroid.content.bricks;
 
+import android.support.annotation.NonNull;
+
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
@@ -29,8 +31,6 @@ import org.catrobat.catroid.content.WhenScript;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
 
 import java.util.List;
-
-import javax.annotation.Nonnull;
 
 public class WhenBrick extends BrickBaseType implements ScriptBrick {
 
@@ -42,7 +42,7 @@ public class WhenBrick extends BrickBaseType implements ScriptBrick {
 		this(new WhenScript());
 	}
 
-	public WhenBrick(@Nonnull WhenScript whenScript) {
+	public WhenBrick(@NonNull WhenScript whenScript) {
 		whenScript.setScriptBrick(this);
 		commentedOut = whenScript.isCommentedOut();
 		this.whenScript = whenScript;

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenNfcBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenNfcBrick.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
 import android.database.DataSetObserver;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
@@ -44,8 +45,6 @@ import org.catrobat.catroid.content.actions.ScriptSequenceAction;
 
 import java.util.List;
 
-import javax.annotation.Nonnull;
-
 public class WhenNfcBrick extends BrickBaseType implements ScriptBrick {
 
 	private static final long serialVersionUID = 1L;
@@ -58,7 +57,7 @@ public class WhenNfcBrick extends BrickBaseType implements ScriptBrick {
 		this(new WhenNfcScript());
 	}
 
-	public WhenNfcBrick(@Nonnull WhenNfcScript whenNfcScript) {
+	public WhenNfcBrick(@NonNull WhenNfcScript whenNfcScript) {
 		nfcTag = whenNfcScript.getNfcTag();
 		whenNfcScript.setScriptBrick(this);
 		commentedOut = whenNfcScript.isCommentedOut();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ScratchProgramDetailsActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ScratchProgramDetailsActivity.java
@@ -64,8 +64,6 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Locale;
 
-import static android.support.test.InstrumentationRegistry.getContext;
-
 public class ScratchProgramDetailsActivity extends BaseActivity implements
 		FetchScratchProgramDetailsTask.ScratchProgramListTaskDelegate,
 		JobViewListener, Client.DownloadCallback,
@@ -128,7 +126,7 @@ public class ScratchProgramDetailsActivity extends BaseActivity implements
 			public void onClick(View v) {
 				final int numberOfJobsInProgress = conversionManager.getNumberOfJobsInProgress();
 				if (numberOfJobsInProgress >= Constants.SCRATCH_CONVERTER_MAX_NUMBER_OF_JOBS_PER_CLIENT) {
-					ToastUtil.showError(getContext(), getResources().getQuantityString(
+					ToastUtil.showError(getApplicationContext(), getResources().getQuantityString(
 							R.plurals.error_cannot_convert_more_than_x_programs,
 							Constants.SCRATCH_CONVERTER_MAX_NUMBER_OF_JOBS_PER_CLIENT,
 							Constants.SCRATCH_CONVERTER_MAX_NUMBER_OF_JOBS_PER_CLIENT));


### PR DESCRIPTION
* Replace `espresso-core` dependency with `espresso-idling-resource`
  * Why: `espresso-core` should not be a `compile`/`implementation` dependency,
    only idling resources should be accessible in production
* Fix usages of `espresso-core` usages in production code