### PR TITLE
CATROID-48 Suspend all scripts on scene transition... 

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/SceneTransitionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/SceneTransitionTest.java
@@ -1,0 +1,131 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.stage;
+
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.ChangeVariableBrick;
+import org.catrobat.catroid.content.bricks.SceneStartBrick;
+import org.catrobat.catroid.content.bricks.SceneTransitionBrick;
+import org.catrobat.catroid.content.bricks.SetVariableBrick;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.formulaeditor.datacontainer.DataContainer;
+import org.catrobat.catroid.stage.StageActivity;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.catrobat.catroid.uiespresso.util.UserVariableAssertions.assertUserVariableEqualsWithTimeout;
+import static org.catrobat.catroid.uiespresso.util.UserVariableAssertions.assertUserVariableNotEqualsForTimeMs;
+
+public class SceneTransitionTest {
+	private static final String VARIABLE_NAME = "var1";
+	private static final String SCENE_2_NAME = "Scene 2";
+
+	private UserVariable userVariable;
+	private Project project;
+	private Sprite sprite1;
+	private Script scene1StartScript1;
+	private Script scene1StartScript2;
+
+	private Script scene2StartScript;
+
+	@Rule
+	public BaseActivityInstrumentationRule<StageActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(StageActivity.class, true, false);
+
+	@Before
+	public void setUp() throws Exception {
+		createProject();
+	}
+
+	@Category({Level.Functional.class, Cat.CatrobatLanguage.class})
+	@Test
+	public void suspendAllThreadsOnSceneTransition() {
+		scene1StartScript1.addBrick(new SceneTransitionBrick(SCENE_2_NAME));
+		scene1StartScript2.addBrick(new SetVariableBrick(new Formula(10.0), userVariable));
+		scene2StartScript.addBrick(new ChangeVariableBrick(new Formula(1.0), userVariable));
+
+		baseActivityTestRule.launchActivity(null);
+
+		assertUserVariableEqualsWithTimeout(userVariable, 1.0, 1000);
+	}
+
+	@Category({Level.Functional.class, Cat.CatrobatLanguage.class})
+	@Test
+	public void continueSuspendedThreadsOnContinueScene() {
+		scene1StartScript1.addBrick(new SceneTransitionBrick(SCENE_2_NAME));
+		scene1StartScript1.addBrick(new ChangeVariableBrick(new Formula(1.0), userVariable));
+		scene1StartScript2.addBrick(new ChangeVariableBrick(new Formula(0.0), userVariable)); // do nothing
+		scene1StartScript2.addBrick(new ChangeVariableBrick(new Formula(10.0), userVariable));
+		scene2StartScript.addBrick(new SceneTransitionBrick(project.getDefaultScene().getName()));
+
+		baseActivityTestRule.launchActivity(null);
+
+		assertUserVariableEqualsWithTimeout(userVariable, 11.0, 1000);
+	}
+
+	@Category({Level.Functional.class, Cat.CatrobatLanguage.class})
+	@Test
+	public void discardSuspendedThreadsOnStartScene() {
+		scene1StartScript1.addBrick(new SceneTransitionBrick(SCENE_2_NAME));
+		scene1StartScript1.addBrick(new SetVariableBrick(new Formula(1.0), userVariable));
+		scene2StartScript.addBrick(new SetVariableBrick(new Formula(2.0), userVariable));
+		scene2StartScript.addBrick(new SceneStartBrick(project.getDefaultScene().getName()));
+
+		baseActivityTestRule.launchActivity(null);
+
+		assertUserVariableEqualsWithTimeout(userVariable, 2.0, 1000);
+		assertUserVariableNotEqualsForTimeMs(userVariable, 1.0, 200);
+	}
+
+	private void createProject() {
+		project = UiTestUtils.createEmptyProject("test");
+		DataContainer dataContainer = project.getDefaultScene().getDataContainer();
+		userVariable = new UserVariable(VARIABLE_NAME, 0.0);
+		dataContainer.addUserVariable(userVariable);
+
+		sprite1 = project.getDefaultScene().getBackgroundSprite();
+		scene1StartScript1 = new StartScript();
+		scene1StartScript2 = new StartScript();
+		sprite1.addScript(scene1StartScript2);
+		sprite1.addScript(scene1StartScript1);
+
+		Scene scene2 = new Scene(SCENE_2_NAME, project);
+		Sprite sprite2 = new Sprite();
+		scene2StartScript = new StartScript();
+		sprite2.addScript(scene2StartScript);
+		scene2.addSprite(sprite2);
+		project.addScene(scene2);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/common/ThreadScheduler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/ThreadScheduler.java
@@ -23,6 +23,8 @@
 
 package org.catrobat.catroid.common;
 
+import android.support.annotation.IntDef;
+
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.utils.Array;
@@ -30,13 +32,24 @@ import com.badlogic.gdx.utils.Array;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.actions.EventThread;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.Iterator;
 
 public class ThreadScheduler {
+	@Retention(RetentionPolicy.SOURCE)
+	@IntDef({RUNNING, SUSPENDED})
+	public @interface SchedulerState {
+	}
+
+	public static final int RUNNING = 0;
+	public static final int SUSPENDED = 1;
 
 	private Array<EventThread> startQueue = new Array<>();
 	private Array<Action> stopQueue = new Array<>();
 	private Actor actor;
+	@SchedulerState
+	private int state = RUNNING;
 
 	public ThreadScheduler(Actor actor) {
 		this.actor = actor;
@@ -60,7 +73,7 @@ public class ThreadScheduler {
 	private void runThreadsForOneTick(Array<Action> actions, float delta) {
 		for (int i = 0; i < actions.size; i++) {
 			Action action = actions.get(i);
-			if (action.act(delta)) {
+			if (state == RUNNING && action.act(delta)) {
 				stopQueue.add(action);
 			}
 		}
@@ -106,5 +119,9 @@ public class ThreadScheduler {
 
 	public boolean haveAllThreadsFinished() {
 		return startQueue.size + actor.getActions().size == 0;
+	}
+
+	public void setState(@SchedulerState int schedulerState) {
+		this.state = schedulerState;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -219,6 +219,10 @@ public class Look extends Image {
 		}
 	}
 
+	public void setSchedulerState(@ThreadScheduler.SchedulerState int state) {
+		scheduler.setState(state);
+	}
+
 	protected void checkImageChanged() {
 		if (imageChanged) {
 			if (lookData == null) {

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -54,6 +54,7 @@ import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.ScreenModes;
 import org.catrobat.catroid.common.ScreenValues;
+import org.catrobat.catroid.common.ThreadScheduler;
 import org.catrobat.catroid.content.EventWrapper;
 import org.catrobat.catroid.content.Look;
 import org.catrobat.catroid.content.Project;
@@ -393,6 +394,7 @@ public class StageListener implements ApplicationListener {
 	@Override
 	public void resume() {
 		if (!paused) {
+			setSchedulerStateForAllLooks(ThreadScheduler.RUNNING);
 			FaceDetectionHandler.resumeFaceDetection();
 			SoundManager.getInstance().resume();
 		}
@@ -408,6 +410,7 @@ public class StageListener implements ApplicationListener {
 			return;
 		}
 		if (!paused) {
+			setSchedulerStateForAllLooks(ThreadScheduler.SUSPENDED);
 			FaceDetectionHandler.pauseFaceDetection();
 			SoundManager.getInstance().pause();
 		}
@@ -730,8 +733,13 @@ public class StageListener implements ApplicationListener {
 		return stage;
 	}
 
-	public void removeActor(Look look) {
-		look.remove();
+	private void setSchedulerStateForAllLooks(@ThreadScheduler.SchedulerState int state) {
+		for (Actor actor : stage.getActors()) {
+			if (actor instanceof Look) {
+				Look look = (Look) actor;
+				look.setSchedulerState(state);
+			}
+		}
 	}
 
 	public void setBubbleActorForSprite(Sprite sprite, ShowBubbleActor showBubbleActor) {


### PR DESCRIPTION
...and resume all previously running scripts in the new scene.

A POC for how we could handle it - suspend all schedulers on scene switch and resume schedulers when a scene is continued. This way we can continue scripts that were running during scene switch. Is this desired behaviour?
Tests are WIP.