### PR TITLE
CATROID-88 Devices without Flash should ignore FlashBrick

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -462,9 +462,9 @@ dependencies {
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
 
-    testImplementation 'org.powermock:powermock:1.6.5'
-    testImplementation 'org.powermock:powermock-module-junit4:1.7.0'
-    testImplementation 'org.powermock:powermock-api-mockito2:1.7.0RC2'
+    testImplementation 'org.powermock:powermock:1.6.6'
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.0'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.0'
 
     testImplementation 'org.robolectric:robolectric:4.2'
     testImplementation "org.robolectric:shadows-multidex:4.2"

--- a/catroid/src/main/java/org/catrobat/catroid/camera/CameraManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/camera/CameraManager.java
@@ -27,6 +27,7 @@ import android.graphics.SurfaceTexture;
 import android.graphics.YuvImage;
 import android.hardware.Camera;
 import android.hardware.Camera.Parameters;
+import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 import android.view.ViewGroup;
 import android.view.ViewParent;
@@ -96,6 +97,11 @@ public final class CameraManager implements DeviceCameraControl, Camera.PreviewC
 		return instance;
 	}
 
+	@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+	public static void setInstance(CameraManager cameraManager) {
+		instance = cameraManager;
+	}
+
 	public static void makeInstance() {
 		instance = new CameraManager();
 	}
@@ -120,17 +126,11 @@ public final class CameraManager implements DeviceCameraControl, Camera.PreviewC
 	}
 
 	public boolean hasBackCamera() {
-		if (backCameraInformation == null) {
-			return false;
-		}
-		return true;
+		return backCameraInformation != null;
 	}
 
 	public boolean hasFrontCamera() {
-		if (frontCameraInformation == null) {
-			return false;
-		}
-		return true;
+		return frontCameraInformation != null;
 	}
 
 	private boolean hasCameraFlash(int cameraId) {
@@ -307,7 +307,15 @@ public final class CameraManager implements DeviceCameraControl, Camera.PreviewC
 	}
 
 	public boolean hasCurrentCameraFlash() {
-		return currentCameraInformation.flashAvailable;
+		return (currentCameraInformation != null && currentCameraInformation.flashAvailable);
+	}
+
+	public boolean hasBackCameraFlash() {
+		return (hasBackCamera() && backCameraInformation.flashAvailable);
+	}
+
+	public boolean hasFrontCameraFlash() {
+		return (hasFrontCamera() && frontCameraInformation.flashAvailable);
 	}
 
 	public CameraState getState() {
@@ -543,18 +551,19 @@ public final class CameraManager implements DeviceCameraControl, Camera.PreviewC
 		}
 	}
 
