### PR TITLE
JENKINS-273 Avoid Jenkins errors on emulator crashes.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,7 +99,7 @@ pipeline {
 				// Convert the JaCoCo coverate to the Cobertura XML file format.
 				// This is done since the Jenkins JaCoCo plugin does not work well.
 				// See also JENKINS-212 on jira.catrob.at
-				sh "if [ -f '$JACOCO_UNIT_XML' ]; then ./buildScripts/cover2cover.py $JACOCO_UNIT_XML > $JAVA_SRC/coverage1.xml; fi"
+				sh "./buildScripts/cover2cover.py $JACOCO_UNIT_XML $JAVA_SRC/coverage1.xml"
 
 				// Run device tests for package: org.catrobat.catroid.test
 				sh '''./gradlew -PenableCoverage -Pemulator=android24 startEmulator createCatroidDebugAndroidTestCoverageReport \
@@ -107,7 +107,7 @@ pipeline {
 				// Convert the JaCoCo coverate to the Cobertura XML file format.
 				// This is done since the Jenkins JaCoCo plugin does not work well.
 				// See also JENKINS-212 on jira.catrob.at
-				sh "if [ -f '$JACOCO_XML' ]; then ./buildScripts/cover2cover.py $JACOCO_XML > $JAVA_SRC/coverage2.xml; fi"
+				sh "./buildScripts/cover2cover.py $JACOCO_XML $JAVA_SRC/coverage2.xml"
 				// ensure that the following test run does not overwrite the results
 				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results1"
 
@@ -117,7 +117,7 @@ pipeline {
 				// Convert the JaCoCo coverate to the Cobertura XML file format.
 				// This is done since the Jenkins JaCoCo plugin does not work well.
 				// See also JENKINS-212 on jira.catrob.at
-				sh "if [ -f '$JACOCO_XML' ]; then ./buildScripts/cover2cover.py $JACOCO_XML > $JAVA_SRC/coverage3.xml; fi"
+				sh "./buildScripts/cover2cover.py $JACOCO_XML $JAVA_SRC/coverage3.xml"
 				// ensure that the following test run does not overwrite the results
 				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results2"
 			}
@@ -140,7 +140,7 @@ pipeline {
 							startEmulator createCatroidDebugAndroidTestCoverageReport \
 							-Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.QuarantineTestSuite'''
 				archiveArtifacts "$JACOCO_XML"
-				sh "if [ -f '$JACOCO_XML' ]; then ./buildScripts/cover2cover.py $JACOCO_XML > $JAVA_SRC/coverage4.xml; fi"
+				sh "./buildScripts/cover2cover.py $JACOCO_XML $JAVA_SRC/coverage4.xml"
 
 			}
 

--- a/buildScripts/log_parser_rules
+++ b/buildScripts/log_parser_rules
@@ -3,3 +3,4 @@
 
 error /(?i)Instrumentation run failed due/
 error /(?i)ddmlib.*Exception/
+error /Cobertura conversion failed/


### PR DESCRIPTION
Issue
=====
When the emulator crashes the cover2cover.py script fails.
This leads to a corrupt coverage.xml file and skipping all following steps
in the current stage.
So following build steps are not executed, even if they might succeed.
This is inconsistent: Gradle itself is configured to ignore failed tests,
it also ignores emulator crashes.

Also at the end of the build the cobertura step in the post-block of the
Jenkinsfile fails. Any succeeding steps are skipped here as well.

Solution
========
* More handling is moved to cover2cover.py not only simplifying the Jenkinsile
  but also ensuring that the resulting coverage.xml file is valid.
* cover2cover.py always has an exit code of 0, even if the input
  xml file was corrupt.
* The log parser rules are adapted to detect failures of the cover2cover script.