### PR TITLE
CATROID-117 Manual thumbnails (preview screenshots) lost after entering project (including in Tic Tac Toe Master)

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/io/XstreamSerializer.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/XstreamSerializer.java
@@ -27,7 +27,6 @@ import android.util.Log;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
-import com.parrot.freeflight.utils.FileUtils;
 import com.thoughtworks.xstream.converters.reflection.FieldDictionary;
 import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
 
@@ -584,11 +583,11 @@ public final class XstreamSerializer {
 		StorageOperations.copyDir(new File(projectDir, SOUND_DIRECTORY_NAME), new File(sceneDir, SOUND_DIRECTORY_NAME));
 
 		if (automaticScreenshot.exists()) {
-			FileUtils.copyFileToDir(automaticScreenshot, sceneDir);
+			StorageOperations.copyFileToDir(automaticScreenshot, sceneDir);
 			automaticScreenshot.delete();
 		}
 		if (manualScreenshot.exists()) {
-			FileUtils.copyFileToDir(manualScreenshot, sceneDir);
+			StorageOperations.copyFileToDir(manualScreenshot, sceneDir);
 			manualScreenshot.delete();
 		}
 


### PR DESCRIPTION

 * the 3 Projects, which mentioned in the ticket's description, have an old structure (no scene folder, see attached screenshot) (I didn't know that before ^_^).
 * the problem was, the method FileUtils.copyFileToDir(File srcFile, File destFile) somehow doesn't work.