### PR TITLE
CATROID-32/33/34/35

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/FormulaEditorDataListAdapterArraysValueTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/FormulaEditorDataListAdapterArraysValueTest.java
@@ -1,0 +1,116 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.formulaeditor;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.BrickValues;
+import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.SingleSprite;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.SetXBrick;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.UserList;
+import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.formulaeditor.datacontainer.DataContainer;
+import org.catrobat.catroid.utils.NumberFormats;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class FormulaEditorDataListAdapterArraysValueTest {
+	private DataContainer dataContainer;
+	private String userVarName = "userVar";
+	private String userListName = "LIST";
+
+	@Before
+	public void setUp() throws Exception {
+		createProject();
+		dataContainer = ProjectManager.getInstance().getCurrentlyEditedScene().getDataContainer();
+		UserVariable userVariable = new UserVariable(userVarName);
+		userVariable.setValue(NumberFormats.stringWithoutTrailingZero("1.0"));
+		UserList userList = new UserList(userListName);
+		userList.addListItem(NumberFormats.stringWithoutTrailingZero("1.0"));
+		userList.addListItem(NumberFormats.stringWithoutTrailingZero("1.0"));
+		userList.addListItem(NumberFormats.stringWithoutTrailingZero("1.05"));
+		dataContainer.addUserList(userList);
+		dataContainer.addUserVariable(userVariable);
+	}
+
+	@Test
+	public void testValuesOfUserList() {
+		List<Object> userList = dataContainer.getUserList(userListName).getList();
+
+		assertEquals(3, userList.size());
+		assertEquals(String.valueOf(1), userList.get(0));
+		assertEquals(String.valueOf(1), userList.get(1));
+		assertEquals(String.valueOf(1.05), userList.get(2));
+	}
+
+	@Test
+	public void testValueOfUserVariable() {
+		UserVariable userVar = dataContainer.getProjectUserVariable(userVarName);
+		assertEquals(String.valueOf(1), userVar.getValue());
+	}
+
+	private void createProject() {
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), "Pro");
+
+		Sprite firstSprite = new SingleSprite("firstSprite");
+
+		Script firstScript = new StartScript();
+		firstScript.addBrick(new SetXBrick(new Formula(BrickValues.X_POSITION)));
+		firstScript.addBrick(new SetXBrick(new Formula(BrickValues.X_POSITION)));
+		firstSprite.addScript(firstScript);
+
+		Script secondScript = new StartScript();
+		secondScript.addBrick(new SetXBrick(new Formula(BrickValues.X_POSITION)));
+		secondScript.addBrick(new SetXBrick(new Formula(BrickValues.X_POSITION)));
+		secondScript.addBrick(new SetXBrick(new Formula(BrickValues.X_POSITION)));
+		firstSprite.addScript(secondScript);
+
+		LookData lookData = new LookData();
+		lookData.setName("red");
+		firstSprite.getLookList().add(lookData);
+
+		LookData anotherLookData = new LookData();
+		anotherLookData.setName("blue");
+		firstSprite.getLookList().add(anotherLookData);
+
+		project.getDefaultScene().addSprite(firstSprite);
+
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(firstSprite);
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestUserLists.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/ParserTestUserLists.java
@@ -135,7 +135,7 @@ public class ParserTestUserLists {
 		userListValuesStringsAndNumbers.add("WORLDS");
 
 		assertTrue(dataContainer.addUserList(new UserList(PROJECT_USER_LIST_NAME, userListValuesStringsAndNumbers)));
-		assertEquals("Hello 42.0 WORLDS", interpretUserList(PROJECT_USER_LIST_NAME));
+		assertEquals("Hello 42 WORLDS", interpretUserList(PROJECT_USER_LIST_NAME));
 	}
 
 	@Test

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/NumberFormatsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/NumberFormatsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.utiltests;
+
+import android.support.annotation.IdRes;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+
+import static junit.framework.Assert.assertEquals;
+
+import static org.catrobat.catroid.utils.NumberFormats.stringWithoutTrailingZero;
+
+@RunWith(Parameterized.class)
+public class NumberFormatsTest {
+
+	@Parameterized.Parameter
+	public @IdRes String name;
+	@Parameterized.Parameter(1)
+	public @IdRes String stringWithoutTrailingZero;
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> data() {
+		return Arrays.asList(new Object[][]{
+				{"0", stringWithoutTrailingZero(String.valueOf(0))},
+				{"8", stringWithoutTrailingZero(String.valueOf(8))},
+				{"-120", stringWithoutTrailingZero(String.valueOf(-120))},
+				{"0", stringWithoutTrailingZero(String.valueOf(0.0))},
+				{"0.5", stringWithoutTrailingZero(String.valueOf(0.5))},
+				{"0.7", stringWithoutTrailingZero(String.valueOf(0.70))},
+				{"0.103", stringWithoutTrailingZero(String.valueOf(0.1030))},
+				{"15.05", stringWithoutTrailingZero(String.valueOf(15.050))},
+				{"string.1900", stringWithoutTrailingZero("string.1900")},
+				{"Pocket", stringWithoutTrailingZero("Pocket")}
+		});
+	}
+
+	@Test
+	public void testStringWithoutTrailingZero() {
+		assertEquals(stringWithoutTrailingZero, name);
+	}
+}
+

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/SetVariableTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/SetVariableTest.java
@@ -132,7 +132,7 @@ public class SetVariableTest {
 				.perform(typeText(userVariableName));
 		onView(withText(R.string.ok))
 				.perform(click());
-		onView(allOf(withChild(withText(userVariableName)), withChild(withText("0.0"))))
+		onView(allOf(withChild(withText(userVariableName)), withChild(withText("0"))))
 				.check(matches(isDisplayed()));
 		pressBack();
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorEditTextTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorEditTextTest.java
@@ -226,7 +226,7 @@ public class FormulaEditorEditTextTest {
 		onFormulaEditor()
 				.performClickOn(COMPUTE);
 		onView(withId(R.id.formula_editor_compute_dialog_textview))
-				.check(matches(withText("-2.0")));
+				.check(matches(withText("-2")));
 		pressBack();
 
 		onFormulaEditor()

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentTest.java
@@ -191,7 +191,7 @@ public class FormulaEditorFragmentTest {
 		onFormulaEditor()
 				.performCompute();
 		onView(withId(R.id.formula_editor_compute_dialog_textview))
-				.check(matches(withText(String.valueOf(1.0))));
+				.check(matches(withText(String.valueOf(1))));
 	}
 
 	@After

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/FormulaEditorComputeDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/FormulaEditorComputeDialogTest.java
@@ -43,7 +43,6 @@ import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper;
 import org.catrobat.catroid.uiespresso.testsuites.Cat;
 import org.catrobat.catroid.uiespresso.testsuites.Level;
-import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
 import org.junit.Before;
 import org.junit.Rule;
@@ -89,8 +88,7 @@ public class FormulaEditorComputeDialogTest {
 	public void dialogCreationTest() {
 		openComputeDialog();
 
-		String computedValueText = Integer.toString(someIntegerVaule)
-				+ UiTestUtils.getResourcesString(R.string.formula_editor_decimal_mark) + "0";
+		String computedValueText = Integer.toString(someIntegerVaule);
 
 		onView(withId(R.id.formula_editor_compute_dialog_textview))
 				.check(matches(withText(computedValueText)));

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
@@ -34,6 +34,8 @@ import org.catrobat.catroid.formulaeditor.datacontainer.DataContainer;
 import java.io.Serializable;
 import java.util.Set;
 
+import static org.catrobat.catroid.utils.NumberFormats.stringWithoutTrailingZero;
+
 public class Formula implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -161,7 +163,8 @@ public class Formula implements Serializable {
 			throw new InterpretationException("NaN in interpretString()");
 		}
 
-		return String.valueOf(interpretation);
+		String value = String.valueOf(interpretation);
+		return stringWithoutTrailingZero(value);
 	}
 
 	public Object interpretObject(Sprite sprite) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ScratchProgramDetailsActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ScratchProgramDetailsActivity.java
@@ -64,6 +64,8 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Locale;
 
+import static org.catrobat.catroid.utils.NumberFormats.humanFriendlyFormattedShortNumber;
+
 public class ScratchProgramDetailsActivity extends BaseActivity implements
 		FetchScratchProgramDetailsTask.ScratchProgramListTaskDelegate,
 		JobViewListener, Client.DownloadCallback,
@@ -266,11 +268,11 @@ public class ScratchProgramDetailsActivity extends BaseActivity implements
 		}
 
 		((TextView) findViewById(R.id.scratch_project_favorites_text))
-				.setText(Utils.humanFriendlyFormattedShortNumber(programData.getFavorites()));
+				.setText(humanFriendlyFormattedShortNumber(programData.getFavorites()));
 		((TextView) findViewById(R.id.scratch_project_loves_text))
-				.setText(Utils.humanFriendlyFormattedShortNumber(programData.getLoves()));
+				.setText(humanFriendlyFormattedShortNumber(programData.getLoves()));
 		((TextView) findViewById(R.id.scratch_project_views_text))
-				.setText(Utils.humanFriendlyFormattedShortNumber(programData.getViews()));
+				.setText(humanFriendlyFormattedShortNumber(programData.getViews()));
 
 		TextView dateSharedView = findViewById(R.id.date_shared_view);
 		TextView dateModifiedView = findViewById(R.id.date_modified_view);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/FormulaEditorComputeDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/FormulaEditorComputeDialog.java
@@ -44,6 +44,8 @@ import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
 import org.catrobat.catroid.formulaeditor.SensorHandler;
 
+import static org.catrobat.catroid.utils.NumberFormats.stringWithoutTrailingZero;
+
 public class FormulaEditorComputeDialog extends AlertDialog implements SensorEventListener {
 
 	private Formula formulaToCompute = null;
@@ -126,7 +128,7 @@ public class FormulaEditorComputeDialog extends AlertDialog implements SensorEve
 		}
 
 		String result = formulaToCompute.getResultForComputeDialog(context);
-		setDialogTextView(result);
+		setDialogTextView(stringWithoutTrailingZero(result));
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/ListRVAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/ListRVAdapter.java
@@ -35,6 +35,8 @@ import org.catrobat.catroid.ui.recyclerview.viewholder.ListVH;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.catrobat.catroid.utils.NumberFormats.stringWithoutTrailingZero;
+
 public class ListRVAdapter extends RVAdapter<UserList> {
 
 	ListRVAdapter(List<UserList> items) {
@@ -57,7 +59,7 @@ public class ListRVAdapter extends RVAdapter<UserList> {
 
 		List<String> userList = new ArrayList<>();
 		for (Object userListItem : item.getList()) {
-			userList.add(userListItem.toString());
+			userList.add(stringWithoutTrailingZero(userListItem.toString()));
 		}
 
 		listVH.spinner.setAdapter(new UserListValuesAdapter(holder.itemView.getContext(), userList));

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/VariableRVAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/VariableRVAdapter.java
@@ -33,6 +33,8 @@ import org.catrobat.catroid.ui.recyclerview.viewholder.VariableVH;
 
 import java.util.List;
 
+import static org.catrobat.catroid.utils.NumberFormats.stringWithoutTrailingZero;
+
 public class VariableRVAdapter extends RVAdapter<UserVariable> {
 
 	VariableRVAdapter(List<UserVariable> items) {
@@ -52,6 +54,6 @@ public class VariableRVAdapter extends RVAdapter<UserVariable> {
 		UserVariable item = items.get(position);
 		VariableVH variableVH = (VariableVH) holder;
 		variableVH.title.setText(item.getName());
-		variableVH.value.setText(item.getValue().toString());
+		variableVH.value.setText(stringWithoutTrailingZero(item.getValue().toString()));
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/utils/NumberFormats.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/NumberFormats.java
@@ -1,0 +1,51 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.utils;
+
+public final class NumberFormats {
+
+	private NumberFormats() {
+		throw new AssertionError();
+	}
+	public static final String TAG = NumberFormats.class.getSimpleName();
+
+	public static String stringWithoutTrailingZero(String value) {
+		if (value.contains(".") && value.matches("[0-9.-]+")) {
+			value = !value.contains(".") ? value : value.replaceAll("0*$", "").replaceAll("\\.$", "");
+		}
+		return value;
+	}
+
+	public static String humanFriendlyFormattedShortNumber(final int number) {
+		if (number < 1_000) {
+			return Integer.toString(number);
+		} else if (number < 10_000) {
+			return Integer.toString(number / 1_000) + (number % 1_000 > 100 ? "."
+					+ Integer.toString((number % 1_000) / 100) : "") + "k";
+		} else if (number < 1_000_000) {
+			return Integer.toString(number / 1_000) + "k";
+		}
+		return Integer.toString(number / 1_000_000) + "M";
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
@@ -247,18 +247,6 @@ public final class Utils {
 				.replace("x" + height, "x" + Integer.toString(newHeight));
 	}
 
-	public static String humanFriendlyFormattedShortNumber(final int number) {
-		if (number < 1_000) {
-			return Integer.toString(number);
-		} else if (number < 10_000) {
-			return Integer.toString(number / 1_000) + (number % 1_000 > 100 ? "."
-					+ Integer.toString((number % 1_000) / 100) : "") + "k";
-		} else if (number < 1_000_000) {
-			return Integer.toString(number / 1_000) + "k";
-		}
-		return Integer.toString(number / 1_000_000) + "M";
-	}
-
 	public static String md5Checksum(File file) {
 
 		if (!file.isFile()) {


### PR DESCRIPTION
 * 32-In Say and Think bubbles, no trailing zeroes (.0 etc) should be shown
 * 33-Compute" in the formula editor should show no trailing zeroes (.0 etc)
 * Strip any trailing 0 from numbers before converting them into text strings
 * Do not show any trailing 0 in the list of values of variables and lists