### PR TITLE
CATROID-194 Downloaded APKs cannot be installed via notification area

### DIFF
--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
@@ -25,10 +25,8 @@ package org.catrobat.catroid.ui;
 import android.annotation.SuppressLint;
 import android.app.DownloadManager;
 import android.app.ProgressDialog;
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -132,27 +130,12 @@ public class WebViewActivity extends BaseActivity {
 							DownloadUtil.getInstance().getProjectNameFromUrl(url) + ANDROID_APPLICATION_EXTENSION);
 					request.setMimeType(mimetype);
 
-					registerReceiver(onDownloadComplete, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
-
 					DownloadManager downloadManager = (DownloadManager) getSystemService(Context.DOWNLOAD_SERVICE);
 					downloadManager.enqueue(request);
 				}
 			}
 		});
 	}
-
-	BroadcastReceiver onDownloadComplete = new BroadcastReceiver() {
-		public void onReceive(Context context, Intent intent) {
-
-			long id = intent.getExtras().getLong(DownloadManager.EXTRA_DOWNLOAD_ID);
-			DownloadManager downloadManager = (DownloadManager) getSystemService(DOWNLOAD_SERVICE);
-			intent = new Intent(Intent.ACTION_VIEW);
-			intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-			intent.setDataAndType(downloadManager.getUriForDownloadedFile(id),
-					downloadManager.getMimeTypeForDownloadedFile(id));
-			startActivity(intent);
-		}
-	};
 
 	@Override
 	public boolean onKeyDown(int keyCode, KeyEvent event) {


### PR DESCRIPTION
tested on Devices with SDK 21, 23, 26 , 
Emulators with SDK 24, 25, 26, 27, 28
not testable on emulators with SDKs below 24 because of : the web-view doesn't support the new design of share website.
if you got a msg like "could n't install the Apk || or App not installed" please disable the play protect feature from play store.
