### PR TITLE
CATROID-124 Split script when dragging empty script 

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/ui/brickadapter/BrickAdapterDragAndDropTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/ui/brickadapter/BrickAdapterDragAndDropTest.java
@@ -28,6 +28,7 @@ import android.support.test.runner.AndroidJUnit4;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.WhenConditionScript;
 import org.catrobat.catroid.content.WhenScript;
 import org.catrobat.catroid.content.WhenTouchDownScript;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -103,9 +104,12 @@ public class BrickAdapterDragAndDropTest {
 		whenScript.addBrick(new SetXBrick());
 		whenScript.addBrick(new SetYBrick());
 
+		WhenConditionScript whenConditionScript = new WhenConditionScript();
+
 		sprite.addScript(startScript);
 		sprite.addScript(touchDownScript);
 		sprite.addScript(whenScript);
+		sprite.addScript(whenConditionScript);
 
 		adapter = new BrickAdapter(sprite);
 	}
@@ -174,8 +178,62 @@ public class BrickAdapterDragAndDropTest {
 		assertTrue(adapter.onItemMove(10, 9));
 		assertTrue(adapter.onItemMove(9, 8));
 
-		adapter.moveItemsTo(9, bricksToMove);
+		adapter.moveItemsTo(8, bricksToMove);
 		assertEquals(1, sprite.getScriptIndex(scriptToMove));
+	}
+
+	@Test
+	public void testDragScriptBrickIntoOtherScriptWithoutControlStructure() {
+		Script scriptToMove = sprite.getScript(3);
+		Script scriptToSplit = sprite.getScript(2);
+
+		SetYBrick brickToTakeOverFromOtherScript = (SetYBrick) sprite.getScript(2).getBrickList().get(1);
+
+		List<Brick> bricksInScript = scriptToMove.getBrickList();
+
+		assertTrue(bricksInScript.isEmpty());
+
+		List<BrickBaseType> bricksToMove = new ArrayList<>();
+		bricksToMove.add((BrickBaseType) scriptToMove.getScriptBrick());
+
+		assertTrue(adapter.onItemMove(15, 14));
+
+		adapter.moveItemsTo(14, bricksToMove);
+		assertEquals(3, sprite.getScriptIndex(scriptToMove));
+		assertTrue(scriptToMove.containsBrick(brickToTakeOverFromOtherScript));
+		assertFalse(scriptToSplit.containsBrick(brickToTakeOverFromOtherScript));
+	}
+
+	@Test
+	public void testDragScriptBrickIntoOtherScriptWithControlStructure() {
+		Script scriptToMove = sprite.getScript(3);
+		Script scriptToSplit = sprite.getScript(0);
+
+		List<Brick> bricksInScript = scriptToMove.getBrickList();
+
+		List<Brick> bricksToTakeOverFromOtherScript = new ArrayList<>();
+		bricksToTakeOverFromOtherScript.add(scriptToSplit.getBrick(5));
+		bricksToTakeOverFromOtherScript.add(scriptToSplit.getBrick(6));
+		bricksToTakeOverFromOtherScript.add(scriptToSplit.getBrick(7));
+
+		assertTrue(bricksInScript.isEmpty());
+
+		List<BrickBaseType> bricksToMove = new ArrayList<>();
+		bricksToMove.add((BrickBaseType) scriptToMove.getScriptBrick());
+
+		assertTrue(adapter.onItemMove(12, 11));
+		assertTrue(adapter.onItemMove(11, 10));
+		assertTrue(adapter.onItemMove(10, 9));
+		assertTrue(adapter.onItemMove(9, 8));
+		assertTrue(adapter.onItemMove(8, 7));
+		assertTrue(adapter.onItemMove(7, 6));
+		assertTrue(adapter.onItemMove(6, 5));
+
+		adapter.moveItemsTo(5, bricksToMove);
+		assertEquals(2, sprite.getScriptIndex(scriptToMove));
+
+		assertTrue(scriptToMove.getBrickList().containsAll(bricksToTakeOverFromOtherScript));
+		assertFalse(scriptToSplit.getBrickList().containsAll(bricksToTakeOverFromOtherScript));
 	}
 
 	@Test

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/BrickAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/BrickAdapter.java
@@ -63,6 +63,7 @@ public class BrickAdapter extends BaseAdapter implements BrickAdapterInterface,
 	@Retention(RetentionPolicy.SOURCE)
 	@IntDef({NONE, ALL, SCRIPTS_ONLY})
 	@interface CheckBoxMode {}
+
 	public static final int NONE = 0;
 	public static final int ALL = 1;
 	public static final int SCRIPTS_ONLY = 2;
@@ -299,8 +300,32 @@ public class BrickAdapter extends BaseAdapter implements BrickAdapterInterface,
 
 		BrickBaseType firstBrickInItemsToMove = itemsToMove.get(0);
 		if (firstBrickInItemsToMove instanceof ScriptBrick) {
+
 			Script scriptToInsert = ((ScriptBrick) firstBrickInItemsToMove).getScript();
+			Script scriptAtPosition = getScriptAtPosition(position - 1);
 			scripts.remove(scriptToInsert);
+
+			boolean divideScriptAtPositionAndAddBricksToMovingScript = itemsToMove.size() == 1
+					&& !scriptAtPosition.getBrickList().isEmpty();
+
+			if (divideScriptAtPositionAndAddBricksToMovingScript) {
+				List<Brick> bricksOfScriptAtPosition = scriptAtPosition.getBrickList();
+
+				int positionToDivideScriptAt = getPositionWithinScript(position, scriptAtPosition);
+
+				for (int i = 0; i < positionToDivideScriptAt; i++) {
+					BrickBaseType brick = (BrickBaseType) bricksOfScriptAtPosition.get(i);
+					if (brick instanceof ControlStructureBrick) {
+						positionToDivideScriptAt = bricksOfScriptAtPosition
+								.indexOf(((ControlStructureBrick) brick).getLastBrick()) + 1;
+					}
+				}
+
+				while (positionToDivideScriptAt < bricksOfScriptAtPosition.size()) {
+					scriptToInsert.addBrick(bricksOfScriptAtPosition.get(positionToDivideScriptAt));
+					bricksOfScriptAtPosition.remove(positionToDivideScriptAt);
+				}
+			}
 
 			int whereToInsertScript = getPositionToInsertScript((ScriptBrick) firstBrickInItemsToMove);
 			if (whereToInsertScript == scripts.size()) {


### PR DESCRIPTION
 - when the user drags an empty script by its script brick and
   adds it somewhere in another script, this other script is split
   at the next possible (after nested brick - i.e. control structures)
   position (similar to the bahavior before scripts were draggable).