### PR TITLE
JENKINS-250 Build errors are found when trying to run tests on the emulator.

### DIFF
--- a/buildScripts/build_helper_run_tests_on_emulator
+++ b/buildScripts/build_helper_run_tests_on_emulator
@@ -51,7 +51,7 @@ print("Calling: " + " ".join(disable_cmd))
 return_code = subprocess.run( disable_cmd, cwd=os.environ['REPO_DIR'] ).returncode
 
 ## RUN tests
-test_runner_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_cmd_wrapper') + [ '-I', build_helper_functions.get_relative_gradle_name(), '-PenableCoverage', 'clean', 'adbDisableAnimationsGlobally', 'createCatroidDebugAndroidTestCoverageReport' ]
+test_runner_cmd = build_helper_functions.get_jenkins_android_helper_executable('jenkins_android_cmd_wrapper') + [ build_helper_functions.get_relative_gradle_name(), '-PenableCoverage', 'clean', 'adbDisableAnimationsGlobally', 'createCatroidDebugAndroidTestCoverageReport' ]
 if test_runner_arg is not None and test_runner_arg != "":
     test_runner_cmd = test_runner_cmd + [ test_runner_arg ]
 


### PR DESCRIPTION
Problem
=======
Months ago there was the issue that tests were flaky or that the emulator
crashed, leading to an exit code of 1 for gradle.
This aborted the Jenkins build right away, not trying to run other build
steps that could have been useful in finding further issues.

Thus a workaround was added to keep the build running even if tests failed.
After such a build completed failing tests would still be recorded as part
of the JUnit-Test results.

Yet this also lead to build-errors being hidden wrongfully, as it turned out.
Unfortunately this was the case for the release-build for release 09.42.0
where Jenkins indicated a green job wrongfully.

Solution
========
Exit codes unequal to 0 are not ignored anymore, while failing tests
do not abort the build job right away.

Actually the later part was implemented already for months via the
"ignoreFailures" gradle setting for tests.
This setting indicates a successful gradle build even if tests failed.
Of course the test result XML files still track the failed tests.
That way Jenkins still can report the failing tests and mark the build
as unstable/failed.
