### PR TITLE
CATROID-101 Remove paramters to not clash with the job dsl.

### DIFF
--- a/Jenkinsfile.ManualTests
+++ b/Jenkinsfile.ManualTests
@@ -16,13 +16,6 @@ pipeline {
 		}
 	}
 
-	parameters {
-		choice(name: 'TYPE', choices: ['class', 'package'], description: 'Are the tests in a package or in a class?')
-		string(name: 'NAME', description: 'The fully qualified name of the test class or test package.',
-				defaultValue: 'org.catrobat.catroid.uiespresso.testsuites.ApiLevel19RegressionTestsSuite')
-		choice(name: 'EMULATOR', choices: ['android19', 'android24'], description: 'The emulator to use, as specified in build.gradle')
-	}
-
 	environment {
 		//////// Define environment variables to point to the correct locations inside the container ////////
 		//////////// Most likely not edited by the developer
@@ -53,7 +46,7 @@ pipeline {
 		stage('Prepare build') {
 			steps {
 				script {
-					currentBuild.displayName = params.NAME
+					currentBuild.displayName = env.NAME
 				}
 			}
 		}
@@ -68,8 +61,8 @@ pipeline {
 
 		stage('Unit and Device tests') {
 			steps {
-				sh """./gradlew -PenableCoverage -Pemulator=${params.EMULATOR} startEmulator \
-							createCatroidDebugAndroidTestCoverageReport -Pandroid.testInstrumentationRunnerArguments.${params.TYPE}=${params.NAME}"""
+				sh """./gradlew -PenableCoverage -Pemulator=${env.EMULATOR} startEmulator \
+							createCatroidDebugAndroidTestCoverageReport -Pandroid.testInstrumentationRunnerArguments.${env.TYPE}=${env.NAME}"""
 			}
 
 			post {


### PR DESCRIPTION
The job dsl has to create paramters for the git repository/branch.
Yet these two paramters clear all other paramters, also those defined in the Jenkinsfile.
Since the job dsl is run once per day it could result in users having
to start the ManualTests job twice.
Once to create the necessary paramters and a second time to fill in these paramters.

To avoid such inconvenience it is better to manage the paramters soley
via the job dsl.