### PR TITLE
JENKINS-297 Add a suffix for the APKs that contains the branch name a…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,6 +98,7 @@ pipeline {
                                 // Build the flavors so that they can be installed next independently of older versions.
                                 sh "./gradlew ${useWebTestParameter()} -Pindependent='#$env.BUILD_NUMBER $env.BRANCH_NAME' assembleCatroidDebug ${allFlavoursParameters()}"
 
+                                renameApks("${env.BRANCH_NAME}-${env.BUILD_NUMBER}")
                                 archiveArtifacts '**/*.apk'
                             }
                         }


### PR DESCRIPTION
…nd the build number.

This makes it easier to track where an APK came from.
Especially when you store multiple APKs locally.