### PR TITLE
DO NOT MERGE CATROID-48 Crash when switching scene

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/SceneTransitionAwareTemporalAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/SceneTransitionAwareTemporalAction.java
@@ -23,23 +23,20 @@
 
 package org.catrobat.catroid.content.actions;
 
-import org.catrobat.catroid.content.Sprite;
+import android.support.annotation.CallSuper;
+
+import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
+
 import org.catrobat.catroid.stage.StageActivity;
 
-public class CloneAction extends SceneTransitionAwareTemporalAction {
-
-	private Sprite sprite;
-
+public abstract class SceneTransitionAwareTemporalAction extends TemporalAction {
+	@CallSuper
 	@Override
-	protected void update(float percent) {
-		if (sprite == null) {
-			return;
+	public boolean act(float delta) {
+		if (StageActivity.stageListener.getInSceneTransition()) {
+			return false;
 		}
 
-		StageActivity.stageListener.cloneSpriteAndAddToStage(sprite);
-	}
-
-	public void setSprite(Sprite sprite) {
-		this.sprite = sprite;
+		return super.act(delta);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -102,6 +102,7 @@ public class StageListener implements ApplicationListener {
 	private boolean paused = false;
 	private boolean finished = false;
 	private boolean reloadProject = false;
+	private boolean inSceneTransition = false;
 	public boolean firstFrameDrawn = false;
 
 	private static boolean checkIfAutomaticScreenshotShouldBeTaken = true;
@@ -333,6 +334,8 @@ public class StageListener implements ApplicationListener {
 			return;
 		}
 
+		inSceneTransition = true;
+
 		stageBackupMap.put(scene.getName(), saveToBackup());
 		pause();
 		scene = ProjectManager.getInstance().getCurrentProject().getSceneByName(sceneName);
@@ -488,6 +491,7 @@ public class StageListener implements ApplicationListener {
 			while (deltaTime > 0f) {
 				physicsWorld.step(optimizedDeltaTime);
 				stage.act(optimizedDeltaTime);
+				inSceneTransition = false;
 				deltaTime -= optimizedDeltaTime;
 			}
 			long executionTimeOfActionsUpdate = SystemClock.uptimeMillis() - timeBeforeActionsUpdate;
@@ -739,6 +743,10 @@ public class StageListener implements ApplicationListener {
 
 	public Stage getStage() {
 		return stage;
+	}
+
+	public boolean getInSceneTransition() {
+		return inSceneTransition;
 	}
 
 	public void removeActor(Look look) {


### PR DESCRIPTION
PoC for fixing CATROID-48 by adding abstract scene-transition aware actions

when continuing scene in example program (see jira ticket), code not executed due to scene switch gets executed after ContinueScene Action