### PR TITLE
CATROID-159/285: Merge Project name dialog and error check

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/MergeProjectDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/MergeProjectDialogFragment.java
@@ -1,0 +1,82 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2019 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.ui.recyclerview.dialog;
+
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.Context;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
+import android.view.View;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.utils.Utils;
+
+public class MergeProjectDialogFragment extends DialogFragment {
+
+	@RequiresApi(api = Build.VERSION_CODES.M)
+	@Override
+	public Dialog onCreateDialog(Bundle savedInstanceState) {
+		View view = View.inflate(getActivity(), R.layout.dialog_merge_project_name, null);
+
+		final TextInputDialog.TextWatcher textWatcher = new TextInputDialog.TextWatcher() {
+			@Nullable
+			@Override
+			public String validateInput(String input, Context context) {
+				String error = null;
+				if (input.isEmpty()) {
+					return context.getString(R.string.name_empty);
+				}
+
+				input = input.trim();
+				if (input.isEmpty()) {
+					error = context.getString(R.string.name_consists_of_spaces_only);
+				} else if (Utils.checkIfProjectExistsOrIsDownloadingIgnoreCase(input)) {
+					error = context.getString(R.string.name_already_exists);
+				}
+
+				return error;
+			}
+		};
+
+		TextInputDialog.Builder builder = new TextInputDialog.Builder(this.getContext())
+				.setHint(getString(R.string.project_name_label))
+				.setTextWatcher(textWatcher)
+				.setPositiveButton(getString(R.string.ok), (TextInputDialog.OnClickListener) (dialog, textInput) -> {
+					showNextDialog(textInput, true);
+				});
+
+		return builder
+				.setTitle(R.string.new_merge_project_dialog_title)
+				.setView(view)
+				.setNegativeButton(R.string.cancel, null)
+				.create();
+	}
+
+	void showNextDialog(String projectName, boolean createEmptyProject) {
+
+	}
+}
+

--- a/catroid/src/main/res/layout/dialog_merge_project_name.xml
+++ b/catroid/src/main/res/layout/dialog_merge_project_name.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+      ~ Catroid: An on-device visual programming system for Android devices
+      ~ Copyright (C) 2010-2018 The Catrobat Team
+      ~ (<http://developer.catrobat.org/credits>)
+      ~
+      ~ This program is free software: you can redistribute it and/or modify
+      ~ it under the terms of the GNU Affero General Public License as
+      ~ published by the Free Software Foundation, either version 3 of the
+      ~ License, or (at your option) any later version.
+      ~
+      ~ An additional term exception under section 7 of the GNU Affero
+      ~ General Public License, version 3, is available at
+      ~ http://developer.catrobat.org/license_additional_term
+      ~
+      ~ This program is distributed in the hope that it will be useful,
+      ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+      ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+      ~ GNU Affero General Public License for more details.
+      ~
+      ~ You should have received a copy of the GNU Affero General Public License
+      ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+      -->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingEnd="@dimen/dialog_content_area_padding_input"
+    android:paddingStart="@dimen/dialog_content_area_padding_input"
+    android:paddingTop="@dimen/dialog_content_area_padding_top">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:hintEnabled="true">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/input_edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:selectAllOnFocus="true" />
+
+        </android.support.design.widget.TextInputLayout>
+
+    </LinearLayout>
+</ScrollView>
+


### PR DESCRIPTION
This dialog enables the user to enter the name of the newly merged project and checks if the name is valid. Thus, it checks if the name has not already been used.