### PR TITLE
JENKINS-296 Add legacy tests to the Catroid job.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,6 +142,20 @@ pipeline {
                             }
                         }
 
+                        stage('Legacy Tests') {
+                            steps {
+                                sh '''./gradlew -PenableCoverage -PlogcatFile=legacy_logcat.txt -Pemulator=android19 \
+                                            startEmulator createCatroidDebugAndroidTestCoverageReport \
+                                            -Pandroid.testInstrumentationRunnerArguments.class=org.catrobat.catroid.uiespresso.testsuites.ApiLevel19RegressionTestsSuite'''
+                            }
+
+                            post {
+                                always {
+                                    postEmulator 'legacy'
+                                }
+                            }
+                        }
+
                         stage('Quarantined Tests') {
                             when {
                                 expression { isJobStartedByTimer() }


### PR DESCRIPTION
The legacy tests are there to detect regressions with older Android versions,
in this case for Android 19.