### PR TITLE
Fix layout margins of delete key in formula editor

### DIFF
--- a/catroid/src/main/res/layout/formula_editor_keyboard.xml
+++ b/catroid/src/main/res/layout/formula_editor_keyboard.xml
@@ -56,9 +56,8 @@
 
         <ImageButton
             android:id="@+id/formula_editor_keyboard_delete"
-            style="@style/FormulaEditorImageButton"
+            style="@style/FormulaEditorButton"
             android:layout_marginTop="@dimen/key_margin"
-            android:layout_height="match_parent"
             android:contentDescription="@string/formula_editor_image_button_description_delete"
             android:src="@android:drawable/ic_input_delete"
             android:layout_span="2" />

--- a/catroid/src/main/res/values/styles.xml
+++ b/catroid/src/main/res/values/styles.xml
@@ -447,12 +447,6 @@
         <item name="android:layout_below">@+id/formula_editor_keyboard_decimal_mark</item>
     </style>
 
-    <style name="FormulaEditorImageButton">
-        <item name="android:background">@drawable/formula_editor_keyboard_button</item>
-        <item name="android:layout_marginBottom">@dimen/key_margin</item>
-        <item name="android:layout_marginEnd">@dimen/key_margin</item>
-    </style>
-
     <style name="BrickCategory">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">@dimen/brick_category_height</item>


### PR DESCRIPTION
* Fixes the margins of the delete key in formula editor

| Before | After |
|----------|--------|
| <img src="https://user-images.githubusercontent.com/30626927/63383926-1240da80-c39e-11e9-9813-b25766f33f39.png" width="300" /> | <img src="https://user-images.githubusercontent.com/30626927/63383933-17058e80-c39e-11e9-8f61-5899293463b6.png" width="300" /> |