-	public boolean switchToCameraWithFlash() {
+	public boolean isCameraFlashAvailable() {
+		return (hasBackCameraFlash() || hasFrontCameraFlash());
+	}
+
+	public void switchToCameraWithFlash() {
 		if (hasCurrentCameraFlash()) {
-			return true;
+			return;
 		}
-		if (frontCameraInformation.flashAvailable) {
+
+		if (hasFrontCameraFlash()) {
 			updateCamera(frontCameraInformation);
-			return true;
-		}
-		if (backCameraInformation.flashAvailable) {
+		} else if (hasBackCameraFlash()) {
 			updateCamera(backCameraInformation);
-			return true;
 		}
-		return false;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageResourceHolder.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageResourceHolder.java
@@ -301,12 +301,11 @@ public class StageResourceHolder implements GatherCollisionInformationTask.OnPol
 
 		if (requiredResourcesSet.contains(Brick.CAMERA_FLASH)) {
 			CameraManager.makeInstance();
-			if (CameraManager.getInstance().switchToCameraWithFlash()) {
-				FlashUtil.initializeFlash();
-				resourceInitialized();
-			} else {
-				resourceFailed(Brick.CAMERA_FLASH);
+			if (CameraManager.getInstance().isCameraFlashAvailable()) {
+				CameraManager.getInstance().switchToCameraWithFlash();
 			}
+			FlashUtil.initializeFlash();
+			resourceInitialized();
 		}
 
 		if (requiredResourcesSet.contains(Brick.VIBRATOR)) {
@@ -488,10 +487,6 @@ public class StageResourceHolder implements GatherCollisionInformationTask.OnPol
 				case Brick.CAMERA_FRONT:
 					failedResourcesMessage = failedResourcesMessage + stageActivity.getString(R.string
 							.prestage_no_front_camera_available);
-					break;
-				case Brick.CAMERA_FLASH:
-					failedResourcesMessage = failedResourcesMessage + stageActivity.getString(R.string
-							.prestage_no_flash_available);
 					break;
 				case Brick.VIBRATOR:
 					failedResourcesMessage = failedResourcesMessage + stageActivity.getString(R.string

--- a/catroid/src/main/java/org/catrobat/catroid/utils/FlashUtil.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/FlashUtil.java
@@ -23,13 +23,11 @@
 package org.catrobat.catroid.utils;
 
 import android.hardware.Camera;
-import android.util.Log;
 
 import org.catrobat.catroid.camera.CameraManager;
 
 public final class FlashUtil {
 
-	private static final String TAG = FlashUtil.class.getSimpleName();
 	private static Camera.Parameters paramsOn = null;
 	private static Camera.Parameters paramsOff = null;
 
@@ -51,8 +49,11 @@ public final class FlashUtil {
 		return currentFlashValue;
 	}
 
+	public static boolean isPaused() {
+		return paused;
+	}
+
 	public static void pauseFlash() {
-		Log.d(TAG, "pauseFlash");
 		if (!paused && isAvailable()) {
 			paused = true;
 			if (isOn()) {
@@ -63,8 +64,7 @@ public final class FlashUtil {
 	}
 
 	public static void resumeFlash() {
-		Log.d(TAG, "resumeFlash()");
-		if (paused) {
+		if (paused && isAvailable()) {
 			initializeFlash();
 			if (startAgain) {
 				flashOn();
@@ -75,7 +75,6 @@ public final class FlashUtil {
 	}
 
 	public static void destroy() {
-		Log.d(TAG, "reset all variables - called by StageActivity::onDestroy");
 		currentFlashValue = false;
 		paused = false;
 		available = false;
@@ -92,9 +91,12 @@ public final class FlashUtil {
 	}
 
 	public static void initializeFlash() {
-		Log.d(TAG, "initializeFlash()");
+		available = CameraManager.getInstance().hasCurrentCameraFlash();
 
-		available = true;
+		if (!available) {
+			destroy();
+			return;
+		}
 
 		if (!CameraManager.getInstance().isReady()) {
 			CameraManager.getInstance().startCamera();
@@ -111,18 +113,20 @@ public final class FlashUtil {
 	}
 
 	public static void flashOn() {
-		Log.d(TAG, "flashOn()");
-		if (!CameraManager.getInstance().hasCurrentCameraFlash()) {
-			currentFlashValue = false;
-			CameraManager.getInstance().destroyStage();
-		} else {
-			CameraManager.getInstance().setFlashParams(paramsOn);
-			currentFlashValue = true;
+		if (!available) {
+			destroy();
+			return;
 		}
+
+		CameraManager.getInstance().setFlashParams(paramsOn);
+		currentFlashValue = true;
 	}
 
 	public static void flashOff() {
-		Log.d(TAG, "flashOff()");
+		if (!isAvailable()) {
+			return;
+		}
+
 		CameraManager.getInstance().setFlashParams(paramsOff);
 		currentFlashValue = false;
 	}

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -996,7 +996,6 @@
         The following components are unavailable:\n\n</string>
     <string name="prestage_resource_in_use_text">Another device is connected to the Jumping Sumo. Make sure you
         are the one connected to the drone.</string>
-    <string name="prestage_no_flash_available">\u2022 Flash\n</string>
     <string name="prestage_no_vibrator_available">\u2022 Vibration\n</string>
     <string name="prestage_no_acceleration_sensor_available">\u2022 Acceleration sensor\n</string>
     <string name="prestage_no_inclination_sensor_available">\u2022 Inclination sensor\n</string>

--- a/catroid/src/test/java/org/catrobat/catroid/test/utiltests/FlashUtilTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/utiltests/FlashUtilTest.java
@@ -1,0 +1,181 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.utiltests;
+
+import android.hardware.Camera;
+
+import org.catrobat.catroid.camera.CameraManager;
+import org.catrobat.catroid.utils.FlashUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertFalse;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CameraManager.class, Camera.class})
+public class FlashUtilTest {
+
+	private CameraManager oldCameraManagerInstance;
+	private CameraManager cameraManagerMock;
+
+	@Before
+	public void setUp() {
+		oldCameraManagerInstance = CameraManager.getInstance();
+		cameraManagerMock = PowerMockito.mock(CameraManager.class);
+		Camera cameraMock = PowerMockito.mock(Camera.class);
+		Camera.Parameters parametersMock = PowerMockito.mock(Camera.Parameters.class);
+		when(cameraMock.getParameters()).thenReturn(parametersMock);
+		when(cameraManagerMock.getCurrentCamera()).thenReturn(cameraMock);
+
+		CameraManager.setInstance(cameraManagerMock);
+		FlashUtil.reset();
+	}
+
+	@After
+	public void resetInstance() {
+		CameraManager.setInstance(oldCameraManagerInstance);
+	}
+
+	private void simFlashAvailable(boolean flashAvailable) {
+		when(cameraManagerMock.isCameraFlashAvailable()).thenReturn(flashAvailable);
+		when(cameraManagerMock.hasCurrentCameraFlash()).thenReturn(flashAvailable);
+		when(cameraManagerMock.startCamera()).thenReturn(flashAvailable);
+	}
+
+	@Test
+	public void testInitializeFlashWithoutCameraFlash() {
+		simFlashAvailable(false);
+		FlashUtil.initializeFlash();
+
+		assertFalse(FlashUtil.isAvailable());
+	}
+
+	@Test
+	public void testInitializeFlashWithCameraFlash() {
+		simFlashAvailable(true);
+		FlashUtil.initializeFlash();
+
+		assertTrue(FlashUtil.isAvailable());
+	}
+
+	@Test
+	public void testFlashOnWithoutCameraFlash() {
+		simFlashAvailable(false);
+		FlashUtil.initializeFlash();
+		FlashUtil.flashOn();
+
+		assertFalse(FlashUtil.isOn());
+	}
+
+	@Test
+	public void testFlashOnWithCameraFlash() {
+		simFlashAvailable(true);
+		FlashUtil.initializeFlash();
+		FlashUtil.flashOn();
+
+		assertTrue(FlashUtil.isOn());
+	}
+
+	@Test
+	public void testFlashOffWithoutCameraFlash() {
+		simFlashAvailable(false);
+		FlashUtil.initializeFlash();
+		FlashUtil.flashOff();
+
+		assertFalse(FlashUtil.isOn());
+	}
+
+	@Test
+	public void testFlashOffWithCameraFlash() {
+		simFlashAvailable(true);
+		FlashUtil.initializeFlash();
+		FlashUtil.flashOff();
+
+		assertFalse(FlashUtil.isOn());
+	}
+
+	@Test
+	public void testPauseFlashWithoutCameraFlash() {
+		simFlashAvailable(false);
+		FlashUtil.initializeFlash();
+		FlashUtil.pauseFlash();
+
+		assertFalse(FlashUtil.isPaused());
+	}
+
+	@Test
+	public void testResumeFlashWithoutCameraFlash() {
+		simFlashAvailable(false);
+		FlashUtil.initializeFlash();
+		FlashUtil.pauseFlash();
+		FlashUtil.resumeFlash();
+
+		assertFalse(FlashUtil.isPaused());
+	}
+
+	@Test
+	public void testPauseFlashWithCameraFlash() {
+		simFlashAvailable(true);
+		FlashUtil.initializeFlash();
+		FlashUtil.pauseFlash();
+
+		assertTrue(FlashUtil.isPaused());
+	}
+
+	@Test
+	public void testResumeFlashWithCameraFlash() {
+		simFlashAvailable(true);
+		FlashUtil.initializeFlash();
+		FlashUtil.pauseFlash();
+
+		assertTrue(FlashUtil.isPaused());
+
+		FlashUtil.resumeFlash();
+
+		assertFalse(FlashUtil.isPaused());
+	}
+
+	@Test
+	public void testChangeCameraAndResumeFlash() {
+		simFlashAvailable(true);
+		FlashUtil.initializeFlash();
+		FlashUtil.pauseFlash();
+
+		simFlashAvailable(false);
+		FlashUtil.resumeFlash();
+
+		assertFalse(FlashUtil.isAvailable());
+		assertFalse(FlashUtil.isOn());
+		assertFalse(FlashUtil.isPaused());
+	}
+}
+


### PR DESCRIPTION
When camera device has no flash available, the flash brick action should simply be ignored.
e.g. emulators or tablets
Added tests for FlashUtil so CameraManager and Camera are PowerMocks for simulating environment.