### PR TITLE
CATROID-224 ListWithoutDuplicates Implementation for RV

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/ListWithoutDuplicates.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/ListWithoutDuplicates.java
@@ -1,0 +1,138 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.content;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ListWithoutDuplicates<T> extends ArrayList<T> {
+
+	private final Set<T> comparingSet = new HashSet<T>();
+
+	private Collection<T> getUniqueValues(Collection<? extends T> collection) {
+		Collection<T> uniqueValues = new ArrayList<T>();
+		for (T element : collection) {
+			if (comparingSet.add(element)) {
+				uniqueValues.add(element);
+			}
+		}
+
+		return uniqueValues;
+	}
+
+	@Override
+	public boolean add(T t) {
+		return comparingSet.add(t) && super.add(t);
+	}
+
+	@Override
+	public void add(int index, T element) {
+		if (comparingSet.add(element)) {
+			try {
+				super.add(index, element);
+			} catch (IndexOutOfBoundsException ioobException) {
+				comparingSet.remove(element);
+				throw ioobException;
+			}
+		}
+	}
+
+	@Override
+	public boolean addAll(Collection<? extends T> c) {
+		Collection<T> uniqueValuesToAdd = getUniqueValues(c);
+		if (uniqueValuesToAdd.isEmpty()) {
+			return false;
+		}
+
+		return super.addAll(uniqueValuesToAdd);
+	}
+
+	@Override
+	public boolean addAll(int index, Collection<? extends T> c) {
+		Collection<T> uniqueValuesToAdd = getUniqueValues(c);
+		if (uniqueValuesToAdd.isEmpty()) {
+			return false;
+		}
+
+		try {
+			return super.addAll(index, uniqueValuesToAdd);
+		} catch (IndexOutOfBoundsException ioobException) {
+			comparingSet.removeAll(uniqueValuesToAdd);
+			throw ioobException;
+		}
+	}
+
+	@Override
+	public void clear() {
+		comparingSet.clear();
+		super.clear();
+	}
+
+	@Override
+	public T remove(int index) {
+		try {
+			T removedObject = super.remove(index);
+			comparingSet.remove(removedObject);
+			return removedObject;
+		} catch (IndexOutOfBoundsException ioobException) {
+			throw ioobException;
+		}
+	}
+
+	@Override
+	public boolean remove(Object o) {
+		return comparingSet.remove(o) && super.remove(o);
+	}
+
+	@Override
+	public boolean removeAll(Collection<?> c) {
+		return comparingSet.removeAll(c) && super.removeAll(c);
+	}
+
+	@Override
+	public boolean retainAll(Collection<?> c) {
+		return comparingSet.retainAll(c) && super.retainAll(c);
+	}
+
+	@Override
+	public T set(int index, T element) {
+		try {
+			if (element.equals(this.get(index))) {
+				return element;
+			}
+
+			T oldObject = null;
+			if (comparingSet.add(element)) {
+				oldObject = super.set(index, element);
+				comparingSet.remove(oldObject);
+			}
+
+			return oldObject;
+		} catch (IndexOutOfBoundsException ioobException) {
+			throw ioobException;
+		}
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -67,9 +67,9 @@ public class Project implements Serializable {
 	@XStreamAlias("settings")
 	private List<Setting> settings = new ArrayList<>();
 	@XStreamAlias("programVariableList")
-	private List<UserVariable> userVariables = new ArrayList<>();
+	private List<UserVariable> userVariables = new ListWithoutDuplicates<>();
 	@XStreamAlias("programListOfLists")
-	private List<UserList> userLists = new ArrayList<>();
+	private List<UserList> userLists = new ListWithoutDuplicates<>();
 	@XStreamAlias("scenes")
 	private List<Scene> sceneList = new ArrayList<>();
 
@@ -165,7 +165,7 @@ public class Project implements Serializable {
 
 	public List<UserVariable> getUserVariables() {
 		if (userVariables == null) {
-			userVariables = new ArrayList<>();
+			userVariables = new ListWithoutDuplicates<>();
 		}
 		return userVariables;
 	}
@@ -194,7 +194,7 @@ public class Project implements Serializable {
 
 	public List<UserList> getUserLists() {
 		if (userLists == null) {
-			userLists = new ArrayList<>();
+			userLists = new ListWithoutDuplicates<>();
 		}
 		return userLists;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -85,8 +85,8 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 	private List<LookData> lookList = new ArrayList<>();
 	private List<SoundInfo> soundList = new ArrayList<>();
 	private List<NfcTagData> nfcTagList = new ArrayList<>();
-	private List<UserVariable> userVariables = new ArrayList<>();
-	private List<UserList> userLists = new ArrayList<>();
+	private List<UserVariable> userVariables = new ListWithoutDuplicates<>();
+	private List<UserList> userLists = new ListWithoutDuplicates<>();
 
 	private transient ActionFactory actionFactory = new ActionFactory();
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -41,6 +41,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.cast.CastManager;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.SoundInfo;
+import org.catrobat.catroid.content.ListWithoutDuplicates;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
@@ -68,7 +69,6 @@ import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.catrobat.catroid.common.Constants.DEFAULT_IMAGE_EXTENSION;
@@ -705,11 +705,11 @@ public class SpriteActivity extends BaseActivity {
 
 		makeListCheckBox.setVisibility(View.VISIBLE);
 
-		List<UserData> variables = new ArrayList<>();
+		final List<UserData> variables = new ListWithoutDuplicates<>();
 		variables.addAll(currentProject.getUserVariables());
 		variables.addAll(currentSprite.getUserVariables());
 
-		List<UserData> lists = new ArrayList<>();
+		final List<UserData> lists = new ListWithoutDuplicates<>();
 		lists.addAll(currentProject.getUserLists());
 		lists.addAll(currentSprite.getUserLists());
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/DataListAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/DataListAdapter.java
@@ -31,6 +31,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.ListWithoutDuplicates;
 import org.catrobat.catroid.formulaeditor.UserData;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
@@ -275,7 +276,7 @@ public class DataListAdapter extends RecyclerView.Adapter<CheckableVH> implement
 	}
 
 	public List<UserData> getItems() {
-		List<UserData> items = new ArrayList<>();
+		List<UserData> items = new ListWithoutDuplicates<>();
 		items.addAll(globalVarAdapter.getItems());
 		items.addAll(localVarAdapter.getItems());
 		items.addAll(globalListAdapter.getItems());
@@ -284,14 +285,14 @@ public class DataListAdapter extends RecyclerView.Adapter<CheckableVH> implement
 	}
 
 	public List<UserVariable> getVariables() {
-		List<UserVariable> items = new ArrayList<>();
+		List<UserVariable> items = new ListWithoutDuplicates<>();
 		items.addAll(globalVarAdapter.getItems());
 		items.addAll(localVarAdapter.getItems());
 		return items;
 	}
 
 	public List<UserList> getLists() {
-		List<UserList> items = new ArrayList<>();
+		List<UserList> items = new ListWithoutDuplicates<>();
 		items.addAll(globalListAdapter.getItems());
 		items.addAll(localListAdapter.getItems());
 		return items;

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/ListWithoutDuplicatesTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/ListWithoutDuplicatesTest.java
@@ -1,0 +1,347 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content;
+
+import org.catrobat.catroid.content.ListWithoutDuplicates;
+import org.catrobat.catroid.formulaeditor.UserList;
+import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class ListWithoutDuplicatesTest<T> {
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{"Integer", Integer.class,
+						new Integer[]{1, 2, 3},
+						new Integer[]{4, 5},
+						new Integer[]{1, 2}},
+				{"String", String.class,
+						new String[]{"a", "b", "c"},
+						new String[]{"d", "e"},
+						new String[]{"a", "b"}},
+				{"UserVariable", UserVariable.class,
+						new UserVariable[]{new UserVariable("x"), new UserVariable("y"), new UserVariable("z")},
+						new UserVariable[]{new UserVariable("q"), new UserVariable("r")},
+						new UserVariable[]{new UserVariable("x"), new UserVariable("y")}},
+				{"UserList", UserList.class,
+						new UserList[]{new UserList("list1"), new UserList("list2"), new UserList("list3")},
+						new UserList[]{new UserList("list4"), new UserList("list5")},
+						new UserList[]{new UserList("list1"), new UserList("list2")}},
+		});
+	}
+
+	@Parameterized.Parameter
+	public String name;
+
+	@Parameterized.Parameter(1)
+	public Class<T> clazz;
+
+	@Parameterized.Parameter(2)
+	public T[] initialValues;
+
+	@Parameterized.Parameter(3)
+	public T[] itemsCurrentlyNotInList;
+
+	@Parameterized.Parameter(4)
+	public T[] itemsCurrentlyInList;
+
+	private ListWithoutDuplicates<T> testListWithoutDuplicates;
+	private Set<T> comparingHashSet;
+
+	@Before
+	public void setUp() {
+		testListWithoutDuplicates = new ListWithoutDuplicates<T>();
+		testListWithoutDuplicates.addAll(Arrays.asList(initialValues));
+
+		comparingHashSet = new HashSet<T>();
+		comparingHashSet.addAll(Arrays.asList(initialValues));
+
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void addNonExistingItem() {
+		boolean addNonExistingItem = testListWithoutDuplicates.add(itemsCurrentlyNotInList[0]);
+		assertTrue(addNonExistingItem);
+		assertEquals(addNonExistingItem, comparingHashSet.add(itemsCurrentlyNotInList[0]));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void addExistingItem() {
+		boolean addExistingItem = testListWithoutDuplicates.add(itemsCurrentlyInList[0]);
+		assertFalse(addExistingItem);
+		assertEquals(addExistingItem, comparingHashSet.add(itemsCurrentlyInList[0]));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test(expected = IndexOutOfBoundsException.class)
+	public void addIndexOutOfBoundsBehind() {
+		testListWithoutDuplicates.add(5, itemsCurrentlyNotInList[0]);
+	}
+
+	@Test(expected = IndexOutOfBoundsException.class)
+	public void addIndexOutOfBoundsNegative() {
+		testListWithoutDuplicates.add(-1, itemsCurrentlyNotInList[0]);
+	}
+
+	@Test
+	public void addIndexNonExistingItem() {
+		testListWithoutDuplicates.add(0, itemsCurrentlyNotInList[0]);
+		comparingHashSet.add(itemsCurrentlyNotInList[0]);
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+		assertEquals(testListWithoutDuplicates.get(0), itemsCurrentlyNotInList[0]);
+	}
+
+	@Test
+	public void addIndexExistingItem() {
+		T itemAtIndex = testListWithoutDuplicates.get(0);
+		testListWithoutDuplicates.add(0, itemsCurrentlyInList[0]);
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+		assertEquals(testListWithoutDuplicates.get(0), itemAtIndex);
+	}
+
+	@Test
+	public void addAllNonExistingItems() {
+		List<T> listToAdd = Arrays.asList(itemsCurrentlyNotInList[0], itemsCurrentlyNotInList[1]);
+		boolean addAllNonExistingItem = testListWithoutDuplicates.addAll(listToAdd);
+		assertTrue(addAllNonExistingItem);
+		assertEquals(addAllNonExistingItem, comparingHashSet.addAll(listToAdd));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void addAllNonAndExistingItem() {
+		List<T> listToAdd = Arrays.asList(itemsCurrentlyInList[0], itemsCurrentlyNotInList[0]);
+		boolean addAllNonAndExistingItem = testListWithoutDuplicates.addAll(listToAdd);
+		assertTrue(addAllNonAndExistingItem);
+		assertEquals(addAllNonAndExistingItem, comparingHashSet.addAll(listToAdd));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void addAllExistingItem() {
+		List<T> listToAdd = Arrays.asList(itemsCurrentlyInList[0], itemsCurrentlyInList[1]);
+		boolean addAllExistingItem = testListWithoutDuplicates.addAll(listToAdd);
+		assertFalse(addAllExistingItem);
+		assertEquals(addAllExistingItem, comparingHashSet.addAll(listToAdd));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test(expected = IndexOutOfBoundsException.class)
+	public void addAllIndexOutOfBoundsBehind() {
+		List<T> listToAdd = Arrays.asList(itemsCurrentlyNotInList[0], itemsCurrentlyNotInList[1]);
+		testListWithoutDuplicates.addAll(5, listToAdd);
+	}
+
+	@Test(expected = IndexOutOfBoundsException.class)
+	public void addAllIndexOutOfBoundsNegative() {
+		List<T> listToAdd = Arrays.asList(itemsCurrentlyNotInList[0], itemsCurrentlyNotInList[1]);
+		testListWithoutDuplicates.addAll(-1, listToAdd);
+	}
+
+	@Test
+	public void addAllIndexNonExistingItem() {
+		List<T> listToAdd = Arrays.asList(itemsCurrentlyNotInList[0], itemsCurrentlyNotInList[1]);
+		assertTrue(comparingHashSet.addAll(listToAdd));
+		assertTrue(testListWithoutDuplicates.addAll(0, listToAdd));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+		assertEquals(testListWithoutDuplicates.get(0), itemsCurrentlyNotInList[0]);
+		assertEquals(testListWithoutDuplicates.get(1), itemsCurrentlyNotInList[1]);
+	}
+
+	@Test
+	public void addAllIndexNonAndExistingItem() {
+		List<T> listToAdd = Arrays.asList(itemsCurrentlyInList[0], itemsCurrentlyNotInList[0]);
+		T itemAtIndex = testListWithoutDuplicates.get(0);
+		assertTrue(comparingHashSet.addAll(listToAdd));
+		assertTrue(testListWithoutDuplicates.addAll(0, listToAdd));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+		assertEquals(testListWithoutDuplicates.get(0), itemsCurrentlyNotInList[0]);
+		assertEquals(testListWithoutDuplicates.get(1), itemAtIndex);
+	}
+
+	@Test
+	public void addAllIndexExistingItem() {
+		List<T> listToAdd = Arrays.asList(itemsCurrentlyInList[0], itemsCurrentlyInList[1]);
+		T itemAtIndex = testListWithoutDuplicates.get(0);
+		assertFalse(comparingHashSet.addAll(listToAdd));
+		assertFalse(testListWithoutDuplicates.addAll(0, listToAdd));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+		assertEquals(testListWithoutDuplicates.get(0), itemAtIndex);
+	}
+
+	@Test
+	public void addEmptyCollection() {
+		List<T> emptyList = new ArrayList<>();
+		boolean addEmptyCollection = testListWithoutDuplicates.addAll(emptyList);
+		assertFalse(addEmptyCollection);
+		assertEquals(addEmptyCollection, comparingHashSet.addAll(emptyList));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void addIndexExceptionTest() {
+		try {
+			testListWithoutDuplicates.add(4, itemsCurrentlyNotInList[0]);
+		} catch (IndexOutOfBoundsException ioobException) {
+			assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+			testListWithoutDuplicates.add(0, itemsCurrentlyNotInList[0]);
+			comparingHashSet.add(itemsCurrentlyNotInList[0]);
+			assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+			assertEquals(testListWithoutDuplicates.get(0), itemsCurrentlyNotInList[0]);
+		}
+	}
+
+	@Test
+	public void addAllIndexExceptionTest() {
+		List<T> listToAdd = Arrays.asList(itemsCurrentlyInList[0], itemsCurrentlyNotInList[0]);
+		try {
+			testListWithoutDuplicates.addAll(5, listToAdd);
+		} catch (IndexOutOfBoundsException ioobException) {
+			assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+			testListWithoutDuplicates.addAll(0, listToAdd);
+			comparingHashSet.addAll(listToAdd);
+			assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+			assertEquals(testListWithoutDuplicates.get(0), itemsCurrentlyNotInList[0]);
+		}
+	}
+
+	@Test
+	public void clearTest() {
+		testListWithoutDuplicates.clear();
+		comparingHashSet.clear();
+		assertTrue(testListWithoutDuplicates.isEmpty());
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void removeByIndex() {
+		T removedObjectAtIndex = testListWithoutDuplicates.get(0);
+		comparingHashSet.remove(removedObjectAtIndex);
+		assertEquals(testListWithoutDuplicates.remove(0), removedObjectAtIndex);
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test(expected = IndexOutOfBoundsException.class)
+	public void removeByIndexOutOfBounds() {
+		testListWithoutDuplicates.remove(5);
+	}
+
+	@Test
+	public void removeByObject() {
+		T removeObject = initialValues[0];
+		assertEquals(testListWithoutDuplicates.remove(removeObject), comparingHashSet.remove(removeObject));
+		assertEquals(testListWithoutDuplicates.remove(removeObject), comparingHashSet.remove(removeObject));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void removeAllEmptyCollection() {
+		List<T> emptyList = new ArrayList<>();
+		assertEquals(testListWithoutDuplicates.removeAll(emptyList), comparingHashSet.removeAll(emptyList));
+		assertFalse(testListWithoutDuplicates.isEmpty());
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void removeAllNonAndExistingItems() {
+		List<T> listToRemove = Arrays.asList(itemsCurrentlyInList[0], itemsCurrentlyNotInList[0]);
+		assertEquals(testListWithoutDuplicates.removeAll(listToRemove), comparingHashSet.removeAll(listToRemove));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void removeAllNonExistingItems() {
+		List<T> listToRemove = Arrays.asList(itemsCurrentlyNotInList[0], itemsCurrentlyNotInList[1]);
+		assertEquals(testListWithoutDuplicates.removeAll(listToRemove), comparingHashSet.removeAll(listToRemove));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void removeAllExistingItems() {
+		List<T> listToRemove = Arrays.asList(itemsCurrentlyInList[0], itemsCurrentlyInList[1]);
+		assertEquals(testListWithoutDuplicates.removeAll(listToRemove), comparingHashSet.removeAll(listToRemove));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void retainAllEmptyList() {
+		List<T> emptyList = new ArrayList<>();
+		assertEquals(testListWithoutDuplicates.retainAll(emptyList), comparingHashSet.retainAll(emptyList));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void retainAllNonExistingItems() {
+		List<T> listToRetain = Arrays.asList(itemsCurrentlyNotInList[0], itemsCurrentlyNotInList[1]);
+		assertEquals(testListWithoutDuplicates.retainAll(listToRetain), comparingHashSet.retainAll(listToRetain));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test
+	public void retainAllNonAndExistingItems() {
+		List<T> listToRetain = Arrays.asList(itemsCurrentlyInList[0], itemsCurrentlyInList[1]);
+		assertEquals(testListWithoutDuplicates.retainAll(listToRetain), comparingHashSet.retainAll(listToRetain));
+		assertThat(testListWithoutDuplicates, containsInAnyOrder(comparingHashSet.toArray()));
+	}
+
+	@Test(expected = IndexOutOfBoundsException.class)
+	public void setElementAtIndexOutOfBounds() {
+		testListWithoutDuplicates.set(5, itemsCurrentlyNotInList[0]);
+	}
+
+	@Test
+	public void setElementAtIndexToExisting() {
+		testListWithoutDuplicates.set(0, itemsCurrentlyInList[0]);
+		assertArrayEquals(testListWithoutDuplicates.toArray(), initialValues);
+	}
+
+	@Test
+	public void setElementAtIndexToNonExisting() {
+		testListWithoutDuplicates.set(0, itemsCurrentlyNotInList[0]);
+		assertEquals(testListWithoutDuplicates.get(0), itemsCurrentlyNotInList[0]);
+		assertEquals(testListWithoutDuplicates.get(1), initialValues[1]);
+		assertEquals(testListWithoutDuplicates.get(2), initialValues[2]);
+	}
+}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/userdata/UserListTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/userdata/UserListTest.java
@@ -1,0 +1,59 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.userdata;
+
+import org.catrobat.catroid.formulaeditor.UserList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+@RunWith(JUnit4.class)
+public class UserListTest {
+
+	private UserList userListX;
+	private UserList userListY;
+
+	@Before
+	public void setUp() {
+		userListX = new UserList("x");
+		userListY = new UserList("y");
+	}
+
+	@Test
+	public void testEqualwithDifferentLists() {
+		boolean testEquality = userListX.equals(userListY);
+		assertFalse(testEquality);
+	}
+
+	@Test
+	public void testEqualwithSameLists() {
+		UserList equalVariable = new UserList("x");
+		boolean testEquality = userListX.equals(equalVariable);
+		assertTrue(testEquality);
+	}
+}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/userdata/UserVariableTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/userdata/UserVariableTest.java
@@ -1,0 +1,59 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.userdata;
+
+import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+@RunWith(JUnit4.class)
+public class UserVariableTest {
+
+	private UserVariable userVariableX;
+	private UserVariable userVariableY;
+
+	@Before
+	public void setUp() {
+		userVariableX = new UserVariable("x");
+		userVariableY = new UserVariable("y");
+	}
+
+	@Test
+	public void testEqualwithDifferentVariables() {
+		boolean testEquality = userVariableX.equals(userVariableY);
+		assertFalse(testEquality);
+	}
+
+	@Test
+	public void testEqualwithSameVariable() {
+		UserVariable equalVariable = new UserVariable("x");
+		boolean testEquality = userVariableX.equals(equalVariable);
+		assertTrue(testEquality);
+	}
+}


### PR DESCRIPTION
Custom implementation of an ArrayList which acts like a HashSet. 

- RecyclerView-Adapter needs a list, so some functions which HashSet doesnt provide can be used. (Index-based array operations)

- Theres also an internal HashSet running in background so that checks for duplicates can be executed in O(1). List.contain(...) needs O(n).

- The tests added should check the behaviour of the custom list, to act like kind of a HashSet. Operation comparison between custom List and java HashSet. Tests are parameterized so tests for every new object that uses this list implementation can be added within 4 lines of code.

- HashSet does automatically sort the data after operations. Since we need logic of a programming language, this should be users task and we'll keep insertion order like a list.

- Since this implementation relies on the correct implementation of the equal() - function (which needs to be implemented for every "custom" object in java), i also added tests for equal() of UserVariable and UserList

ListWithoutDuplicates is currently in use for UserVariable and UserList - Lists for Project and Sprite. (see ticket description [CATROID-224](https://jira.catrob.at/browse/CATROID-224))