### PR TITLE
CATROID-107 No keyboard for dialogs with text-input field.

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/TextInputDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/TextInputDialog.java
@@ -31,6 +31,7 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.AlertDialog;
 import android.text.Editable;
+import android.view.WindowManager;
 
 import org.catrobat.catroid.R;
 
@@ -84,6 +85,7 @@ public final class TextInputDialog extends AlertDialog {
 		@Override
 		public AlertDialog create() {
 			final AlertDialog alertDialog = super.create();
+			alertDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
 
 			alertDialog.setOnShowListener(new OnShowListener() {
 				@Override


### PR DESCRIPTION
* since all of the dialogs with editText inherit TextInputDialog.java (thanks to @thmq ), one line of code is enough to fix this.
* I couldn't find a way to test if the keyboard is shown! if you have one, please share with me.