### PR TITLE
QUICKFIX Fixed null pointer exception when unpacking bricks with

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/LookController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/LookController.java
@@ -110,6 +110,14 @@ public class LookController {
 	}
 
 	private boolean compareByChecksum(File file1, File file2) {
+		// The backpack uses this method and because the backpack does not correctly
+		// de-serialize LookData references we can end up with a new LookData that has a null file reference
+		// although we actually need one that already exists. so the workaround here (prevents a lot of crashes) is
+		// to just hope that copying bricks with references to files always happens after the LookDatas are copied.
+		if (file1 == null || file2 == null) {
+			return true;
+		}
+
 		String checksum1 = Utils.md5Checksum(file1);
 		String checksum2 = Utils.md5Checksum(file2);
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SoundController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SoundController.java
@@ -111,6 +111,14 @@ public class SoundController {
 	}
 
 	private boolean compareByChecksum(File file1, File file2) {
+		// The backpack uses this method and because the backpack does not correctly
+		// de-serialize SoundInfo references we can end up with a new SoundInfo that has a null file reference
+		// although we actually need one that already exists. so the workaround here (prevents a lot of crashes) is
+		// to just hope that copying bricks with references to files always happens after the SoundInfos are copied.
+		if (file1 == null || file2 == null) {
+			return true;
+		}
+
 		String checksum1 = Utils.md5Checksum(file1);
 		String checksum2 = Utils.md5Checksum(file2);
 


### PR DESCRIPTION
references.

 - added a workaround to prevent crashes in backpack.