### PR TITLE
CATROID-104 touches_object not working correctly anymore

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/common/LookDataTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/common/LookDataTest.java
@@ -1,0 +1,92 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.common;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.io.ResourceImporter;
+import org.catrobat.catroid.io.StorageOperations;
+import org.catrobat.catroid.utils.ImageEditing;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+
+import static junit.framework.Assert.assertEquals;
+
+import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME;
+
+@RunWith(AndroidJUnit4.class)
+public class LookDataTest {
+	private LookData lookData;
+	private File imageFolder;
+	private final String fileName = "collision_donut.png";
+
+	@Before
+	public void setUp() throws Exception {
+		StorageOperations.deleteDir(InstrumentationRegistry.getTargetContext().getCacheDir());
+		imageFolder = new File(InstrumentationRegistry.getTargetContext().getCacheDir(), IMAGE_DIRECTORY_NAME);
+		if (!imageFolder.exists()) {
+			imageFolder.mkdirs();
+		}
+
+		File imageFile = ResourceImporter.createImageFileFromResourcesInDirectory(
+				InstrumentationRegistry.getContext().getResources(),
+				org.catrobat.catroid.test.R.raw.collision_donut,
+				imageFolder, fileName, 1.0);
+
+		lookData = new LookData("test", imageFile);
+	}
+
+	@After
+	public void tearDown() throws IOException {
+		StorageOperations.deleteDir(InstrumentationRegistry.getTargetContext().getCacheDir());
+	}
+
+	@Test
+	public void testCollisionInformation() {
+		String metadata = ImageEditing.readMetaDataStringFromPNG(imageFolder.getAbsolutePath() + "/" + fileName,
+				Constants.COLLISION_PNG_META_TAG_KEY);
+
+		assertEquals("", metadata);
+
+		lookData.getCollisionInformation().loadOrCreateCollisionPolygon();
+
+		metadata = ImageEditing.readMetaDataStringFromPNG(imageFolder.getAbsolutePath() + "/" + fileName,
+				Constants.COLLISION_PNG_META_TAG_KEY);
+
+		final String expectedMetadata = "0.0;228.0;9.0;321.0;57.0;411.0;136.0;474.0;228.0;500.0;305.0;495.0;375.0;"
+				+ "468.0;436.0;419.0;474.0;364.0;497.0;295.0;499.0;218.0;481.0;151.0;443.0;89.0;385.0;38.0;321.0;9.0;"
+				+ "179.0;9.0;115.0;38.0;57.0;89.0;19.0;151.0|125.0;248.0;154.0;330.0;201.0;365.0;248.0;375.0;313.0;"
+				+ "358.0;365.0;299.0;374.0;234.0;346.0;170.0;285.0;130.0;206.0;133.0;150.0;175.0";
+
+		assertEquals(expectedMetadata, metadata);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
@@ -213,10 +213,22 @@ public class LookData implements Cloneable, Nameable, Serializable {
 		return new int[] {width, height};
 	}
 
+	public void clearCollisionInformation() {
+		collisionInformation = null;
+	}
+
 	public CollisionInformation getCollisionInformation() {
 		if (collisionInformation == null) {
 			collisionInformation = new CollisionInformation(this);
 		}
 		return collisionInformation;
+	}
+
+	public String getImageMimeType() {
+		String pathName = file.getAbsolutePath();
+		BitmapFactory.Options options = new BitmapFactory.Options();
+		options.inJustDecodeBounds = true;
+		BitmapFactory.decodeFile(pathName, options);
+		return options.outMimeType;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -274,7 +274,10 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 						File imageDirectory = new File(currentScene.getDirectory(), IMAGE_DIRECTORY_NAME);
 						File file = StorageOperations
 								.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
-						sprite.getLookList().add(new LookData(textInput, file));
+
+						LookData lookData = new LookData(textInput, file);
+						sprite.getLookList().add(lookData);
+						lookData.getCollisionInformation().calculate();
 					} catch (IOException e) {
 						Log.e(TAG, Log.getStackTraceString(e));
 					}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -396,7 +396,9 @@ public class SpriteActivity extends BaseActivity {
 						File imageDirectory = new File(currentScene.getDirectory(), IMAGE_DIRECTORY_NAME);
 						File file = StorageOperations
 								.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
-						sprite.getLookList().add(new LookData(textInput, file));
+						LookData lookData = new LookData(textInput, file);
+						sprite.getLookList().add(lookData);
+						lookData.getCollisionInformation().calculate();
 					} catch (IOException e) {
 						Log.e(TAG, Log.getStackTraceString(e));
 					}
@@ -448,6 +450,7 @@ public class SpriteActivity extends BaseActivity {
 			File file = StorageOperations.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
 			LookData look = new LookData(lookDataName, file);
 			currentSprite.getLookList().add(look);
+			look.getCollisionInformation().calculate();
 			if (onNewLookListener != null) {
 				onNewLookListener.addItem(look);
 			}
@@ -482,6 +485,7 @@ public class SpriteActivity extends BaseActivity {
 			File file = StorageOperations.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
 			LookData look = new LookData(lookDataName, file);
 			currentSprite.getLookList().add(look);
+			look.getCollisionInformation().calculate();
 			if (onNewLookListener != null) {
 				onNewLookListener.addItem(look);
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
@@ -188,6 +188,7 @@ public class LookListFragment extends RecyclerViewFragment<LookData> {
 		}
 
 		item.invalidateThumbnailBitmap();
+		item.clearCollisionInformation();
 
 		Intent intent = new Intent("android.intent.action.MAIN");
 		intent.setComponent(new ComponentName(getActivity(), POCKET_PAINT_INTENT_ACTIVITY_NAME));

--- a/catroid/src/test/java/org/catrobat/catroid/test/common/LookDataTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/common/LookDataTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(JUnit4.class)
 public class LookDataTest {
-
 	@Test
 	public void testPixmapAndTextureRegionDisposal() {
 		LookData lookData = new LookData();


### PR DESCRIPTION
- collision information gets already calculated in the background
on look creation/edition
- file ending gets extracted over mime type (png relevant)
- small test for the collision functionality

Edited recently opened PR [#3198](https://github.com/Catrobat/Catroid/pull/3198) of Patrick S. and modified files by the requested changes:

- [PRODUCTION] `getImageMimeType()` is now function of `LookData` Object
- [TESTS]                Now running sepparately on emulator and local JVM
- [TESTS]                No more references to Project or Sprite, image gets created in cache directory
- [TESTS]                `tearDown()` method to clear cache directory afterwards

Pocket Code test program to show touches object now working: [TouchesObject](https://share.catrob.at/pocketcode/program/86900) (Currently not working with PS Version - build develop)