### PR TITLE
CATROID-129, JENKINS-278 - Cleanup Jenkinsfiles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,7 @@ pipeline {
             // It checks that the job builds with the parameters to have unique APKs, reducing the risk of breaking gradle changes.
             // The resulting APK is not verified on itself.
             steps {
-                sh "./gradlew assembleCatroidDebug -Pindependent='#$BUILD_NUMBER $BRANCH_NAME'"
+                sh "./gradlew assembleCatroidDebug -Pindependent='#$env.BUILD_NUMBER $env.BRANCH_NAME'"
                 archiveArtifacts "${env.APK_LOCATION_DEBUG}"
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,11 +169,9 @@ pipeline {
             junit '**/*TEST*.xml'
             cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: "$javaSrc/coverage*.xml", failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false, failNoReports: false
             step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
-
-            // Send notifications with standalone=false
-            script {
-                sendNotifications false
-            }
+        }
+        changed {
+            notifyChat()
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,187 +1,187 @@
 #!groovy
 
 pipeline {
-	agent {
-		dockerfile {
-			filename 'Dockerfile.jenkins'
-			// 'docker build' would normally copy the whole build-dir to the container, changing the
-			// docker build directory avoids that overhead
-			dir 'docker'
-			// Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
-			// corresponding user can be added. This is needed to provide the jenkins user inside
-			// the container for the ssh-agent to work.
-			// Another way would be to simply map the passwd file, but would spoil additional information
-			additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-			// Currently there are two different NDK behaviors in place, one to keep NDK r16b, which
-			// was needed because of the removal of armeabi and MIPS support and one to always use the
-			// latest NDK, which is the suggestion from the NDK documentations.
-			// Therefore two different SDK locations on the host are currently in place:
-			// NDK r16b  : /var/local/container_shared/android-sdk
-			// NDK latest: /var/local/container_shared/android-sdk-ndk-latest
-			// As android-sdk was used from the beginning and is already 'released' this can't be changed
-			// to eg android-sdk-ndk-r16b and must be kept to the previously used value
-			args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk-ndk-latest:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
-		}
-	}
+    agent {
+        dockerfile {
+            filename 'Dockerfile.jenkins'
+            // 'docker build' would normally copy the whole build-dir to the container, changing the
+            // docker build directory avoids that overhead
+            dir 'docker'
+            // Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
+            // corresponding user can be added. This is needed to provide the jenkins user inside
+            // the container for the ssh-agent to work.
+            // Another way would be to simply map the passwd file, but would spoil additional information
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
+            // Currently there are two different NDK behaviors in place, one to keep NDK r16b, which
+            // was needed because of the removal of armeabi and MIPS support and one to always use the
+            // latest NDK, which is the suggestion from the NDK documentations.
+            // Therefore two different SDK locations on the host are currently in place:
+            // NDK r16b  : /var/local/container_shared/android-sdk
+            // NDK latest: /var/local/container_shared/android-sdk-ndk-latest
+            // As android-sdk was used from the beginning and is already 'released' this can't be changed
+            // to eg android-sdk-ndk-r16b and must be kept to the previously used value
+            args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk-ndk-latest:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+        }
+    }
 
-	environment {
-		//////// Define environment variables to point to the correct locations inside the container ////////
-		//////////// Most likely not edited by the developer
-		ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-		// Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-		ANDROID_HOME = "/usr/local/android-sdk"
-		ANDROID_SDK_HOME = "/"
-		// Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
-		ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-		ANDROID_NDK = ""
-		// This is important, as we want the keep our gradle cache, but we can't share it between containers
-		// the cache could only be shared if the gradle instances could comunicate with each other
-		// imho keeping the cache per executor will have the least space impact
-		GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-		// Otherwise user.home returns ? for java applications
-		JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
+    environment {
+        //////// Define environment variables to point to the correct locations inside the container ////////
+        //////////// Most likely not edited by the developer
+        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
+        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
+        ANDROID_HOME = "/usr/local/android-sdk"
+        ANDROID_SDK_HOME = "/"
+        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
+        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
+        ANDROID_NDK = ""
+        // This is important, as we want the keep our gradle cache, but we can't share it between containers
+        // the cache could only be shared if the gradle instances could comunicate with each other
+        // imho keeping the cache per executor will have the least space impact
+        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
+        // Otherwise user.home returns ? for java applications
+        JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
 
-		//////// Build specific variables ////////
-		//////////// May be edited by the developer on changing the build steps
-		// modulename
-		GRADLE_PROJECT_MODULE_NAME = "catroid"
+        //////// Build specific variables ////////
+        //////////// May be edited by the developer on changing the build steps
+        // modulename
+        GRADLE_PROJECT_MODULE_NAME = "catroid"
 
-		// APK build output locations
-		APK_LOCATION_DEBUG = "${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/apk/catroid/debug/catroid-catroid-debug.apk"
-		APK_LOCATION_STANDALONE = "${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/apk/standalone/debug/catroid-standalone-debug.apk"
+        // APK build output locations
+        APK_LOCATION_DEBUG = "${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/apk/catroid/debug/catroid-catroid-debug.apk"
+        APK_LOCATION_STANDALONE = "${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/apk/standalone/debug/catroid-standalone-debug.apk"
 
-		JACOCO_XML = "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/coverage/catroid/debug/report.xml"
-		JACOCO_UNIT_XML = "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/jacoco/jacocoTestCatroidDebugUnitTestReport/jacocoTestCatroidDebugUnitTestReport.xml"
+        JACOCO_XML = "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/coverage/catroid/debug/report.xml"
+        JACOCO_UNIT_XML = "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/jacoco/jacocoTestCatroidDebugUnitTestReport/jacocoTestCatroidDebugUnitTestReport.xml"
 
-		// place the cobertura xml relative to the source, so that the source can be found
-		JAVA_SRC = "${env.GRADLE_PROJECT_MODULE_NAME}/src/main/java"
-	}
+        // place the cobertura xml relative to the source, so that the source can be found
+        JAVA_SRC = "${env.GRADLE_PROJECT_MODULE_NAME}/src/main/java"
+    }
 
-	options {
-		timeout(time: 2, unit: 'HOURS')
-		timestamps()
-		buildDiscarder(logRotator(numToKeepStr: '30'))
-	}
+    options {
+        timeout(time: 2, unit: 'HOURS')
+        timestamps()
+        buildDiscarder(logRotator(numToKeepStr: '30'))
+    }
 
-	triggers {
-		cron(env.BRANCH_NAME == 'develop' ? '@midnight' : '')
-		issueCommentTrigger('.*test this please.*')
-	}
+    triggers {
+        cron(env.BRANCH_NAME == 'develop' ? '@midnight' : '')
+        issueCommentTrigger('.*test this please.*')
+    }
 
-	stages {
-		stage('Setup Android SDK') {
-			steps {
-				// Install Android SDK
-				lock("update-android-sdk-on-${env.NODE_NAME}") {
-					sh './gradlew -PinstallSdk'
-				}
-			}
-		}
+    stages {
+        stage('Setup Android SDK') {
+            steps {
+                // Install Android SDK
+                lock("update-android-sdk-on-${env.NODE_NAME}") {
+                    sh './gradlew -PinstallSdk'
+                }
+            }
+        }
 
-		stage('Static Analysis') {
-			steps {
-				sh './gradlew pmd checkstyle lint'
-			}
+        stage('Static Analysis') {
+            steps {
+                sh './gradlew pmd checkstyle lint'
+            }
 
-			post {
-				always {
-					pmd         canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/pmd.xml",        unHealthy: '', unstableTotalAll: '0'
-					checkstyle  canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/checkstyle.xml", unHealthy: '', unstableTotalAll: '0'
-					androidLint canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/lint*.xml",      unHealthy: '', unstableTotalAll: '0'
-				}
-			}
-		}
+            post {
+                always {
+                    pmd         canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/pmd.xml",        unHealthy: '', unstableTotalAll: '0'
+                    checkstyle  canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/checkstyle.xml", unHealthy: '', unstableTotalAll: '0'
+                    androidLint canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "${env.GRADLE_PROJECT_MODULE_NAME}/build/reports/lint*.xml",      unHealthy: '', unstableTotalAll: '0'
+                }
+            }
+        }
 
-		stage('Unit and Device tests') {
-			steps {
-				// Run local unit tests
-				sh './gradlew -PenableCoverage jacocoTestCatroidDebugUnitTestReport'
-				// Convert the JaCoCo coverate to the Cobertura XML file format.
-				// This is done since the Jenkins JaCoCo plugin does not work well.
-				// See also JENKINS-212 on jira.catrob.at
-				sh "./buildScripts/cover2cover.py $JACOCO_UNIT_XML $JAVA_SRC/coverage1.xml"
+        stage('Unit and Device tests') {
+            steps {
+                // Run local unit tests
+                sh './gradlew -PenableCoverage jacocoTestCatroidDebugUnitTestReport'
+                // Convert the JaCoCo coverate to the Cobertura XML file format.
+                // This is done since the Jenkins JaCoCo plugin does not work well.
+                // See also JENKINS-212 on jira.catrob.at
+                sh "./buildScripts/cover2cover.py $JACOCO_UNIT_XML $JAVA_SRC/coverage1.xml"
 
-				// Run device tests for package: org.catrobat.catroid.test
-				sh '''./gradlew -PenableCoverage -Pemulator=android24 startEmulator createCatroidDebugAndroidTestCoverageReport \
-							-Pandroid.testInstrumentationRunnerArguments.package=org.catrobat.catroid.test'''
-				// Convert the JaCoCo coverate to the Cobertura XML file format.
-				// This is done since the Jenkins JaCoCo plugin does not work well.
-				// See also JENKINS-212 on jira.catrob.at
-				sh "./buildScripts/cover2cover.py $JACOCO_XML $JAVA_SRC/coverage2.xml"
-				// ensure that the following test run does not overwrite the results
-				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results1"
+                // Run device tests for package: org.catrobat.catroid.test
+                sh '''./gradlew -PenableCoverage -Pemulator=android24 startEmulator createCatroidDebugAndroidTestCoverageReport \
+                            -Pandroid.testInstrumentationRunnerArguments.package=org.catrobat.catroid.test'''
+                // Convert the JaCoCo coverate to the Cobertura XML file format.
+                // This is done since the Jenkins JaCoCo plugin does not work well.
+                // See also JENKINS-212 on jira.catrob.at
+                sh "./buildScripts/cover2cover.py $JACOCO_XML $JAVA_SRC/coverage2.xml"
+                // ensure that the following test run does not overwrite the results
+                sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results1"
 
-				// Run device tests for class: org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite
-				sh '''./gradlew -PenableCoverage -Pemulator=android24 startEmulator createCatroidDebugAndroidTestCoverageReport \
-							-Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite'''
-				// Convert the JaCoCo coverate to the Cobertura XML file format.
-				// This is done since the Jenkins JaCoCo plugin does not work well.
-				// See also JENKINS-212 on jira.catrob.at
-				sh "./buildScripts/cover2cover.py $JACOCO_XML $JAVA_SRC/coverage3.xml"
-				// ensure that the following test run does not overwrite the results
-				sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results2"
-			}
+                // Run device tests for class: org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite
+                sh '''./gradlew -PenableCoverage -Pemulator=android24 startEmulator createCatroidDebugAndroidTestCoverageReport \
+                            -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite'''
+                // Convert the JaCoCo coverate to the Cobertura XML file format.
+                // This is done since the Jenkins JaCoCo plugin does not work well.
+                // See also JENKINS-212 on jira.catrob.at
+                sh "./buildScripts/cover2cover.py $JACOCO_XML $JAVA_SRC/coverage3.xml"
+                // ensure that the following test run does not overwrite the results
+                sh "mv ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results ${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/androidTest-results2"
+            }
 
-			post {
-				always {
-					sh './gradlew stopEmulator clearAvdStore'
-					archiveArtifacts 'logcat.txt'
-				}
-			}
-		}
+            post {
+                always {
+                    sh './gradlew stopEmulator clearAvdStore'
+                    archiveArtifacts 'logcat.txt'
+                }
+            }
+        }
 
-		stage('Quarantined Tests') {
-			when {
-				expression { isJobStartedByTimer() }
-			}
+        stage('Quarantined Tests') {
+            when {
+                expression { isJobStartedByTimer() }
+            }
 
-			steps {
-				sh '''./gradlew -PenableCoverage -PlogcatFile=quarantined_logcat.txt -Pemulator=android24 \
-							startEmulator createCatroidDebugAndroidTestCoverageReport \
-							-Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.QuarantineTestSuite'''
-				archiveArtifacts "$JACOCO_XML"
-				sh "./buildScripts/cover2cover.py $JACOCO_XML $JAVA_SRC/coverage4.xml"
+            steps {
+                sh '''./gradlew -PenableCoverage -PlogcatFile=quarantined_logcat.txt -Pemulator=android24 \
+                            startEmulator createCatroidDebugAndroidTestCoverageReport \
+                            -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.QuarantineTestSuite'''
+                archiveArtifacts "$JACOCO_XML"
+                sh "./buildScripts/cover2cover.py $JACOCO_XML $JAVA_SRC/coverage4.xml"
 
-			}
+            }
 
-			post {
-				always {
-					sh './gradlew stopEmulator clearAvdStore'
-					archiveArtifacts 'quarantined_logcat.txt'
-				}
-			}
-		}
+            post {
+                always {
+                    sh './gradlew stopEmulator clearAvdStore'
+                    archiveArtifacts 'quarantined_logcat.txt'
+                }
+            }
+        }
 
-		stage('Standalone-APK') {
-			// It checks that the creation of standalone APKs (APK for a Pocketcode app) works, reducing the risk of breaking gradle changes.
-			// The resulting APK is not verified itself.
-			steps {
-				sh '''./gradlew assembleStandaloneDebug -Papk_generator_enabled=true -Psuffix=generated817.catrobat \
-							-Pdownload='https://share.catrob.at/pocketcode/download/817.catrobat' '''
-				archiveArtifacts "${env.APK_LOCATION_STANDALONE}"
-			}
-		}
+        stage('Standalone-APK') {
+            // It checks that the creation of standalone APKs (APK for a Pocketcode app) works, reducing the risk of breaking gradle changes.
+            // The resulting APK is not verified itself.
+            steps {
+                sh '''./gradlew assembleStandaloneDebug -Papk_generator_enabled=true -Psuffix=generated817.catrobat \
+                            -Pdownload='https://share.catrob.at/pocketcode/download/817.catrobat' '''
+                archiveArtifacts "${env.APK_LOCATION_STANDALONE}"
+            }
+        }
 
-		stage('Independent-APK') {
-			// It checks that the job builds with the parameters to have unique APKs, reducing the risk of breaking gradle changes.
-			// The resulting APK is not verified on itself.
-			steps {
-				sh "./gradlew assembleCatroidDebug -Pindependent='#$BUILD_NUMBER $BRANCH_NAME'"
-				archiveArtifacts "${env.APK_LOCATION_DEBUG}"
-			}
-		}
-	}
+        stage('Independent-APK') {
+            // It checks that the job builds with the parameters to have unique APKs, reducing the risk of breaking gradle changes.
+            // The resulting APK is not verified on itself.
+            steps {
+                sh "./gradlew assembleCatroidDebug -Pindependent='#$BUILD_NUMBER $BRANCH_NAME'"
+                archiveArtifacts "${env.APK_LOCATION_DEBUG}"
+            }
+        }
+    }
 
-	post {
-		always {
-			junit '**/*TEST*.xml'
-			cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: "$JAVA_SRC/coverage*.xml", failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false, failNoReports: false
-			step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
+    post {
+        always {
+            junit '**/*TEST*.xml'
+            cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: "$JAVA_SRC/coverage*.xml", failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false, failNoReports: false
+            step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
 
-			// Send notifications with standalone=false
-			script {
-				sendNotifications false
-			}
-		}
-	}
+            // Send notifications with standalone=false
+            script {
+                sendNotifications false
+            }
+        }
+    }
 }

--- a/Jenkinsfile.BuildStandalone
+++ b/Jenkinsfile.BuildStandalone
@@ -1,76 +1,76 @@
 #!groovy
 
 pipeline {
-	agent {
-		dockerfile {
-			filename 'Dockerfile.jenkins'
-			// 'docker build' would normally copy the whole build-dir to the container, changing the
-			// docker build directory avoids that overhead
-			dir 'docker'
-			// Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
-			// corresponding user can be added. This is needed to provide the jenkins user inside
-			// the container for the ssh-agent to work.
-			// Another way would be to simply map the passwd file, but would spoil additional information
-			additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-			args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
-			// Add specific 'Standalone'-label, so it can be made sure, that there is a dedicated host for standalone builds
-			label 'Standalone'
-		}
-	}
+    agent {
+        dockerfile {
+            filename 'Dockerfile.jenkins'
+            // 'docker build' would normally copy the whole build-dir to the container, changing the
+            // docker build directory avoids that overhead
+            dir 'docker'
+            // Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
+            // corresponding user can be added. This is needed to provide the jenkins user inside
+            // the container for the ssh-agent to work.
+            // Another way would be to simply map the passwd file, but would spoil additional information
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
+            args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+            // Add specific 'Standalone'-label, so it can be made sure, that there is a dedicated host for standalone builds
+            label 'Standalone'
+        }
+    }
 
-	environment {
-		//////// Define environment variables to point to the correct locations inside the container ////////
-		//////////// Most likely not edited by the developer
-		ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-		// Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-		ANDROID_HOME = "/usr/local/android-sdk"
-		ANDROID_SDK_HOME = "/"
-		// Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
-		ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-		ANDROID_NDK = ""
-		// This is important, as we want the keep our gradle cache, but we can't share it between containers
-		// the cache could only be shared if the gradle instances could comunicate with each other
-		// imho keeping the cache per executor will have the least space impact
-		GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-		// Otherwise user.home returns ? for java applications
-		JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
+    environment {
+        //////// Define environment variables to point to the correct locations inside the container ////////
+        //////////// Most likely not edited by the developer
+        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
+        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
+        ANDROID_HOME = "/usr/local/android-sdk"
+        ANDROID_SDK_HOME = "/"
+        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
+        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
+        ANDROID_NDK = ""
+        // This is important, as we want the keep our gradle cache, but we can't share it between containers
+        // the cache could only be shared if the gradle instances could comunicate with each other
+        // imho keeping the cache per executor will have the least space impact
+        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
+        // Otherwise user.home returns ? for java applications
+        JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
 
-		//////// Build specific variables ////////
-		//////////// May be edited by the developer on changing the build steps
-		// modulename
-		GRADLE_PROJECT_MODULE_NAME = "catroid"
+        //////// Build specific variables ////////
+        //////////// May be edited by the developer on changing the build steps
+        // modulename
+        GRADLE_PROJECT_MODULE_NAME = "catroid"
 
-		// APK build output locations
-		APK_LOCATION_STANDALONE = "${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/apk/standalone/debug/catroid-standalone-debug.apk"
-	}
+        // APK build output locations
+        APK_LOCATION_STANDALONE = "${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/apk/standalone/debug/catroid-standalone-debug.apk"
+    }
 
-	options {
-		timeout(time: 600, unit: 'SECONDS')
-		timestamps()
-	}
+    options {
+        timeout(time: 600, unit: 'SECONDS')
+        timestamps()
+    }
 
-	stages {
-		stage('Prepare build') {
-			steps {
-				script {
-					currentBuild.displayName = "${env.DOWNLOAD}"
-				}
-			}
-		}
+    stages {
+        stage('Prepare build') {
+            steps {
+                script {
+                    currentBuild.displayName = "${env.DOWNLOAD}"
+                }
+            }
+        }
 
-		stage('Setup Android SDK') {
-			steps {
-				// Install Android SDK
-				lock("update-android-sdk-on-${env.NODE_NAME}") {
-					sh './gradlew -PinstallSdk'
-				}
-			}
-		}
+        stage('Setup Android SDK') {
+            steps {
+                // Install Android SDK
+                lock("update-android-sdk-on-${env.NODE_NAME}") {
+                    sh './gradlew -PinstallSdk'
+                }
+            }
+        }
 
-		stage('Check-for-invalid-program-upload') {
-			steps {
-				script {
-					def ret = sh returnStatus: true, script: '''#!/bin/sh
+        stage('Check-for-invalid-program-upload') {
+            steps {
+                script {
+                    def ret = sh returnStatus: true, script: '''#!/bin/sh
 SLEEP_TIME=5
 RETRIES=5
 
@@ -105,64 +105,64 @@ while true; do
 done
 '''
 
-					// if no error, we are done
-					if (ret == 0) {
-						return
-					}
+                    // if no error, we are done
+                    if (ret == 0) {
+                        return
+                    }
 
-					// Handle special error from the script, if the program download was not
-					// possible because of the HTTP error 528, we set the build to UNSTABLE
-					try {
-						error('')
-					} catch (err) {
-						if (ret == 200) {
-							currentBuild.result = 'UNSTABLE'
-						} else {
-							currentBuild.result = 'FAILURE'
-						}
-					}
-				}
-			}
-		}
+                    // Handle special error from the script, if the program download was not
+                    // possible because of the HTTP error 528, we set the build to UNSTABLE
+                    try {
+                        error('')
+                    } catch (err) {
+                        if (ret == 200) {
+                            currentBuild.result = 'UNSTABLE'
+                        } else {
+                            currentBuild.result = 'FAILURE'
+                        }
+                    }
+                }
+            }
+        }
 
-		stage('Build APK') {
-			// needed, as long as we mark the build unstable when we receive the 528 error from WEB
-			when {
-				expression {
-					currentBuild.result == null
-				}
-			}
+        stage('Build APK') {
+            // needed, as long as we mark the build unstable when we receive the 528 error from WEB
+            when {
+                expression {
+                    currentBuild.result == null
+                }
+            }
 
-			steps {
-				sh "./gradlew clean assembleStandaloneDebug -Papk_generator_enabled=true -Psuffix='$SUFFIX' -Pdownload='$DOWNLOAD'"
-				archiveArtifacts "${env.APK_LOCATION_STANDALONE}"
-			}
-		}
+            steps {
+                sh "./gradlew clean assembleStandaloneDebug -Papk_generator_enabled=true -Psuffix='$SUFFIX' -Pdownload='$DOWNLOAD'"
+                archiveArtifacts "${env.APK_LOCATION_STANDALONE}"
+            }
+        }
 
-		stage('Upload to Web') {
-			// needed, as long as we mark the build unstable when we receive the 528 error from WEB
-			when {
-				expression {
-					currentBuild.result == null
-				}
-			}
+        stage('Upload to Web') {
+            // needed, as long as we mark the build unstable when we receive the 528 error from WEB
+            when {
+                expression {
+                    currentBuild.result == null
+                }
+            }
 
-			steps {
-				script {
-					uploadFileToWeb "${env.APK_LOCATION_STANDALONE}", "${env.UPLOAD}"
-				}
-			}
-		}
-	}
+            steps {
+                script {
+                    uploadFileToWeb "${env.APK_LOCATION_STANDALONE}", "${env.UPLOAD}"
+                }
+            }
+        }
+    }
 
-	post {
-		always {
-			step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
+    post {
+        always {
+            step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
 
-			// Send notifications with standalone=true
-			script {
-				sendNotifications true
-			}
-		}
-	}
+            // Send notifications with standalone=true
+            script {
+                sendNotifications true
+            }
+        }
+    }
 }

--- a/Jenkinsfile.BuildStandalone
+++ b/Jenkinsfile.BuildStandalone
@@ -1,5 +1,7 @@
 #!groovy
 
+def standaloneApk = 'catroid/build/outputs/apk/standalone/debug/catroid-standalone-debug.apk'
+
 pipeline {
     agent {
         dockerfile {
@@ -34,14 +36,6 @@ pipeline {
         GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
         // Otherwise user.home returns ? for java applications
         JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
-
-        //////// Build specific variables ////////
-        //////////// May be edited by the developer on changing the build steps
-        // modulename
-        GRADLE_PROJECT_MODULE_NAME = "catroid"
-
-        // APK build output locations
-        APK_LOCATION_STANDALONE = "${env.GRADLE_PROJECT_MODULE_NAME}/build/outputs/apk/standalone/debug/catroid-standalone-debug.apk"
     }
 
     options {
@@ -135,7 +129,7 @@ done
 
             steps {
                 sh "./gradlew clean assembleStandaloneDebug -Papk_generator_enabled=true -Psuffix='$SUFFIX' -Pdownload='$DOWNLOAD'"
-                archiveArtifacts "${env.APK_LOCATION_STANDALONE}"
+                archiveArtifacts standaloneApk
             }
         }
 
@@ -149,7 +143,7 @@ done
 
             steps {
                 script {
-                    uploadFileToWeb "${env.APK_LOCATION_STANDALONE}", "${env.UPLOAD}"
+                    uploadFileToWeb standaloneApk, "${env.UPLOAD}"
                 }
             }
         }

--- a/Jenkinsfile.BuildStandalone
+++ b/Jenkinsfile.BuildStandalone
@@ -64,56 +64,13 @@ pipeline {
         stage('Check-for-invalid-program-upload') {
             steps {
                 script {
-                    def ret = sh returnStatus: true, script: '''#!/bin/sh
-SLEEP_TIME=5
-RETRIES=5
-
-HTTP_STATUS_OK=200
-HTTP_STATUS_INVALID_FILE_UPLOAD=528
-
-## check if program is downloadable from web
-## If we can't load it, we retry it ${RETRIES} times
-## On a 528 status (invalid upload), we return 200 which
-## should get interpreted as UNSTABLE build
-while true; do
-    HTTP_STATUS=`curl --write-out %{http_code} --silent --output /dev/null "${DOWNLOAD}"`
-
-    if [ ${HTTP_STATUS} -eq ${HTTP_STATUS_OK} ]; then
-        break
-    fi
-
-
-    RETRIES=$((RETRIES-1))
-    if [ ${RETRIES} -eq 0 ]; then
-        if [ ${HTTP_STATUS} -eq ${HTTP_STATUS_INVALID_FILE_UPLOAD} ]; then
-            echo "Uploaded file seems to be invalid, request to '${DOWNLOAD}' returned HTTP Status ${HTTP_STATUS}"
-            exit 200
-        else
-            echo "Could not download '${DOWNLOAD}', giving up!"
-            exit 1
-        fi
-    fi
-
-    echo "Could not retrieve '${DOWNLOAD}' (HTTP Status ${HTTP_STATUS}), sleep for ${SLEEP_TIME}s and retry a maximum of ${RETRIES} times"
-    sleep ${SLEEP_TIME}
-done
-'''
-
-                    // if no error, we are done
-                    if (ret == 0) {
-                        return
-                    }
-
-                    // Handle special error from the script, if the program download was not
-                    // possible because of the HTTP error 528, we set the build to UNSTABLE
-                    try {
-                        error('')
-                    } catch (err) {
-                        if (ret == 200) {
-                            currentBuild.result = 'UNSTABLE'
-                        } else {
-                            currentBuild.result = 'FAILURE'
-                        }
+                    def ret = sh script: "./buildScripts/checkUrlExists.sh '$env.DOWNLOAD'", returnStatus: true
+                    if (ret == 200) {
+                        // Handle special error from the script, if the program download was not
+                        // possible because of the HTTP error 528, we set the build to UNSTABLE
+                        currentBuild.result = 'UNSTABLE'
+                    } else if (ret != 0) {
+                        currentBuild.result = 'FAILURE'
                     }
                 }
             }

--- a/Jenkinsfile.BuildStandalone
+++ b/Jenkinsfile.BuildStandalone
@@ -152,11 +152,9 @@ done
     post {
         always {
             step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
-
-            // Send notifications with standalone=true
-            script {
-                sendNotifications true
-            }
+        }
+        failure {
+            notifyChat(['#ci-status', '#ci-status-standalone'])
         }
     }
 }

--- a/Jenkinsfile.ManualTests
+++ b/Jenkinsfile.ManualTests
@@ -1,84 +1,84 @@
 #!groovy
 
 pipeline {
-	agent {
-		dockerfile {
-			filename 'Dockerfile.jenkins'
-			// 'docker build' would normally copy the whole build-dir to the container, changing the
-			// docker build directory avoids that overhead
-			dir 'docker'
-			// Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
-			// corresponding user can be added. This is needed to provide the jenkins user inside
-			// the container for the ssh-agent to work.
-			// Another way would be to simply map the passwd file, but would spoil additional information
-			additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-			args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
-		}
-	}
+    agent {
+        dockerfile {
+            filename 'Dockerfile.jenkins'
+            // 'docker build' would normally copy the whole build-dir to the container, changing the
+            // docker build directory avoids that overhead
+            dir 'docker'
+            // Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
+            // corresponding user can be added. This is needed to provide the jenkins user inside
+            // the container for the ssh-agent to work.
+            // Another way would be to simply map the passwd file, but would spoil additional information
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
+            args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+        }
+    }
 
-	environment {
-		//////// Define environment variables to point to the correct locations inside the container ////////
-		//////////// Most likely not edited by the developer
-		ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-		// Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-		ANDROID_HOME = "/usr/local/android-sdk"
-		ANDROID_SDK_HOME = "/"
-		// Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
-		ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-		ANDROID_NDK = ""
-		// This is important, as we want the keep our gradle cache, but we can't share it between containers
-		// the cache could only be shared if the gradle instances could comunicate with each other
-		// imho keeping the cache per executor will have the least space impact
-		GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-		// Otherwise user.home returns ? for java applications
-		JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
+    environment {
+        //////// Define environment variables to point to the correct locations inside the container ////////
+        //////////// Most likely not edited by the developer
+        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
+        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
+        ANDROID_HOME = "/usr/local/android-sdk"
+        ANDROID_SDK_HOME = "/"
+        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
+        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
+        ANDROID_NDK = ""
+        // This is important, as we want the keep our gradle cache, but we can't share it between containers
+        // the cache could only be shared if the gradle instances could comunicate with each other
+        // imho keeping the cache per executor will have the least space impact
+        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
+        // Otherwise user.home returns ? for java applications
+        JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
 
-		//////// Build specific variables ////////
-		//////////// May be edited by the developer on changing the build steps
-	}
+        //////// Build specific variables ////////
+        //////////// May be edited by the developer on changing the build steps
+    }
 
-	options {
-		timeout(time: 2, unit: 'HOURS')
-		timestamps()
-	}
+    options {
+        timeout(time: 2, unit: 'HOURS')
+        timestamps()
+    }
 
-	stages {
-		stage('Prepare build') {
-			steps {
-				script {
-					currentBuild.displayName = env.NAME
-				}
-			}
-		}
+    stages {
+        stage('Prepare build') {
+            steps {
+                script {
+                    currentBuild.displayName = env.NAME
+                }
+            }
+        }
 
-		stage('Setup Android SDK') {
-			steps {
-				lock("update-android-sdk-on-${env.NODE_NAME}") {
-					sh './gradlew -PinstallSdk'
-				}
-			}
-		}
+        stage('Setup Android SDK') {
+            steps {
+                lock("update-android-sdk-on-${env.NODE_NAME}") {
+                    sh './gradlew -PinstallSdk'
+                }
+            }
+        }
 
-		stage('Unit and Device tests') {
-			steps {
-				sh """./gradlew -PenableCoverage -Pemulator=${env.EMULATOR} startEmulator \
-							createCatroidDebugAndroidTestCoverageReport -Pandroid.testInstrumentationRunnerArguments.${env.TYPE}=${env.NAME}"""
-			}
+        stage('Unit and Device tests') {
+            steps {
+                sh """./gradlew -PenableCoverage -Pemulator=${env.EMULATOR} startEmulator \
+                            createCatroidDebugAndroidTestCoverageReport -Pandroid.testInstrumentationRunnerArguments.${env.TYPE}=${env.NAME}"""
+            }
 
-			post {
-				always {
-					junit '**/*TEST*.xml'
+            post {
+                always {
+                    junit '**/*TEST*.xml'
 
-					sh './gradlew stopEmulator clearAvdStore'
-					archiveArtifacts 'logcat.txt'
-				}
-			}
-		}
-	}
+                    sh './gradlew stopEmulator clearAvdStore'
+                    archiveArtifacts 'logcat.txt'
+                }
+            }
+        }
+    }
 
-	post {
-		always {
-			step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
-		}
-	}
+    post {
+        always {
+            step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
+        }
+    }
 }

--- a/Jenkinsfile.ManualTests
+++ b/Jenkinsfile.ManualTests
@@ -32,9 +32,6 @@ pipeline {
         GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
         // Otherwise user.home returns ? for java applications
         JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
-
-        //////// Build specific variables ////////
-        //////////// May be edited by the developer on changing the build steps
     }
 
     options {

--- a/Jenkinsfile.SensorboxTests
+++ b/Jenkinsfile.SensorboxTests
@@ -65,10 +65,9 @@ pipeline {
     post {
         always {
             step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
-
-            script {
-                sendNotifications false
-            }
+        }
+        changed {
+            notifyChat()
         }
     }
 }

--- a/Jenkinsfile.SensorboxTests
+++ b/Jenkinsfile.SensorboxTests
@@ -31,10 +31,6 @@ pipeline {
         // the cache could only be shared if the gradle instances could comunicate with each other
         // imho keeping the cache per executor will have the least space impact
         GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-        //////// Build specific variables ////////
-        //////////// May be edited by the developer on changing the build steps
-        // modulename
-        GRADLE_PROJECT_MODULE_NAME = "catroid"
     }
 
     options {

--- a/Jenkinsfile.SensorboxTests
+++ b/Jenkinsfile.SensorboxTests
@@ -1,6 +1,6 @@
 #!groovy
 pipeline {
-     agent {
+    agent {
         dockerfile {
             filename 'Dockerfile.jenkins'
             // 'docker build' would normally copy the whole build-dir to the container, changing the

--- a/Jenkinsfile.buildDebugApks
+++ b/Jenkinsfile.buildDebugApks
@@ -72,11 +72,9 @@ pipeline {
     post {
         always {
             step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
-
-            // Send notifications with standalone=false
-            script {
-                sendNotifications false
-            }
+        }
+        changed {
+            notifyChat()
         }
     }
 }

--- a/Jenkinsfile.buildDebugApks
+++ b/Jenkinsfile.buildDebugApks
@@ -32,9 +32,6 @@ pipeline {
         GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
         // Otherwise user.home returns ? for java applications
         JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
-
-        //////// Build specific variables ////////
-        //////////// May be edited by the developer on changing the build steps
     }
 
     options {

--- a/Jenkinsfile.buildMetadata
+++ b/Jenkinsfile.buildMetadata
@@ -1,141 +1,141 @@
 #!groovy
 
 pipeline {
-	agent {
-		dockerfile {
-			filename 'Dockerfile.jenkins'
-			// 'docker build' would normally copy the whole build-dir to the container, changing the
-			// docker build directory avoids that overhead
-			dir 'docker'
-			// Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
-			// corresponding user can be added. This is needed to provide the jenkins user inside
-			// the container for the ssh-agent to work.
-			// Another way would be to simply map the passwd file, but would spoil additional information
-			additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-			args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
-		}
-	}
+    agent {
+        dockerfile {
+            filename 'Dockerfile.jenkins'
+            // 'docker build' would normally copy the whole build-dir to the container, changing the
+            // docker build directory avoids that overhead
+            dir 'docker'
+            // Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
+            // corresponding user can be added. This is needed to provide the jenkins user inside
+            // the container for the ssh-agent to work.
+            // Another way would be to simply map the passwd file, but would spoil additional information
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
+            args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+        }
+    }
 
-	environment {
-		//////// Define environment variables to point to the correct locations inside the container ////////
-		//////////// Most likely not edited by the developer
-		ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-		// Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-		ANDROID_HOME = "/usr/local/android-sdk"
-		ANDROID_SDK_HOME = "/"
-		// Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
-		ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-		ANDROID_NDK = ""
-		// This is important, as we want the keep our gradle cache, but we can't share it between containers
-		// the cache could only be shared if the gradle instances could comunicate with each other
-		// imho keeping the cache per executor will have the least space impact
-		GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-		// Otherwise user.home returns ? for java applications
-		JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
+    environment {
+        //////// Define environment variables to point to the correct locations inside the container ////////
+        //////////// Most likely not edited by the developer
+        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
+        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
+        ANDROID_HOME = "/usr/local/android-sdk"
+        ANDROID_SDK_HOME = "/"
+        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
+        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
+        ANDROID_NDK = ""
+        // This is important, as we want the keep our gradle cache, but we can't share it between containers
+        // the cache could only be shared if the gradle instances could comunicate with each other
+        // imho keeping the cache per executor will have the least space impact
+        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
+        // Otherwise user.home returns ? for java applications
+        JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
 
-		//////// Build specific variables ////////
-		//////////// May be edited by the developer on changing the build steps
-	}
+        //////// Build specific variables ////////
+        //////////// May be edited by the developer on changing the build steps
+    }
 
-	options {
-		timeout(time: 6, unit: 'HOURS')
-		timestamps()
-	}
+    options {
+        timeout(time: 6, unit: 'HOURS')
+        timestamps()
+    }
 
-	stages {
-		stage('Prepare build') {
-			steps {
-				script {
-					currentBuild.displayName = "#${env.BUILD_NUMBER}"
-				}
-			}
-		}
+    stages {
+        stage('Prepare build') {
+            steps {
+                script {
+                    currentBuild.displayName = "#${env.BUILD_NUMBER}"
+                }
+            }
+        }
 
-		stage('Setup Android SDK') {
-			steps {
-				// Install Android SDK
-				lock("update-android-sdk-on-${env.NODE_NAME}") {
-					sh './gradlew -PinstallSdk'
-				}
-			}
-		}
+        stage('Setup Android SDK') {
+            steps {
+                // Install Android SDK
+                lock("update-android-sdk-on-${env.NODE_NAME}") {
+                    sh './gradlew -PinstallSdk'
+                }
+            }
+        }
 
-		stage('Setup Translations') {
-			steps {
-			    sh '''
-					set +x
-					./gradlew generateCrowdinMetadataCatroid -PcrowdinKey=$crowdinKey
-			    '''
-			}
-		}
+        stage('Setup Translations') {
+            steps {
+                sh '''
+                    set +x
+                    ./gradlew generateCrowdinMetadataCatroid -PcrowdinKey=$crowdinKey
+                '''
+            }
+        }
 
-		stage('Start emulator') {
-			steps {
-				sh './gradlew -Pemulator=android24 startEmulator'
-			}
-		}
+        stage('Start emulator') {
+            steps {
+                sh './gradlew -Pemulator=android24 startEmulator'
+            }
+        }
 
-		stage('Create Screenshots') {
-			steps {
-				sh "./gradlew generateScreenshotsCatroid"
-			}
-			post {
-			    always {
-					sh './gradlew stopEmulator'
-				}
+        stage('Create Screenshots') {
+            steps {
+                sh "./gradlew generateScreenshotsCatroid"
+            }
+            post {
+                always {
+                    sh './gradlew stopEmulator'
+                }
 
-				success {
-					publishHTML target: [
-					allowMissing: false,
-					alwaysLinkToLastBuild: false,
-					keepAll: true,
-					reportDir: 'fastlane/metadata/android',
-					reportFiles: 'screenshots.html',
-					reportName: 'Screenshots'
-					]
-				}
-			}
-		}
+                success {
+                    publishHTML target: [
+                    allowMissing: false,
+                    alwaysLinkToLastBuild: false,
+                    keepAll: true,
+                    reportDir: 'fastlane/metadata/android',
+                    reportFiles: 'screenshots.html',
+                    reportName: 'Screenshots'
+                    ]
+                }
+            }
+        }
 
-		stage('Review') {
-			//agent none
-			options {
-				timeout(time: 6, unit: 'HOURS')
-			}
-			steps {
-				script {
-					env.APPROVE_DEPLOY = input message: 'User input required',
-						parameters: [choice(name: 'Deploy', choices: 'no\nyes',
-						description: 'Please review the Screenshots! Do you want to deploy this to Google Play?')]
-				}
-			}
-		}
+        stage('Review') {
+            //agent none
+            options {
+                timeout(time: 6, unit: 'HOURS')
+            }
+            steps {
+                script {
+                    env.APPROVE_DEPLOY = input message: 'User input required',
+                        parameters: [choice(name: 'Deploy', choices: 'no\nyes',
+                        description: 'Please review the Screenshots! Do you want to deploy this to Google Play?')]
+                }
+            }
+        }
 
-		stage('Upload Metadata') {
-			when {
-				environment name: 'APPROVE_DEPLOY', value: 'yes'
-			}
-			steps {
-				sh "fastlane android upload_Metadata_Catroid"
-			}
-		}
+        stage('Upload Metadata') {
+            when {
+                environment name: 'APPROVE_DEPLOY', value: 'yes'
+            }
+            steps {
+                sh "fastlane android upload_Metadata_Catroid"
+            }
+        }
 
-		stage('Promote APK to production') {
-			when {
-				environment name: 'APPROVE_DEPLOY', value: 'yes'
-			}
-			steps {
-				sh "fastlane android promote_Catroid"
-			}
-		}
-	}
+        stage('Promote APK to production') {
+            when {
+                environment name: 'APPROVE_DEPLOY', value: 'yes'
+            }
+            steps {
+                sh "fastlane android promote_Catroid"
+            }
+        }
+    }
 
-	post {
-		always {
-			// Send notifications with standalone=false
-			script {
-				sendNotifications false
-			}
-		}
-	}
+    post {
+        always {
+            // Send notifications with standalone=false
+            script {
+                sendNotifications false
+            }
+        }
+    }
 }

--- a/Jenkinsfile.buildMetadata
+++ b/Jenkinsfile.buildMetadata
@@ -32,9 +32,6 @@ pipeline {
         GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
         // Otherwise user.home returns ? for java applications
         JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
-
-        //////// Build specific variables ////////
-        //////////// May be edited by the developer on changing the build steps
     }
 
     options {

--- a/Jenkinsfile.buildMetadata
+++ b/Jenkinsfile.buildMetadata
@@ -128,11 +128,8 @@ pipeline {
     }
 
     post {
-        always {
-            // Send notifications with standalone=false
-            script {
-                sendNotifications false
-            }
+        changed {
+            notifyChat()
         }
     }
 }

--- a/Jenkinsfile.releaseAPK
+++ b/Jenkinsfile.releaseAPK
@@ -1,112 +1,112 @@
 #!groovy
 
 pipeline {
-	agent {
-		dockerfile {
-			filename 'Dockerfile.jenkins'
-			// 'docker build' would normally copy the whole build-dir to the container, changing the
-			// docker build directory avoids that overhead
-			dir 'docker'
-			// Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
-			// corresponding user can be added. This is needed to provide the jenkins user inside
-			// the container for the ssh-agent to work.
-			// Another way would be to simply map the passwd file, but would spoil additional information
-			additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-			args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
-		}
-	}
+    agent {
+        dockerfile {
+            filename 'Dockerfile.jenkins'
+            // 'docker build' would normally copy the whole build-dir to the container, changing the
+            // docker build directory avoids that overhead
+            dir 'docker'
+            // Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
+            // corresponding user can be added. This is needed to provide the jenkins user inside
+            // the container for the ssh-agent to work.
+            // Another way would be to simply map the passwd file, but would spoil additional information
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
+            args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+        }
+    }
 
-	environment {
-		//////// Define environment variables to point to the correct locations inside the container ////////
-		//////////// Most likely not edited by the developer
-		ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-		// Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-		ANDROID_HOME = "/usr/local/android-sdk"
-		ANDROID_SDK_HOME = "/"
-		// Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
-		ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-		ANDROID_NDK = ""
-		// This is important, as we want the keep our gradle cache, but we can't share it between containers
-		// the cache could only be shared if the gradle instances could comunicate with each other
-		// imho keeping the cache per executor will have the least space impact
-		GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-		// Otherwise user.home returns ? for java applications
-		JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
+    environment {
+        //////// Define environment variables to point to the correct locations inside the container ////////
+        //////////// Most likely not edited by the developer
+        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
+        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
+        ANDROID_HOME = "/usr/local/android-sdk"
+        ANDROID_SDK_HOME = "/"
+        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
+        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
+        ANDROID_NDK = ""
+        // This is important, as we want the keep our gradle cache, but we can't share it between containers
+        // the cache could only be shared if the gradle instances could comunicate with each other
+        // imho keeping the cache per executor will have the least space impact
+        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
+        // Otherwise user.home returns ? for java applications
+        JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
 
-		//////// Build specific variables ////////
-		//////////// May be edited by the developer on changing the build steps
-	}
+        //////// Build specific variables ////////
+        //////////// May be edited by the developer on changing the build steps
+    }
 
-	options {
-		timeout(time: 2, unit: 'HOURS')
-		timestamps()
-	}
+    options {
+        timeout(time: 2, unit: 'HOURS')
+        timestamps()
+    }
 
-	stages {
-		stage('Prepare build') {
-			steps {
-				script {
-					currentBuild.displayName = "#${env.BUILD_NUMBER}"
-				}
-			}
-		}
+    stages {
+        stage('Prepare build') {
+            steps {
+                script {
+                    currentBuild.displayName = "#${env.BUILD_NUMBER}"
+                }
+            }
+        }
 
-		stage('Setup Android SDK') {
-			steps {
-				// Install Android SDK
-				lock("update-android-sdk-on-${env.NODE_NAME}") {
-					sh './gradlew -PinstallSdk'
-				}
-			}
-		}
+        stage('Setup Android SDK') {
+            steps {
+                // Install Android SDK
+                lock("update-android-sdk-on-${env.NODE_NAME}") {
+                    sh './gradlew -PinstallSdk'
+                }
+            }
+        }
 
-		stage('Build signed APK') {
-			steps {
-				// Build, zipalign and sign releasable APK
-				withCredentials([file(credentialsId: 'a925b6e8-b3c6-407e-8cad-65886e330037', variable: 'SIGNING_KEYSTORE')]) {
-					sh '''
-						set +x
-						./gradlew assembleCatroidSignedRelease \
-						-PsigningKeystore=${SIGNING_KEYSTORE} \
-						-PsigningKeystorePassword=$signingKeystorePassword \
-						-PsigningKeyAlias=$signingKeyAlias \
-						-PsigningKeyPassword=$signingKeyPassword \
-						-PfirebaseApiKey=$firebaseApiKey \
-						-PfabricApiKey=$fabricApiKey \
-						-PfabricApiSecret=$fabricApiSecret
-					'''
-				}
-				archiveArtifacts artifacts: 'catroid/build/outputs/apk/**/*signedRelease.apk', fingerprint: true
-			}
-		}
-		
-		stage('Approve upload') {
-			options {
-				timeout(time: 60, unit: 'MINUTES')
-			}
-			steps {
-				script {
-					env.APPROVE_UPLOAD_APK = input message: 'User input required',
-						parameters: [choice(name: 'Upload', choices: 'no\nyes',
-						description: 'Do you want to upload this APK to Alpha Channel on Google Play?')]
-				}
-			}
-		}
+        stage('Build signed APK') {
+            steps {
+                // Build, zipalign and sign releasable APK
+                withCredentials([file(credentialsId: 'a925b6e8-b3c6-407e-8cad-65886e330037', variable: 'SIGNING_KEYSTORE')]) {
+                    sh '''
+                        set +x
+                        ./gradlew assembleCatroidSignedRelease \
+                        -PsigningKeystore=${SIGNING_KEYSTORE} \
+                        -PsigningKeystorePassword=$signingKeystorePassword \
+                        -PsigningKeyAlias=$signingKeyAlias \
+                        -PsigningKeyPassword=$signingKeyPassword \
+                        -PfirebaseApiKey=$firebaseApiKey \
+                        -PfabricApiKey=$fabricApiKey \
+                        -PfabricApiSecret=$fabricApiSecret
+                    '''
+                }
+                archiveArtifacts artifacts: 'catroid/build/outputs/apk/**/*signedRelease.apk', fingerprint: true
+            }
+        }
 
-		stage('Upload AKP to Alpha') {
-			when {
-				environment name: 'APPROVE_UPLOAD_APK', value: 'yes'
-			}
-			steps {
-				sh "fastlane android upload_APK_Catroid"
-			}
-		}
-	}
+        stage('Approve upload') {
+            options {
+                timeout(time: 60, unit: 'MINUTES')
+            }
+            steps {
+                script {
+                    env.APPROVE_UPLOAD_APK = input message: 'User input required',
+                        parameters: [choice(name: 'Upload', choices: 'no\nyes',
+                        description: 'Do you want to upload this APK to Alpha Channel on Google Play?')]
+                }
+            }
+        }
 
-	post {
-		always {
-			// clean workspace
-			deleteDir()
-		}
-	}
+        stage('Upload AKP to Alpha') {
+            when {
+                environment name: 'APPROVE_UPLOAD_APK', value: 'yes'
+            }
+            steps {
+                sh "fastlane android upload_APK_Catroid"
+            }
+        }
+    }
+
+    post {
+        always {
+            // clean workspace
+            deleteDir()
+        }
+    }
 }

--- a/Jenkinsfile.releaseAPK
+++ b/Jenkinsfile.releaseAPK
@@ -32,9 +32,6 @@ pipeline {
         GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
         // Otherwise user.home returns ? for java applications
         JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
-
-        //////// Build specific variables ////////
-        //////////// May be edited by the developer on changing the build steps
     }
 
     options {

--- a/buildScripts/checkUrlExists.sh
+++ b/buildScripts/checkUrlExists.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# check if program at $URL is downloadable from web.
+# If we can't load it, we retry it $RETRIES times
+# On a 528 status (invalid upload), we return 200 which
+# should get interpreted as UNSTABLE build
+
+URL="$1"
+SLEEP_TIME=5
+RETRIES=5
+
+HTTP_STATUS_OK=200
+HTTP_STATUS_INVALID_FILE_UPLOAD=528
+
+while true; do
+    HTTP_STATUS=`curl --write-out %{http_code} --silent --output /dev/null "${URL}"`
+
+    if [ ${HTTP_STATUS} -eq ${HTTP_STATUS_OK} ]; then
+        break
+    fi
+
+
+    RETRIES=$((RETRIES-1))
+    if [ ${RETRIES} -eq 0 ]; then
+        if [ ${HTTP_STATUS} -eq ${HTTP_STATUS_INVALID_FILE_UPLOAD} ]; then
+            echo "Uploaded file seems to be invalid, request to '${URL}' returned HTTP Status ${HTTP_STATUS}"
+            exit 200
+        else
+            echo "Could not download '${URL}', giving up!"
+            exit 1
+        fi
+    fi
+
+    echo "Could not retrieve '${URL}' (HTTP Status ${HTTP_STATUS}), sleep for ${SLEEP_TIME}s and retry a maximum of ${RETRIES} times"
+    sleep ${SLEEP_TIME}
+done


### PR DESCRIPTION
From the story:

The Jenkinsfiles already have some cruft.
So clean them up.

* One that changes everything to whitespaces.
* Fewer environment variables. Instead use local variables where useful.
* Better stages, i.e. one for tests with sub stages for the different kinds of tests. This makes it easier to parallelize these stages later on.
* Helper functions to make what is used clearer. Especially avoid moving results etc!