### PR TITLE
Share Update Fix - Http Headers contentDisposition has changed

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
@@ -252,8 +252,7 @@ public class WebViewActivity extends BaseActivity {
 	private String getExtensionFromContentDisposition(String contentDisposition) {
 		int extensionIndex = contentDisposition.lastIndexOf('.');
 		String extension = contentDisposition.substring(extensionIndex);
-		extension = extension.substring(0, extension.length() - 1);
-		return extension;
+		return extension.replace("\"","");
 	}
 
 	public static void clearCookies() {


### PR DESCRIPTION
under discussion...

either web team fixes this to format the contentDisposition in http header the same as they did before, or we can fix this via this. (whats going on with catty regarding this issue?)