### PR TITLE
CATROID-55,56,59 private Storage tickets

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ImportProjectsFromExternalStorageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ImportProjectsFromExternalStorageTest.java
@@ -1,0 +1,157 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.activity;
+
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.defaultprojectcreators.DefaultProjectCreator;
+import org.catrobat.catroid.io.StorageOperations;
+import org.catrobat.catroid.io.XstreamSerializer;
+import org.catrobat.catroid.test.utils.TestUtils;
+import org.catrobat.catroid.ui.MainMenuActivity;
+import org.catrobat.catroid.uiespresso.util.actions.CustomActions;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.withDecorView;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.catrobat.catroid.common.FlavoredConstants.DEFAULT_ROOT_DIRECTORY;
+import static org.catrobat.catroid.common.FlavoredConstants.EXTERNAL_STORAGE_ROOT_DIRECTORY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.SHOW_COPY_PROJECTS_FROM_EXTERNAL_STORAGE_DIALOG;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class ImportProjectsFromExternalStorageTest {
+	@Rule
+	public BaseActivityInstrumentationRule<MainMenuActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(MainMenuActivity.class);
+	private String projectName = "testImportProjectsFromExternalStorage";
+	private String renamedProjectName = "testImportProjectsFromExternalStorag_#0e";
+	private SharedPreferences sharedPreferences;
+	private boolean hasUserAgreedToPrivacyPolicyBuffer;
+	private boolean doNotShowImportProjectsDialog;
+
+	@Before
+	public void setUp() throws Exception {
+		new DefaultProjectCreator().createDefaultProject(projectName, InstrumentationRegistry.getTargetContext(), false);
+		StorageOperations.copyDir(internalProjectFolder(projectName), externalProjectFolder(projectName));
+
+		sharedPreferences = PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext());
+		hasUserAgreedToPrivacyPolicyBuffer = sharedPreferences.getBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, false);
+		doNotShowImportProjectsDialog = sharedPreferences.getBoolean(SHOW_COPY_PROJECTS_FROM_EXTERNAL_STORAGE_DIALOG, false);
+		sharedPreferences.edit().putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, true).commit();
+		sharedPreferences.edit().putBoolean(SHOW_COPY_PROJECTS_FROM_EXTERNAL_STORAGE_DIALOG, true).commit();
+		baseActivityTestRule.launchActivity();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		sharedPreferences.edit().putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, hasUserAgreedToPrivacyPolicyBuffer).commit();
+		sharedPreferences.edit().putBoolean(SHOW_COPY_PROJECTS_FROM_EXTERNAL_STORAGE_DIALOG, doNotShowImportProjectsDialog).commit();
+		if (EXTERNAL_STORAGE_ROOT_DIRECTORY.exists()) {
+			StorageOperations.deleteDir(EXTERNAL_STORAGE_ROOT_DIRECTORY);
+		}
+		TestUtils.deleteProjects(projectName);
+		TestUtils.deleteProjects(renamedProjectName);
+	}
+
+	@Test
+	public void testCopingProjects() {
+		onView(withText(R.string.import_dialog_title))
+				.check(matches(isDisplayed()));
+		onView(withText(R.string.import_dialog_message))
+				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.import_dialog_copy_btn))
+				.check(matches(isDisplayed()))
+				.perform(click());
+
+		// needed for testing the ToastMassage
+		onView(isRoot())
+				.perform(CustomActions.wait(800));
+
+		onView(withText(R.string.projects_successful_copied_toast))
+				.inRoot(withDecorView(not(is(baseActivityTestRule.getActivity().getWindow().getDecorView()))))
+				.check(matches(isDisplayed()));
+
+		assertTrue(XstreamSerializer.getInstance().projectExists(projectName));
+		assertTrue(XstreamSerializer.getInstance().projectExists(renamedProjectName));
+		assertTrue(externalProjectFolder(projectName).exists());
+	}
+
+	@Test
+	public void testMovingProjects() {
+		onView(withText(R.string.import_dialog_title))
+				.check(matches(isDisplayed()));
+		onView(withText(R.string.import_dialog_message))
+				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.import_dialog_move_btn))
+				.check(matches(isDisplayed()))
+				.perform(click());
+
+		// needed for testing the ToastMassage
+		onView(isRoot())
+				.perform(CustomActions.wait(800));
+
+		onView(withText(R.string.projects_successful_moved_toast))
+				.inRoot(withDecorView(not(is(baseActivityTestRule.getActivity().getWindow().getDecorView()))))
+				.check(matches(isDisplayed()));
+
+		assertTrue(XstreamSerializer.getInstance().projectExists(projectName));
+		assertTrue(XstreamSerializer.getInstance().projectExists(renamedProjectName));
+		assertFalse(externalProjectFolder(projectName).exists());
+	}
+
+	private File internalProjectFolder(String projectName) {
+		return new File(DEFAULT_ROOT_DIRECTORY, projectName);
+	}
+
+	private File externalProjectFolder(String projectName) {
+		if (!EXTERNAL_STORAGE_ROOT_DIRECTORY.exists()) {
+			EXTERNAL_STORAGE_ROOT_DIRECTORY.mkdirs();
+		}
+		return new File(EXTERNAL_STORAGE_ROOT_DIRECTORY, projectName);
+	}
+}

