### PR TITLE
CATROID-293: Fix GET_TASKS permission warning

### DIFF
--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.GET_TASKS" tools:node="remove" />
 
     <uses-feature
         android:name="android.hardware.camera"
@@ -76,8 +77,7 @@
     <uses-permission android:name="android.permission.NFC" />
 
     <!-- Prevent manifest merger from automatically added phone permission -->
-    <uses-permission android:name="android.permission.READ_PHONE_STATE"
-        tools:node="remove"/>
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
 
     <uses-feature
         android:glEsVersion="0x00020000"


### PR DESCRIPTION
This permission gets merged from libARDiscovery and is a system permission starting from 21.