### PR TITLE
JENKINS-236 Activate JaCoCo for tests only if -PenableCoverage is spe…

### DIFF
--- a/buildScripts/build_helper_run_tests_on_emulator
+++ b/buildScripts/build_helper_run_tests_on_emulator
@@ -51,7 +51,7 @@ print("Calling: " + " ".join(disable_cmd))
 return_code = subprocess.run( disable_cmd, cwd=os.environ['REPO_DIR'] ).returncode
 
 ## RUN tests
-test_runner_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_cmd_wrapper') + [ '-I', build_helper_functions.get_relative_gradle_name(), 'clean', 'adbDisableAnimationsGlobally', 'createCatroidDebugAndroidTestCoverageReport' ]
+test_runner_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_cmd_wrapper') + [ '-I', build_helper_functions.get_relative_gradle_name(), '-PenableCoverage', 'clean', 'adbDisableAnimationsGlobally', 'createCatroidDebugAndroidTestCoverageReport' ]
 if test_runner_arg is not None and test_runner_arg != "":
     test_runner_cmd = test_runner_cmd + [ test_runner_arg ]
 

--- a/buildScripts/build_step_run_unit_tests__all_tests
+++ b/buildScripts/build_step_run_unit_tests__all_tests
@@ -19,7 +19,7 @@ The environment variable ANDROID_SDK_ROOT needs to be set.""")
 build_helper_functions.check_number_of_parameters(valid_param_count=0, usage_func=usage)
 
 ## RUN tests
-test_runner_cmd = [ build_helper_functions.get_relative_gradle_name(), 'clean', 'jacocoTestCatroidDebugUnitTestReport' ]
+test_runner_cmd = [ build_helper_functions.get_relative_gradle_name(), '-PenableCoverage', 'clean', 'jacocoTestCatroidDebugUnitTestReport' ]
 
 print("Calling: " + " ".join(test_runner_cmd))
 return_code = subprocess.run( test_runner_cmd, cwd=os.environ['REPO_DIR'] ).returncode

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -153,7 +153,7 @@ android {
             buildConfigField "boolean", "CRASHLYTICS_CRASH_REPORT_ENABLED", "true"
             resValue "string", "SNACKBAR_HINTS_ENABLED", "false"
             ext.enableCrashlytics = false
-            testCoverageEnabled = true
+            testCoverageEnabled = project.hasProperty('enableCoverage')
         }
         release {
             buildConfigField "boolean", "FEATURE_EMBROIDERY_ENABLED", "false"


### PR DESCRIPTION
…cified in the gradle call.

Unfortunately running JaCoCo leads to a worse experience debugging the code.
The debugger does not show the value of variables anymore.
This is a known issue, see also https://issuetracker.google.com/issues/37019591

The property -PenableCoverage is set by Jenkins builds automatically.
No debugger needed there. ;)
Manually running tests in Android Studio with code coverage still works
and is not affected by this change.

:exclamation: Before merging check that the code coverage is roughly the same as on develop. This would indicate that code coverage collecting still works with these changes.