### PR TITLE
CATROID-FIX Fix notification start downloaded project

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/MainMenuFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/MainMenuFragment.java
@@ -134,6 +134,7 @@ public class MainMenuFragment extends Fragment implements
 
 		String projectName = getActivity().getIntent().getStringExtra(StatusBarNotificationManager.EXTRA_PROJECT_NAME);
 		if (projectName != null) {
+			getActivity().getIntent().removeExtra(StatusBarNotificationManager.EXTRA_PROJECT_NAME);
 			loadDownloadedProject(projectName);
 		}
 	}


### PR DESCRIPTION
After opening a downloaded project via the notification, the back-button won't work anymore.
(The application loads the project again)
This line solves the problem.