### PR TITLE
JENKINS-248: Add Playground-App support for release pipeline testing

### DIFF
--- a/Jenkinsfile.buildMetadata
+++ b/Jenkinsfile.buildMetadata
@@ -27,17 +27,26 @@ pipeline {
         stage('Prepare build') {
             steps {
                 script {
-                    currentBuild.displayName = "#${env.BUILD_NUMBER}"
+                    currentBuild.displayName = "#${env.BUILD_NUMBER} | ${env.flavor} | ${env.gitBranch}"
                 }
             }
         }
 
         stage('Setup Translations') {
             steps {
-                sh '''
-                    set +x
-                    ./gradlew generateCrowdinMetadataCatroid -PcrowdinKey=$crowdinKey
-                '''
+                script {
+                    if (env.flavor == 'Playground') {
+                        sh '''
+                            set +x
+                            ./gradlew generateCrowdinMetadataCatroid -PcrowdinKey=$crowdinKey
+                        '''
+                    } else {
+                        sh '''
+                            set +x
+                            ./gradlew generateCrowdinMetadata${flavor} -PcrowdinKey=$crowdinKey
+                        '''
+                    }
+                }
             }
         }
 
@@ -49,7 +58,15 @@ pipeline {
 
         stage('Create Screenshots') {
             steps {
-                sh "./gradlew generateScreenshotsCatroid"
+                script {
+                    if (env.flavor == 'Playground') {
+                        sh './gradlew generateScreenshotsCatroid'
+                    } else {
+                        sh './gradlew generateScreenshots${flavor}'
+                    }
+                }
+                zip zipFile: 'metadata.zip', archive: false, dir: 'fastlane/metadata'
+                archiveArtifacts artifacts: 'metadata.zip', fingerprint: true
             }
             post {
                 always {
@@ -88,7 +105,7 @@ pipeline {
                 environment name: 'APPROVE_DEPLOY', value: 'yes'
             }
             steps {
-                sh "fastlane android upload_Metadata_Catroid"
+                sh 'fastlane android upload_Metadata_${flavor}'
             }
         }
 
@@ -97,12 +114,24 @@ pipeline {
                 environment name: 'APPROVE_DEPLOY', value: 'yes'
             }
             steps {
-                sh "fastlane android promote_Catroid"
+                script {
+                    if (env.flavor == 'Playground') {
+                        echo 'Playground cannot be promoted to production!'
+                    } else {
+                        // deactivated for testing to not publish by accident
+                        //sh 'fastlane android promote_${flavor}'
+                        echo 'The promotion of the APK is currently deactivated!'
+                    }
+                }
             }
         }
     }
 
     post {
+        always {
+            // clean workspace
+            deleteDir()
+        }
         changed {
             notifyChat()
         }

--- a/Jenkinsfile.releaseAPK
+++ b/Jenkinsfile.releaseAPK
@@ -27,7 +27,7 @@ pipeline {
         stage('Prepare build') {
             steps {
                 script {
-                    currentBuild.displayName = "#${env.BUILD_NUMBER}"
+                    currentBuild.displayName = "#${env.BUILD_NUMBER} | ${env.flavor} | ${env.gitBranch}"
                 }
             }
         }
@@ -36,17 +36,46 @@ pipeline {
             steps {
                 // Build, zipalign and sign releasable APK
                 withCredentials([file(credentialsId: 'a925b6e8-b3c6-407e-8cad-65886e330037', variable: 'SIGNING_KEYSTORE')]) {
-                    sh '''
-                        set +x
-                        ./gradlew assembleCatroidSignedRelease \
-                        -PsigningKeystore=${SIGNING_KEYSTORE} \
-                        -PsigningKeystorePassword=$signingKeystorePassword \
-                        -PsigningKeyAlias=$signingKeyAlias \
-                        -PsigningKeyPassword=$signingKeyPassword \
-                        -PfirebaseApiKey=$firebaseApiKey \
-                        -PfabricApiKey=$fabricApiKey \
-                        -PfabricApiSecret=$fabricApiSecret
-                    '''
+                    script {
+                        if (env.flavor == 'All') {
+                            sh '''
+                                set +x
+                                ./gradlew assembleSignedRelease \
+                                -PsigningKeystore=${SIGNING_KEYSTORE} \
+                                -PsigningKeystorePassword=$signingKeystorePassword \
+                                -PsigningKeyAlias=$signingKeyAlias \
+                                -PsigningKeyPassword=$signingKeyPassword \
+                                -PfirebaseApiKey=$firebaseApiKey \
+                                -PfabricApiKey=$fabricApiKey \
+                                -PfabricApiSecret=$fabricApiSecret
+                            '''
+                        } else if (env.flavor == 'Playground') {
+                            sh '''
+                                set +x
+                                ./gradlew assembleCatroidSignedRelease \
+                                -PsigningKeystore=${SIGNING_KEYSTORE} \
+                                -PsigningKeystorePassword=$signingKeystorePassword \
+                                -PsigningKeyAlias=$signingKeyAlias \
+                                -PsigningKeyPassword=$signingKeyPassword \
+                                -PfirebaseApiKey=$firebaseApiKey \
+                                -PfabricApiKey=$fabricApiKey \
+                                -PfabricApiSecret=$fabricApiSecret \
+                                -Pplayground=true
+                            '''
+                        } else {
+                            sh '''
+                                set +x
+                                ./gradlew assemble${flavor}SignedRelease \
+                                -PsigningKeystore=${SIGNING_KEYSTORE} \
+                                -PsigningKeystorePassword=$signingKeystorePassword \
+                                -PsigningKeyAlias=$signingKeyAlias \
+                                -PsigningKeyPassword=$signingKeyPassword \
+                                -PfirebaseApiKey=$firebaseApiKey \
+                                -PfabricApiKey=$fabricApiKey \
+                                -PfabricApiSecret=$fabricApiSecret
+                            '''
+                        }
+                    }
                 }
                 archiveArtifacts artifacts: 'catroid/build/outputs/apk/**/*signedRelease.apk', fingerprint: true
             }
@@ -70,7 +99,18 @@ pipeline {
                 environment name: 'APPROVE_UPLOAD_APK', value: 'yes'
             }
             steps {
-                sh "fastlane android upload_APK_Catroid"
+                script {
+                    if (env.flavor == 'All') {
+                        sh '''
+                            fastlane android upload_APK_Catroid \
+                            fastlane android upload_APK_CreateAtSchool
+                            fastlane android upload_APK_LunaAndCat \
+                            fastlane android upload_APK_Phiro \
+                        '''
+                    } else {
+                        sh 'fastlane android upload_APK_${flavor}'
+                    }
+                }
             }
         }
     }

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -111,6 +111,13 @@ if (project.hasProperty('independent')) {
     manifestAppName = appName
 }
 
+if (project.hasProperty('playground') && project.getProperties().get('playground') == 'true') {
+    logger.lifecycle('playground true: ' + project.getProperties().get('playground'))
+    appId = 'org.catrobat.catroid.test'
+    appName = 'Catrobat Playground'
+    manifestAppName = appName
+}
+
 if (!project.hasProperty("signingKeystore")) {
     ext.signingKeystore = "dummyKeystore"
 }

--- a/catroid/gradle/release_fastlane_tasks.gradle
+++ b/catroid/gradle/release_fastlane_tasks.gradle
@@ -65,7 +65,7 @@ android.productFlavors.all { flavor ->
 
         String fastlaneCommand = "fastlane screengrab" +
                 " --app_package_name 'org.catrobat.catroid'" +
-                " --use_tests_in_packages 'org.catrobat.catroid.screenshots.${flavor.name}'" +
+                " --use_tests_in_packages 'org.catrobat.catroid.screenshots.${flavor.name.toLowerCase()}'" +
                 " --app_apk_path './catroid/build/outputs/apk/${flavor.name}/debug/catroid-${flavor.name}-debug.apk'" +
                 " --tests_apk_path './catroid/build/outputs/apk/androidTest/${flavor.name}/debug/catroid-${flavor.name}-debug-androidTest.apk'" +
                 " --test_instrumentation_runner 'android.support.test.runner.AndroidJUnitRunner'" +

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,24 +24,8 @@ platform :android do
     gradle(task: "test")
   end
 
-  desc "Submit a new Beta Build to Crashlytics Beta"
-  lane :beta do
-    gradle(task: "clean assembleRelease")
-    crashlytics
-  
-    # sh "your_script.sh"
-    # You can also use other beta testing services here
-  end
-
-  desc "Deploy a new version to the Google Play"
-  lane :deploy do
-    gradle(task: "clean assembleRelease")
-    upload_to_play_store
-  end
-
   desc "upload Catroid metadata only"
   lane :upload_Metadata_Catroid do
-    # ...
     upload_to_play_store(
       package_name:               'org.catrobat.catroid',
       track:                      'alpha',
@@ -58,7 +42,6 @@ platform :android do
 
   desc "upload Catroid APK to alpha track"
   lane :upload_APK_Catroid do
-    # ...
     upload_to_play_store(
       package_name:               'org.catrobat.catroid',
       track:                      'alpha',
@@ -75,7 +58,6 @@ platform :android do
 
   desc "promote Catroid APK on alpha track to production"
   lane :promote_Catroid do
-    # ...
     upload_to_play_store(
       package_name:               'org.catrobat.catroid',
       track:                      'alpha',
@@ -88,15 +70,169 @@ platform :android do
       skip_upload_screenshots:    'true',
     )
   end
-  
+
+  desc "upload CreateAtSchool metadata only"
+  lane :upload_Metadata_CreateAtSchool do
+    upload_to_play_store(
+      package_name:               'org.catrobat.catroid.createatschool',
+      track:                      'alpha',
+      json_key_data:              ENV['googlePlayJsonKey'],
+      metadata_path:              './fastlane/metadata/android',
+      skip_upload_apk:            'true',
+      skip_upload_metadata:       'false',
+      skip_upload_images:         'false',
+      skip_upload_screenshots:    'false',
+      validate_only:              'false',
+      check_superseded_tracks:    'false',
+    )
+  end
+
+  desc "upload CreateAtSchool APK to alpha track"
+  lane :upload_APK_CreateAtSchool do
+    upload_to_play_store(
+      package_name:               'org.catrobat.catroid.createatschool',
+      track:                      'alpha',
+      json_key_data:              ENV['googlePlayJsonKey'],
+      apk_paths:                  './catroid/build/outputs/apk/createatschool/signedRelease/catroid-createatschool-signedRelease.apk',
+      skip_upload_apk:            'false',
+      skip_upload_metadata:       'true',
+      skip_upload_images:         'true',
+      skip_upload_screenshots:    'true',
+      validate_only:              'false',
+      check_superseded_tracks:    'false',
+    )
+  end
+
+  desc "promote CreateAtSchool APK on alpha track to production"
+  lane :promote_CreateAtSchool do
+    upload_to_play_store(
+      package_name:               'org.catrobat.catroid.createatschool',
+      track:                      'alpha',
+      track_promote_to:           'production',
+      json_key_data:              ENV['googlePlayJsonKey'],
+      metadata_path:              './fastlane/metadata/android',
+      skip_upload_apk:            'true',
+      skip_upload_metadata:       'true',
+      skip_upload_images:         'true',
+      skip_upload_screenshots:    'true',
+    )
+  end
+
+  desc "upload Luna&Cat metadata only"
+  lane :upload_Metadata_LunaAndCat do
+    upload_to_play_store(
+      package_name:               'org.catrobat.catroid.lunaandcat',
+      track:                      'alpha',
+      json_key_data:              ENV['googlePlayJsonKey'],
+      metadata_path:              './fastlane/metadata/android',
+      skip_upload_apk:            'true',
+      skip_upload_metadata:       'false',
+      skip_upload_images:         'false',
+      skip_upload_screenshots:    'false',
+      validate_only:              'false',
+      check_superseded_tracks:    'false',
+    )
+  end
+
   desc "upload Luna&Cat APK to alpha track"
   lane :upload_APK_LunaAndCat do
-    # ...
     upload_to_play_store(
-      package_name:               'org.catrobat.catroid',
+      package_name:               'org.catrobat.catroid.lunaandcat',
       track:                      'alpha',
       json_key_data:              ENV['googlePlayJsonKey'],
       apk_paths:                  './catroid/build/outputs/apk/lunaAndCat/signedRelease/catroid-lunaAndCat-signedRelease.apk',
+      skip_upload_apk:            'false',
+      skip_upload_metadata:       'true',
+      skip_upload_images:         'true',
+      skip_upload_screenshots:    'true',
+      validate_only:              'false',
+      check_superseded_tracks:    'false',
+    )
+  end
+
+  desc "promote Luna&Cat APK on alpha track to production"
+  lane :promote_LunaAndCat do
+    upload_to_play_store(
+      package_name:               'org.catrobat.catroid.lunaandcat',
+      track:                      'alpha',
+      track_promote_to:           'production',
+      json_key_data:              ENV['googlePlayJsonKey'],
+      metadata_path:              './fastlane/metadata/android',
+      skip_upload_apk:            'true',
+      skip_upload_metadata:       'true',
+      skip_upload_images:         'true',
+      skip_upload_screenshots:    'true',
+    )
+  end
+
+  desc "upload Phiro metadata only"
+  lane :upload_Metadata_Phiro do
+    upload_to_play_store(
+      package_name:               'org.catrobat.catroid.phiro',
+      track:                      'alpha',
+      json_key_data:              ENV['googlePlayJsonKey'],
+      metadata_path:              './fastlane/metadata/android',
+      skip_upload_apk:            'true',
+      skip_upload_metadata:       'false',
+      skip_upload_images:         'false',
+      skip_upload_screenshots:    'false',
+      validate_only:              'false',
+      check_superseded_tracks:    'false',
+    )
+  end
+
+  desc "upload Phiro APK to alpha track"
+  lane :upload_APK_Phiro do
+    upload_to_play_store(
+      package_name:               'org.catrobat.catroid.phiro',
+      track:                      'alpha',
+      json_key_data:              ENV['googlePlayJsonKey'],
+      apk_paths:                  './catroid/build/outputs/apk/phiro/signedRelease/catroid-phiro-signedRelease.apk',
+      skip_upload_apk:            'false',
+      skip_upload_metadata:       'true',
+      skip_upload_images:         'true',
+      skip_upload_screenshots:    'true',
+    )
+  end
+
+  desc "promote Phiro APK on alpha track to production"
+  lane :promote_Phiro do
+    upload_to_play_store(
+      package_name:               'org.catrobat.catroid.phiro',
+      track:                      'alpha',
+      track_promote_to:           'production',
+      json_key_data:              ENV['googlePlayJsonKey'],
+      metadata_path:              './fastlane/metadata/android',
+      skip_upload_apk:            'true',
+      skip_upload_metadata:       'true',
+      skip_upload_images:         'true',
+      skip_upload_screenshots:    'true',
+    )
+  end
+
+  desc "upload Playground metadata only"
+  lane :upload_Metadata_Playground do
+    upload_to_play_store(
+      package_name:               'org.catrobat.catroid.test',
+      track:                      'alpha',
+      json_key_data:              ENV['googlePlayJsonKey'],
+      metadata_path:              './fastlane/metadata/android',
+      skip_upload_apk:            'true',
+      skip_upload_metadata:       'false',
+      skip_upload_images:         'false',
+      skip_upload_screenshots:    'false',
+      validate_only:              'false',
+      check_superseded_tracks:    'false',
+    )
+  end
+
+  desc "upload Playground APK to alpha track"
+  lane :upload_APK_Playground do
+    upload_to_play_store(
+      package_name:               'org.catrobat.catroid.test',
+      track:                      'alpha',
+      json_key_data:              ENV['googlePlayJsonKey'],
+      apk_paths:                  './catroid/build/outputs/apk/catroid/signedRelease/catroid-catroid-signedRelease.apk',
       skip_upload_apk:            'false',
       skip_upload_metadata:       'true',
       skip_upload_images:         'true',


### PR DESCRIPTION
- add the option to upload the Playground-App to org.catrobat.catroid.test on Google Play
- add flavor selection in Jenkinsfiles for APK-Release and Metadata