### PR TITLE
CATROID-104 touches_object not working correctly anymore

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/common/LookDataTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/common/LookDataTest.java
@@ -23,22 +23,85 @@
 
 package org.catrobat.catroid.test.common;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.SingleSprite;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.io.ResourceImporter;
+import org.catrobat.catroid.io.StorageOperations;
+import org.catrobat.catroid.io.XstreamSerializer;
+import org.catrobat.catroid.utils.ImageEditing;
+import org.catrobat.catroid.utils.PathBuilder;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.File;
+import java.io.IOException;
+
+import static junit.framework.Assert.assertEquals;
+
+import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(AndroidJUnit4.class)
 public class LookDataTest {
+	private LookData lookData;
+	private String filePath;
+
+	final String expectedMetadata = "0.0;228.0;9.0;321.0;57.0;411.0;136.0;474.0;228.0;500.0;305.0;495.0;375.0;468.0;"
+			+ "436.0;419.0;474.0;364.0;497.0;295.0;499.0;218.0;481.0;151.0;443.0;89.0;385.0;38.0;321.0;9.0;179.0;"
+			+ "9.0;115.0;38.0;57.0;89.0;19.0;151.0|125.0;248.0;154.0;330.0;201.0;365.0;248.0;375.0;313.0;358.0;"
+			+ "365.0;299.0;374.0;234.0;346.0;170.0;285.0;130.0;206.0;133.0;150.0;175.0";
+
+	@Before
+	public void setUp() throws Exception {
+		Project project = new Project(InstrumentationRegistry.getTargetContext(), getClass().getSimpleName());
+		filePath = project.getDefaultScene().getDirectory() + "/" + IMAGE_DIRECTORY_NAME + "/collision_donut.png";
+
+		Sprite sprite = new SingleSprite("testSprite");
+		project.getDefaultScene().addSprite(sprite);
+
+		ProjectManager.getInstance().setCurrentProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+		XstreamSerializer.getInstance().saveProject(project);
+
+		File imageFile = ResourceImporter.createImageFileFromResourcesInDirectory(
+				InstrumentationRegistry.getContext().getResources(),
+				org.catrobat.catroid.test.R.raw.collision_donut,
+				new File(project.getDefaultScene().getDirectory(), IMAGE_DIRECTORY_NAME),
+				"collision_donut.png",
+				1);
+
+		lookData = new LookData("test", imageFile);
+		sprite.getLookList().add(lookData);
+	}
+
+	@Test
+	public void testCollisionInformation() throws IOException, InterruptedException {
+		lookData.getCollisionInformation().loadOrCreateCollisionPolygon();
+
+		String metadata = ImageEditing.readMetaDataStringFromPNG(filePath, Constants.COLLISION_PNG_META_TAG_KEY);
+
+		assertEquals(expectedMetadata, metadata);
+	}
+
+	@After
+	public void tearDown() throws IOException {
+		StorageOperations.deleteDir(new File(PathBuilder.buildProjectPath(getClass().getSimpleName())));
+	}
 
 	@Test
 	public void testPixmapAndTextureRegionDisposal() {

--- a/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
@@ -213,6 +213,10 @@ public class LookData implements Cloneable, Nameable, Serializable {
 		return new int[] {width, height};
 	}
 
+	public void clearCollisionInformation() {
+		collisionInformation = null;
+	}
+
 	public CollisionInformation getCollisionInformation() {
 		if (collisionInformation == null) {
 			collisionInformation = new CollisionInformation(this);

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
@@ -37,6 +37,7 @@ import org.catrobat.catroid.utils.ImageEditing;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -78,11 +79,18 @@ public class CollisionInformation {
 		return size;
 	}
 
+	public String getImageMimeType(String pathName) {
+		BitmapFactory.Options options = new BitmapFactory.Options();
+		options.inJustDecodeBounds = true;
+		BitmapFactory.decodeFile(pathName, options);
+		return options.outMimeType;
+	}
+
 	public void loadOrCreateCollisionPolygon() {
 		isCalculationThreadCancelled = false;
 		String path = lookData.getFile().getAbsolutePath();
 		if (collisionPolygons == null) {
-			if (!path.endsWith(".png")) {
+			if (!getImageMimeType(path).equals("image/png")) {
 				Bitmap bitmap = BitmapFactory.decodeFile(path);
 				collisionPolygons = createCollisionPolygonByHitbox(bitmap);
 				return;
@@ -175,8 +183,8 @@ public class CollisionInformation {
 			if (lookData.getCollisionInformation().isCalculationThreadCancelled) {
 				return new ArrayList<>();
 			}
-
-			CollisionPolygonVertex end = finalVertices.get(polygonNumber).get(finalVertices.get(polygonNumber)
+			List<CollisionPolygonVertex> currentPolygonVertex = finalVertices.get(polygonNumber);
+			CollisionPolygonVertex end = currentPolygonVertex.get(currentPolygonVertex
 					.size() - 1);
 			boolean found = false;
 			for (int h = 0; h < horizontal.size(); h++) {
@@ -184,12 +192,9 @@ public class CollisionInformation {
 					finalVertices.get(polygonNumber).add(horizontal.get(h));
 					horizontal.remove(h);
 					found = true;
+					end = currentPolygonVertex.get(currentPolygonVertex.size() - 1);
 					break;
 				}
-			}
-
-			if (found) {
-				end = finalVertices.get(polygonNumber).get(finalVertices.get(polygonNumber).size() - 1);
 			}
 
 			for (int v = 0; v < vertical.size(); v++) {
@@ -369,10 +374,12 @@ public class CollisionInformation {
 	public static boolean[][] createCollisionGrid(Bitmap bitmap) {
 		int width = bitmap.getWidth();
 		int height = bitmap.getHeight();
+		int[] pixels = new int[width * height];
+		bitmap.getPixels(pixels, 0, width, 0, 0, width, height);
 		boolean[][] grid = new boolean[width][height];
 		for (int x = 0; x < width; x++) {
 			for (int y = 0; y < height; y++) {
-				if (bitmap.getPixel(x, y) != 0) {
+				if (pixels[y * width + x] != 0) {
 					grid[x][y] = true;
 				}
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -251,7 +251,10 @@ public class ProjectActivity extends BaseCastActivity {
 							File imageDirectory = new File(currentScene.getDirectory(), IMAGE_DIRECTORY_NAME);
 							File file = StorageOperations
 									.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
-							sprite.getLookList().add(new LookData(textInput, file));
+
+							LookData lookData = new LookData(textInput, file);
+							sprite.getLookList().add(lookData);
+							lookData.getCollisionInformation().calculate();
 						} catch (IOException e) {
 							Log.e(TAG, Log.getStackTraceString(e));
 						}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -376,7 +376,9 @@ public class SpriteActivity extends BaseActivity {
 							File imageDirectory = new File(currentScene.getDirectory(), IMAGE_DIRECTORY_NAME);
 							File file = StorageOperations
 									.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
-							sprite.getLookList().add(new LookData(textInput, file));
+							LookData lookData = new LookData(textInput, file);
+							sprite.getLookList().add(lookData);
+							lookData.getCollisionInformation().calculate();
 						} catch (IOException e) {
 							Log.e(TAG, Log.getStackTraceString(e));
 						}
@@ -430,6 +432,7 @@ public class SpriteActivity extends BaseActivity {
 			File file = StorageOperations.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
 			LookData look = new LookData(lookDataName, file);
 			currentSprite.getLookList().add(look);
+			look.getCollisionInformation().calculate();
 			if (onNewLookListener != null) {
 				onNewLookListener.addItem(look);
 			}
@@ -464,6 +467,7 @@ public class SpriteActivity extends BaseActivity {
 			File file = StorageOperations.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
 			LookData look = new LookData(lookDataName, file);
 			currentSprite.getLookList().add(look);
+			look.getCollisionInformation().calculate();
 			if (onNewLookListener != null) {
 				onNewLookListener.addItem(look);
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
@@ -187,6 +187,7 @@ public class LookListFragment extends RecyclerViewFragment<LookData> {
 		}
 
 		item.invalidateThumbnailBitmap();
+		item.clearCollisionInformation();
 
 		Intent intent = new Intent("android.intent.action.MAIN");
 		intent.setComponent(new ComponentName(getActivity(), POCKET_PAINT_INTENT_ACTIVITY_NAME));


### PR DESCRIPTION
- fixed that stage starts before collision calculation finished
- collision information now gets already calculated in the background
  on look creation/edition
- file ending gets extracted over mime type (png relevant)
- small test for the collision functionality