### PR TITLE
PAINT-332: Update Pocket Paint dependency

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -236,7 +236,7 @@ ext {
     mockitoVersion = "2.8.47"
     espressoVersion = "3.0.1"
     supportLibraryVersion = "27.1.0"
-    paintroidVersion = "2.1.0"
+    paintroidVersion = "2.1.1"
 }
 
 configurations {


### PR DESCRIPTION
* Use the latest hotfix release, including an "about" dialog and
  a fix for devices with display notch(es), preventing you from
  switching the current tool.