### PR TITLE
UTIL Removed REORDER_TASKS permission.

### DIFF
--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -39,7 +39,6 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.REORDER_TASKS" />
 
     <uses-feature
         android:name="android.hardware.camera"


### PR DESCRIPTION
  - used to be necessary to correctly handle cases
    where pocket paint was not installed on device.