### PR TITLE
CATROID-109, JENKINS-272 The application name for debug APKs includes the branch name.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,7 @@ pipeline {
 			// It checks that the job builds with the parameters to have unique APKs, reducing the risk of breaking gradle changes.
 			// The resulting APK is not verified on itself.
 			steps {
-				sh "./gradlew assembleCatroidDebug -Pindependent='Code Nightly #$BUILD_NUMBER'"
+				sh "./gradlew assembleCatroidDebug -Pindependent='#$BUILD_NUMBER $BRANCH_NAME'"
 				archiveArtifacts "${env.APK_LOCATION_DEBUG}"
 			}
 		}


### PR DESCRIPTION
The new name is "#BUILD_NUMBER BRANCH_NAME".
The build-number is first to ensure that it is visible even for longer branch names.
This should make it easier to identify which build an APK is related to.
In the previous case the APKs would always have an application name of
"Code Nightly #BUILD_NUMBER" which is confusing for PRs as it is not clear
which PR they refer to.

Testing done:
Installed APKs generated that way on my local device.
Names that were fully visible "#12 PR-12345" "#1234 develop".
Longer branch names were cut off.
For these cases the application has to be started to get the full name.