### PR TITLE
CATROID-123, JENKINS-277 Add support for multiple hardware sensor boxes.

### DIFF
--- a/Jenkinsfile.SensorboxTests
+++ b/Jenkinsfile.SensorboxTests
@@ -54,7 +54,7 @@ pipeline {
 
         stage('Unit and Device tests') {
             steps {
-                lock("run-sensorbox-tests-on-${env.NODE_NAME}") {
+                lock(resource: null, label: "HardwareSensorBox-${env.NODE_NAME}", quantity: 1, variable: 'ANDROID_SERIAL') {
                     sh './gradlew -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.SensorboxTestSuite connectedCatroidDebugAndroidTest'
                 }
             }


### PR DESCRIPTION
Initial Issue
=============
Initially there was only support for one HardwareSensorBox and even just one
Android device per slave.
This was due to the ANDROID_SERIAL being set on the Slave itself.

Adding further devices would be very complicated in such a setup, as the
ANDROID_SERIAL would have to be set to a different value.

Solution
========
The solution is to create one resource per device in "Configure System" of Jenkins.
This resource has the Android serial as its name.

Then it has two labels
* HardwareSensorBox-${NAME_OF_SLAVE_THE_RESOURCE_IS_PRESENT_ON},
  e.g. HardwareSensorBox-Slave1-HardwareSensorBox, to run tests on the
  hardware sensor box.
* AndroidDevice-${NAME_OF_SLAVE_THE_RESOURCE_IS_PRESENT_ON},
  e.g. AndroidDevice-Slave1-HardwareSensorBox, to run tests directly on
  Android devices instead of the emulator.

Inside the Jenkinsfile one resource is requested based on the label, which
automatically picks a free resource with the associated label.
That allows to have multiple resources (Android serials) with the same label.

Of course slaves with attached hardware boxes still need the HardwareSensorBox label.