### PR TITLE
CATROID-139 Fix second brick not being visible

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ScriptFragment.java
@@ -425,8 +425,8 @@ public class ScriptFragment extends ListFragment implements
 				sprite.addScript(0, ((ScriptBrick) brick).getScript());
 			} else {
 				sprite.getScriptList().get(0).addBricks(new ArrayList<Brick>(bricksToAdd));
-				adapter.updateItems(sprite);
 			}
+			adapter.updateItems(sprite);
 		} else {
 			int firstVisibleBrick = listView.getFirstVisiblePosition();
 			int lastVisibleBrick = listView.getLastVisiblePosition();


### PR DESCRIPTION
After first brick was added, if second brick was of ScriptBrick type then adapter.updateItems(sprite) was not being called which was fixed .