### PR TITLE
CATROID-175 Fix concurrency issues in StageListener

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -419,20 +419,6 @@ public class StageListener implements ApplicationListener {
 		}
 	}
 
-	public void finish() {
-		SoundManager.getInstance().clear();
-		PhysicsShapeBuilder.getInstance().reset();
-		if (CameraManager.getInstance() != null) {
-			CameraManager.getInstance().setToDefaultCamera();
-		}
-		if (penActor != null) {
-			penActor.dispose();
-		}
-
-		embroideryList = null;
-		finished = true;
-	}
-
 	@Override
 	public void render() {
 		if (CameraManager.getInstance() != null && CameraManager.getInstance().getState() == CameraManager.CameraState.previewRunning) {
@@ -589,8 +575,24 @@ public class StageListener implements ApplicationListener {
 		disposeStageButKeepActors();
 		font.dispose();
 		axes.dispose();
+
 		disposeTextures();
 		disposeClonedSprites();
+
+		SoundManager.getInstance().clear();
+		PhysicsShapeBuilder.getInstance().reset();
+		embroideryList = null;
+		if (penActor != null) {
+			penActor.dispose();
+		}
+	}
+
+	public void finish() {
+		if (CameraManager.getInstance() != null) {
+			CameraManager.getInstance().setToDefaultCamera();
+		}
+
+		finished = true;
 	}
 
 	public boolean takeScreenshot(String screenshotName) {


### PR DESCRIPTION
The app crashes many times when leaving the stage due to concurrency
issues during releasing resources.

When leaving the Stage, StageListener.finish is called from the Android
UI thread, ApplicationListener methods (e.g. render or dispose) are
called from the OpenGL thread. Since finish will free up resources that
may be still used in render/dispose, the app will crash.

The proper way to release resources in libgdx is by using the
overwritten ApplicationListener.dispose method. Since all
ApplicationListener methods are called synchronously by the OpenGL
thread, moving most of the code from finish to dispose will fix all
concurrency issues.

I'm not sure if also moving the CameraManager, which is used by the
FaceDetection and maybe other features, from finish to dispose will
create new problems. So I kept it in the finish method.
___
Please, please, please don't make me write tests here :pray::sweat_smile: I know you can call `create` and `dispose` directly, wrap the dispose stuff in classes or add some getters and mocks, but still nah!…
