### PR TITLE
CATROID-39 bug fix regarding uploading a project after session expired.

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/transfers/FacebookLoginHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/FacebookLoginHandler.java
@@ -97,7 +97,7 @@ public class FacebookLoginHandler implements FacebookCallback<LoginResult>,
 
 	@Override
 	public void forceSignIn() {
-		ToastUtil.showError(activity, activity.getString(R.string.error_facebook_session_expired));
+		ToastUtil.showError(activity, activity.getString(R.string.error_session_expired));
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/activity/ProjectUploadActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/activity/ProjectUploadActivity.java
@@ -208,8 +208,14 @@ public class ProjectUploadActivity extends BaseActivity implements
 	@Override
 	public void onTokenCheckComplete(boolean tokenValid, boolean connectionFailed) {
 		if (connectionFailed) {
-			ToastUtil.showError(this, R.string.error_internet_connection);
-			finish();
+			if (!tokenValid) {
+				ToastUtil.showError(this, R.string.error_session_expired);
+				Utils.logoutUser(this);
+				startSignInWorkflow();
+			} else {
+				ToastUtil.showError(this, R.string.error_internet_connection);
+				finish();
+			}
 		} else if (!tokenValid) {
 			startSignInWorkflow();
 		} else {

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -952,7 +952,7 @@
     <string name="show_password">Show password</string>
     <string name="sign_in_error">Error during sign-sn</string>
     <string name="error_google_plus_sign_in">Google sign-in error. Status: %s</string>
-    <string name="error_facebook_session_expired">Session expired, please log in.</string>
+    <string name="error_session_expired">Session expired, please log in.</string>
     <string name="sign_in_with_facebook">Sign in with Facebook</string>
     <string name="sign_in_with_google">Sign in with Google</string>
     <string name="error_register_empty_username">Empty username</string>


### PR DESCRIPTION
Toast message shows to check internet connection. But  the error that session expired and a redirection to
signinworkflow should displayed. Test cannot be written because for reproducing issue
needs second device/emulator which signs in and first emulator/device
tries to upload a project.