### PR TITLE
CATROID-63 The formula when selecting Edit Formula in the menu for bricks with multiple formulas isn't properly defined

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/BricksWithMultipleBrickFieldsEditFormulaTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/BricksWithMultipleBrickFieldsEditFormulaTest.java
@@ -1,0 +1,191 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.content.brick.app;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.ArduinoSendDigitalValueBrick;
+import org.catrobat.catroid.content.bricks.ArduinoSendPWMValueBrick;
+import org.catrobat.catroid.content.bricks.DroneMoveBackwardBrick;
+import org.catrobat.catroid.content.bricks.DroneMoveDownBrick;
+import org.catrobat.catroid.content.bricks.DroneMoveForwardBrick;
+import org.catrobat.catroid.content.bricks.DroneMoveLeftBrick;
+import org.catrobat.catroid.content.bricks.DroneMoveRightBrick;
+import org.catrobat.catroid.content.bricks.DroneMoveUpBrick;
+import org.catrobat.catroid.content.bricks.DroneTurnLeftBrick;
+import org.catrobat.catroid.content.bricks.DroneTurnRightBrick;
+import org.catrobat.catroid.content.bricks.GlideToBrick;
+import org.catrobat.catroid.content.bricks.InsertItemIntoUserListBrick;
+import org.catrobat.catroid.content.bricks.JumpingSumoMoveBackwardBrick;
+import org.catrobat.catroid.content.bricks.JumpingSumoMoveForwardBrick;
+import org.catrobat.catroid.content.bricks.LegoEv3PlayToneBrick;
+import org.catrobat.catroid.content.bricks.LegoNxtPlayToneBrick;
+import org.catrobat.catroid.content.bricks.PhiroRGBLightBrick;
+import org.catrobat.catroid.content.bricks.PlaceAtBrick;
+import org.catrobat.catroid.content.bricks.RaspiPwmBrick;
+import org.catrobat.catroid.content.bricks.RaspiSendDigitalValueBrick;
+import org.catrobat.catroid.content.bricks.ReplaceItemInUserListBrick;
+import org.catrobat.catroid.content.bricks.SayForBubbleBrick;
+import org.catrobat.catroid.content.bricks.SetPenColorBrick;
+import org.catrobat.catroid.content.bricks.ShowTextBrick;
+import org.catrobat.catroid.content.bricks.ThinkForBubbleBrick;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.physics.content.bricks.SetGravityBrick;
+import org.catrobat.catroid.physics.content.bricks.SetVelocityBrick;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityInstrumentationRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+
+@RunWith(AndroidJUnit4.class)
+public class BricksWithMultipleBrickFieldsEditFormulaTest {
+	@Rule
+	public BaseActivityInstrumentationRule<SpriteActivity> baseActivityTestRule = new
+			BaseActivityInstrumentationRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+	private int arduinoDigitalPinNumber = 13;
+	private int arduinoDigitalPinValue = 1;
+	private int arduinoPwdPinNumber = 3;
+	private int arduinoPwdPinValue = 255;
+	private float raspiPwmFrequency = 50;
+	private float raspiPwmPercentage = 100;
+	private int raspiPwmPinNumber = 3;
+	private int raspiPinValue = 1;
+	private double legoDuration = 1.01;
+	private double legoFrequency = 2.02;
+	private double legoVolume = 100;
+	private int droneDuration = 1;
+	private int dronePower = 20;
+	private int xCoordinate = 100;
+	private int yCoordinate = 200;
+	private double droneDurationFormulaEditor = droneDuration / 1000.0;
+
+	@Before
+	public void setUp() throws Exception {
+		createProject("editFormulaTest");
+		baseActivityTestRule.launchActivity();
+	}
+
+	@Test
+	public void testEditFormula() {
+		checkFormulaEditorStartWithFirstBrickField(1, arduinoDigitalPinNumber + " ");
+		checkFormulaEditorStartWithFirstBrickField(2, arduinoPwdPinNumber + " ");
+
+		checkFormulaEditorStartWithFirstBrickField(3, raspiPwmPinNumber + " ");
+		checkFormulaEditorStartWithFirstBrickField(4, raspiPwmPinNumber + " ");
+
+		checkFormulaEditorStartWithFirstBrickField(5, legoDuration + " ");
+		checkFormulaEditorStartWithFirstBrickField(6, legoDuration + " ");
+
+		checkFormulaEditorStartWithFirstBrickField(7, droneDurationFormulaEditor + " ");
+		checkFormulaEditorStartWithFirstBrickField(8, droneDurationFormulaEditor + " ");
+		checkFormulaEditorStartWithFirstBrickField(9, droneDurationFormulaEditor + " ");
+		checkFormulaEditorStartWithFirstBrickField(10, droneDurationFormulaEditor + " ");
+		checkFormulaEditorStartWithFirstBrickField(11, droneDurationFormulaEditor + " ");
+		checkFormulaEditorStartWithFirstBrickField(12, droneDurationFormulaEditor + " ");
+		checkFormulaEditorStartWithFirstBrickField(13, droneDurationFormulaEditor + " ");
+		checkFormulaEditorStartWithFirstBrickField(14, droneDurationFormulaEditor + " ");
+		checkFormulaEditorStartWithFirstBrickField(15, droneDurationFormulaEditor + " ");
+		checkFormulaEditorStartWithFirstBrickField(16, droneDurationFormulaEditor + " ");
+
+		checkFormulaEditorStartWithFirstBrickField(17, xCoordinate + " ");
+		checkFormulaEditorStartWithFirstBrickField(18, 1 + " ");
+		checkFormulaEditorStartWithFirstBrickField(19, 1 + " ");
+
+		checkFormulaEditorStartWithFirstBrickField(20, "'Servus' ");
+		checkFormulaEditorStartWithFirstBrickField(21, "'Serwaas' ");
+		checkFormulaEditorStartWithFirstBrickField(22, "'red' ");
+		checkFormulaEditorStartWithFirstBrickField(23, "'r' ");
+
+		checkFormulaEditorStartWithFirstBrickField(24, xCoordinate + " ");
+		checkFormulaEditorStartWithFirstBrickField(25, droneDurationFormulaEditor + " ");
+		checkFormulaEditorStartWithFirstBrickField(26, 1 + " ");
+		checkFormulaEditorStartWithFirstBrickField(27, 5 + " ");
+	}
+
+	private void checkFormulaEditorStartWithFirstBrickField(int brickPosition, String shownText) {
+		onBrickAtPosition(brickPosition)
+				.performEditFormula();
+		onFormulaEditor()
+				.checkShows(shownText);
+		onFormulaEditor()
+				.performCloseAndSave();
+	}
+
+	private void createProject(String projectName) {
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), projectName);
+		Sprite sprite1 = new Sprite("testSprite");
+		Script sprite1StartScript = new StartScript();
+		sprite1.addScript(sprite1StartScript);
+
+		project.getDefaultScene().addSprite(sprite1);
+		ProjectManager.getInstance().setProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite1);
+
+		sprite1StartScript.addBrick(new ArduinoSendDigitalValueBrick(arduinoDigitalPinNumber, arduinoDigitalPinValue));
+		sprite1StartScript.addBrick(new ArduinoSendPWMValueBrick(arduinoPwdPinNumber, arduinoPwdPinValue));
+
+		sprite1StartScript.addBrick(new RaspiPwmBrick(raspiPwmPinNumber, raspiPwmFrequency, raspiPwmPercentage));
+		sprite1StartScript.addBrick(new RaspiSendDigitalValueBrick(raspiPwmPinNumber, raspiPinValue));
+
+		sprite1StartScript.addBrick(new LegoEv3PlayToneBrick(legoFrequency, legoDuration, legoVolume));
+		sprite1StartScript.addBrick(new LegoNxtPlayToneBrick(legoFrequency, legoDuration));
+
+		sprite1StartScript.addBrick(new DroneMoveUpBrick(droneDuration, dronePower));
+		sprite1StartScript.addBrick(new DroneMoveDownBrick(droneDuration, dronePower));
+		sprite1StartScript.addBrick(new DroneMoveLeftBrick(droneDuration, dronePower));
+		sprite1StartScript.addBrick(new DroneMoveRightBrick(droneDuration, dronePower));
+		sprite1StartScript.addBrick(new DroneMoveForwardBrick(droneDuration, dronePower));
+		sprite1StartScript.addBrick(new DroneMoveBackwardBrick(droneDuration, dronePower));
+		sprite1StartScript.addBrick(new DroneTurnLeftBrick(droneDuration, dronePower));
+		sprite1StartScript.addBrick(new DroneTurnRightBrick(droneDuration, dronePower));
+
+		sprite1StartScript.addBrick(new JumpingSumoMoveBackwardBrick(droneDuration, dronePower));
+		sprite1StartScript.addBrick(new JumpingSumoMoveForwardBrick(droneDuration, dronePower));
+
+		sprite1StartScript.addBrick(new ShowTextBrick(xCoordinate, yCoordinate));
+		sprite1StartScript.addBrick(new InsertItemIntoUserListBrick(new Formula(1), new Formula(1)));
+		sprite1StartScript.addBrick(new ReplaceItemInUserListBrick(new Formula(1), new Formula(1)));
+
+		sprite1StartScript.addBrick(new SayForBubbleBrick("Servus", droneDuration));
+		sprite1StartScript.addBrick(new ThinkForBubbleBrick("Serwaas", droneDuration));
+		sprite1StartScript.addBrick(new PhiroRGBLightBrick(PhiroRGBLightBrick.Eye.RIGHT, new Formula("red"), new Formula(0), new Formula(255)));
+		sprite1StartScript.addBrick(new SetPenColorBrick(new Formula("r"), new Formula(0), new Formula(255)));
+
+		sprite1StartScript.addBrick(new PlaceAtBrick(xCoordinate, yCoordinate));
+		sprite1StartScript.addBrick(new GlideToBrick(xCoordinate, yCoordinate, droneDuration));
+		sprite1StartScript.addBrick(new SetVelocityBrick(new Formula(1), new Formula(3)));
+		sprite1StartScript.addBrick(new SetGravityBrick(new Formula(5), new Formula(8)));
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickDataInteractionWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickDataInteractionWrapper.java
@@ -117,4 +117,12 @@ public class BrickDataInteractionWrapper extends DataInteractionWrapper {
 		onView(withText(R.string.yes))
 				.perform(click());
 	}
