### PR TITLE
QUICKFIX Removed OS file picker for project import

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ProjectListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ProjectListFragment.java
@@ -25,7 +25,6 @@ package org.catrobat.catroid.ui.recyclerview.fragment;
 
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.PluralsRes;
 import android.support.v7.app.AlertDialog;
@@ -142,17 +141,8 @@ public class ProjectListFragment extends RecyclerViewFragment<ProjectData> imple
 
 			@Override
 			public void task() {
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-					Intent intent = new Intent(Intent.ACTION_GET_CONTENT)
-							.addCategory(Intent.CATEGORY_OPENABLE)
-							.setType("application/zip");
-
-					startActivityForResult(Intent
-							.createChooser(intent, getString(R.string.import_project)), REQUEST_IMPORT_PROJECT);
-				} else {
-					startActivityForResult(
-							new Intent(getContext(), FilePickerActivity.class), REQUEST_IMPORT_PROJECT);
-				}
+				startActivityForResult(
+						new Intent(getContext(), FilePickerActivity.class), REQUEST_IMPORT_PROJECT);
 			}
 		}.execute(getActivity());
 	}


### PR DESCRIPTION
 - file picker fails to recognize some .catrobat files as zip files.
 - removed file picker and replaced it with custom implmentation
   (that we already used on devices running apis < 17) to
   curcumvent this problem.