### PR TITLE
JENKINS-317 Fix APKs not being uploaded to Google Play

### DIFF
--- a/Jenkinsfile.releaseAPK
+++ b/Jenkinsfile.releaseAPK
@@ -102,10 +102,10 @@ pipeline {
                 script {
                     if (env.flavor == 'All') {
                         sh '''
-                            fastlane android upload_APK_Catroid \
+                            fastlane android upload_APK_Catroid 
                             fastlane android upload_APK_CreateAtSchool
-                            fastlane android upload_APK_LunaAndCat \
-                            fastlane android upload_APK_Phiro \
+                            fastlane android upload_APK_LunaAndCat 
+                            fastlane android upload_APK_Phiro 
                         '''
                     } else {
                         sh 'fastlane android upload_APK_${flavor}'


### PR DESCRIPTION
Fixes bug preventing CreateAtSchool and Phiro release apks being
uploaded to the alpha track on Google Play. Extra \ characters in
lines made sh put two fastlane commands into one line, thereby
effectively ignoring the second command.