### PR TITLE
CATROID-67 Fix builds failing on ndk r18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
     dependencies {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.3'
     }

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -81,7 +81,6 @@ jacocoAndroidUnitTestReport {
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 17

--- a/catroid/src/main/res/layout/dialog_brick_editor_edit_element.xml
+++ b/catroid/src/main/res/layout/dialog_brick_editor_edit_element.xml
@@ -22,6 +22,7 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical" >
@@ -31,6 +32,7 @@
         android:labelFor="@+id/dialog_brick_editor_edit_element_edit_text"
         android:inputType="text"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        tools:ignore="LabelFor" />
 
 </LinearLayout>

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,10 @@
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-XX:MaxPermSize=1024m
+
+# Needed for tests working in multidex applications
+# See https://github.com/googlesamples/android-testing/issues/179
+# This is a temporary workaround that fixes the issue when using the android gradle plugin 3.1.x,
+# which will stop working in 3.2.x
+# https://issuetracker.google.com/u/0/issues/78108767
+android.enableD8MainDexList=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
* Update android gradle plugin to `3.1.4`
  * See https://android.googlesource.com/platform/ndk/+/ndk-release-r18/CHANGELOG.md#known-issues on why this is necessary
* Update gradle to `4.4` (Needed for android gradle plugin `3.1.x`)
  * See https://developer.android.com/studio/releases/gradle-plugin#updating-gradle on why this is necessary
* Set `android.enableD8MainDexList` to false in `gradle.properties`
  * This is a workaround to allow tests being run in multidex apps on API <21
  * See https://issuetracker.google.com/u/0/issues/78108767 for more info
* Remove `buildToolsVersion` as it's ignored/obsolete with android gradle plugin `3.1.x`