### PR TITLE
STCC-182 Fetching Meta Data in Pocket Code fails

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/web/ServerCalls.java
+++ b/catroid/src/main/java/org/catrobat/catroid/web/ServerCalls.java
@@ -219,7 +219,6 @@ public final class ServerCalls implements ScratchDataFetcher {
 			final int favorites = jsonData.getInt("favorites");
 			final int loves = jsonData.getInt("loves");
 			final ScratchVisibilityState visibilityState = ScratchVisibilityState.valueOf(jsonObject.getInt("visibility"));
-			final JSONArray jsonTags = jsonData.getJSONArray("tags");
 
 			Date sharedDate;
 			try {
@@ -250,10 +249,6 @@ public final class ServerCalls implements ScratchDataFetcher {
 			programData.setLoves(loves);
 			programData.setFavorites(favorites);
 			programData.setVisibilityState(visibilityState);
-
-			for (int i = 0; i < jsonTags.length(); i++) {
-				programData.addTag(jsonTags.getString(i));
-			}
 
 			JSONArray remixes = jsonData.getJSONArray("remixes");
 			for (int i = 0; i < remixes.length(); ++i) {


### PR DESCRIPTION
"tags" are no longer available in the scratch metadata, it doesn't seem there is any replacement for them. Removing them solves the "Whoops Server did not reply" and missing metadata.