### PR TITLE
JENKINS-285 Actually only build flavours when the option was selected in Jenkins.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
                                 sh "./gradlew assembleCatroidDebug -Pindependent='#$env.BUILD_NUMBER $env.BRANCH_NAME'"
                                 // Build the flavors so that they can be installed next independently of older versions.
                                 sh """./gradlew -Pindependent='#$env.BUILD_NUMBER $env.BRANCH_NAME' assembleCatroidDebug \
-                                            ${env.BUILD_ALL_FLAVOURS ? 'assembleCreateAtSchoolDebug assembleLunaAndCatDebug assemblePhiroDebug' : ''}"""
+                                            ${env.BUILD_ALL_FLAVOURS?.toBoolean() ? 'assembleCreateAtSchoolDebug assembleLunaAndCatDebug assemblePhiroDebug' : ''}"""
 
                                 archiveArtifacts '**/*.apk'
                             }


### PR DESCRIPTION
The previous code did not work, as the environment variable is set to 'true'
or 'false' and any non-empty string is treated as true implicitly in Groovy.
So currently all APKs are build for every build.

This was not noticed as the first build _did_ work as expected.
But only because for the first build the build parameters do not exist yet
and therefore env.BUILD_ALL_FLAVOURS was null which is treated as false.
For the second build I selected the BUILD_ALL_FLAVOURS option, which also worked.
Yet I did not run a third build with that option deselected.