### PR TITLE
CATROID-307 Upgrade Facebook SDK to v5.1.1

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -446,7 +446,7 @@ dependencies {
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-armeabi-v7a"
     natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-arm64-v8a"
 
-    implementation 'com.facebook.android:facebook-android-sdk:4.14.1'
+    implementation 'com.facebook.android:facebook-android-sdk:5.1.1'
     implementation 'com.google.android.gms:play-services-auth:12.0.0'
 
     androidTestImplementation ('tools.fastlane:screengrab:1.1.0'){

--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -104,7 +104,8 @@
             android:name="com.facebook.FacebookActivity"
             android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
             android:label="${appName}"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            tools:replace="android:theme"/>
 
         <activity
             android:name=".ui.SettingsActivity"


### PR DESCRIPTION
As far as i can test it seems like there are no problems with just updating the reference. But to be aware, we are currently restricted, so it's still the same error message as before.