### PR TITLE
 CAT-49  BUG Discard Changes

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorDiscardChangesTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorDiscardChangesTest.java
@@ -1,0 +1,161 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.formulaeditor;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.bricks.PlaceAtBrick;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
+import org.catrobat.catroid.uiespresso.testsuites.Cat;
+import org.catrobat.catroid.uiespresso.testsuites.Level;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.pressBack;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.getResourcesString;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.onToast;
+
+@RunWith(AndroidJUnit4.class)
+public class FormulaEditorDiscardChangesTest {
+
+	private int brickPosition;
+	private String no = getResourcesString(R.string.no);
+	private String yes = getResourcesString(R.string.yes);
+
+	@Rule
+	public BaseActivityInstrumentationRule<SpriteActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+
+	@Before
+	public void setUp() throws Exception {
+		brickPosition = 1;
+		Script script = BrickTestUtils.createProjectAndGetStartScript("FormulaEditorDiscardChangesTest");
+		script.addBrick(new PlaceAtBrick());
+		baseActivityTestRule.launchActivity();
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testGoBackToDiscardXChanges() {
+		onBrickAtPosition(brickPosition).checkShowsText(R.string.brick_place_at);
+		onBrickAtPosition(brickPosition).onFormulaTextField(R.id.brick_place_at_edit_text_x)
+				.perform(click());
+		onFormulaEditor()
+				.performEnterFormula("1234");
+		pressBack();
+		onView(withText(R.string.formula_editor_save_changes_dialog_title))
+				.check(matches(isDisplayed()));
+		onView(withText(no))
+				.perform(click());
+		onToast(withText(R.string.formula_editor_changes_discarded))
+				.check(matches(isDisplayed()));
+		onBrickAtPosition(brickPosition).onFormulaTextField(R.id.brick_place_at_edit_text_x)
+				.checkShowsNumber(0);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testGoBackToDiscardYChanges() {
+		onBrickAtPosition(brickPosition).checkShowsText(R.string.brick_place_at);
+		onBrickAtPosition(brickPosition).onFormulaTextField(R.id.brick_place_at_edit_text_y)
+				.perform(click());
+		onFormulaEditor()
+				.performEnterFormula("5678");
+		pressBack();
+		onView(withText(R.string.formula_editor_save_changes_dialog_title))
+				.check(matches(isDisplayed()));
+		onView(withText(no))
+				.perform(click());
+		onToast(withText(R.string.formula_editor_changes_discarded))
+				.check(matches(isDisplayed()));
+		onBrickAtPosition(brickPosition).onFormulaTextField(R.id.brick_place_at_edit_text_y)
+				.checkShowsNumber(0);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testGoBackToDiscardXYChanges() {
+		onBrickAtPosition(brickPosition).checkShowsText(R.string.brick_place_at);
+		onBrickAtPosition(brickPosition).onFormulaTextField(R.id.brick_place_at_edit_text_x)
+				.perform(click());
+		onFormulaEditor()
+				.performEnterFormula("1234");
+		onView(withId(R.id.brick_place_at_edit_text_y))
+				.perform(click());
+		onFormulaEditor()
+				.performEnterFormula("5678");
+		pressBack();
+		onView(withText(R.string.formula_editor_save_changes_dialog_title))
+				.check(matches(isDisplayed()));
+		onView(withText(no))
+				.perform(click());
+		onToast(withText(R.string.formula_editor_changes_discarded))
+				.check(matches(isDisplayed()));
+		onBrickAtPosition(brickPosition).onFormulaTextField(R.id.brick_place_at_edit_text_x)
+				.checkShowsNumber(0);
+		onBrickAtPosition(brickPosition).onFormulaTextField(R.id.brick_place_at_edit_text_y)
+				.checkShowsNumber(0);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testSaveXYChanges() {
+		onBrickAtPosition(brickPosition).checkShowsText(R.string.brick_place_at);
+		onBrickAtPosition(brickPosition).onFormulaTextField(R.id.brick_place_at_edit_text_x)
+				.perform(click());
+		onFormulaEditor()
+				.performEnterFormula("1234");
+		onView(withId(R.id.brick_place_at_edit_text_y))
+				.perform(click());
+		onFormulaEditor()
+				.performEnterFormula("5678");
+		pressBack();
+		onView(withText(R.string.formula_editor_save_changes_dialog_title))
+				.check(matches(isDisplayed()));
+		onView(withText(yes))
+				.perform(click());
+		onToast(withText(R.string.formula_editor_changes_saved))
+				.check(matches(isDisplayed()));
+		onBrickAtPosition(brickPosition).onFormulaTextField(R.id.brick_place_at_edit_text_x)
+				.checkShowsNumber(1234);
+		onBrickAtPosition(brickPosition).onFormulaTextField(R.id.brick_place_at_edit_text_y)
+				.checkShowsNumber(5678);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/UndoState.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/UndoState.java
@@ -1,0 +1,56 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.formulaeditor;
+
+import com.google.common.base.Objects;
+
+import org.catrobat.catroid.content.bricks.Brick;
+
+public class UndoState {
+
+	public final InternFormulaState internFormulaState;
+	public final Brick.BrickField brickField;
+
+	public UndoState(InternFormulaState internFormulaState, Brick.BrickField brickField) {
+		this.brickField = brickField;
+		this.internFormulaState = internFormulaState;
+	}
+
+	@Override
+	public boolean equals(Object objectCompareTo) {
+		if (this == objectCompareTo) {
+			return true;
+		}
+		if (!(objectCompareTo instanceof UndoState)) {
+			return false;
+		}
+		UndoState stateCompareTo = (UndoState) objectCompareTo;
+		return Objects.equal(this.internFormulaState, stateCompareTo.internFormulaState)
+				&& this.brickField == stateCompareTo.brickField;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(internFormulaState, brickField);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -55,9 +55,12 @@ import org.catrobat.catroid.content.commands.OnFormulaChangedListener;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaEditorEditText;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.catrobat.catroid.formulaeditor.InternFormula;
 import org.catrobat.catroid.formulaeditor.InternFormulaKeyboardAdapter;
 import org.catrobat.catroid.formulaeditor.InternFormulaParser;
+import org.catrobat.catroid.formulaeditor.InternFormulaState;
 import org.catrobat.catroid.formulaeditor.SensorHandler;
+import org.catrobat.catroid.formulaeditor.UndoState;
 import org.catrobat.catroid.formulaeditor.UserData;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
@@ -70,6 +73,8 @@ import org.catrobat.catroid.ui.recyclerview.fragment.CategoryListFragment;
 import org.catrobat.catroid.ui.recyclerview.fragment.DataListFragment;
 import org.catrobat.catroid.utils.SnackbarUtil;
 import org.catrobat.catroid.utils.ToastUtil;
+
+import java.util.Map;
 
 import static org.catrobat.catroid.utils.SnackbarUtil.wasHintAlreadyShown;
 
@@ -464,7 +469,8 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 
 		switch (mode) {
 			case SET_FORMULA_ON_CREATE_VIEW:
-				formulaEditorEditText.enterNewFormula(currentFormula.getInternFormulaState());
+				formulaEditorEditText.enterNewFormula(new UndoState(currentFormula.getInternFormulaState(),
+								brickField));
 				refreshFormulaPreviewString(formulaEditorEditText.getStringFromInternFormula());
 				break;
 
@@ -495,7 +501,8 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 				formulaEditorEditText.endEdit();
 				currentBrickField = brickField;
 				currentFormula = newFormula;
-				formulaEditorEditText.enterNewFormula(newFormula.getInternFormulaState());
+				formulaEditorEditText.enterNewFormula(new UndoState(currentFormula.getInternFormulaState(),
+						currentBrickField));
 				refreshFormulaPreviewString(formulaEditorEditText.getStringFromInternFormula());
 				break;
 			default:
@@ -555,15 +562,11 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	}
 
 	public void promptSave() {
-		if (hasFormulaBeenChanged) {
-			ToastUtil.showSuccess(getActivity(), R.string.formula_editor_changes_saved);
-			hasFormulaBeenChanged = false;
-		}
 		exitFormulaEditorFragment();
 	}
 
 	private void exitFormulaEditorFragment() {
-		if (formulaEditorEditText.hasChanges()) {
+		if (hasFormulaBeenChanged || formulaEditorEditText.hasChanges()) {
 			AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
 			builder.setTitle(R.string.formula_editor_discard_changes_dialog_title)
 					.setMessage(R.string.formula_editor_discard_changes_dialog_message)
@@ -571,6 +574,9 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 
 						@Override
 						public void onClick(DialogInterface dialog, int which) {
+							Map<Brick.BrickField, InternFormulaState> initialStates = formulaEditorEditText
+									.getHistory().getInitialStates();
+							restoreInitialStates(initialStates);
 							ToastUtil.showError(getActivity(), R.string.formula_editor_changes_discarded);
 							onUserDismiss();
 						}
@@ -695,6 +701,10 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		return formulaEditorEditText.getSelectedTextFromInternFormula();
 	}
 
+	public Brick.BrickField getCurrentBrickField() {
+		return currentBrickField;
+	}
+
 	public void overrideSelectedText(String string) {
 		formulaEditorEditText.overrideSelectedText(string);
 	}
@@ -723,6 +733,13 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		} else {
 			backspaceOnKeyboard.setAlpha(255);
 			backspaceOnKeyboard.setEnabled(true);
+		}
+	}
+	private void restoreInitialStates(Map<Brick.BrickField, InternFormulaState> initialStates) {
+		for (Map.Entry<Brick.BrickField, InternFormulaState> state : initialStates.entrySet()) {
+			InternFormula internFormula = state.getValue().createInternFormulaFromState();
+			formulaBrick.setFormulaWithBrickField(state.getKey(),
+					new Formula(internFormula.getInternFormulaParser().parseFormula()));
 		}
 	}
 }

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1883,6 +1883,7 @@
     <string name="formula_editor_list_dialog_title">New List</string>
     <string name="formula_editor_discard_changes_dialog_message">Do you want to save your changes?</string>
     <string name="formula_editor_discard_changes_dialog_title">Save changes?</string>
+    <string name="formula_editor_save_changes_dialog_title">Save changes?</string>
     <string name="formula_editor_new_string_name">New Text</string>
     <string name="formula_editor_dialog_change_text">Change Text</string>
     <string name="formula_editor_fragment_data_current_items">current items</string>


### PR DESCRIPTION
New Class named UndoState waas created for saving the initalStates(first values of the bricks) in map. The map stores all initial values of brickfields. If the  user discards the changes the old ones are used which are taken from the initialstates map, so discarding the changes over many bricks will result in an expected behaviour. 