### PR TITLE
CATROID-120, JENKINS-274 Add Jenkinsfile to build all flavours and archive them.

### DIFF
--- a/Jenkinsfile.buildDebugApks
+++ b/Jenkinsfile.buildDebugApks
@@ -1,0 +1,85 @@
+#!groovy
+
+pipeline {
+    agent {
+        dockerfile {
+            filename 'Dockerfile.jenkins'
+            // 'docker build' would normally copy the whole build-dir to the container, changing the
+            // docker build directory avoids that overhead
+            dir 'docker'
+            // Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
+            // corresponding user can be added. This is needed to provide the jenkins user inside
+            // the container for the ssh-agent to work.
+            // Another way would be to simply map the passwd file, but would spoil additional information
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
+            args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+        }
+    }
+
+    environment {
+        //////// Define environment variables to point to the correct locations inside the container ////////
+        //////////// Most likely not edited by the developer
+        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
+        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
+        ANDROID_HOME = "/usr/local/android-sdk"
+        ANDROID_SDK_HOME = "/"
+        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
+        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
+        ANDROID_NDK = ""
+        // This is important, as we want the keep our gradle cache, but we can't share it between containers
+        // the cache could only be shared if the gradle instances could comunicate with each other
+        // imho keeping the cache per executor will have the least space impact
+        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
+        // Otherwise user.home returns ? for java applications
+        JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
+
+        //////// Build specific variables ////////
+        //////////// May be edited by the developer on changing the build steps
+    }
+
+    options {
+        timeout(time: 2, unit: 'HOURS')
+        timestamps()
+    }
+
+    stages {
+        stage('Prepare build') {
+            steps {
+                script {
+                    currentBuild.description = """
+<ul>
+    <li>Repository: $REPO</li>
+    <li>Branch: $BRANCH</li>
+</ul>"""
+                }
+            }
+        }
+
+        stage('Setup Android SDK') {
+            steps {
+                lock("update-android-sdk-on-${env.NODE_NAME}") {
+                    sh './gradlew -PinstallSdk'
+                }
+            }
+        }
+
+        stage('Independent-APKs') {
+            steps {
+                sh "./gradlew assembleDebug -Pindependent='#$BUILD_NUMBER $BRANCH'"
+                archiveArtifacts '**/*.apk'
+            }
+
+        }
+    }
+
+    post {
+        always {
+            step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
+
+            // Send notifications with standalone=false
+            script {
+                sendNotifications false
+            }
+        }
+    }
+}


### PR DESCRIPTION
The APKs can be installed independently of the released APKs since they
have a name based on the branch that was built.