### PR TITLE
CATROID-108 Fix "When becomes true" looses formula

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickCloneTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickCloneTest.java
@@ -30,6 +30,7 @@ import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.WhenConditionScript;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.ChangeBrightnessByNBrick;
 import org.catrobat.catroid.content.bricks.ChangeColorByNBrick;
@@ -64,6 +65,7 @@ import org.catrobat.catroid.content.bricks.TurnRightBrick;
 import org.catrobat.catroid.content.bricks.UserVariableBrick;
 import org.catrobat.catroid.content.bricks.VibrationBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
+import org.catrobat.catroid.content.bricks.WhenConditionBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
@@ -80,6 +82,7 @@ import java.lang.reflect.Constructor;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNotSame;
+import static junit.framework.Assert.assertSame;
 
 @RunWith(AndroidJUnit4.class)
 public class BrickCloneTest {
@@ -189,6 +192,13 @@ public class BrickCloneTest {
 
 		brick = new SpeakBrick(String.valueOf(BRICK_FORMULA_VALUE));
 		brickClone(brick, Brick.BrickField.SPEAK);
+	}
+
+	@Test
+	public void testWhenConditionBrickFormulaMapSameAsWhenConditionScriptFormulaMap() throws CloneNotSupportedException {
+		WhenConditionBrick brickClone =
+				(WhenConditionBrick) new WhenConditionBrick(new WhenConditionScript(new Formula(0))).clone();
+		assertSame(brickClone.getFormulaMap(), ((WhenConditionScript) brickClone.getScript()).getFormulaMap());
 	}
 
 	@Test

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.content.bricks;
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.support.annotation.CallSuper;
+import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
@@ -114,6 +115,11 @@ public abstract class FormulaBrick extends BrickBaseType implements View.OnClick
 
 	public List<Formula> getFormulas() {
 		return new ArrayList<>(formulaMap.values());
+	}
+
+	@VisibleForTesting
+	public ConcurrentFormulaHashMap getFormulaMap() {
+		return formulaMap;
 	}
 
 	public TextView getTextView(BrickField brickField) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenConditionBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenConditionBrick.java
@@ -53,6 +53,7 @@ public class WhenConditionBrick extends FormulaBrick implements ScriptBrick {
 		WhenConditionBrick clone = (WhenConditionBrick) super.clone();
 		clone.script = (WhenConditionScript) script.clone();
 		clone.script.setScriptBrick(clone);
+		clone.formulaMap = clone.script.getFormulaMap();
 		return clone;
 	}
 


### PR DESCRIPTION
WhenConditionBrick has a ConcurrentFormulaHashMap because it's extended
from Formula. WhenConditionScript has a ConcurrentFormulaHashMap because
the map is serialized. To work correctly, both members have to point to
the same instance.

When cloning a WhenConditionBrick, these two members pointed to
different ConcurrentFormulaHashMap thus causing CATROID-108.
___
- You can find the same info but a little more detailed (or phrased differently) at [CATROID-108](https://jira.catrob.at/browse/CATROID-108).
- Feel free to comment(criticize) on the test implementation :wink: 

Please consider a fix for [CATROID-108](https://jira.catrob.at/browse/CATROID-108) for the next release :grimacing: