### PR TITLE
MAINTENANCE: Solve lint issues and reenable lint rules

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,7 +116,7 @@ pipeline {
                         stage('Static Analysis') {
                             steps {
                                 catchError(buildResult: 'FAILURE' ,stageResult: 'FAILURE') {
-                                    sh './gradlew pmd checkstyle lint detekt'
+                                    sh './gradlew pmd checkstyle lintCatroidDebug detekt'
                                 }
                             }
 

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -180,13 +180,7 @@ android {
 
     lintOptions {
         lintConfig file('config/lint.xml')
-        // IconMissingDensityFolder: we do not provide xxxhdpi icons (yet).
-        ignore 'ContentDescription', 'InvalidPackage', 'GradleDependency',
-                'ClickableViewAccessibility', 'UnusedAttribute', 'CommitPrefEdits', 'OldTargetApi',
-                'RtlSymmetry', 'RtlHardcoded', 'HandlerLeak', 'IconMissingDensityFolder',
-                'WrongRegion', 'RelativeOverlap', 'IconColors', 'MissingTranslation', 'ExtraTranslation',
-                'GradleCompatible', 'WifiManagerLeak', 'ApplySharedPref', 'ObsoleteSdkInt',
-                'StaticFieldLeak'
+        ignore 'GradleDependency', 'OldTargetApi', 'ExtraTranslation', 'MissingTranslation', 'LintBaseline'
 
         abortOnError false
 
@@ -195,6 +189,7 @@ android {
         htmlReport true
         xmlOutput file("build/reports/lint-report.xml")
         htmlOutput file("build/reports/lint-report.html")
+        baseline file('config/lint-baseline.xml')
     }
 
     testOptions {
@@ -310,6 +305,8 @@ dependencies {
     implementation "com.android.support:cardview-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
     implementation "com.android.support:customtabs:$supportLibraryVersion"
+    implementation "com.android.support:exifinterface:$supportLibraryVersion"
+    implementation "com.android.support:support-v4:$supportLibraryVersion"
 
     implementation "com.android.support.test.espresso:espresso-idling-resource:$espressoVersion"
     implementation 'com.android.support:multidex:1.0.3'

--- a/catroid/config/lint-baseline.xml
+++ b/catroid/config/lint-baseline.xml
@@ -1,0 +1,1469 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2018 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<issues format="5" by="lint 3.5.2" client="gradle" variant="catroidDebug" version="3.5.2">
+
+    <issue
+        id="StaticFieldLeak"
+        message="Do not place Android context classes in static fields (static reference to `CastManager` which has field `initializingActivity` pointing to `AppCompatActivity`); this is a memory leak"
+        errorLine1=" private static final CastManager INSTANCE = new CastManager();"
+        errorLine2="         ~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/cast/CastManager.java"
+            line="71"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="Do not place Android context classes in static fields; this is a memory leak"
+        errorLine1=" private static Context context;"
+        errorLine2="         ~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/CatroidApplication.java"
+            line="44"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This field leaks a context object"
+        errorLine1=" private Activity activity;"
+        errorLine2=" ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/transfers/CheckOAuthTokenTask.java"
+            line="39"
+            column="2"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This `AsyncTask` class should be static or leaks might occur (org.catrobat.catroid.bluetooth.ConnectBluetoothDeviceActivity.ConnectDeviceTask)"
+        errorLine1=" private class ConnectDeviceTask extends AsyncTask&lt;String, Void, BluetoothConnection.State> {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/bluetooth/ConnectBluetoothDeviceActivity.java"
+            line="154"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This field leaks a context object"
+        errorLine1=" private Context context;"
+        errorLine2=" ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/transfers/DeleteTestUserTask.java"
+            line="38"
+            column="2"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This `AsyncTask` class should be static or leaks might occur (anonymous com.parrot.freeflight.tasks.CheckDroneNetworkAvailabilityTask)"
+        errorLine1="  checkDroneConnectionTask = new CheckDroneNetworkAvailabilityTask() {"
+        errorLine2="                             ^">
+        <location
+            file="src/main/java/org/catrobat/catroid/drone/ardrone/DroneInitializer.java"
+            line="100"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This field leaks a context object"
+        errorLine1=" private Context context;"
+        errorLine2=" ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/transfers/FetchScratchProgramDetailsTask.java"
+            line="52"
+            column="2"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="Do not place Android context classes in static fields (static reference to `FormulaEditorEditText` which has field `context` pointing to `Context`); this is a memory leak"
+        errorLine1=" private static FormulaEditorEditText formulaEditorEditText;"
+        errorLine2="         ~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java"
+            line="99"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="Do not place Android context classes in static fields; this is a memory leak"
+        errorLine1=" private static LinearLayout formulaEditorBrick;"
+        errorLine2="         ~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java"
+            line="101"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="Do not place Android context classes in static fields (static reference to `FormulaBrick` which has field `view` pointing to `View`); this is a memory leak"
+        errorLine1=" private static FormulaBrick formulaBrick;"
+        errorLine2="         ~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java"
+            line="103"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This field leaks a context object"
+        errorLine1=" private Context context;"
+        errorLine2=" ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/transfers/GoogleExchangeCodeTask.java"
+            line="42"
+            column="2"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This field leaks a context object"
+        errorLine1=" private Context context;"
+        errorLine2=" ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/transfers/GoogleLogInTask.java"
+            line="43"
+            column="2"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This field leaks a context object"
+        errorLine1=" private Context context;"
+        errorLine2=" ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/transfers/LogoutTask.java"
+            line="33"
+            column="2"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This `AsyncTask` class should be static or leaks might occur (org.catrobat.catroid.content.actions.ReadListFromDeviceAction.ReadTask)"
+        errorLine1=" private class ReadTask extends AsyncTask&lt;UserList, Void, Void> {"
+        errorLine2="               ~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/content/actions/ReadListFromDeviceAction.java"
+            line="58"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This `AsyncTask` class should be static or leaks might occur (org.catrobat.catroid.content.actions.ReadVariableFromDeviceAction.ReadTask)"
+        errorLine1=" private class ReadTask extends AsyncTask&lt;UserVariable, Void, Void> {"
+        errorLine2="               ~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/content/actions/ReadVariableFromDeviceAction.java"
+            line="57"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This `AsyncTask` class should be static or leaks might occur (org.catrobat.catroid.ui.dialogs.StageDialog.FinishThreadAndDisposeTexturesTask)"
+        errorLine1=" private class FinishThreadAndDisposeTexturesTask extends AsyncTask&lt;Void, Void, Void> {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/ui/dialogs/StageDialog.java"
+            line="234"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="Do not place Android context classes in static fields; this is a memory leak"
+        errorLine1=" private static Context context = null;"
+        errorLine2="         ~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/utils/VibratorUtil.java"
+            line="37"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This `AsyncTask` class should be static or leaks might occur (org.catrobat.catroid.content.actions.WriteListOnDeviceAction.WriteTask)"
+        errorLine1=" private class WriteTask extends AsyncTask&lt;UserList, Void, Void> {"
+        errorLine2="               ~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/content/actions/WriteListOnDeviceAction.java"
+            line="61"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="StaticFieldLeak"
+        message="This `AsyncTask` class should be static or leaks might occur (org.catrobat.catroid.content.actions.WriteVariableOnDeviceAction.WriteTask)"
+        errorLine1=" private class WriteTask extends AsyncTask&lt;UserVariable, Void, Void> {"
+        errorLine2="               ~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/content/actions/WriteVariableOnDeviceAction.java"
+            line="59"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-hdpi/icon_redo.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-ldrtl-hdpi/icon_redo.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-ldrtl-mdpi/icon_redo.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-ldrtl-xhdpi/icon_redo.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-mdpi/icon_redo.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-xhdpi/icon_redo.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-hdpi/icon_undo.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-ldrtl-hdpi/icon_undo.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-ldrtl-mdpi/icon_undo.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-ldrtl-xhdpi/icon_undo.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-mdpi/icon_undo.png"/>
+    </issue>
+
+    <issue
+        id="IconColors"
+        message="Action Bar icons should use a single gray color (`#333333` for light themes (with 60%/30% opacity for enabled/disabled), and `#FFFFFF` with opacity 80%/30% for dark themes">
+        <location
+            file="src/main/res/drawable-xhdpi/icon_undo.png"/>
+    </issue>
+
+    <issue
+        id="IconDensities"
+        message="Missing the following drawables in `drawable-hdpi`: brick_blue_1h.9.png, brick_blue_2h.9.png, brick_blue_2h_when_9.9.png, brick_blue_3h.9.png, brick_brown_1h_when_9.9.png... (46 more)">
+        <location
+            file="src/main/res/drawable-hdpi"/>
+    </issue>
+
+    <issue
+        id="IconDensities"
+        message="Missing the following drawables in `drawable-mdpi`: ardrone_neg.png, ardrone_pos.png, arduino_neg.png, arduino_pos.png, brick_selection_background_bluetooth.9.png... (44 more)">
+        <location
+            file="src/main/res/drawable-mdpi"/>
+    </issue>
+
+    <issue
+        id="IconDensities"
+        message="Missing the following drawables in `drawable-xhdpi`: embroidery_neg.png, embroidery_pos.png, favorites_72x72.png, formula_editor_button.9.png, formula_editor_button_pressed.9.png... (5 more)">
+        <location
+            file="src/main/res/drawable-xhdpi"/>
+    </issue>
+
+    <issue
+        id="IconDensities"
+        message="Missing the following drawables in `drawable-xxhdpi`: ardrone_neg.png, ardrone_pos.png, arduino_neg.png, arduino_pos.png, brick_blue_1h.9.png... (117 more)">
+        <location
+            file="src/main/res/drawable-xxhdpi"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view `BrickListView` overrides `onTouchEvent` but not `performClick`"
+        errorLine1=" public boolean onTouchEvent(MotionEvent event) {"
+        errorLine2="                ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/ui/dragndrop/BrickListView.java"
+            line="167"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="`onTouch` should call `View#performClick` when a click is detected"
+        errorLine1="    public boolean onTouch(View v, MotionEvent event) {"
+        errorLine2="                   ~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/content/bricks/brickspinner/BrickSpinner.java"
+            line="166"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="`onTouch` should call `View#performClick` when a click is detected"
+        errorLine1="   public boolean onTouch(View v, MotionEvent event) {"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/cast/CastManager.java"
+            line="206"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view ``ImageButton`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="   btn.setOnTouchListener(otl);"
+        errorLine2="   ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/cast/CastManager.java"
+            line="223"
+            column="4"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="`onTouch` should call `View#performClick` when a click is detected"
+        errorLine1="   public boolean onTouch(View v, MotionEvent event) {"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/pocketmusic/fastscroller/FastScroller.java"
+            line="151"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view ``FormulaEditorEditText`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="  this.setOnTouchListener(this);"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java"
+            line="148"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="`onTouch` should call `View#performClick` when a click is detected"
+        errorLine1="   public boolean onTouch(View view, MotionEvent event) {"
+        errorLine2="                  ~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java"
+            line="282"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view `TactScrollRecyclerView` overrides `onTouchEvent` but not `performClick`"
+        errorLine1=" public boolean onTouchEvent(MotionEvent e) {"
+        errorLine2="                ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/pocketmusic/ui/TactScrollRecyclerView.java"
+            line="96"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="Custom view ``FrameLayout`` has `setOnTouchListener` called on it but does not override `performClick`"
+        errorLine1="  frameLayout.setOnTouchListener(this);"
+        errorLine2="  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/visualplacement/VisualPlacementActivity.java"
+            line="285"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="ClickableViewAccessibility"
+        message="`VisualPlacementActivity#onTouch` should call `View#performClick` when a click is detected"
+        errorLine1=" public boolean onTouch(View view, MotionEvent event) {"
+        errorLine2="                ~~~~~~~">
+        <location
+            file="src/main/java/org/catrobat/catroid/visualplacement/VisualPlacementActivity.java"
+            line="289"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/accessibility_profile.xml"
+            line="43"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_main_menu_splashscreen.xml"
+            line="30"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageButton"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_pocketmusic.xml"
+            line="37"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="                    &lt;ImageView"
+        errorLine2="                     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_scratch_project_details.xml"
+            line="87"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stage_gamepad.xml"
+            line="31"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stage_gamepad.xml"
+            line="40"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stage_gamepad.xml"
+            line="52"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stage_gamepad.xml"
+            line="66"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stage_gamepad.xml"
+            line="77"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stage_gamepad.xml"
+            line="87"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stage_gamepad.xml"
+            line="97"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_stage_gamepad.xml"
+            line="108"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_standalone_advertising.xml"
+            line="50"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_upload.xml"
+            line="45"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/bottom_bar.xml"
+            line="33"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/bottom_bar.xml"
+            line="39"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_stage.xml"
+            line="34"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_stage.xml"
+            line="91"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_stage.xml"
+            line="99"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_upload_project_progress.xml"
+            line="51"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageButton"
+        errorLine2="     ~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/fragment_brick_add_userbrick.xml"
+            line="44"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/fragment_project_show_details.xml"
+            line="38"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_ardrone.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_arduino.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_chromecast.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_control.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_data.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_embroidery.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_event.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_legonxt.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_look.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_motion.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_pen.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_phiro.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_raspberrypi.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_sound.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/icon_brick_category_userbrick.xml"
+            line="28"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/scratch_social_bar.xml"
+            line="33"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/scratch_social_bar.xml"
+            line="49"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/scratch_social_bar.xml"
+            line="66"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;ImageView"
+        errorLine2="     ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/vh_button.xml"
+            line="37"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/vh_sprite_group.xml"
+            line="51"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/vh_sprite_group_item.xml"
+            line="50"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="        &lt;ImageView"
+        errorLine2="         ~~~~~~~~~">
+        <location
+            file="src/main/res/layout/vh_with_checkbox.xml"
+            line="51"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/material_design_spacing_large&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_sign_in.xml"
+            line="58"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="             android:paddingStart=&quot;5dip&quot;"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_drone_move_backward.xml"
+            line="69"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_drone_move_down.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_drone_move_forward.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_drone_move_left.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_drone_move_right.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_drone_move_up.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_drone_turn_left.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_drone_turn_right.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_ev3_motor_move.xml"
+            line="64"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_if_begin_if.xml"
+            line="53"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_if_begin_if.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_if_begin_if.xml"
+            line="66"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_if_begin_if.xml"
+            line="66"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="             android:paddingStart=&quot;5dip&quot;"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_if_begin_if.xml"
+            line="73"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="             android:paddingStart=&quot;5dip&quot;"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_if_begin_if.xml"
+            line="73"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="           android:paddingStart=&quot;5dip&quot;"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_if_begin_if.xml"
+            line="80"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="           android:paddingStart=&quot;5dip&quot;"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_if_begin_if.xml"
+            line="80"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_if_then_begin_if.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_if_then_begin_if.xml"
+            line="66"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_jumping_sumo_move_backward.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_jumping_sumo_move_forward.xml"
+            line="69"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_nxt_motor_action.xml"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_phiro_if_sensor.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/material_design_spacing_small&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_place_at.xml"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_raspi_if_begin_if.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_raspi_if_begin_if.xml"
+            line="66"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="             android:paddingStart=&quot;5dip&quot;"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_raspi_if_begin_if.xml"
+            line="73"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="           android:paddingStart=&quot;5dip&quot;"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_raspi_if_begin_if.xml"
+            line="80"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_repeat_until.xml"
+            line="53"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_repeat_until.xml"
+            line="60"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/material_design_spacing_small&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_show_variable.xml"
+            line="76"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/material_design_spacing_small&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_tap_at.xml"
+            line="65"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_wait_until.xml"
+            line="54"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_wait_until.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout-ar/brick_when_condition_true.xml"
+            line="54"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;5dip&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/brick_when_condition_true.xml"
+            line="59"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="        android:paddingStart=&quot;@dimen/device_text_view_padding&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/device_list.xml"
+            line="34"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="        android:paddingStart=&quot;@dimen/device_text_view_padding&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/device_list.xml"
+            line="55"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/material_design_spacing_large&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_orientation.xml"
+            line="44"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/material_design_spacing_large&quot;/>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_orientation.xml"
+            line="52"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="             android:paddingStart=&quot;@dimen/material_design_spacing_large&quot;/>"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_orientation.xml"
+            line="61"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="        android:paddingStart=&quot;5dp&quot;>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/dialog_select_cast.xml"
+            line="35"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/material_design_spacing_large&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/fragment_accesibility_profiles.xml"
+            line="37"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingStart` you should probably also define `paddingEnd` for right-to-left symmetry"
+        errorLine1="            android:paddingStart=&quot;@dimen/material_design_spacing_large&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/fragment_accesibility_profiles.xml"
+            line="54"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
+        errorLine1="        android:paddingEnd=&quot;@dimen/material_design_spacing_small&quot; />"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/single_seek_bar_view.xml"
+            line="42"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
+        errorLine1="            android:paddingEnd=&quot;@dimen/details_spacing&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/vh_list.xml"
+            line="54"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="RtlSymmetry"
+        message="When you define `paddingEnd` you should probably also define `paddingStart` for right-to-left symmetry"
+        errorLine1="            android:paddingEnd=&quot;@dimen/details_spacing&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/vh_variable.xml"
+            line="54"
+            column="13"/>
+    </issue>
+
+</issues>

--- a/catroid/config/lint.xml
+++ b/catroid/config/lint.xml
@@ -22,29 +22,12 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <lint >
-    <issue id="IconDensities">
-        <ignore path="src/main/res/drawable-mdpi" />
-        <ignore path="src/main/res/drawable-hdpi" />
-        <ignore path="src/main/res/drawable-xhdpi" />
-        <ignore path="src/main/res/drawable-xxhdpi" />
-    </issue >
-
-    <issue id="InflateParams">
-        <ignore path="src/main/java/org/catrobat/catroid/content/bricks/**" />
-        <ignore path="src/main/java/org/catrobat/catroid/ui/dialogs/AboutDialogFragment.java" />
-        <ignore path="src/main/java/org/catrobat/catroid/ui/dialogs/AcceptTermsOfUseDialogFragment.java" />
-        <ignore path="src/main/java/org/catrobat/catroid/ui/dialogs/CustomAlertDialogBuilder.java" />
-        <ignore path="src/main/java/org/catrobat/catroid/ui/dialogs/NewLookDialog.java" />
-        <ignore path="src/main/java/org/catrobat/catroid/ui/dialogs/NewSpriteDialog.java" />
-        <ignore path="src/main/java/org/catrobat/catroid/ui/dialogs/TermsOfUseDialogFragment.java" />
-        <ignore path="src/main/java/org/catrobat/catroid/utils/Utils.java" />
-        <ignore path="src/main/java/org/catrobat/catroid/ui/fragment/ScriptFragment.java" />
-    </issue >
-
     <issue id="UnusedResources">
         <ignore regexp=".*/values-(?!de).*/strings.xml$" />
-        <ignore path="src/main/res/drawable-nodpi/icon.png" />
-        <ignore path="**/google-services/**" />
+    </issue>
+
+     <issue id="UnusedAttribute">
+        <ignore regexp="usesCleartextTraffic"/>
     </issue>
 
     <issue id="ImpliedQuantity">
@@ -62,4 +45,9 @@
     <issue id="Typos">
         <ignore regexp=".*/values-(?!de).*/strings.xml$" />
     </issue >
+
+    <issue id="InvalidPackage">
+        <ignore path="*/com.thoughtworks.xstream/xstream/*"/>
+        <ignore path="*/ar.com.hjg/pngj/*"/>
+    </issue>
 </lint >

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/web/AuthenticationCallsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/web/AuthenticationCallsTest.java
@@ -86,7 +86,7 @@ public class AuthenticationCallsTest implements DeleteTestUserTask.OnDeleteTestU
 		listenerMock = Mockito.mock(TaskListener.class);
 		sharedPreferences = PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext());
 		authenticator = new ServerAuthenticator(testUser, testPassword, token, CatrobatWebClient.INSTANCE.getClient(),
-				BASE_URL_TEST_HTTPS, sharedPreferences.edit(), listenerMock);
+				BASE_URL_TEST_HTTPS, sharedPreferences, listenerMock);
 	}
 
 	@After

--- a/catroid/src/main/java/org/catrobat/catroid/scratchconverter/ScratchConversionManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/scratchconverter/ScratchConversionManager.java
@@ -156,7 +156,7 @@ public class ScratchConversionManager implements ConversionManager {
 		SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(currentActivity.getApplicationContext());
 		SharedPreferences.Editor editor = settings.edit();
 		editor.putLong(SCRATCH_CONVERTER_CLIENT_ID_PREFERENCE_KEY, clientID);
-		editor.commit();
+		editor.apply();
 		Log.i(TAG, "Connection established (clientID: " + clientID + ")");
 		Preconditions.checkState(client.isAuthenticated());
 		client.retrieveInfo();
@@ -485,7 +485,7 @@ public class ScratchConversionManager implements ConversionManager {
 			Log.d(TAG, downloadStates.toString());
 			editor.putString(SCRATCH_CONVERTER_DOWNLOAD_STATE_PREFERENCE_KEY,
 					new JSONObject(downloadStates).toString());
-			editor.commit();
+			editor.apply();
 		} catch (JSONException e) {
 			Log.e(TAG, e.getMessage());
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageResourceHolder.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageResourceHolder.java
@@ -196,7 +196,8 @@ public class StageResourceHolder implements GatherCollisionInformationTask.OnPol
 										.findViewById(R.id.dialog_terms_of_use_check_box_agree_permanently);
 								PreferenceManager.getDefaultSharedPreferences(stageActivity)
 										.edit()
-										.putBoolean(SETTINGS_PARROT_AR_DRONE_CATROBAT_TERMS_OF_SERVICE_ACCEPTED_PERMANENTLY, checkBox.isChecked());
+										.putBoolean(SETTINGS_PARROT_AR_DRONE_CATROBAT_TERMS_OF_SERVICE_ACCEPTED_PERMANENTLY, checkBox.isChecked())
+										.apply();
 								onDroneTermsOfUseAgreed();
 							}
 						})
@@ -244,7 +245,8 @@ public class StageResourceHolder implements GatherCollisionInformationTask.OnPol
 								PreferenceManager.getDefaultSharedPreferences(stageActivity)
 										.edit()
 										.putBoolean(SETTINGS_PARROT_JUMPING_SUMO_CATROBAT_TERMS_OF_SERVICE_ACCEPTED_PERMANENTLY,
-												checkBox.isChecked());
+												checkBox.isChecked())
+										.apply();
 								onJSDroneTermsOfUseAgreed();
 							}
 						})

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/GooglePlusLoginHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/GooglePlusLoginHandler.java
@@ -108,13 +108,14 @@ public class GooglePlusLoginHandler implements GoogleApiClient.ConnectionCallbac
 		String idToken = account.getIdToken();
 		String code = account.getServerAuthCode();
 
-		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(activity);
-		sharedPreferences.edit().putString(Constants.GOOGLE_ID, id).commit();
-		sharedPreferences.edit().putString(Constants.GOOGLE_USERNAME, personName).commit();
-		sharedPreferences.edit().putString(Constants.GOOGLE_EMAIL, email).commit();
-		sharedPreferences.edit().putString(Constants.GOOGLE_LOCALE, locale).commit();
-		sharedPreferences.edit().putString(Constants.GOOGLE_ID_TOKEN, idToken).commit();
-		sharedPreferences.edit().putString(Constants.GOOGLE_EXCHANGE_CODE, code).commit();
+		PreferenceManager.getDefaultSharedPreferences(activity).edit()
+				.putString(Constants.GOOGLE_ID, id)
+				.putString(Constants.GOOGLE_USERNAME, personName)
+				.putString(Constants.GOOGLE_EMAIL, email)
+				.putString(Constants.GOOGLE_LOCALE, locale)
+				.putString(Constants.GOOGLE_ID_TOKEN, idToken)
+				.putString(Constants.GOOGLE_EXCHANGE_CODE, code)
+				.apply();
 
 		CheckOAuthTokenTask checkOAuthTokenTask = new CheckOAuthTokenTask(activity, id, Constants.GOOGLE_PLUS);
 		checkOAuthTokenTask.setOnCheckOAuthTokenCompleteListener(this);

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/LoginTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/LoginTask.java
@@ -94,7 +94,7 @@ public class LoginTask extends AsyncTask<Void, Void, Void> {
 		ServerAuthenticator authenticator = new ServerAuthenticator(username, password, token,
 				CatrobatWebClient.INSTANCE.getClient(),
 				FlavoredConstants.BASE_URL_HTTPS,
-				sharedPreferences.edit(),
+				sharedPreferences,
 				new ServerAuthenticator.TaskListener() {
 					@Override
 					public void onError(int statusCode, String errorMessage) {

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/RegistrationTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/RegistrationTask.java
@@ -97,7 +97,7 @@ public class RegistrationTask extends AsyncTask<Void, Void, Void> {
 				new ServerAuthenticator(username, password, token,
 						CatrobatWebClient.INSTANCE.getClient(),
 						FlavoredConstants.BASE_URL_HTTPS,
-						sharedPreferences.edit(),
+						sharedPreferences,
 						new ServerAuthenticator.TaskListener() {
 							@Override
 							public void onError(int statusCode, String errorMessage) {

--- a/catroid/src/main/java/org/catrobat/catroid/transfers/project/ProjectUpload.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/transfers/project/ProjectUpload.kt
@@ -74,7 +74,7 @@ class ProjectUpload(
                 sharedPreferences.edit()
                     .putString(Constants.TOKEN, successToken)
                     .putString(Constants.USERNAME, successUsername)
-                    .commit()
+                    .apply()
 
                 successCallback(projectId)
                 projectArchive.delete()

--- a/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.java
@@ -118,7 +118,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Permissi
 			if (activity instanceof MainMenuActivity) {
 				PreferenceManager.getDefaultSharedPreferences(this).edit()
 						.putBoolean(RECOVERED_FROM_CRASH, false)
-						.commit();
+						.apply();
 			} else {
 				activity.finish();
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/BaseExceptionHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/BaseExceptionHandler.java
@@ -47,7 +47,9 @@ public class BaseExceptionHandler implements
 	public void uncaughtException(Thread thread, Throwable exception) {
 		Log.e(TAG, "uncaughtException: ", exception);
 		CrashReporter.storeUnhandledException(exception);
-		preferences.edit().putBoolean(RECOVERED_FROM_CRASH, true).commit();
+		preferences.edit()
+				.putBoolean(RECOVERED_FROM_CRASH, true)
+				.apply();
 		exit();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -96,7 +96,7 @@ public class MainMenuActivity extends BaseCastActivity implements
 				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION, getResources()
 						.getString(R.string.dialog_privacy_policy_text)
 						.hashCode())
-				.commit();
+				.apply();
 		loadContent();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
@@ -350,7 +350,7 @@ public class ProjectUploadActivity extends BaseActivity implements
 		int numberOfUploadedProjects = sharedPreferences.getInt(NUMBER_OF_UPLOADED_PROJECTS, 0) + 1;
 		sharedPreferences.edit()
 				.putInt(NUMBER_OF_UPLOADED_PROJECTS, numberOfUploadedProjects)
-				.commit();
+				.apply();
 
 		if (numberOfUploadedProjects != 2) {
 			return;
@@ -371,7 +371,7 @@ public class ProjectUploadActivity extends BaseActivity implements
 				.setNeutralButton(getString(R.string.rating_dialog_rate_later), (dialog, which) -> sharedPreferences
 						.edit()
 						.putInt(NUMBER_OF_UPLOADED_PROJECTS, 0)
-						.commit())
+						.apply())
 				.setNegativeButton(getString(R.string.rating_dialog_rate_never), null)
 				.setCancelable(false)
 				.show();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/LegoSensorConfigInfoDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/LegoSensorConfigInfoDialog.java
@@ -114,7 +114,7 @@ public class LegoSensorConfigInfoDialog extends DialogFragment {
 
 							PreferenceManager.getDefaultSharedPreferences(getActivity()).edit()
 									.putBoolean(preferenceKey, true)
-									.commit();
+									.apply();
 						}
 					}
 				})

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/backpack/BackpackRecyclerViewFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/backpack/BackpackRecyclerViewFragment.java
@@ -213,7 +213,7 @@ public abstract class BackpackRecyclerViewFragment<T> extends Fragment implement
 				PreferenceManager.getDefaultSharedPreferences(getActivity())
 						.edit()
 						.putBoolean(sharedPreferenceDetailsKey, adapter.showDetails)
-						.commit();
+						.apply();
 				adapter.notifyDataSetChanged();
 				break;
 			default:

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/OAuthUsernameDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/OAuthUsernameDialogFragment.java
@@ -112,7 +112,9 @@ public class OAuthUsernameDialogFragment extends DialogFragment implements
 		} else {
 			SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
 			if (openAuthProvider.equals(Constants.GOOGLE_PLUS)) {
-				sharedPreferences.edit().putString(Constants.GOOGLE_USERNAME, username).commit();
+				sharedPreferences.edit()
+						.putString(Constants.GOOGLE_USERNAME, username)
+						.apply();
 
 				GoogleExchangeCodeTask googleExchangeCodeTask = new GoogleExchangeCodeTask(getActivity(),
 						sharedPreferences.getString(Constants.GOOGLE_EXCHANGE_CODE, Constants.NO_GOOGLE_EXCHANGE_CODE),

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/RecyclerViewFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/RecyclerViewFragment.java
@@ -294,7 +294,7 @@ public abstract class RecyclerViewFragment<T extends Nameable> extends Fragment 
 				PreferenceManager.getDefaultSharedPreferences(getActivity())
 						.edit()
 						.putBoolean(sharedPreferenceDetailsKey, adapter.showDetails)
-						.commit();
+						.apply();
 				adapter.notifyDataSetChanged();
 				break;
 			default:

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/scratchconverter/ScratchSearchResultsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/scratchconverter/ScratchSearchResultsFragment.java
@@ -277,7 +277,7 @@ public class ScratchSearchResultsFragment extends Fragment implements
 				PreferenceManager.getDefaultSharedPreferences(getActivity())
 						.edit()
 						.putBoolean(SHOW_DETAILS_SCRATCH_PROJECTS_PREFERENCE_KEY, adapter.showDetails)
-						.commit();
+						.apply();
 				adapter.notifyDataSetChanged();
 				break;
 			default:

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/AccessibilityProfile.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/AccessibilityProfile.java
@@ -92,9 +92,9 @@ public class AccessibilityProfile {
 	}
 
 	void saveAsCustomProfile(SharedPreferences sharedPreferences) {
-		SharedPreferences.Editor editor = sharedPreferences.edit();
-		editor.putStringSet(CUSTOM_ACCESSIBILITY_PROFILE, setPreferences);
-		editor.commit();
+		sharedPreferences.edit()
+				.putStringSet(CUSTOM_ACCESSIBILITY_PROFILE, setPreferences)
+				.apply();
 	}
 
 	private void clearCurrent(SharedPreferences sharedPreferences) {
@@ -103,7 +103,7 @@ public class AccessibilityProfile {
 			editor.putBoolean(preference, false);
 		}
 		editor.putString(FONT_STYLE, SANS_SERIF);
-		editor.commit();
+		editor.apply();
 	}
 
 	public void setAsCurrent(SharedPreferences sharedPreferences) {
@@ -118,7 +118,7 @@ public class AccessibilityProfile {
 				editor.putBoolean(preference, true);
 			}
 		}
-		editor.commit();
+		editor.apply();
 	}
 
 	public void applyAccessibilityStyles(Resources.Theme theme) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/AccessibilityProfilesFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/AccessibilityProfilesFragment.java
@@ -140,7 +140,9 @@ public class AccessibilityProfilesFragment extends Fragment implements View.OnCl
 		AccessibilityProfile currentProfile = AccessibilityProfile.fromCurrentPreferences(sharedPreferences);
 		if (sharedPreferences.getBoolean(CUSTOM_PROFILE, false)) {
 			currentProfile.saveAsCustomProfile(sharedPreferences);
-			sharedPreferences.edit().putBoolean(CUSTOM_PROFILE, false).commit();
+			sharedPreferences.edit()
+					.putBoolean(CUSTOM_PROFILE, false)
+					.apply();
 		}
 
 		AccessibilityProfile newProfile;
@@ -159,7 +161,9 @@ public class AccessibilityProfilesFragment extends Fragment implements View.OnCl
 				break;
 			case R.id.custom_profile:
 				newProfile = AccessibilityProfile.fromCustomProfile(sharedPreferences);
-				sharedPreferences.edit().putBoolean(CUSTOM_PROFILE, true).commit();
+				sharedPreferences.edit()
+						.putBoolean(CUSTOM_PROFILE, true)
+						.apply();
 				break;
 			case R.id.default_profile:
 			default:
@@ -168,7 +172,7 @@ public class AccessibilityProfilesFragment extends Fragment implements View.OnCl
 
 		sharedPreferences.edit()
 				.putInt(ACCESSIBILITY_PROFILE_PREFERENCE_KEY, v.getId())
-				.commit();
+				.apply();
 
 		newProfile.setAsCurrent(sharedPreferences);
 		startActivity(new Intent(getActivity().getBaseContext(), MainMenuActivity.class));

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/AccessibilitySettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/AccessibilitySettingsFragment.java
@@ -84,7 +84,9 @@ public class AccessibilitySettingsFragment extends PreferenceFragment implements
 	@Override
 	public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
 		preferenceChanged = true;
-		sharedPreferences.edit().putBoolean(CUSTOM_PROFILE, true);
+		sharedPreferences.edit()
+				.putBoolean(CUSTOM_PROFILE, true)
+				.apply();
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -264,21 +264,21 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static void setPhiroSharedPreferenceEnabled(Context context, boolean value) {
-		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-		editor.putBoolean(SETTINGS_SHOW_PHIRO_BRICKS, value);
-		editor.commit();
+		getSharedPreferences(context).edit()
+				.putBoolean(SETTINGS_SHOW_PHIRO_BRICKS, value)
+				.apply();
 	}
 
 	public static void setJumpingSumoSharedPreferenceEnabled(Context context, boolean value) {
-		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-		editor.putBoolean(PARROT_JUMPING_SUMO_SCREEN_KEY, value);
-		editor.commit();
+		getSharedPreferences(context).edit()
+				.putBoolean(PARROT_JUMPING_SUMO_SCREEN_KEY, value)
+				.apply();
 	}
 
 	public static void setArduinoSharedPreferenceEnabled(Context context, boolean value) {
-		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-		editor.putBoolean(SETTINGS_SHOW_ARDUINO_BRICKS, value);
-		editor.commit();
+		getSharedPreferences(context).edit()
+				.putBoolean(SETTINGS_SHOW_ARDUINO_BRICKS, value)
+				.apply();
 	}
 
 	public static boolean isArduinoSharedPreferenceEnabled(Context context) {
@@ -290,9 +290,9 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static void setAutoCrashReportingEnabled(Context context, boolean isEnabled) {
-		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-		editor.putBoolean(SETTINGS_CRASH_REPORTS, isEnabled);
-		editor.commit();
+		getSharedPreferences(context).edit()
+				.putBoolean(SETTINGS_CRASH_REPORTS, isEnabled)
+				.apply();
 		if (isEnabled) {
 			CrashReporter.initialize(context);
 		}
@@ -344,7 +344,7 @@ public class SettingsFragment extends PreferenceFragment {
 			editor.putString(NXT_SENSORS[i], sensorMapping[i].getSensorCode());
 		}
 
-		editor.commit();
+		editor.apply();
 	}
 
 	public static void setLegoMindstormsEV3SensorMapping(Context context, EV3Sensor.Sensor[] sensorMapping) {
@@ -353,19 +353,19 @@ public class SettingsFragment extends PreferenceFragment {
 			editor.putString(EV3_SENSORS[i], sensorMapping[i].getSensorCode());
 		}
 
-		editor.commit();
+		editor.apply();
 	}
 
 	public static void setLegoMindstormsNXTSensorMapping(Context context, NXTSensor.Sensor sensor, String sensorSetting) {
-		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-		editor.putString(sensorSetting, sensor.getSensorCode());
-		editor.commit();
+		getSharedPreferences(context).edit()
+				.putString(sensorSetting, sensor.getSensorCode())
+				.apply();
 	}
 
 	public static void setLegoMindstormsEV3SensorMapping(Context context, EV3Sensor.Sensor sensor, String sensorSetting) {
-		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-		editor.putString(sensorSetting, sensor.getSensorCode());
-		editor.commit();
+		getSharedPreferences(context).edit()
+				.putString(sensorSetting, sensor.getSensorCode())
+				.apply();
 	}
 
 	public static DroneConfigPreference.Preferences[] getDronePreferenceMapping(Context context) {
@@ -389,15 +389,15 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static void enableLegoMindstormsNXTBricks(Context context) {
-		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-		editor.putBoolean(SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, true);
-		editor.commit();
+		getSharedPreferences(context).edit()
+				.putBoolean(SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, true)
+				.apply();
 	}
 
 	public static void enableLegoMindstormsEV3Bricks(Context context) {
-		SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-		editor.putBoolean(SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED, true);
-		editor.commit();
+		getSharedPreferences(context).edit()
+				.putBoolean(SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED, true)
+				.apply();
 	}
 
 	private void setLanguage() {
@@ -440,7 +440,7 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static void setToChosenLanguage(Activity activity) {
-		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(activity.getApplicationContext());
+		SharedPreferences sharedPreferences = getSharedPreferences(activity.getApplicationContext());
 		String languageTag = sharedPreferences.getString(LANGUAGE_TAG_KEY, "");
 		Locale mLocale = Arrays.asList(LANGUAGE_CODE).contains(languageTag)
 				? getLocaleFromLanguageTag(languageTag)
@@ -471,13 +471,14 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static void setLanguageSharedPreference(Context context, String value) {
-		SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(context).edit();
-		editor.putString(LANGUAGE_TAG_KEY, value);
-		editor.commit();
+		getSharedPreferences(context).edit()
+				.putString(LANGUAGE_TAG_KEY, value)
+				.apply();
 	}
 
-	public static void removeLanguageSharedPreference(Context mContext) {
-		SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(mContext).edit();
-		editor.remove(LANGUAGE_TAG_KEY).commit();
+	public static void removeLanguageSharedPreference(Context context) {
+		getSharedPreferences(context).edit()
+				.remove(LANGUAGE_TAG_KEY)
+				.apply();
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/utils/CrashReporter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/CrashReporter.java
@@ -87,7 +87,7 @@ public final class CrashReporter {
 	private static void storeException(Throwable exception) {
 		preferences.edit()
 				.putString(EXCEPTION_FOR_REPORT, serializeException(exception))
-				.commit();
+				.apply();
 	}
 
 	private static Throwable getStoredException() {
@@ -101,7 +101,7 @@ public final class CrashReporter {
 	private static void removeStoredException() {
 		preferences.edit()
 				.remove(EXCEPTION_FOR_REPORT)
-				.commit();
+				.apply();
 	}
 
 	private static String serializeException(Throwable exception) {

--- a/catroid/src/main/java/org/catrobat/catroid/utils/SnackbarUtil.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/SnackbarUtil.java
@@ -75,10 +75,11 @@ public final class SnackbarUtil {
 	}
 
 	public static void setHintShown(Activity activity, String messageId) {
-		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
 		Set<String> hintList = getStringSetFromSharedPreferences(activity);
 		hintList.add(messageId);
-		prefs.edit().putStringSet(SnackbarUtil.SHOWN_HINT_LIST, hintList).commit();
+		PreferenceManager.getDefaultSharedPreferences(activity).edit()
+				.putStringSet(SnackbarUtil.SHOWN_HINT_LIST, hintList)
+				.apply();
 	}
 
 	public static boolean wasHintAlreadyShown(Activity activity, String messageId) {

--- a/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/Utils.java
@@ -332,7 +332,7 @@ public final class Utils {
 		PreferenceManager.getDefaultSharedPreferences(context)
 				.edit()
 				.putString(PREF_PROJECTNAME_KEY, projectName)
-				.commit();
+				.apply();
 	}
 
 	public static boolean isDefaultProject(Project projectToCheck, Context context) {
@@ -403,19 +403,16 @@ public final class Utils {
 		LogoutTask logoutTask = new LogoutTask(context, userName);
 		logoutTask.execute();
 
-		SharedPreferences.Editor sharedPreferenceEditor = sharedPreferences.edit();
-
-		sharedPreferenceEditor.putString(Constants.TOKEN, Constants.NO_TOKEN)
-				.putString(Constants.USERNAME, Constants.NO_USERNAME);
-
-		sharedPreferenceEditor.putString(Constants.GOOGLE_EXCHANGE_CODE, Constants.NO_GOOGLE_EXCHANGE_CODE)
+		sharedPreferences.edit()
+				.putString(Constants.TOKEN, Constants.NO_TOKEN)
+				.putString(Constants.USERNAME, Constants.NO_USERNAME)
+				.putString(Constants.GOOGLE_EXCHANGE_CODE, Constants.NO_GOOGLE_EXCHANGE_CODE)
 				.putString(Constants.GOOGLE_EMAIL, Constants.NO_GOOGLE_EMAIL)
 				.putString(Constants.GOOGLE_USERNAME, Constants.NO_GOOGLE_USERNAME)
 				.putString(Constants.GOOGLE_ID, Constants.NO_GOOGLE_ID)
 				.putString(Constants.GOOGLE_LOCALE, Constants.NO_GOOGLE_LOCALE)
-				.putString(Constants.GOOGLE_ID_TOKEN, Constants.NO_GOOGLE_ID_TOKEN);
-
-		sharedPreferenceEditor.commit();
+				.putString(Constants.GOOGLE_ID_TOKEN, Constants.NO_GOOGLE_ID_TOKEN)
+				.apply();
 		WebViewActivity.clearCookies();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/web/CatrobatServerCalls.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/web/CatrobatServerCalls.kt
@@ -130,8 +130,10 @@ class CatrobatServerCalls(private val okHttpClient: OkHttpClient = CatrobatWebCl
 
                 if (tokenAvailable && oauthProvider == Constants.GOOGLE_PLUS) {
                     val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-                    sharedPreferences.edit().putString(Constants.GOOGLE_USERNAME, serverUsername).commit()
-                    sharedPreferences.edit().putString(Constants.GOOGLE_EMAIL, serverEmail).commit()
+                    sharedPreferences.edit()
+                        .putString(Constants.GOOGLE_USERNAME, serverUsername)
+                        .putString(Constants.GOOGLE_EMAIL, serverEmail)
+                        .apply()
                 }
 
                 return tokenAvailable

--- a/catroid/src/main/java/org/catrobat/catroid/web/ServerAuthenticator.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/web/ServerAuthenticator.kt
@@ -50,7 +50,7 @@ class ServerAuthenticator(
     private val token: String,
     private val okHttpClient: OkHttpClient,
     private val baseUrl: String,
-    val sharedPreferencesEditor: SharedPreferences.Editor,
+    val sharedPreferences: SharedPreferences,
     private val taskListener: TaskListener
 ) {
 
@@ -109,13 +109,15 @@ class ServerAuthenticator(
         }
 
         val tokenReceived = resultJsonObject.optString(JSON_TOKEN)
-        sharedPreferencesEditor.putString(Constants.TOKEN, tokenReceived).commit()
-        sharedPreferencesEditor.putString(Constants.USERNAME, username).commit()
+        val sharedPreferencesEditor = sharedPreferences.edit()
+        sharedPreferencesEditor.putString(Constants.TOKEN, tokenReceived)
+        sharedPreferencesEditor.putString(Constants.USERNAME, username)
 
         val eMail = resultJsonObject.optString(Constants.EMAIL)
         if (eMail.isNotEmpty()) {
-            sharedPreferencesEditor.putString(Constants.EMAIL, eMail).commit()
+            sharedPreferencesEditor.putString(Constants.EMAIL, eMail)
         }
+        sharedPreferencesEditor.apply()
         taskListener.onSuccess()
     }
 

--- a/catroid/src/main/java/org/catrobat/catroid/web/ServerCalls.java
+++ b/catroid/src/main/java/org/catrobat/catroid/web/ServerCalls.java
@@ -468,8 +468,10 @@ public final class ServerCalls implements ScratchDataFetcher {
 
 	private void refreshUploadTokenAndUsername(String newToken, String username, Context context) {
 		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
-		sharedPreferences.edit().putString(Constants.TOKEN, newToken).commit();
-		sharedPreferences.edit().putString(Constants.USERNAME, username).commit();
+		sharedPreferences.edit()
+				.putString(Constants.TOKEN, newToken)
+				.putString(Constants.USERNAME, username)
+				.apply();
 	}
 
 	public interface UploadSuccessCallback {

--- a/catroid/src/main/res/font/opendyslexic.xml
+++ b/catroid/src/main/res/font/opendyslexic.xml
@@ -22,10 +22,7 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<font-family xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <font android:fontStyle="normal" android:fontWeight="400" android:font="@font/opendyslexic_regular"
-        app:fontStyle="normal" app:fontWeight="400" app:font="@font/opendyslexic_regular"/>
-    <font android:fontStyle="italic" android:fontWeight="400" android:font="@font/opendyslexic_regular"
-        app:fontStyle="italic" app:fontWeight="400" app:font="@font/opendyslexic_regular" />
+<font-family xmlns:app="http://schemas.android.com/apk/res-auto">
+    <font app:fontStyle="normal" app:fontWeight="400" app:font="@font/opendyslexic_regular"/>
+    <font app:fontStyle="italic" app:fontWeight="400" app:font="@font/opendyslexic_regular" />
 </font-family>

--- a/catroid/src/main/res/font/saudi.xml
+++ b/catroid/src/main/res/font/saudi.xml
@@ -22,10 +22,7 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<font-family xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <font android:fontStyle="normal" android:fontWeight="400" android:font="@font/saudi_regular"
-        app:fontStyle="normal" app:fontWeight="400" app:font="@font/saudi_regular"/>
-    <font android:fontStyle="italic" android:fontWeight="400" android:font="@font/saudi_regular"
-        app:fontStyle="italic" app:fontWeight="400" app:font="@font/saudi_regular" />
+<font-family xmlns:app="http://schemas.android.com/apk/res-auto">
+    <font app:fontStyle="normal" app:fontWeight="400" app:font="@font/saudi_regular"/>
+    <font app:fontStyle="italic" app:fontWeight="400" app:font="@font/saudi_regular" />
 </font-family>

--- a/catroid/src/main/res/font/stc.xml
+++ b/catroid/src/main/res/font/stc.xml
@@ -22,10 +22,7 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<font-family xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <font android:fontStyle="normal" android:fontWeight="400" android:font="@font/stc_regular"
-        app:fontStyle="normal" app:fontWeight="400" app:font="@font/stc_regular"/>
-    <font android:fontStyle="italic" android:fontWeight="400" android:font="@font/stc_regular"
-        app:fontStyle="italic" app:fontWeight="400" app:font="@font/stc_regular" />
+<font-family xmlns:app="http://schemas.android.com/apk/res-auto">
+    <font app:fontStyle="normal" app:fontWeight="400" app:font="@font/stc_regular"/>
+    <font app:fontStyle="italic" app:fontWeight="400" app:font="@font/stc_regular" />
 </font-family>

--- a/catroid/src/main/res/layout/activity_scratch_project_details.xml
+++ b/catroid/src/main/res/layout/activity_scratch_project_details.xml
@@ -147,6 +147,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_alignParentStart="true"
+                        android:layout_toStartOf="@id/date_modified_view"
                         android:textSize="?attr/small"
                         android:textStyle="italic" />
                 </RelativeLayout>

--- a/catroid/src/main/res/layout/dialog_orientation.xml
+++ b/catroid/src/main/res/layout/dialog_orientation.xml
@@ -41,7 +41,7 @@
             android:layout_height="match_parent"
             android:layout_weight="0.33"
             android:drawableStart="@drawable/dialog_orientation_portrait"
-            android:paddingLeft="@dimen/material_design_spacing_large"/>
+            android:paddingStart="@dimen/material_design_spacing_large"/>
 
         <RadioButton
             android:id="@+id/landscape_mode"
@@ -49,7 +49,7 @@
             android:layout_height="match_parent"
             android:layout_weight="0.33"
             android:drawableStart="@drawable/dialog_orientation_landscape"
-            android:paddingLeft="@dimen/material_design_spacing_large"/>
+            android:paddingStart="@dimen/material_design_spacing_large"/>
 
          <RadioButton
              android:id="@+id/cast"
@@ -58,7 +58,7 @@
              android:layout_weight="0.33"
              android:drawableStart="@drawable/ic_tv_black_24dp"
              android:visibility="gone"
-             android:paddingLeft="@dimen/material_design_spacing_large"/>
+             android:paddingStart="@dimen/material_design_spacing_large"/>
 
     </RadioGroup>
 </ScrollView>

--- a/catroid/src/test/java/org/catrobat/catroid/test/web/ServerAuthenticatorTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/web/ServerAuthenticatorTest.java
@@ -97,10 +97,12 @@ public class ServerAuthenticatorTest {
 		PowerMockito.mockStatic(CatrobatWebClientKt.class);
 		taskListenerMock = mock(TaskListener.class);
 		okHttpClientMock = mock(OkHttpClient.class);
-		sharedPreferencesEditorMock = PowerMockito.mock(SharedPreferences.Editor.class);
+		SharedPreferences sharedPreferencesMock = mock(SharedPreferences.class);
+		sharedPreferencesEditorMock = mock(SharedPreferences.Editor.class);
+		when(sharedPreferencesMock.edit()).thenReturn(sharedPreferencesEditorMock);
 		when(sharedPreferencesEditorMock.putString(anyString(), anyString())).thenReturn(sharedPreferencesEditorMock);
 		authenticatorSpy = PowerMockito.spy(new ServerAuthenticator(USERNAME, PASSWORD, TOKEN, okHttpClientMock,
-				BASE_URL_TEST_HTTPS, sharedPreferencesEditorMock, taskListenerMock));
+				BASE_URL_TEST_HTTPS, sharedPreferencesMock, taskListenerMock));
 	}
 
 	@Test
@@ -193,7 +195,7 @@ public class ServerAuthenticatorTest {
 		verify(sharedPreferencesEditorMock, times(1)).putString(eq(Constants.TOKEN), eq(expectedToken));
 		verify(sharedPreferencesEditorMock, times(1)).putString(Constants.USERNAME, USERNAME);
 		verify(sharedPreferencesEditorMock, times(1)).putString(eq(Constants.EMAIL), eq(expectedEmail));
-		verify(sharedPreferencesEditorMock, atLeastOnce()).commit();
+		verify(sharedPreferencesEditorMock, times(1)).apply();
 		verifyNoMoreInteractions(sharedPreferencesEditorMock);
 	}
 


### PR DESCRIPTION
Fixed Lint warnings
---

* Introduce a baseline file that will set our lint violation count to zero
  but will fail when there are new violations. This means that, while many
  issues are not fixed in this commit, we hopefully will see fewer violations
  in the future
* Fix InvalidPackage
  * Add a list of offenders to the lint ignore file
* Fix RtlHardcoded
* Fix UnusedAttribute
* Fix CommitPrefEdits
  * Add some changes to ensure that a `commit`/`apply` happens on every `SharedPreferencesEditor`
* Fix WifiManagerLeak
  * This was never an issue
* Fix ObsoleteSdkInt
* Fix IconColors
* Fix RelativeOverlap
* Fix StaticFieldLeak
  * These have to be solved on a case-by-case basis
* Fix WrongRegion
* Fix RtlSymmetry
* Fix ContentDescription
* Fix ClickableViewAccessibility
* Fix IconMissingDensityFolder
* Fix HandlerLeak
* Fix GradleCompatible
  * Update the support library to `28.0.0` as recommended by this rule
* Fix ApplySharedPref
  * According to the android documentation any `commit` can be replaced with `apply`
    The difference is while `apply` also sets the values to `SharedPreferences` instantly,
    it writes to persistent storage in the background.
* Fix InflateParams
  * Seems that this has been addressed already
* Fix IconDensities
* Fix UnusedResource (partially)

Additionally
---

* Gradle adds a lint task for each `flavor * build type = 6 * 3 = 18` lint tasks when just running `lint`
* Enabling those lint rules slows down each lint task by about *10 seconds*, adding up to *3 minutes* additional runtime overall
* This seems unsustainable and very unnecessary, as we have pretty much no flavor specific code.
* Suggested resolution: Only lint the catroid flavor
* Expected outcome: linting only the catroid flavor reduces linting time from `8` minutes to `~1` minute