### PR TITLE
CATROID-141, JENKINS-246 Improve the performance of the Catroid Job and moves dependencies to Docker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,25 @@
 #!groovy
 
+class DockerParameters {
+    def fileName = 'Dockerfile.jenkins'
+
+    // 'docker build' would normally copy the whole build-dir to the container, changing the
+    // docker build directory avoids that overhead
+    def dir = 'docker'
+
+    // Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
+    // corresponding user can be added. This is needed to provide the jenkins user inside
+    // the container for the ssh-agent to work.
+    // Another way would be to simply map the passwd file, but would spoil additional information
+    // Also hand in the group id of kvm to allow using /dev/kvm.
+    def buildArgs = '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg KVM_GROUP_ID=$(getent group kvm | cut -d: -f3)'
+
+    def args = '--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle -m=6.5G'
+    def label = 'LimitedEmulator'
+}
+
+def d = new DockerParameters()
+
 def junitAndCoverage(String jacocoReportDir, String jacocoReportXml, String coverageName) {
     // Consume all test xml files. Otherwise tests would be tracked multiple
     // times if this function was called again.
@@ -20,22 +40,7 @@ def postEmulator(String coverageNameAndLogcatPrefix) {
 }
 
 pipeline {
-    agent {
-        dockerfile {
-            filename 'Dockerfile.jenkins'
-            // 'docker build' would normally copy the whole build-dir to the container, changing the
-            // docker build directory avoids that overhead
-            dir 'docker'
-            // Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
-            // corresponding user can be added. This is needed to provide the jenkins user inside
-            // the container for the ssh-agent to work.
-            // Another way would be to simply map the passwd file, but would spoil additional information
-            // Also hand in the group id of kvm to allow using /dev/kvm.
-            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg KVM_GROUP_ID=$(getent group kvm | cut -d: -f3)'
-            args '--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle -m=6.5G'
-            label 'LimitedEmulator'
-        }
-    }
+    agent none
 
     parameters {
         booleanParam name: 'BUILD_ALL_FLAVOURS', defaultValue: false, description: 'When selected all flavours are built and archived as artifacts that can be installed alongside other versions of the same APK.'
@@ -53,91 +58,128 @@ pipeline {
     }
 
     stages {
-        stage('APKs') {
-            steps {
-                // Checks that the creation of standalone APKs (APK for a Pocketcode app) works, reducing the risk of breaking gradle changes.
-                // The resulting APK is not verified itself.
-                sh '''./gradlew assembleStandaloneDebug -Papk_generator_enabled=true -Psuffix=generated817.catrobat \
-                            -Pdownload='https://share.catrob.at/pocketcode/download/817.catrobat' '''
+        stage('All') {
+            parallel {
+                stage('1') {
+                    agent {
+                        dockerfile {
+                            filename d.fileName
+                            dir d.dir
+                            additionalBuildArgs d.buildArgs
+                            args d.args
+                            label d.label
+                        }
+                    }
 
-                // Build the flavors so that they can be installed next independently of older versions.
-                sh """./gradlew -Pindependent='#$env.BUILD_NUMBER $env.BRANCH_NAME' assembleCatroidDebug \
-                    ${env.BUILD_ALL_FLAVOURS ? 'assembleCreateAtSchoolDebug assembleLunaAndCatDebug assemblePhiroDebug' : ''}"""
+                    stages {
+                        stage('APKs') {
+                            steps {
+                                // Checks that the creation of standalone APKs (APK for a Pocketcode app) works, reducing the risk of breaking gradle changes.
+                                // The resulting APK is not verified itself.
+                                sh '''./gradlew assembleStandaloneDebug -Papk_generator_enabled=true -Psuffix=generated817.catrobat \
+                                            -Pdownload='https://share.catrob.at/pocketcode/download/817.catrobat' '''
 
-                archiveArtifacts '**/*.apk'
-            }
-        }
+                                // Checks that the job builds with the parameters to have unique APKs, reducing the risk of breaking gradle changes.
+                                // The resulting APK is not verified on itself.
+                                sh "./gradlew assembleCatroidDebug -Pindependent='#$env.BUILD_NUMBER $env.BRANCH_NAME'"
+                                // Build the flavors so that they can be installed next independently of older versions.
+                                sh """./gradlew -Pindependent='#$env.BUILD_NUMBER $env.BRANCH_NAME' assembleCatroidDebug \
+                                            ${env.BUILD_ALL_FLAVOURS ? 'assembleCreateAtSchoolDebug assembleLunaAndCatDebug assemblePhiroDebug' : ''}"""
 
-        stage('Static Analysis') {
-            steps {
-                sh './gradlew pmd checkstyle lint'
-            }
+                                archiveArtifacts '**/*.apk'
+                            }
+                        }
 
-            post {
-                always {
-                    pmd         canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "catroid/build/reports/pmd.xml",        unHealthy: '', unstableTotalAll: '0'
-                    checkstyle  canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "catroid/build/reports/checkstyle.xml", unHealthy: '', unstableTotalAll: '0'
-                    androidLint canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "catroid/build/reports/lint*.xml",      unHealthy: '', unstableTotalAll: '0'
-                }
-            }
-        }
+                        stage('Static Analysis') {
+                            steps {
+                                sh './gradlew pmd checkstyle lint'
+                            }
 
-        stage('Tests') {
-            stages {
-                stage('Unit Tests') {
-                    steps {
-                        sh './gradlew -PenableCoverage jacocoTestCatroidDebugUnitTestReport'
+                            post {
+                                always {
+                                    pmd         canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "catroid/build/reports/pmd.xml",        unHealthy: '', unstableTotalAll: '0'
+                                    checkstyle  canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "catroid/build/reports/checkstyle.xml", unHealthy: '', unstableTotalAll: '0'
+                                    androidLint canComputeNew: false, canRunOnFailed: true, defaultEncoding: '', healthy: '', pattern: "catroid/build/reports/lint*.xml",      unHealthy: '', unstableTotalAll: '0'
+                                }
+                            }
+                        }
+
+                        stage('Unit Tests') {
+                            steps {
+                                sh './gradlew -PenableCoverage jacocoTestCatroidDebugUnitTestReport'
+                            }
+
+                            post {
+                                always {
+                                    junitAndCoverage 'catroid/build/reports/jacoco/jacocoTestCatroidDebugUnitTestReport', 'jacocoTestCatroidDebugUnitTestReport.xml', 'unit'
+                                }
+                            }
+                        }
+
+                        stage('Instrumented Unit Tests') {
+                            steps {
+                                sh '''./gradlew -PenableCoverage -PlogcatFile=instrumented_unit_logcat.txt -Pemulator=android24 \
+                                            startEmulator createCatroidDebugAndroidTestCoverageReport \
+                                            -Pandroid.testInstrumentationRunnerArguments.package=org.catrobat.catroid.test'''
+                            }
+
+                            post {
+                                always {
+                                    postEmulator 'instrumented_unit'
+                                }
+                            }
+                        }
+
+                        stage('Quarantined Tests') {
+                            when {
+                                expression { isJobStartedByTimer() }
+                            }
+
+                            steps {
+                                sh '''./gradlew -PenableCoverage -PlogcatFile=quarantined_logcat.txt -Pemulator=android24 \
+                                            startEmulator createCatroidDebugAndroidTestCoverageReport \
+                                            -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.QuarantineTestSuite'''
+                            }
+
+                            post {
+                                always {
+                                    postEmulator 'quarantined'
+                                }
+                            }
+                        }
                     }
 
                     post {
                         always {
-                            junitAndCoverage 'catroid/build/reports/jacoco/jacocoTestCatroidDebugUnitTestReport', 'jacocoTestCatroidDebugUnitTestReport.xml', 'unit'
+                            stash name: 'logParserRules', includes: 'buildScripts/log_parser_rules'
                         }
                     }
                 }
 
-                stage('Instrumented Unit Tests') {
-                    steps {
-                        sh '''./gradlew -PenableCoverage -PlogcatFile=instrumented_unit_logcat.txt -Pemulator=android24 \
-                                    startEmulator createCatroidDebugAndroidTestCoverageReport \
-                                    -Pandroid.testInstrumentationRunnerArguments.package=org.catrobat.catroid.test'''
-                    }
-
-                    post {
-                        always {
-                            postEmulator 'instrumented_unit'
+                stage('2') {
+                    agent {
+                        dockerfile {
+                            filename d.fileName
+                            dir d.dir
+                            additionalBuildArgs d.buildArgs
+                            args d.args
+                            label d.label
                         }
                     }
-                }
 
-                stage('Pull Request Suite') {
-                    steps {
-                        sh '''./gradlew -PenableCoverage -PlogcatFile=pull_request_suite_logcat.txt -Pemulator=android24 \
-                                    startEmulator createCatroidDebugAndroidTestCoverageReport \
-                                    -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite'''
-                    }
+                    stages {
+                        stage('Pull Request Suite') {
+                            steps {
+                                sh '''./gradlew -PenableCoverage -PlogcatFile=pull_request_suite_logcat.txt -Pemulator=android24 \
+                                            startEmulator createCatroidDebugAndroidTestCoverageReport \
+                                            -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.PullRequestTriggerSuite'''
+                            }
 
-                    post {
-                        always {
-                            postEmulator 'pull_request_suite'
-                        }
-                    }
-                }
-
-                stage('Quarantined Tests') {
-                    when {
-                        expression { isJobStartedByTimer() }
-                    }
-
-                    steps {
-                        sh '''./gradlew -PenableCoverage -PlogcatFile=quarantined_logcat.txt -Pemulator=android24 \
-                                    startEmulator createCatroidDebugAndroidTestCoverageReport \
-                                    -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.QuarantineTestSuite'''
-                    }
-
-                    post {
-                        always {
-                            postEmulator 'quarantined'
+                            post {
+                                always {
+                                    postEmulator 'pull_request_suite'
+                                }
+                            }
                         }
                     }
                 }
@@ -147,10 +189,15 @@ pipeline {
 
     post {
         always {
-            step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
+            node('master') {
+                unstash 'logParserRules'
+                step([$class: 'LogParserPublisher', failBuildOnError: true, projectRulePath: 'buildScripts/log_parser_rules', unstableOnWarning: true, useProjectRule: true])
+            }
         }
         changed {
-            notifyChat()
+            node('master') {
+                notifyChat()
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ def junitAndCoverage(String jacocoReportDir, String jacocoReportXml, String cove
 }
 
 def postEmulator(String coverageNameAndLogcatPrefix) {
-    sh './gradlew stopEmulator clearAvdStore'
+    sh './gradlew stopEmulator'
 
     def jacocoReportDir = 'catroid/build/reports/coverage/catroid/debug'
     junitAndCoverage jacocoReportDir, 'report.xml', coverageNameAndLogcatPrefix
@@ -30,39 +30,15 @@ pipeline {
             // corresponding user can be added. This is needed to provide the jenkins user inside
             // the container for the ssh-agent to work.
             // Another way would be to simply map the passwd file, but would spoil additional information
-            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-            // Currently there are two different NDK behaviors in place, one to keep NDK r16b, which
-            // was needed because of the removal of armeabi and MIPS support and one to always use the
-            // latest NDK, which is the suggestion from the NDK documentations.
-            // Therefore two different SDK locations on the host are currently in place:
-            // NDK r16b  : /var/local/container_shared/android-sdk
-            // NDK latest: /var/local/container_shared/android-sdk-ndk-latest
-            // As android-sdk was used from the beginning and is already 'released' this can't be changed
-            // to eg android-sdk-ndk-r16b and must be kept to the previously used value
-            args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk-ndk-latest:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+            // Also hand in the group id of kvm to allow using /dev/kvm.
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg KVM_GROUP_ID=$(getent group kvm | cut -d: -f3)'
+            args '--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle -m=6.5G'
+            label 'LimitedEmulator'
         }
     }
 
     parameters {
         booleanParam name: 'BUILD_ALL_FLAVOURS', defaultValue: false, description: 'When selected all flavours are built and archived as artifacts that can be installed alongside other versions of the same APK.'
-    }
-
-    environment {
-        //////// Define environment variables to point to the correct locations inside the container ////////
-        //////////// Most likely not edited by the developer
-        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-        ANDROID_HOME = "/usr/local/android-sdk"
-        ANDROID_SDK_HOME = "/"
-        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
-        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-        ANDROID_NDK = ""
-        // This is important, as we want the keep our gradle cache, but we can't share it between containers
-        // the cache could only be shared if the gradle instances could comunicate with each other
-        // imho keeping the cache per executor will have the least space impact
-        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-        // Otherwise user.home returns ? for java applications
-        JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
     }
 
     options {
@@ -77,15 +53,6 @@ pipeline {
     }
 
     stages {
-        stage('Setup Android SDK') {
-            steps {
-                // Install Android SDK
-                lock("update-android-sdk-on-${env.NODE_NAME}") {
-                    sh './gradlew -PinstallSdk'
-                }
-            }
-        }
-
         stage('APKs') {
             steps {
                 // Checks that the creation of standalone APKs (APK for a Pocketcode app) works, reducing the risk of breaking gradle changes.

--- a/Jenkinsfile.BuildStandalone
+++ b/Jenkinsfile.BuildStandalone
@@ -13,29 +13,12 @@ pipeline {
             // corresponding user can be added. This is needed to provide the jenkins user inside
             // the container for the ssh-agent to work.
             // Another way would be to simply map the passwd file, but would spoil additional information
-            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-            args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+            // Also hand in the group id of kvm to allow using /dev/kvm.
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg KVM_GROUP_ID=$(getent group kvm | cut -d: -f3)'
+            args '--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle'
             // Add specific 'Standalone'-label, so it can be made sure, that there is a dedicated host for standalone builds
             label 'Standalone'
         }
-    }
-
-    environment {
-        //////// Define environment variables to point to the correct locations inside the container ////////
-        //////////// Most likely not edited by the developer
-        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-        ANDROID_HOME = "/usr/local/android-sdk"
-        ANDROID_SDK_HOME = "/"
-        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
-        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-        ANDROID_NDK = ""
-        // This is important, as we want the keep our gradle cache, but we can't share it between containers
-        // the cache could only be shared if the gradle instances could comunicate with each other
-        // imho keeping the cache per executor will have the least space impact
-        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-        // Otherwise user.home returns ? for java applications
-        JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
     }
 
     options {
@@ -48,15 +31,6 @@ pipeline {
             steps {
                 script {
                     currentBuild.displayName = "${env.DOWNLOAD}"
-                }
-            }
-        }
-
-        stage('Setup Android SDK') {
-            steps {
-                // Install Android SDK
-                lock("update-android-sdk-on-${env.NODE_NAME}") {
-                    sh './gradlew -PinstallSdk'
                 }
             }
         }

--- a/Jenkinsfile.ManualTests
+++ b/Jenkinsfile.ManualTests
@@ -11,27 +11,11 @@ pipeline {
             // corresponding user can be added. This is needed to provide the jenkins user inside
             // the container for the ssh-agent to work.
             // Another way would be to simply map the passwd file, but would spoil additional information
-            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-            args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+            // Also hand in the group id of kvm to allow using /dev/kvm.
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg KVM_GROUP_ID=$(getent group kvm | cut -d: -f3)'
+            args '--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle -m=6.5G'
+            label 'LimitedEmulator'
         }
-    }
-
-    environment {
-        //////// Define environment variables to point to the correct locations inside the container ////////
-        //////////// Most likely not edited by the developer
-        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-        ANDROID_HOME = "/usr/local/android-sdk"
-        ANDROID_SDK_HOME = "/"
-        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
-        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-        ANDROID_NDK = ""
-        // This is important, as we want the keep our gradle cache, but we can't share it between containers
-        // the cache could only be shared if the gradle instances could comunicate with each other
-        // imho keeping the cache per executor will have the least space impact
-        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-        // Otherwise user.home returns ? for java applications
-        JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
     }
 
     options {
@@ -44,14 +28,6 @@ pipeline {
             steps {
                 script {
                     currentBuild.displayName = env.NAME
-                }
-            }
-        }
-
-        stage('Setup Android SDK') {
-            steps {
-                lock("update-android-sdk-on-${env.NODE_NAME}") {
-                    sh './gradlew -PinstallSdk'
                 }
             }
         }

--- a/Jenkinsfile.SensorboxTests
+++ b/Jenkinsfile.SensorboxTests
@@ -6,31 +6,16 @@ pipeline {
             // 'docker build' would normally copy the whole build-dir to the container, changing the
             // docker build directory avoids that overhead
             dir 'docker'
-            // run on slave1 where nexus is connected to
-            label 'HardwareSensorBox'
             // Pass the uid and the gid of the current user (jenkins-user) to the Dockerfile, so a
             // corresponding user can be added. This is needed to provide the jenkins user inside
             // the container for the ssh-agent to work.
             // Another way would be to simply map the passwd file, but would spoil additional information
-            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-            args "--net host -v /dev/bus/usb/:/dev/bus/usb -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+            // Also hand in the group id of kvm to allow using /dev/kvm.
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg KVM_GROUP_ID=$(getent group kvm | cut -d: -f3)'
+            args '--net host -v /dev/bus/usb/:/dev/bus/usb -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle'
+            // run on slave1 where nexus is connected to
+            label 'HardwareSensorBox'
         }
-    }
-
-    environment {
-        //////// Define environment variables to point to the correct locations inside the container ////////
-        //////////// Most likely not edited by the developer
-        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-        ANDROID_HOME = "/usr/local/android-sdk"
-        ANDROID_SDK_HOME = "/"
-        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
-        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-        ANDROID_NDK = ""
-        // This is important, as we want the keep our gradle cache, but we can't share it between containers
-        // the cache could only be shared if the gradle instances could comunicate with each other
-        // imho keeping the cache per executor will have the least space impact
-        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
     }
 
     options {
@@ -39,15 +24,6 @@ pipeline {
     }
 
     stages {
-        stage('Setup Android SDK') {
-            steps {
-                // Install Android SDK
-                lock("update-android-sdk-on-${env.NODE_NAME}") {
-                    sh './gradlew -PinstallSdk'
-                }
-            }
-        }
-
         stage('Unit and Device tests') {
             steps {
                 lock(resource: null, label: "HardwareSensorBox-${env.NODE_NAME}", quantity: 1, variable: 'ANDROID_SERIAL') {

--- a/Jenkinsfile.buildMetadata
+++ b/Jenkinsfile.buildMetadata
@@ -11,27 +11,11 @@ pipeline {
             // corresponding user can be added. This is needed to provide the jenkins user inside
             // the container for the ssh-agent to work.
             // Another way would be to simply map the passwd file, but would spoil additional information
-            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-            args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+            // Also hand in the group id of kvm to allow using /dev/kvm.
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg KVM_GROUP_ID=$(getent group kvm | cut -d: -f3)'
+            args '--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle -m=6.5G'
+            label 'LimitedEmulator'
         }
-    }
-
-    environment {
-        //////// Define environment variables to point to the correct locations inside the container ////////
-        //////////// Most likely not edited by the developer
-        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-        ANDROID_HOME = "/usr/local/android-sdk"
-        ANDROID_SDK_HOME = "/"
-        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
-        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-        ANDROID_NDK = ""
-        // This is important, as we want the keep our gradle cache, but we can't share it between containers
-        // the cache could only be shared if the gradle instances could comunicate with each other
-        // imho keeping the cache per executor will have the least space impact
-        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-        // Otherwise user.home returns ? for java applications
-        JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
     }
 
     options {
@@ -44,15 +28,6 @@ pipeline {
             steps {
                 script {
                     currentBuild.displayName = "#${env.BUILD_NUMBER}"
-                }
-            }
-        }
-
-        stage('Setup Android SDK') {
-            steps {
-                // Install Android SDK
-                lock("update-android-sdk-on-${env.NODE_NAME}") {
-                    sh './gradlew -PinstallSdk'
                 }
             }
         }

--- a/Jenkinsfile.releaseAPK
+++ b/Jenkinsfile.releaseAPK
@@ -11,27 +11,11 @@ pipeline {
             // corresponding user can be added. This is needed to provide the jenkins user inside
             // the container for the ssh-agent to work.
             // Another way would be to simply map the passwd file, but would spoil additional information
-            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-            args "--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle/:/.gradle -v /var/local/container_shared/android-sdk:/usr/local/android-sdk -v /var/local/container_shared/android-home:/.android -v /var/local/container_shared/emulator_console_auth_token:/.emulator_console_auth_token -v /var/local/container_shared/analytics.settings:/analytics.settings"
+            // Also hand in the group id of kvm to allow using /dev/kvm.
+            additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg KVM_GROUP_ID=$(getent group kvm | cut -d: -f3)'
+            args '--device /dev/kvm:/dev/kvm -v /var/local/container_shared/gradle_cache/$EXECUTOR_NUMBER:/home/user/.gradle -m=6.5G'
+            label 'LimitedEmulator'
         }
-    }
-
-    environment {
-        //////// Define environment variables to point to the correct locations inside the container ////////
-        //////////// Most likely not edited by the developer
-        ANDROID_SDK_ROOT = "/usr/local/android-sdk"
-        // Deprecated: Still used by the used gradle version, once gradle respects ANDROID_SDK_ROOT, this can be removed
-        ANDROID_HOME = "/usr/local/android-sdk"
-        ANDROID_SDK_HOME = "/"
-        // Needed for compatibiliby to current Jenkins-wide Envs. Can be removed, once all builds are migrated to Pipeline
-        ANDROID_SDK_LOCATION = "/usr/local/android-sdk"
-        ANDROID_NDK = ""
-        // This is important, as we want the keep our gradle cache, but we can't share it between containers
-        // the cache could only be shared if the gradle instances could comunicate with each other
-        // imho keeping the cache per executor will have the least space impact
-        GRADLE_USER_HOME = "/.gradle/${env.EXECUTOR_NUMBER}"
-        // Otherwise user.home returns ? for java applications
-        JAVA_TOOL_OPTIONS = "-Duser.home=/tmp/"
     }
 
     options {
@@ -44,15 +28,6 @@ pipeline {
             steps {
                 script {
                     currentBuild.displayName = "#${env.BUILD_NUMBER}"
-                }
-            }
-        }
-
-        stage('Setup Android SDK') {
-            steps {
-                // Install Android SDK
-                lock("update-android-sdk-on-${env.NODE_NAME}") {
-                    sh './gradlew -PinstallSdk'
                 }
             }
         }

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -46,15 +46,9 @@ ext {
 
 apply plugin: 'org.catrobat.gradle.androidemulators'
 
+// The emulators to use on Jenkins.
+// Note: When you specify new system images ensure that they are installed on the Docker image.
 emulators {
-    install project.hasProperty('installSdk')
-
-    dependencies {
-        sdk {
-            version = '26.1.1'
-        }
-    }
-
     emulatorTemplate 'template1', {
         avd {
             systemImage = 'system-images;android-24;default;x86_64'

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -53,15 +53,14 @@ emulators {
         avd {
             systemImage = 'system-images;android-24;default;x86_64'
             sdcardSizeMb = 200
-            hardwareProperties += ['hw.camera': 'yes', 'hw.ramSize': 2048, 'hw.gpu.enabled': 'yes',
+            hardwareProperties += ['hw.camera': 'yes', 'hw.ramSize': 800, 'hw.gpu.enabled': 'yes',
                                    'hw.camera.front': 'emulated', 'hw.camera.back': 'emulated', 'hw.gps': 'yes',
-                                   'hw.mainKeys': 'no', 'hw.keyboard': 'yes', 'disk.dataPartition.size': '512M',
-                                   'vm.heapSize': 128]
-            screenDensity = 'xxhdpi'
+                                   'hw.mainKeys': 'no', 'hw.keyboard': 'yes', 'vm.heapSize': 128]
+            screenDensity = 'xhdpi'
         }
 
         parameters {
-            resolution = '1080x1920'
+            resolution = '768x1280'
             language = 'en'
             country = 'US'
         }

--- a/docker/Dockerfile.jenkins
+++ b/docker/Dockerfile.jenkins
@@ -1,24 +1,54 @@
 FROM openjdk:8-jdk
 
-LABEL maintainer="contact@catrobat.org"
+# Android Dependencies
+# --------------------
+# Adapt the paramters below to change the dependencies.
+#
 
-## Default values for the arguments to be passed from the Jenkinsfile.
-## Those contain the uid and gid of the Jenkins user, and are used to
-## create this user inside of the container, needed for eg ssh-agent to work
+# Android SDK 26.1.1
+ARG ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
+
+# No Android NDK needed
+ARG ANDROID_NDK_URL
+
+ARG SDKMANAGER_PACKAGES="build-tools;27.0.3 emulator platform-tools platforms;android-26 system-images;android-19;default;x86 system-images;android-24;default;x86_64 system-images;android-28;default;x86_64"
+
+
+# Arguments, Environment
+# ----------------------
+#
+
+# Default values for the arguments to be passed from the Jenkinsfile.
+# Those contain the uid and gid of the Jenkins user, and are used to
+# create this user inside of the container, needed for eg ssh-agent to work
 ARG USER_ID=1000
+ARG USER_HOME=/home/user
 ARG GROUP_ID=1000
+ARG KVM_GROUP_ID=999
 
-## python3/lsof: buildScripts
-## curl/openssh-client: upload to web/share
+# Environment variables that are needed by the build job.
+
+ENV ANDROID_SDK_ROOT=$USER_HOME/android/sdk
+ENV ANDROID_AVD_HOME=$USER_HOME/avds
+
+# Deprecated: Still used by gradle, once gradle respects ANDROID_SDK_ROOT, this can be removed
+ENV ANDROID_HOME=$ANDROID_SDK_ROOT
+
+ARG _SDKMANAGER=$ANDROID_SDK_ROOT/tools/bin/sdkmanager
+
+# System Packages
+# ---------------
+#
+
+# curl/openssh-client: upload to web/share
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		lsof \
-		python3 \
-		curl \
-		openssh-client \
-	&& rm -rf /var/lib/apt/lists/*
-## Install Fastlane
+        curl \
+        openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Fastlane
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        rubygems \ 
+        rubygems \
         ruby-dev \
         g++ \
         make \
@@ -30,6 +60,58 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ruby-dev \
         g++ \
         make
-## add the 'Jenkins' user
-## RUN groupadd -g $GROUP_ID user && useradd -M -u $USER_ID -g $GROUP_ID -d / -s /usr/sbin/nologin user
-RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -g $GROUP_ID -d /home/catroid -s /usr/sbin/nologin user
+
+# User Management
+# ---------------
+#
+
+# add the 'Jenkins' user
+# Add group of the user used by Jenkins during building.
+RUN if [ ! $(getent group $GROUP_ID) ]; then groupadd -g $GROUP_ID user; fi
+
+RUN groupadd -g $KVM_GROUP_ID kvm
+
+# Add the user used by Jenkins during building.
+RUN useradd -m -u $USER_ID -g $GROUP_ID -G $KVM_GROUP_ID -d $USER_HOME -s /usr/sbin/nologin user
+
+# Run all other commands as user
+USER user
+
+RUN mkdir -p $ANDROID_AVD_HOME
+
+
+# Android SDK
+# ------------------
+#
+RUN curl $ANDROID_SDK_URL --output /tmp/android_sdk.zip \
+    && mkdir -p $ANDROID_SDK_ROOT \
+    && unzip -d $ANDROID_SDK_ROOT /tmp/android_sdk.zip \
+    && rm /tmp/android_sdk.zip
+
+
+# Android NDK
+# ----------------
+#
+RUN if [ ! -z "$ANDROID_NDK_URL" ]; then \
+        curl $ANDROID_NDK_URL --output /tmp/android_ndk.zip \
+        && mkdir -p $ANDROID_SDK_ROOT /tmp/ndk \
+        && unzip -d /tmp/ndk /tmp/android_ndk.zip \
+        && mv /tmp/ndk/* $ANDROID_SDK_ROOT/ndk-bundle \
+        && rm /tmp/android_ndk.zip; \
+    fi
+
+
+# Installing SDK Packages
+# -----------------------
+#
+RUN if [ ! -z "$SDKMANAGER_PACKAGES" ]; then yes | $_SDKMANAGER $SDKMANAGER_PACKAGES; fi
+
+# Performance related settings for the JVM
+# - Respect the cgroup settings for memory.
+#
+# Note: Usage of _JAVA_OPTIONS is in general discouraged.
+#       This is an internal flag that will be preferred over
+#       JAVA_TOOL_OPTIONS and the command line parameters.
+#       We still use it here to ensure that these settings
+#       are respected, no matter what is configured elsewhere.
+ENV _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"


### PR DESCRIPTION
* All Android dependencies are handled inside of Docker
* Uses faster emulator settings
* Parallelize the build, often leading to build times of 13 minutes.