### PR TITLE
CATROID-65 Support iOS and other platform version formats in XmlHeader

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/project/ProjectTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/project/ProjectTest.java
@@ -23,6 +23,7 @@
 package org.catrobat.catroid.test.content.project;
 
 import android.content.pm.PackageInfo;
+import android.os.Build;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -46,6 +47,7 @@ public class ProjectTest {
 	private static final float OLD_LANGUAGE_VERSION = 0.8f;
 	private static final String OLD_APPLICATION_NAME = "catty";
 	private static final String OLD_PLATFORM = "iOS";
+	private static final String OLD_PLATFORM_VERSION = "1.0.0 beta";
 
 	@Test
 	public void testVersionName() throws Exception {
@@ -109,11 +111,13 @@ public class ProjectTest {
 		header.setCatrobatLanguageVersion(OLD_LANGUAGE_VERSION);
 		header.setApplicationName(OLD_APPLICATION_NAME);
 		header.setPlatform(OLD_PLATFORM);
+		header.setPlatformVersion(OLD_PLATFORM_VERSION);
 
 		project.setDeviceData(InstrumentationRegistry.getTargetContext());
 
 		assertEquals(Constants.CURRENT_CATROBAT_LANGUAGE_VERSION, header.getCatrobatLanguageVersion());
 		assertEquals(InstrumentationRegistry.getTargetContext().getString(R.string.app_name), header.getApplicationName());
 		assertEquals(Constants.PLATFORM_NAME, header.getPlatform());
+		assertEquals(String.valueOf(Build.VERSION.SDK_INT), header.getPlatformVersion());
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -277,7 +277,7 @@ public class Project implements Serializable {
 	public void setDeviceData(Context context) {
 		// TODO add other header values
 		xmlHeader.setPlatform(Constants.PLATFORM_NAME);
-		xmlHeader.setPlatformVersion((double) Build.VERSION.SDK_INT);
+		xmlHeader.setPlatformVersion(String.valueOf(Build.VERSION.SDK_INT));
 		xmlHeader.setDeviceName(Build.MODEL);
 
 		xmlHeader.setCatrobatLanguageVersion(Constants.CURRENT_CATROBAT_LANGUAGE_VERSION);

--- a/catroid/src/main/java/org/catrobat/catroid/content/XmlHeader.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/XmlHeader.java
@@ -60,7 +60,7 @@ public class XmlHeader implements Serializable {
 	private String applicationVersion = "";
 	private String deviceName = "";
 	private String platform = "";
-	private double platformVersion = 0;
+	private String platformVersion = "";
 	@SuppressWarnings("unused")
 	private String tags = "";
 	//----------------------------------------------------------------------------------------------
@@ -199,11 +199,11 @@ public class XmlHeader implements Serializable {
 		this.deviceName = deviceName;
 	}
 
-	public double getPlatformVersion() {
+	public String getPlatformVersion() {
 		return platformVersion;
 	}
 
-	public void setPlatformVersion(double platformVersion) {
+	public void setPlatformVersion(String platformVersion) {
 		this.platformVersion = platformVersion;
 	}
 


### PR DESCRIPTION
The Android platform version is an integer and has been stored in the
XmlHeader as double. However, the iOS platform version has a format like
MAJOR.MINOR.PATCH[1]. Programs with such a format can't be loaded by
Catroid.

XStream doesn't store any information about the type of the platform
version in the XmlHeader, e.g. <platformVersion>26.0</platformVersion>.
Simply changing the type from double to String is sufficient to allow
any version format.

[1] https://en.wikipedia.org/wiki/IOS_version_history
___
As you can see, no test. Once you verified everything works as expected (I verified a few random programs and also one with `<platformVersion>26.0.1 beta</platformVersion>`) , testing this is like testing XStream, imo.