### PR TITLE
CATROID-338 fix touches actor name change does not affect formulas

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -407,15 +407,9 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 				if (currentScript == null) {
 					return;
 				}
-				Brick scriptBrick = currentScript.getScriptBrick();
-				if (scriptBrick instanceof FormulaBrick) {
-					FormulaBrick formulaBrick = (FormulaBrick) scriptBrick;
-					for (Formula formula : formulaBrick.getFormulas()) {
-						formula.updateCollisionFormulas(oldName, newName, context);
-					}
-				}
-				List<Brick> brickList = currentScript.getBrickList();
-				for (Brick brick : brickList) {
+				List<Brick> flatList = new ArrayList();
+				currentScript.addToFlatList(flatList);
+				for (Brick brick : flatList) {
 					if (brick instanceof FormulaBrick) {
 						List<Formula> formulaList = ((FormulaBrick) brick).getFormulas();
 						for (Formula formula : formulaList) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SpriteListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SpriteListFragment.java
@@ -298,6 +298,12 @@ public class SpriteListFragment extends RecyclerViewFragment<Sprite> {
 	}
 
 	@Override
+	public void renameItem(Sprite item, String name) {
+		item.rename(name);
+		finishActionMode();
+	}
+
+	@Override
 	public void onItemClick(Sprite item) {
 		if (item instanceof GroupSprite) {
 			GroupSprite groupSprite = (GroupSprite) item;

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickCollisionUpdateTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickCollisionUpdateTest.java
@@ -1,0 +1,144 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.bricks;
+
+import android.content.Context;
+
+import org.catrobat.catroid.CatroidApplication;
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.WhenScript;
+import org.catrobat.catroid.content.bricks.CompositeBrick;
+import org.catrobat.catroid.content.bricks.ConcurrentFormulaHashMap;
+import org.catrobat.catroid.content.bricks.ForeverBrick;
+import org.catrobat.catroid.content.bricks.FormulaBrick;
+import org.catrobat.catroid.content.bricks.IfThenLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.RepeatBrick;
+import org.catrobat.catroid.content.bricks.RepeatUntilBrick;
+import org.catrobat.catroid.content.bricks.SetXBrick;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(Parameterized.class)
+@PrepareForTest({CatroidApplication.class})
+public class CompositeBrickCollisionUpdateTest {
+
+	private FormulaBrick formulaBrick;
+	private Sprite sprite;
+	private static final String VARIABLE_NAME = "Test";
+	private static final String DIFFERENT_VARIABLE_NAME = "Abcd";
+	private static final String NEW_VARIABLE_NAME = "NewName";
+	private static final String REPLACED_VARIABLE = "null(" + NEW_VARIABLE_NAME + ") ";
+	private static final String NO_CHANGE_VARIABLE = "null(" + DIFFERENT_VARIABLE_NAME + ") ";
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{IfThenLogicBeginBrick.class.getSimpleName(), IfThenLogicBeginBrick.class},
+				{ForeverBrick.class.getSimpleName(), ForeverBrick.class},
+				{RepeatBrick.class.getSimpleName(), RepeatBrick.class},
+				{RepeatUntilBrick.class.getSimpleName(), RepeatUntilBrick.class},
+		});
+	}
+
+	@Parameterized.Parameter
+	public String name;
+
+	@Parameterized.Parameter(1)
+	public Class<CompositeBrick> compositeBrickClass;
+
+	@Before
+	public void setUp() throws IllegalAccessException, InstantiationException {
+		Context contextMock = Mockito.mock(Context.class);
+		PowerMockito.mockStatic(CatroidApplication.class);
+		PowerMockito.when(CatroidApplication.getAppContext()).thenReturn(contextMock);
+
+		Project project = new Project();
+		Scene scene = new Scene();
+		sprite = new Sprite(VARIABLE_NAME);
+		Script script = new WhenScript();
+		CompositeBrick compositeBrick = compositeBrickClass.newInstance();
+		formulaBrick = new SetXBrick();
+
+		project.addScene(scene);
+		scene.addSprite(sprite);
+		sprite.addScript(script);
+		script.addBrick(compositeBrick);
+		compositeBrick.getNestedBricks().add(formulaBrick);
+
+		ProjectManager.getInstance().setCurrentProject(project);
+		ProjectManager.getInstance().setCurrentlyEditedScene(scene);
+	}
+
+	@Test
+	public void testRenameSprite() {
+		Formula newFormula = new Formula(new FormulaElement(FormulaElement.ElementType.COLLISION_FORMULA,
+				VARIABLE_NAME, null));
+		ConcurrentFormulaHashMap map = formulaBrick.getFormulaMap();
+		map.forEach((k, v) -> {
+			formulaBrick.setFormulaWithBrickField(k, newFormula);
+		});
+
+		sprite.rename(NEW_VARIABLE_NAME);
+
+		map.forEach((k, v) -> {
+			assertEquals(v.getTrimmedFormulaString(CatroidApplication.getAppContext()),
+					REPLACED_VARIABLE);
+		});
+	}
+
+	@Test
+	public void testRenameSpriteNoChange() {
+		Formula newFormula = new Formula(new FormulaElement(FormulaElement.ElementType.COLLISION_FORMULA,
+				DIFFERENT_VARIABLE_NAME, null));
+		ConcurrentFormulaHashMap map = formulaBrick.getFormulaMap();
+		map.forEach((k, v) -> {
+			formulaBrick.setFormulaWithBrickField(k, newFormula);
+		});
+
+		sprite.rename(NEW_VARIABLE_NAME);
+
+		map.forEach((k, v) -> {
+			assertEquals(v.getTrimmedFormulaString(CatroidApplication.getAppContext()),
+					NO_CHANGE_VARIABLE);
+		});
+	}
+}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickWithSecondaryListCollisionUpdateTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickWithSecondaryListCollisionUpdateTest.java
@@ -1,0 +1,165 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.bricks;
+
+import android.content.Context;
+
+import org.catrobat.catroid.CatroidApplication;
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.WhenScript;
+import org.catrobat.catroid.content.bricks.CompositeBrick;
+import org.catrobat.catroid.content.bricks.ConcurrentFormulaHashMap;
+import org.catrobat.catroid.content.bricks.FormulaBrick;
+import org.catrobat.catroid.content.bricks.IfLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.PhiroIfLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.RaspiIfLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.SetXBrick;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(Parameterized.class)
+@PrepareForTest({CatroidApplication.class})
+public class CompositeBrickWithSecondaryListCollisionUpdateTest {
+
+	private FormulaBrick primaryFormulaBrick;
+	private FormulaBrick secondaryFormulaBrick;
+	private Sprite sprite;
+	private static final String VARIABLE_NAME = "Test";
+	private static final String DIFFERENT_VARIABLE_NAME = "Abcd";
+	private static final String NEW_VARIABLE_NAME = "NewName";
+	private static final String REPLACED_VARIABLE = "null(" + NEW_VARIABLE_NAME + ") ";
+	private static final String NO_CHANGE_VARIABLE = "null(" + DIFFERENT_VARIABLE_NAME + ") ";
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{IfLogicBeginBrick.class.getSimpleName(), IfLogicBeginBrick.class},
+				{PhiroIfLogicBeginBrick.class.getSimpleName(), PhiroIfLogicBeginBrick.class},
+				{RaspiIfLogicBeginBrick.class.getSimpleName(), RaspiIfLogicBeginBrick.class},
+		});
+	}
+
+	@Parameterized.Parameter
+	public String name;
+
+	@Parameterized.Parameter(1)
+	public Class<CompositeBrick> compositeBrickClass;
+
+	@Before
+	public void setUp() throws IllegalAccessException, InstantiationException {
+		Context contextMock = Mockito.mock(Context.class);
+		PowerMockito.mockStatic(CatroidApplication.class);
+		PowerMockito.when(CatroidApplication.getAppContext()).thenReturn(contextMock);
+
+		Project project = new Project();
+		Scene scene = new Scene();
+		sprite = new Sprite(VARIABLE_NAME);
+		Script script = new WhenScript();
+		CompositeBrick compositeBrick = compositeBrickClass.newInstance();
+		primaryFormulaBrick = new SetXBrick();
+		secondaryFormulaBrick = new SetXBrick();
+
+		project.addScene(scene);
+		scene.addSprite(sprite);
+		sprite.addScript(script);
+		script.addBrick(compositeBrick);
+		compositeBrick.getNestedBricks().add(primaryFormulaBrick);
+		compositeBrick.getSecondaryNestedBricks().add(secondaryFormulaBrick);
+
+		ProjectManager.getInstance().setCurrentProject(project);
+		ProjectManager.getInstance().setCurrentlyEditedScene(scene);
+	}
+
+	@Test
+	public void testRenameSprite() {
+		Formula newFormula = new Formula(new FormulaElement(FormulaElement.ElementType.COLLISION_FORMULA,
+				VARIABLE_NAME, null));
+
+		ConcurrentFormulaHashMap primaryMap = primaryFormulaBrick.getFormulaMap();
+		ConcurrentFormulaHashMap secondaryMap = primaryFormulaBrick.getFormulaMap();
+
+		primaryMap.forEach((k, v) -> {
+			primaryFormulaBrick.setFormulaWithBrickField(k, newFormula);
+		});
+		secondaryMap.forEach((k, v) -> {
+			primaryFormulaBrick.setFormulaWithBrickField(k, newFormula);
+		});
+
+		sprite.rename(NEW_VARIABLE_NAME);
+
+		primaryMap.forEach((k, v) -> {
+			assertEquals(v.getTrimmedFormulaString(CatroidApplication.getAppContext()),
+					REPLACED_VARIABLE);
+		});
+		secondaryMap.forEach((k, v) -> {
+			assertEquals(v.getTrimmedFormulaString(CatroidApplication.getAppContext()),
+					REPLACED_VARIABLE);
+		});
+	}
+
+	@Test
+	public void testRenameSpriteNoChange() {
+		Formula newFormula = new Formula(new FormulaElement(FormulaElement.ElementType.COLLISION_FORMULA,
+				DIFFERENT_VARIABLE_NAME, null));
+
+		ConcurrentFormulaHashMap primaryMap = primaryFormulaBrick.getFormulaMap();
+		ConcurrentFormulaHashMap secondaryMap = primaryFormulaBrick.getFormulaMap();
+
+		primaryMap.forEach((k, v) -> {
+			primaryFormulaBrick.setFormulaWithBrickField(k, newFormula);
+		});
+		secondaryMap.forEach((k, v) -> {
+			primaryFormulaBrick.setFormulaWithBrickField(k, newFormula);
+		});
+
+		sprite.rename(NEW_VARIABLE_NAME);
+
+		primaryMap.forEach((k, v) -> {
+			assertEquals(v.getTrimmedFormulaString(CatroidApplication.getAppContext()),
+					NO_CHANGE_VARIABLE);
+		});
+		secondaryMap.forEach((k, v) -> {
+			assertEquals(v.getTrimmedFormulaString(CatroidApplication.getAppContext()),
+					NO_CHANGE_VARIABLE);
+		});
+	}
+}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/UpdateCollisionActorScriptBrickTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/UpdateCollisionActorScriptBrickTest.java
@@ -1,0 +1,140 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.content.bricks;
+
+import android.content.Context;
+
+import org.catrobat.catroid.CatroidApplication;
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.bricks.ConcurrentFormulaHashMap;
+import org.catrobat.catroid.content.bricks.FormulaBrick;
+import org.catrobat.catroid.content.bricks.ScriptBrick;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.catrobat.catroid.test.xmlformat.ClassDiscoverer.getAllSubClassesOf;
+import static org.catrobat.catroid.test.xmlformat.ClassDiscoverer.removeAbstractClasses;
+import static org.catrobat.catroid.test.xmlformat.ClassDiscoverer.removeInnerClasses;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(Parameterized.class)
+@PrepareForTest({CatroidApplication.class})
+public class UpdateCollisionActorScriptBrickTest {
+
+	private FormulaBrick formulaBrick;
+	private Sprite sprite;
+	private static final String VARIABLE_NAME = "Test";
+	private static final String DIFFERENT_VARIABLE_NAME = "Abcd";
+	private static final String NEW_VARIABLE_NAME = "NewName";
+	private static final String REPLACED_VARIABLE = "null(" + NEW_VARIABLE_NAME + ") ";
+	private static final String NO_CHANGE_VARIABLE = "null(" + DIFFERENT_VARIABLE_NAME + ") ";
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> data() {
+		List<Object[]> parameters = new ArrayList<>();
+		Set<Class<? extends FormulaBrick>> formulaClasses = getAllSubClassesOf(FormulaBrick.class);
+		formulaClasses = removeAbstractClasses(formulaClasses);
+		formulaClasses = removeInnerClasses(formulaClasses);
+		for (Class<?> formulaClazz : formulaClasses) {
+			if (ScriptBrick.class.isAssignableFrom(formulaClazz)) {
+				parameters.add(new Object[] {formulaClazz.getName(), formulaClazz});
+			}
+		}
+		return parameters;
+	}
+
+	@Parameterized.Parameter
+	public String simpleName;
+	@Parameterized.Parameter(1)
+	public Class formulaClass;
+
+	@Before
+	public void setUp() throws IllegalAccessException, InstantiationException {
+		Context contextMock = Mockito.mock(Context.class);
+		PowerMockito.mockStatic(CatroidApplication.class);
+		PowerMockito.when(CatroidApplication.getAppContext()).thenReturn(contextMock);
+
+		Project project = new Project();
+		Scene scene = new Scene();
+		sprite = new Sprite(VARIABLE_NAME);
+		formulaBrick = (FormulaBrick) formulaClass.newInstance();
+
+		project.addScene(scene);
+		scene.addSprite(sprite);
+		sprite.addScript(formulaBrick.getScript());
+
+		ProjectManager.getInstance().setCurrentProject(project);
+		ProjectManager.getInstance().setCurrentlyEditedScene(scene);
+	}
+
+	@Test
+	public void testRenamingChanges() {
+		Formula newFormula = new Formula(new FormulaElement(FormulaElement.ElementType.COLLISION_FORMULA,
+				VARIABLE_NAME, null));
+		ConcurrentFormulaHashMap map = formulaBrick.getFormulaMap();
+		map.forEach((k, v) -> {
+			formulaBrick.setFormulaWithBrickField(k, newFormula);
+		});
+
+		sprite.rename(NEW_VARIABLE_NAME);
+
+		map.forEach((k, v) -> {
+			assertEquals(v.getTrimmedFormulaString(CatroidApplication.getAppContext()),
+					REPLACED_VARIABLE);
+		});
+	}
+
+	@Test
+	public void testRenamingNoChanges() {
+		Formula newFormula = new Formula(new FormulaElement(FormulaElement.ElementType.COLLISION_FORMULA,
+				DIFFERENT_VARIABLE_NAME, null));
+		ConcurrentFormulaHashMap map = formulaBrick.getFormulaMap();
+		map.forEach((k, v) -> {
+			formulaBrick.setFormulaWithBrickField(k, newFormula);
+		});
+
+		sprite.rename(NEW_VARIABLE_NAME);
+
+		map.forEach((k, v) -> {
+			assertEquals(v.getTrimmedFormulaString(CatroidApplication.getAppContext()),
+					NO_CHANGE_VARIABLE);
+		});
+	}
+}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/UpdateCollisionActorTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/UpdateCollisionActorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.content.bricks;
+
+import android.content.Context;
+
+import org.catrobat.catroid.CatroidApplication;
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.WhenScript;
+import org.catrobat.catroid.content.bricks.ConcurrentFormulaHashMap;
+import org.catrobat.catroid.content.bricks.FormulaBrick;
+import org.catrobat.catroid.content.bricks.ScriptBrick;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.catrobat.catroid.test.xmlformat.ClassDiscoverer.getAllSubClassesOf;
+import static org.catrobat.catroid.test.xmlformat.ClassDiscoverer.removeAbstractClasses;
+import static org.catrobat.catroid.test.xmlformat.ClassDiscoverer.removeInnerClasses;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(Parameterized.class)
+@PrepareForTest({CatroidApplication.class})
+public class UpdateCollisionActorTest {
+
+	private FormulaBrick formulaBrick;
+	private Sprite sprite;
+	private static final String VARIABLE_NAME = "Test";
+	private static final String DIFFERENT_VARIABLE_NAME = "Abcd";
+	private static final String NEW_VARIABLE_NAME = "NewName";
+	private static final String REPLACED_VARIABLE = "null(" + NEW_VARIABLE_NAME + ") ";
+	private static final String NO_CHANGE_VARIABLE = "null(" + DIFFERENT_VARIABLE_NAME + ") ";
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> data() {
+		List<Object[]> parameters = new ArrayList<>();
+		Set<Class<? extends FormulaBrick>> formulaClasses = getAllSubClassesOf(FormulaBrick.class);
+		formulaClasses = removeAbstractClasses(formulaClasses);
+		formulaClasses = removeInnerClasses(formulaClasses);
+		for (Class<?> formulaClazz : formulaClasses) {
+			if (!ScriptBrick.class.isAssignableFrom(formulaClazz)) {
+				parameters.add(new Object[] {formulaClazz.getName(), formulaClazz});
+			}
+		}
+		return parameters;
+	}
+
+	@Parameterized.Parameter
+	public String simpleName;
+	@Parameterized.Parameter(1)
+	public Class formulaClass;
+
+	@Before
+	public void setUp() throws IllegalAccessException, InstantiationException {
+		Context contextMock = Mockito.mock(Context.class);
+		PowerMockito.mockStatic(CatroidApplication.class);
+		PowerMockito.when(CatroidApplication.getAppContext()).thenReturn(contextMock);
+
+		Project project = new Project();
+		Scene scene = new Scene();
+		sprite = new Sprite(VARIABLE_NAME);
+		Script script = new WhenScript();
+		formulaBrick = (FormulaBrick) formulaClass.newInstance();
+
+		project.addScene(scene);
+		scene.addSprite(sprite);
+		sprite.addScript(script);
+		script.addBrick(formulaBrick);
+
+		ProjectManager.getInstance().setCurrentProject(project);
+		ProjectManager.getInstance().setCurrentlyEditedScene(scene);
+	}
+
+	@Test
+	public void testRenamingChanges() {
+		Formula newFormula = new Formula(new FormulaElement(FormulaElement.ElementType.COLLISION_FORMULA,
+				VARIABLE_NAME, null));
+		ConcurrentFormulaHashMap map = formulaBrick.getFormulaMap();
+		map.forEach((k, v) -> {
+			formulaBrick.setFormulaWithBrickField(k, newFormula);
+		});
+
+		sprite.rename(NEW_VARIABLE_NAME);
+
+		map.forEach((k, v) -> {
+			assertEquals(v.getTrimmedFormulaString(CatroidApplication.getAppContext()),
+					REPLACED_VARIABLE);
+		});
+	}
+
+	@Test
+	public void testRenamingNoChanges() {
+		Formula newFormula = new Formula(new FormulaElement(FormulaElement.ElementType.COLLISION_FORMULA,
+				DIFFERENT_VARIABLE_NAME, null));
+		ConcurrentFormulaHashMap map = formulaBrick.getFormulaMap();
+		map.forEach((k, v) -> {
+			formulaBrick.setFormulaWithBrickField(k, newFormula);
+		});
+
+		sprite.rename(NEW_VARIABLE_NAME);
+
+		map.forEach((k, v) -> {
+			assertEquals(v.getTrimmedFormulaString(CatroidApplication.getAppContext()),
+					NO_CHANGE_VARIABLE);
+		});
+	}
+}


### PR DESCRIPTION
- add check in RecyclerViewFragment to call rename instead of setter
- change renameSpriteInCollisionFormulas iteration over bricks
- add Testcases similar to CATROID-258