### PR TITLE
CATROID-256: Merges Two Projects  Without  User Or List Conflict

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -349,4 +349,14 @@ public class Project implements Serializable {
 	public void setXmlHeader(XmlHeader xmlHeader) {
 		this.xmlHeader = xmlHeader;
 	}
+
+	public int getSpriteCount() {
+		int count = 0;
+
+		for (Scene scene : this.getSceneList()) {
+			count += scene.getSpriteList().size();
+		}
+
+		return count;
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/merge/ConflictHelper.java
+++ b/catroid/src/main/java/org/catrobat/catroid/merge/ConflictHelper.java
@@ -1,0 +1,64 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.merge;
+
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.formulaeditor.UserList;
+import org.catrobat.catroid.formulaeditor.UserVariable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConflictHelper {
+	public ConflictHelper() {
+	}
+
+	public boolean getGlobalVariableConflicts(List<UserVariable> project1GlobalVars, List<UserVariable> project2GlobalVars) {
+		List<UserVariable> conflicts = new ArrayList<>();
+		for (UserVariable project1GlobalVar : project1GlobalVars) {
+			for (UserVariable project2GlobalVar : project2GlobalVars) {
+				if (project1GlobalVar.getName().equals(project2GlobalVar.getName())) {
+					conflicts.add(project1GlobalVar);
+				}
+			}
+		}
+		return !conflicts.isEmpty();
+	}
+
+	public boolean getGlobalListConflicts(List<UserList> project1GlobalLists, List<UserList> project2GlobalLists) {
+		List<UserList> conflicts = new ArrayList<>();
+		for (UserList project1GlobalList : project1GlobalLists) {
+			for (UserList project2GlobalList : project2GlobalLists) {
+				if (project1GlobalList.getName().equals(project2GlobalList.getName())) {
+					conflicts.add(project1GlobalList);
+				}
+			}
+		}
+		return !conflicts.isEmpty();
+	}
+
+	public boolean conflictExist(Project firstProject, Project secondProject) {
+		return (getGlobalListConflicts(firstProject.getUserLists(), secondProject.getUserLists())
+				|| getGlobalVariableConflicts(firstProject.getUserVariables(), secondProject.getUserVariables()));
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/merge/MergeTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/merge/MergeTask.java
@@ -1,0 +1,74 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.merge;
+
+import android.content.Context;
+
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.io.XstreamSerializer;
+
+public class MergeTask {
+	private Project firstProject = null;
+	private Project secondProject = null;
+	private Project mergedProject = null;
+	private ConflictHelper conflictHelper = new ConflictHelper();
+	private Context context;
+	private boolean landscapeMode;
+
+	public MergeTask(Project firstProject, Project secondProject, Context context, boolean landscapeMode) {
+		this.firstProject = firstProject;
+		this.secondProject = secondProject;
+		this.context = context;
+		this.landscapeMode = landscapeMode;
+	}
+
+	public boolean performMerge(String mergeProjectName) {
+		if (conflictHelper.conflictExist(firstProject, secondProject)) {
+			return false;
+		}
+
+		mergedProject = new Project(context, mergeProjectName, landscapeMode);
+
+		if (mergedProject.getDefaultScene() != null) {
+			mergedProject.removeScene(mergedProject.getDefaultScene());
+		}
+
+		mergedProject.setXmlHeader(firstProject.getXmlHeader());
+
+		for (String sceneName : firstProject.getSceneNames()) {
+			if (secondProject.getSceneNames().contains(sceneName)) {
+				return false;
+			}
+		}
+
+		mergedProject.getSceneList().addAll(firstProject.getSceneList());
+		mergedProject.getSceneList().addAll(secondProject.getSceneList());
+		mergedProject.getUserVariables().addAll(firstProject.getUserVariables());
+		mergedProject.getUserVariables().addAll(secondProject.getUserVariables());
+		mergedProject.getUserLists().addAll(firstProject.getUserLists());
+		mergedProject.getUserLists().addAll(secondProject.getUserLists());
+		mergedProject.getSettings().addAll(firstProject.getSettings());
+
+		return XstreamSerializer.getInstance().saveProject(mergedProject) ? true : false;
+	}
+}

--- a/catroid/src/test/java/org/catrobat/catroid/test/merge/ConflictHelperTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/merge/ConflictHelperTest.java
@@ -1,0 +1,93 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.merge;
+
+import android.content.Context;
+
+import org.catrobat.catroid.common.FlavoredConstants;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.formulaeditor.UserList;
+import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.io.StorageOperations;
+import org.catrobat.catroid.merge.ConflictHelper;
+import org.catrobat.catroid.test.MockUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static junit.framework.Assert.assertFalse;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnit4.class)
+public class ConflictHelperTest {
+	private Project firstProject;
+	private Project secondProject;
+	private ConflictHelper conflictHelper;
+
+	@Before
+	public void setUp() {
+		conflictHelper = new ConflictHelper();
+		Context mockContext = MockUtil.mockContextForProject();
+		firstProject = new Project(mockContext, "testProject");
+		secondProject = new Project(mockContext, "testProject2");
+		firstProject.addUserList(new UserList("TestUserList1", Arrays.asList(1.0, 2.0)));
+		secondProject.addUserList(new UserList("TestUserList2", Arrays.asList(1.0, 2.0)));
+		firstProject.addUserVariable(new UserVariable("testVariable1", 1));
+		secondProject.addUserVariable(new UserVariable("testVariable2", 1));
+	}
+
+	@After
+	public void tearDown() throws IOException {
+
+	}
+
+	@Test
+	public void testProjectNoGlobalVariableConflicts() {
+		assertFalse(conflictHelper.conflictExist(firstProject, secondProject));
+	}
+
+	@Test
+	public void testProjectGlobalVariableConflict() {
+		secondProject.addUserVariable(new UserVariable("testVariable1", 1));
+		assertTrue(conflictHelper.conflictExist(firstProject, secondProject));
+	}
+
+	@Test
+	public void testProjectNoGlobalUserListConflicts() {
+		assertFalse(conflictHelper.conflictExist(firstProject, secondProject));
+	}
+
+	@Test
+	public void testProjectGlobalUserListConflicts() {
+		secondProject.addUserList(new UserList("TestUserList1", Arrays.asList(1.0, 2.0)));
+		assertTrue(conflictHelper.conflictExist(firstProject, secondProject));
+	}
+}
+

--- a/catroid/src/test/java/org/catrobat/catroid/test/merge/MergeTaskTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/merge/MergeTaskTest.java
@@ -1,0 +1,97 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.merge;
+
+import android.content.Context;
+
+import org.catrobat.catroid.common.FlavoredConstants;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.formulaeditor.UserList;
+import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.io.StorageOperations;
+import org.catrobat.catroid.merge.MergeTask;
+import org.catrobat.catroid.test.MockUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.File;
+import java.io.IOException;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+@RunWith(JUnit4.class)
+public class MergeTaskTest {
+	private Project firstProject;
+	private Project secondProject;
+	private MergeTask mergeTask;
+
+	@Before
+	public void setUp() {
+		Context mockContext = MockUtil.mockContextForProject();
+		firstProject = new Project(mockContext, "testProjectOne");
+		secondProject = new Project(mockContext, "testProjectTwo");
+
+		firstProject.addUserList(new UserList("userListOne"));
+		firstProject.addUserVariable(new UserVariable("userVariableOne"));
+		firstProject.addScene(new Scene("sceneOne", firstProject));
+
+		secondProject.addUserList(new UserList("userListTwo"));
+		secondProject.addUserVariable(new UserVariable("userVariableTwo"));
+		secondProject.addScene(new Scene("sceneTwo", secondProject));
+
+		mergeTask = new MergeTask(firstProject, secondProject, mockContext, false);
+	}
+
+	@After
+	public void tearDown() throws IOException {
+
+	}
+
+	@Test
+	public void mergeTaskNoConflictTest() {
+		assertTrue(mergeTask.performMerge("mergedProject"));
+	}
+
+	@Test
+	public void mergeTaskWithSceneConflictTest() {
+		firstProject.addScene(new Scene("sceneTwo", secondProject));
+		assertFalse(mergeTask.performMerge("mergedProject"));
+	}
+
+	@Test
+	public void mergeTaskWithUserListConflictTest() {
+		firstProject.addUserList(new UserList("userListTwo"));
+		assertFalse(mergeTask.performMerge("mergedProject"));
+	}
+
+	@Test
+	public void mergeTaskWithUserVariableConflictTest() {
+		firstProject.addUserVariable(new UserVariable("userVariableOne"));
+		assertFalse(mergeTask.performMerge("mergedProject"));
+	}
+}


### PR DESCRIPTION
This feature merges two projects into one project. It checks the two projects to make sure there're no name conflicts among variable names and lists. If there's a conflict merging does not happen.
And since catroid-159 and 285 are not testable, I include the code into this PR. I could fully test it when I put everything together. 