+
+	public void performEditFormula() {
+		dataInteraction.perform(new GeneralClickAction(Tap.SINGLE,
+				BrickCoordinatesProvider.UPPER_LEFT_CORNER,
+				Press.FINGER));
+		onView(withText(R.string.brick_context_dialog_formula_edit_brick))
+				.perform(click());
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendDigitalValueBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendDigitalValueBrick.java
@@ -60,6 +60,11 @@ public class ArduinoSendDigitalValueBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.ARDUINO_DIGITAL_PIN_NUMBER;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createSendDigitalArduinoValueAction(sprite,
 				getFormulaWithBrickField(BrickField.ARDUINO_DIGITAL_PIN_NUMBER),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendPWMValueBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendPWMValueBrick.java
@@ -69,6 +69,11 @@ public class ArduinoSendPWMValueBrick extends FormulaBrick {
 		return null;
 	}
 
+	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.ARDUINO_ANALOG_PIN_NUMBER;
+	}
+
 	public void updateArduinoValues994to995() {
 		Formula formula = getFormulaWithBrickField(BrickField.ARDUINO_ANALOG_PIN_VALUE);
 		FormulaElement oldFormulaElement = formula.getFormulaTree();

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveBackwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveBackwardBrick.java
@@ -70,6 +70,11 @@ public class DroneMoveBackwardBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.DRONE_TIME_TO_FLY_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createDroneMoveBackwardAction(sprite,
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveDownBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveDownBrick.java
@@ -70,6 +70,11 @@ public class DroneMoveDownBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.DRONE_TIME_TO_FLY_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createDroneMoveDownAction(sprite,
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveForwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveForwardBrick.java
@@ -70,6 +70,11 @@ public class DroneMoveForwardBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.DRONE_TIME_TO_FLY_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createDroneMoveForwardAction(sprite,
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveLeftBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveLeftBrick.java
@@ -70,6 +70,11 @@ public class DroneMoveLeftBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.DRONE_TIME_TO_FLY_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createDroneMoveLeftAction(sprite,
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveRightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveRightBrick.java
@@ -70,6 +70,11 @@ public class DroneMoveRightBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.DRONE_TIME_TO_FLY_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createDroneMoveRightAction(sprite,
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveUpBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneMoveUpBrick.java
@@ -70,6 +70,11 @@ public class DroneMoveUpBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.DRONE_TIME_TO_FLY_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createDroneMoveUpAction(sprite,
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnLeftBrick.java
@@ -70,6 +70,11 @@ public class DroneTurnLeftBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.DRONE_TIME_TO_FLY_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createDroneTurnLeftAction(sprite,
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/DroneTurnRightBrick.java
@@ -70,6 +70,11 @@ public class DroneTurnRightBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.DRONE_TIME_TO_FLY_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createDroneTurnRightAction(sprite,
 				getFormulaWithBrickField(BrickField.DRONE_TIME_TO_FLY_IN_SECONDS),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
@@ -137,8 +137,12 @@ public abstract class FormulaBrick extends BrickBaseType implements View.OnClick
 		if (brickFieldToTextViewIdMap.inverse().containsKey(view.getId())) {
 			FormulaEditorFragment.showFragment(view.getContext(), this, brickFieldToTextViewIdMap.inverse().get(view.getId()));
 		} else {
-			FormulaEditorFragment.showFragment(view.getContext(), this, formulaMap.keys().nextElement());
+			FormulaEditorFragment.showFragment(view.getContext(), this, getDefaultBrickField());
 		}
+	}
+
+	protected BrickField getDefaultBrickField() {
+		return formulaMap.keys().nextElement();
 	}
 
 	public View getCustomView(Context context) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/GlideToBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/GlideToBrick.java
@@ -68,6 +68,11 @@ public class GlideToBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.DURATION_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createGlideToAction(sprite,
 				getFormulaWithBrickField(BrickField.X_DESTINATION),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/InsertItemIntoUserListBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/InsertItemIntoUserListBrick.java
@@ -57,6 +57,11 @@ public class InsertItemIntoUserListBrick extends UserListBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.INSERT_ITEM_INTO_USERLIST_VALUE;
+	}
+
+	@Override
 	public int getViewResource() {
 		return R.layout.brick_insert_item_into_userlist;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveBackwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveBackwardBrick.java
@@ -61,6 +61,11 @@ public class JumpingSumoMoveBackwardBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.JUMPING_SUMO_TIME_TO_DRIVE_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createJumpingSumoMoveBackwardAction(sprite,
 				getFormulaWithBrickField(BrickField.JUMPING_SUMO_TIME_TO_DRIVE_IN_SECONDS),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveForwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/JumpingSumoMoveForwardBrick.java
@@ -61,6 +61,11 @@ public class JumpingSumoMoveForwardBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.JUMPING_SUMO_TIME_TO_DRIVE_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createJumpingSumoMoveForwardAction(sprite,
 				getFormulaWithBrickField(BrickField.JUMPING_SUMO_TIME_TO_DRIVE_IN_SECONDS),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3PlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoEv3PlayToneBrick.java
@@ -72,6 +72,11 @@ public class LegoEv3PlayToneBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.LEGO_EV3_DURATION_IN_SECONDS;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createLegoEv3PlayToneAction(sprite,
 				getFormulaWithBrickField(BrickField.LEGO_EV3_FREQUENCY),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtPlayToneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/LegoNxtPlayToneBrick.java
@@ -57,6 +57,11 @@ public class LegoNxtPlayToneBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.LEGO_NXT_DURATION_IN_SECONDS;
+	}
+
+	@Override
 	public View getView(Context context) {
 		super.getView(context);
 		setSecondsLabel(view, BrickField.LEGO_NXT_DURATION_IN_SECONDS);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroRGBLightBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroRGBLightBrick.java
@@ -112,6 +112,11 @@ public class PhiroRGBLightBrick extends FormulaBrick {
 		}
 	}
 
+	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.PHIRO_LIGHT_RED;
+	}
+
 	private boolean areAllBrickFieldsNumbers() {
 		return (getFormulaWithBrickField(BrickField.PHIRO_LIGHT_RED).getRoot().getElementType()
 				== FormulaElement.ElementType.NUMBER)

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaceAtBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PlaceAtBrick.java
@@ -38,6 +38,11 @@ public class PlaceAtBrick extends FormulaBrick {
 		addAllowedBrickField(BrickField.Y_POSITION, R.id.brick_place_at_edit_text_y);
 	}
 
+	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.X_POSITION;
+	}
+
 	public PlaceAtBrick(int xPositionValue, int yPositionValue) {
 		this(new Formula(xPositionValue), new Formula(yPositionValue));
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiPwmBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiPwmBrick.java
@@ -62,6 +62,11 @@ public class RaspiPwmBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.RASPI_DIGITAL_PIN_NUMBER;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createSendRaspiPwmValueAction(sprite,
 				getFormulaWithBrickField(BrickField.RASPI_DIGITAL_PIN_NUMBER),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiSendDigitalValueBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RaspiSendDigitalValueBrick.java
@@ -60,6 +60,11 @@ public class RaspiSendDigitalValueBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.RASPI_DIGITAL_PIN_NUMBER;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createSendDigitalRaspiValueAction(sprite,
 				getFormulaWithBrickField(BrickField.RASPI_DIGITAL_PIN_NUMBER),

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ReplaceItemInUserListBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ReplaceItemInUserListBrick.java
@@ -57,6 +57,11 @@ public class ReplaceItemInUserListBrick extends UserListBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.REPLACE_ITEM_IN_USERLIST_INDEX;
+	}
+
+	@Override
 	public int getViewResource() {
 		return R.layout.brick_replace_item_in_userlist;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenColorBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetPenColorBrick.java
@@ -76,6 +76,11 @@ public class SetPenColorBrick extends FormulaBrick {
 		}
 	}
 
+	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.PEN_COLOR_RED;
+	}
+
 	private boolean areAllBrickFieldsNumbers() {
 		return (getFormulaWithBrickField(BrickField.PEN_COLOR_RED).getRoot().getElementType()
 				== FormulaElement.ElementType.NUMBER)

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextBrick.java
@@ -62,6 +62,11 @@ public class ShowTextBrick extends UserVariableBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.X_POSITION;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		if (userVariable == null || userVariable.getName() == null) {
 			userVariable = new UserVariable("NoVariableSet", Constants.NO_VARIABLE_SELECTED);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkForBubbleBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ThinkForBubbleBrick.java
@@ -59,6 +59,11 @@ public class ThinkForBubbleBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.STRING;
+	}
+
+	@Override
 	public View getView(Context context) {
 		super.getView(context);
 		setSecondsLabel(view, BrickField.DURATION_IN_SECONDS);

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetGravityBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetGravityBrick.java
@@ -63,6 +63,11 @@ public class SetGravityBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.PHYSICS_GRAVITY_X;
+	}
+
+	@Override
 	public List<ScriptSequenceAction> addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		sequence.addAction(sprite.getActionFactory().createSetGravityAction(sprite,
 				getFormulaWithBrickField(BrickField.PHYSICS_GRAVITY_X),

--- a/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetVelocityBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/content/bricks/SetVelocityBrick.java
@@ -58,6 +58,11 @@ public class SetVelocityBrick extends FormulaBrick {
 	}
 
 	@Override
+	protected BrickField getDefaultBrickField() {
+		return BrickField.PHYSICS_VELOCITY_X;
+	}
+
+	@Override
 	public int getViewResource() {
 		return R.layout.brick_physics_set_velocity;
 	}


### PR DESCRIPTION
Tap on a brick with multiple formulas to open the menu and select Edit Formula. The Formula Editor opens and the "default formula" will be selected. This formula was once explicitly defined in the code, now isn't (kinda random now, e.g. the default formula of the PlaceAtBrick is Y now).

Simply use the first formula parameter, from the left.