### PR TITLE
CATROID-282 Description not updated/uploaded correctly

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
@@ -50,6 +50,7 @@ import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.io.ProjectAndSceneScreenshotLoader;
 import org.catrobat.catroid.io.asynctask.ProjectLoadTask;
 import org.catrobat.catroid.io.asynctask.ProjectRenameTask;
+import org.catrobat.catroid.io.asynctask.ProjectSaveTask;
 import org.catrobat.catroid.transfers.CheckTokenTask;
 import org.catrobat.catroid.transfers.GetTagsTask;
 import org.catrobat.catroid.transfers.project.ProjectUploadService;
@@ -279,6 +280,7 @@ public class ProjectUploadActivity extends BaseActivity implements
 
 		project.setDescription(description);
 		project.setDeviceData(this);
+		ProjectSaveTask.task(project, getApplicationContext());
 
 		uploadProgressDialog = new AlertDialog.Builder(this)
 				.setTitle(getString(R.string.upload_project_dialog_title))


### PR DESCRIPTION
When uploading a project, you can change description in the upload dialog. But Changes were made only locally.
The web server doesn't fetch the projectDescription Tag of the HTTPRequest. It fetches the description from the code.xml, which was saved only "after" Upload. So the old description still remained in Upload (code.xml)