### PR TITLE
CATROID-83 Added null check crash in showLegoSensorConfig

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -383,6 +383,10 @@ public class ProjectActivity extends BaseCastActivity {
 	}
 
 	private void showLegoSensorConfigInfo() {
+		if (ProjectManager.getInstance().getCurrentProject() == null) {
+			return;
+		}
+
 		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
 		boolean nxtDialogDisabled = preferences
 				.getBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED, false);


### PR DESCRIPTION
 - null check to avoid "random" crashes.
 - no test because it cannot be reproduced consistantly.