--- a/catroid/src/catroid/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/catroid/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -25,17 +25,22 @@ package org.catrobat.catroid.common;
 
 import android.os.Environment;
 
+import org.catrobat.catroid.CatroidApplication;
+
 import java.io.File;
 
 import static org.catrobat.catroid.common.Constants.MAIN_URL_HTTPS;
 
 public final class FlavoredConstants {
-
-	public static final File DEFAULT_ROOT_DIRECTORY = new File(
-			Environment.getExternalStorageDirectory().getAbsolutePath() + "/Pocket Code");
-
 	// Web:
 	public static final String BASE_URL_HTTPS = MAIN_URL_HTTPS + "/pocketcode/";
+
+	public static final String POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME = "Pocket Code";
+
+	public static final File DEFAULT_ROOT_DIRECTORY = CatroidApplication.getAppContext().getFilesDir();
+
+	public static final File EXTERNAL_STORAGE_ROOT_DIRECTORY = new File(
+			Environment.getExternalStorageDirectory().getAbsolutePath(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
 	public static final String LIBRARY_BASE_URL = "https://share.catrob.at/pocketcode/download-media/";

--- a/catroid/src/createAtSchool/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/createAtSchool/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -25,17 +25,22 @@ package org.catrobat.catroid.common;
 
 import android.os.Environment;
 
+import org.catrobat.catroid.CatroidApplication;
+
 import java.io.File;
 
 import static org.catrobat.catroid.common.Constants.MAIN_URL_HTTPS;
 
 public final class FlavoredConstants {
-
-	public static final File DEFAULT_ROOT_DIRECTORY = new File(
-			Environment.getExternalStorageDirectory().getAbsolutePath() + "/Pocket Code");
-
 	// Web:
 	public static final String BASE_URL_HTTPS = MAIN_URL_HTTPS + "/pocketcode/";
+
+	public static final String POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME = "Pocket Code";
+
+	public static final File DEFAULT_ROOT_DIRECTORY = CatroidApplication.getAppContext().getFilesDir();
+
+	public static final File EXTERNAL_STORAGE_ROOT_DIRECTORY = new File(
+			Environment.getExternalStorageDirectory().getAbsolutePath(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
 	public static final String LIBRARY_BASE_URL = "https://share.catrob.at/pocketcode/download-media/";

--- a/catroid/src/lunaAndCat/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/lunaAndCat/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -25,17 +25,22 @@ package org.catrobat.catroid.common;
 
 import android.os.Environment;
 
+import org.catrobat.catroid.CatroidApplication;
+
 import java.io.File;
 
 import static org.catrobat.catroid.common.Constants.MAIN_URL_HTTPS;
 
 public final class FlavoredConstants {
-
-	public static final File DEFAULT_ROOT_DIRECTORY = new File(
-			Environment.getExternalStorageDirectory().getAbsolutePath() + "/Luna&Cat");
-
 	// Web:
 	public static final String BASE_URL_HTTPS = MAIN_URL_HTTPS + "/luna/";
+
+	public static final String POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME = "Luna&Cat";
+
+	public static final File DEFAULT_ROOT_DIRECTORY = CatroidApplication.getAppContext().getFilesDir();
+
+	public static final File EXTERNAL_STORAGE_ROOT_DIRECTORY = new File(
+			Environment.getExternalStorageDirectory().getAbsolutePath(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
 	public static final String LIBRARY_BASE_URL = "https://share.catrob.at/pocketcode/download-media/";

--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -260,5 +260,16 @@
         <service android:name=".utils.StatusBarNotificationManager$NotificationActionService" />
         <service android:name=".cast.CastService" android:exported="false"/>
 
+        <provider
+            android:authorities="${applicationId}.fileProvider"
+            android:name="android.support.v4.content.FileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
     </application>
 </manifest>

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -24,6 +24,8 @@ package org.catrobat.catroid.common;
 
 import android.support.annotation.IntDef;
 
+import org.catrobat.catroid.CatroidApplication;
+
 import java.io.File;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -79,7 +81,7 @@ public final class Constants {
 	public static final File BACKPACK_IMAGE_DIRECTORY = new File(BACKPACK_DIRECTORY, "backpack_image");
 
 	// Temporary Files and Directories:
-	public static final String TMP_PATH = DEFAULT_ROOT_DIRECTORY.getAbsolutePath() + "/tmp";
+	public static final String TMP_PATH = CatroidApplication.getAppContext().getCacheDir().getAbsolutePath() + "/tmp";
 	public static final String TEXT_TO_SPEECH_TMP_PATH = TMP_PATH + "/textToSpeech";
 	public static final String TMP_LOOKS_PATH = TMP_PATH + "/looks";
 	public static final String TMP_SOUNDS_PATH = TMP_PATH + "/sounds";
@@ -164,6 +166,8 @@ public final class Constants {
 	public static final String PLATFORM_DEFAULT = "Android";
 
 	public static final String WHATSAPP_URI = "whatsapp://";
+
+	public static final String FILE_PROVIDER_AUTHORITY = "org.catrobat.catroid.fileProvider";
 
 	// Scratch Converter
 	public static final int DOWNLOAD_FILE_HTTP_TIMEOUT = 30_000;

--- a/catroid/src/main/java/org/catrobat/catroid/common/SharedPreferenceKeys.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/SharedPreferenceKeys.java
@@ -30,6 +30,7 @@ public final class SharedPreferenceKeys {
 
 	public static final String ACCESSIBILITY_PROFILE_PREFERENCE_KEY = "AccessibilityProfile";
 	public static final String AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY = "AgreedToPrivacyPolicy";
+	public static final String SHOW_COPY_PROJECTS_FROM_EXTERNAL_STORAGE_DIALOG = "ShowCopyProjectsToInternalStorage";
 
 	public static final String DEVICE_LANGUAGE = "deviceLanguage";
 	public static final String LANGUAGE_TAG_KEY = "applicationLanguage";

--- a/catroid/src/main/java/org/catrobat/catroid/io/StorageOperations.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/StorageOperations.java
@@ -228,7 +228,7 @@ public final class StorageOperations {
 		return dstDir;
 	}
 
-	private static synchronized File getUniqueFile(String originalName, File dstDir) throws IOException {
+	public static synchronized File getUniqueFile(String originalName, File dstDir) throws IOException {
 		File dstFile = new File(dstDir, originalName);
 
 		if (!dstFile.exists()) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ImportLaunchers.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ImportLaunchers.kt
@@ -28,11 +28,15 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore.ACTION_IMAGE_CAPTURE
-import android.provider.MediaStore.EXTRA_OUTPUT
 import android.support.v7.app.AppCompatActivity
 import org.catrobat.catroid.R
 import org.catrobat.catroid.common.Constants.*
 import org.catrobat.catroid.ui.WebViewActivity.INTENT_PARAMETER_URL
+import android.provider.MediaStore
+import org.catrobat.catroid.common.Constants.FILE_PROVIDER_AUTHORITY
+import android.support.v4.content.FileProvider
+import java.io.File
+
 
 interface ImportLauncher {
 
@@ -72,12 +76,26 @@ class ImportFromFileLauncher(private val activity: AppCompatActivity, private va
     }
 }
 
-class ImportFromCameraLauncher(private val activity: AppCompatActivity, private val uri: Uri) : ImportLauncher {
+class ImportFromCameraLauncher(private val activity: AppCompatActivity) : ImportLauncher {
+
+    fun getCacheCameraUri(): Uri {
+        val childName = activity.getString(R.string.default_look_name)
+        val cacheDir = File(activity.cacheDir.absolutePath + "/cameraCache")
+        if (!cacheDir.exists()) {
+            cacheDir.mkdirs()
+        }
+        val pictureFile = File(cacheDir, "$childName.jpg")
+        return FileProvider.getUriForFile(activity, FILE_PROVIDER_AUTHORITY, pictureFile)
+    }
 
     override fun startActivityForResult(requestCode: Int) {
         val intent = Intent(ACTION_IMAGE_CAPTURE)
-        intent.putExtra(EXTRA_OUTPUT, uri)
+        intent.flags = Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+        val uri = getCacheCameraUri()
+        intent.putExtra(MediaStore.EXTRA_OUTPUT, uri)
         val chooser = Intent.createChooser(intent, activity.getString(R.string.select_look_from_camera))
-        activity.startActivityForResult(chooser, requestCode)
+        if (intent.resolveActivity(activity.packageManager) != null) {
+            activity.startActivityForResult(chooser, requestCode)
+        }
     }
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -64,6 +64,7 @@ import org.catrobat.catroid.ui.recyclerview.dialog.AboutDialogFragment;
 import org.catrobat.catroid.ui.recyclerview.dialog.PrivacyPolicyDialogFragment;
 import org.catrobat.catroid.ui.recyclerview.fragment.MainMenuFragment;
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
+import org.catrobat.catroid.utils.ImportProjectsFromExternalStorage;
 import org.catrobat.catroid.utils.PathBuilder;
 import org.catrobat.catroid.utils.ScreenValueHandler;
 import org.catrobat.catroid.utils.ToastUtil;
@@ -76,6 +77,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import static org.catrobat.catroid.common.Constants.PREF_PROJECTNAME_KEY;
+import static org.catrobat.catroid.common.FlavoredConstants.EXTERNAL_STORAGE_ROOT_DIRECTORY;
 import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY;
 
 public class MainMenuActivity extends BaseCastActivity implements ProjectLoaderTask.ProjectLoaderListener {
@@ -194,6 +196,10 @@ public class MainMenuActivity extends BaseCastActivity implements ProjectLoaderT
 
 		if (SettingsFragment.isCastSharedPreferenceEnabled(this)) {
 			CastManager.getInstance().initializeCast(this);
+		}
+
+		if (EXTERNAL_STORAGE_ROOT_DIRECTORY.exists()) {
+			new ImportProjectsFromExternalStorage(this).showImportProjectsDialog();
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -71,7 +71,6 @@ import java.io.IOException;
 
 import static org.catrobat.catroid.common.Constants.EXTRA_PICTURE_PATH_POCKET_PAINT;
 import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME;
-import static org.catrobat.catroid.common.FlavoredConstants.DEFAULT_ROOT_DIRECTORY;
 import static org.catrobat.catroid.common.FlavoredConstants.LIBRARY_LOOKS_URL;
 import static org.catrobat.catroid.ui.WebViewActivity.MEDIA_FILE_PATH;
 
@@ -214,7 +213,7 @@ public class ProjectActivity extends BaseCastActivity {
 				addSpriteFromUri(uri);
 				break;
 			case SPRITE_CAMERA:
-				uri = Uri.fromFile(new File(DEFAULT_ROOT_DIRECTORY, getString(R.string.default_look_name) + ".jpg"));
+				uri = new ImportFromCameraLauncher(this).getCacheCameraUri();
 				addSpriteFromUri(uri);
 				break;
 		}
@@ -333,8 +332,7 @@ public class ProjectActivity extends BaseCastActivity {
 								.startActivityForResult(SPRITE_FILE);
 						break;
 					case R.id.dialog_new_look_camera:
-						Uri uri = Uri.fromFile(new File(DEFAULT_ROOT_DIRECTORY, getString(R.string.default_look_name) + ".jpg"));
-						new ImportFromCameraLauncher(ProjectActivity.this, uri)
+						new ImportFromCameraLauncher(ProjectActivity.this)
 								.startActivityForResult(SPRITE_CAMERA);
 						break;
 				}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -80,7 +80,6 @@ import java.util.List;
 import static org.catrobat.catroid.common.Constants.EXTRA_PICTURE_PATH_POCKET_PAINT;
 import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME;
 import static org.catrobat.catroid.common.Constants.SOUND_DIRECTORY_NAME;
-import static org.catrobat.catroid.common.FlavoredConstants.DEFAULT_ROOT_DIRECTORY;
 import static org.catrobat.catroid.common.FlavoredConstants.LIBRARY_BACKGROUNDS_URL_LANDSCAPE;
 import static org.catrobat.catroid.common.FlavoredConstants.LIBRARY_BACKGROUNDS_URL_PORTRAIT;
 import static org.catrobat.catroid.common.FlavoredConstants.LIBRARY_LOOKS_URL;
@@ -258,7 +257,7 @@ public class SpriteActivity extends BaseActivity {
 				addSpriteFromUri(uri);
 				break;
 			case SPRITE_CAMERA:
-				uri = Uri.fromFile(new File(DEFAULT_ROOT_DIRECTORY, getString(R.string.default_look_name) + ".jpg"));
+				uri = new ImportFromCameraLauncher(this).getCacheCameraUri();
 				addSpriteFromUri(uri);
 				break;
 			case BACKGROUND_POCKET_PAINT:
@@ -274,7 +273,7 @@ public class SpriteActivity extends BaseActivity {
 				addBackgroundFromUri(uri);
 				break;
 			case BACKGROUND_CAMERA:
-				uri = Uri.fromFile(new File(DEFAULT_ROOT_DIRECTORY, getString(R.string.default_look_name) + ".jpg"));
+				uri = new ImportFromCameraLauncher(this).getCacheCameraUri();
 				addBackgroundFromUri(uri);
 				break;
 			case LOOK_POCKET_PAINT:
@@ -290,7 +289,7 @@ public class SpriteActivity extends BaseActivity {
 				addLookFromUri(uri);
 				break;
 			case LOOK_CAMERA:
-				uri = Uri.fromFile(new File(DEFAULT_ROOT_DIRECTORY, getString(R.string.default_look_name) + ".jpg"));
+				uri = new ImportFromCameraLauncher(this).getCacheCameraUri();
 				addLookFromUri(uri);
 				break;
 			case SOUND_RECORD:
@@ -485,8 +484,7 @@ public class SpriteActivity extends BaseActivity {
 								.startActivityForResult(SPRITE_FILE);
 						break;
 					case R.id.dialog_new_look_camera:
-						Uri uri = Uri.fromFile(new File(DEFAULT_ROOT_DIRECTORY, getString(R.string.default_look_name) + ".jpg"));
-						new ImportFromCameraLauncher(SpriteActivity.this, uri)
+						new ImportFromCameraLauncher(SpriteActivity.this)
 								.startActivityForResult(SPRITE_CAMERA);
 						break;
 				}
@@ -534,8 +532,7 @@ public class SpriteActivity extends BaseActivity {
 								.startActivityForResult(BACKGROUND_FILE);
 						break;
 					case R.id.dialog_new_look_camera:
-						Uri uri = Uri.fromFile(new File(DEFAULT_ROOT_DIRECTORY, getString(R.string.default_look_name) + ".jpg"));
-						new ImportFromCameraLauncher(SpriteActivity.this, uri)
+						new ImportFromCameraLauncher(SpriteActivity.this)
 								.startActivityForResult(BACKGROUND_CAMERA);
 						break;
 				}
@@ -590,8 +587,7 @@ public class SpriteActivity extends BaseActivity {
 								.startActivityForResult(LOOK_FILE);
 						break;
 					case R.id.dialog_new_look_camera:
-						Uri uri = Uri.fromFile(new File(DEFAULT_ROOT_DIRECTORY, getString(R.string.default_look_name) + ".jpg"));
-						new ImportFromCameraLauncher(SpriteActivity.this, uri)
+						new ImportFromCameraLauncher(SpriteActivity.this)
 								.startActivityForResult(LOOK_CAMERA);
 						break;
 				}

--- a/catroid/src/main/java/org/catrobat/catroid/utils/CopyProjectsTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/CopyProjectsTask.java
@@ -1,0 +1,116 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.utils;
+
+import android.app.Activity;
+import android.app.ProgressDialog;
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.FlavoredConstants;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+
+import static org.catrobat.catroid.common.FlavoredConstants.EXTERNAL_STORAGE_ROOT_DIRECTORY;
+import static org.catrobat.catroid.io.StorageOperations.copyDir;
+import static org.catrobat.catroid.io.StorageOperations.deleteDir;
+import static org.catrobat.catroid.io.StorageOperations.getUniqueFile;
+
+public class CopyProjectsTask extends AsyncTask<String, Boolean, Boolean> {
+
+	public static final String TAG = CopyProjectsTask.class.getSimpleName();
+	private WeakReference<Activity> weakActivity;
+	private WeakReference<ProgressDialog> progressDialogWeakReference;
+	private boolean deleteFromExStorage;
+
+	CopyProjectsTask(Activity mActivity, boolean deleteFromExternalStorage) {
+		weakActivity = new WeakReference<>(mActivity);
+		this.deleteFromExStorage = deleteFromExternalStorage;
+	}
+
+	private void copyAllProjects() throws IOException {
+		if (!EXTERNAL_STORAGE_ROOT_DIRECTORY.exists()
+				|| !EXTERNAL_STORAGE_ROOT_DIRECTORY.isDirectory()) {
+			throw new FileNotFoundException("External storage dir does not exist.");
+		}
+
+		File tmpDir = new File(EXTERNAL_STORAGE_ROOT_DIRECTORY, "/tmp");
+		if (tmpDir.exists()) {
+			deleteDir(tmpDir);
+		}
+
+		for (File project : EXTERNAL_STORAGE_ROOT_DIRECTORY.listFiles()) {
+			if (project.isDirectory()) {
+				copyDir(project, getUniqueFile(project.getName(), FlavoredConstants.DEFAULT_ROOT_DIRECTORY));
+			}
+		}
+	}
+
+	@Override
+	protected void onPreExecute() {
+		super.onPreExecute();
+		if (weakActivity.get() == null) {
+			return;
+		}
+		String title = weakActivity.get().getString(R.string.please_wait);
+		String message = weakActivity.get().getString(R.string.copying);
+		progressDialogWeakReference = new WeakReference<>(ProgressDialog.show(weakActivity.get(), title, message));
+	}
+
+	@Override
+	protected Boolean doInBackground(String... strings) {
+		try {
+			copyAllProjects();
+			if (deleteFromExStorage) {
+				deleteDir(EXTERNAL_STORAGE_ROOT_DIRECTORY);
+			}
+			return true;
+		} catch (IOException e) {
+			Log.e(TAG, e.getMessage());
+			return false;
+		}
+	}
+
+	@Override
+	protected void onPostExecute(Boolean success) {
+		super.onPostExecute(success);
+		if (progressDialogWeakReference.get() != null && progressDialogWeakReference.get().isShowing()) {
+			progressDialogWeakReference.get().dismiss();
+
+			if (!success) {
+				ToastUtil.showError(weakActivity.get(), R.string.error_during_copying_projects_toast);
+			} else {
+				if (deleteFromExStorage) {
+					ToastUtil.showSuccess(weakActivity.get(), R.string.projects_successful_moved_toast);
+				} else {
+					ToastUtil.showSuccess(weakActivity.get(), R.string.projects_successful_copied_toast);
+				}
+			}
+		}
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/utils/ImportProjectsFromExternalStorage.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/ImportProjectsFromExternalStorage.java
@@ -1,0 +1,81 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.utils;
+
+import android.app.Activity;
+import android.content.DialogInterface;
+import android.preference.PreferenceManager;
+import android.support.v7.app.AlertDialog;
+
+import org.catrobat.catroid.R;
+
+import static org.catrobat.catroid.common.SharedPreferenceKeys.SHOW_COPY_PROJECTS_FROM_EXTERNAL_STORAGE_DIALOG;
+
+public class ImportProjectsFromExternalStorage implements DialogInterface.OnClickListener {
+
+	public static final String TAG = ImportProjectsFromExternalStorage.class.getSimpleName();
+	private Activity activity;
+
+	public ImportProjectsFromExternalStorage(Activity mActivity) {
+		activity = mActivity;
+	}
+
+	private AlertDialog.Builder createImportProjectsDialog() {
+		AlertDialog.Builder alertDialog = new AlertDialog.Builder(activity);
+		alertDialog.setTitle(R.string.import_dialog_title)
+				.setCancelable(false)
+				.setMessage(R.string.import_dialog_message)
+				.setPositiveButton(R.string.import_dialog_move_btn, this)
+				.setNeutralButton(R.string.import_dialog_copy_btn, this);
+		return alertDialog;
+	}
+
+	public void showImportProjectsDialog() {
+		AlertDialog.Builder alertDialog = createImportProjectsDialog();
+		boolean showDialog = PreferenceManager.getDefaultSharedPreferences(activity).getBoolean(SHOW_COPY_PROJECTS_FROM_EXTERNAL_STORAGE_DIALOG, true);
+		if (showDialog) {
+			alertDialog.show();
+		}
+	}
+
+	@Override
+	public void onClick(DialogInterface dialog, int which) {
+		switch (which) {
+			case DialogInterface.BUTTON_POSITIVE:
+				CopyProjectsTask moveProjectsTask = new CopyProjectsTask(activity, true);
+				moveProjectsTask.execute();
+				doNotShowDialogAgain();
+				break;
+			case DialogInterface.BUTTON_NEUTRAL:
+				CopyProjectsTask copyProjectsTask = new CopyProjectsTask(activity, false);
+				copyProjectsTask.execute();
+				doNotShowDialogAgain();
+				break;
+		}
+	}
+
+	private void doNotShowDialogAgain() {
+		PreferenceManager.getDefaultSharedPreferences(activity).edit().putBoolean(SHOW_COPY_PROJECTS_FROM_EXTERNAL_STORAGE_DIALOG, false).apply();
+	}
+}

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -664,6 +664,14 @@
     <string name="description">Description:</string>
     <string name="set_description">Set description</string>
     <string name="details_date_today">Today</string>
+    <string name="import_dialog_title">Import projects</string>
+    <string name="import_dialog_message">Your projects will be moved to private memory.</string>
+    <string name="import_dialog_copy_btn">Copy</string>
+    <string name="import_dialog_move_btn">Move</string>
+    <string name="projects_successful_moved_toast">Projects successfully moved.\n</string>
+    <string name="projects_successful_copied_toast">Projects successfully copied.\n</string>
+    <string name="error_during_copying_projects_toast">Error during copying / moving projects</string>
+    <string name="copying">Copying......</string>
     <!--  -->
 
     <!-- ScriptListFragment -->

--- a/catroid/src/main/res/xml/file_paths.xml
+++ b/catroid/src/main/res/xml/file_paths.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2018 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<paths>
+    <cache-path name="root" path="." />
+</paths>

--- a/catroid/src/phiro/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/phiro/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -25,17 +25,22 @@ package org.catrobat.catroid.common;
 
 import android.os.Environment;
 
+import org.catrobat.catroid.CatroidApplication;
+
 import java.io.File;
 
 import static org.catrobat.catroid.common.Constants.MAIN_URL_HTTPS;
 
 public final class FlavoredConstants {
-
-	public static final File DEFAULT_ROOT_DIRECTORY = new File(
-			Environment.getExternalStorageDirectory().getAbsolutePath() + "/Pocket Code");
-
 	// Web:
 	public static final String BASE_URL_HTTPS = MAIN_URL_HTTPS + "/pocketcode/";
+
+	public static final String POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME = "Pocket Code";
+
+	public static final File DEFAULT_ROOT_DIRECTORY = CatroidApplication.getAppContext().getFilesDir();
+
+	public static final File EXTERNAL_STORAGE_ROOT_DIRECTORY = new File(
+			Environment.getExternalStorageDirectory().getAbsolutePath(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
 	public static final String LIBRARY_BASE_URL = "https://share.catrob.at/pocketcode/download-media/";

--- a/catroid/src/standalone/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/standalone/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -25,17 +25,22 @@ package org.catrobat.catroid.common;
 
 import android.os.Environment;
 
+import org.catrobat.catroid.CatroidApplication;
+
 import java.io.File;
 
 import static org.catrobat.catroid.common.Constants.MAIN_URL_HTTPS;
 
 public final class FlavoredConstants {
-
-	public static final File DEFAULT_ROOT_DIRECTORY = new File(
-			Environment.getExternalStorageDirectory().getAbsolutePath() + "/Pocket Code");
-
 	// Web:
 	public static final String BASE_URL_HTTPS = MAIN_URL_HTTPS + "/pocketcode/";
+
+	public static final String POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME = "Pocket Code";
+
+	public static final File DEFAULT_ROOT_DIRECTORY = CatroidApplication.getAppContext().getFilesDir();
+
+	public static final File EXTERNAL_STORAGE_ROOT_DIRECTORY = new File(
+			Environment.getExternalStorageDirectory().getAbsolutePath(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
 	public static final String LIBRARY_BASE_URL = "https://share.catrob.at/pocketcode/download-media/";


### PR DESCRIPTION
CATROID-59 Exposing file uris
 * implementing FileProvider

CATROID-56 Import old Pocket Code folder into app-private storage.
CATROID-55Use app-storage instead of folder on external memory

UiTest included.