### PR TITLE
CATROID-401:  Privacy policy update 

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/OpenFromShareLinkTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/OpenFromShareLinkTest.java
@@ -31,10 +31,12 @@ import android.preference.PreferenceManager;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.intent.Intents;
 
+import org.catrobat.catroid.R;
 import org.catrobat.catroid.testsuites.annotations.Cat;
 import org.catrobat.catroid.testsuites.annotations.Level;
 import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.ui.WebViewActivity;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.DontGenerateDefaultProjectActivityTestRule;
 import org.hamcrest.Matcher;
 import org.junit.After;
@@ -51,6 +53,7 @@ import static android.support.test.espresso.intent.Intents.intended;
 import static android.support.test.espresso.intent.Intents.intending;
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasExtras;
 
+import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_VERSION;
 import static org.catrobat.catroid.uiespresso.util.matchers.BundleMatchers.bundleHasMatchingString;
 
 @Category({Cat.AppUi.class, Level.Functional.class})
@@ -61,8 +64,7 @@ public class OpenFromShareLinkTest {
 	public DontGenerateDefaultProjectActivityTestRule<MainMenuActivity> baseActivityTestRule = new
 			DontGenerateDefaultProjectActivityTestRule<>(MainMenuActivity.class, false, false);
 
-	private static final String AGREED_TO_PRIVACY_POLICY_SETTINGS_KEY = "AgreedToPrivacyPolicy";
-	private boolean bufferedPreferenceSetting;
+	private int bufferedPreferenceSetting;
 
 	private Matcher expectedWebIntent;
 	private Uri shareUri;
@@ -86,11 +88,13 @@ public class OpenFromShareLinkTest {
 	public void setUp() throws Exception {
 		bufferedPreferenceSetting = PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry
 				.getTargetContext())
-				.getBoolean(AGREED_TO_PRIVACY_POLICY_SETTINGS_KEY, false);
+				.getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0);
 
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_SETTINGS_KEY, true)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						UiTestUtils.getResourcesString(R.string.dialog_privacy_policy_text)
+						.hashCode())
 				.commit();
 
 		shareUri = new Uri.Builder()
@@ -112,7 +116,7 @@ public class OpenFromShareLinkTest {
 	public void tearDown() {
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_SETTINGS_KEY, bufferedPreferenceSetting)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION, bufferedPreferenceSetting)
 				.commit();
 		Intents.release();
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/PrivacyPolicyDisclaimerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/PrivacyPolicyDisclaimerTest.java
@@ -30,6 +30,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.ui.MainMenuActivity;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.DontGenerateDefaultProjectActivityTestRule;
 import org.junit.After;
 import org.junit.Before;
@@ -43,7 +44,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_VERSION;
 
 @RunWith(AndroidJUnit4.class)
 public class PrivacyPolicyDisclaimerTest {
@@ -52,7 +53,7 @@ public class PrivacyPolicyDisclaimerTest {
 	public DontGenerateDefaultProjectActivityTestRule<MainMenuActivity> baseActivityTestRule = new
 			DontGenerateDefaultProjectActivityTestRule<>(MainMenuActivity.class, false, false);
 
-	private boolean bufferedPrivacyPolicyPreferenceSetting;
+	private int bufferedPrivacyPolicyPreferenceSetting;
 
 	@Before
 	public void setUp() throws Exception {
@@ -60,14 +61,15 @@ public class PrivacyPolicyDisclaimerTest {
 				.getTargetContext());
 
 		bufferedPrivacyPolicyPreferenceSetting = sharedPreferences
-				.getBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, false);
+				.getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0);
 	}
 
 	@After
 	public void tearDown() {
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, bufferedPrivacyPolicyPreferenceSetting)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						bufferedPrivacyPolicyPreferenceSetting)
 				.commit();
 	}
 
@@ -75,7 +77,8 @@ public class PrivacyPolicyDisclaimerTest {
 	public void testShowPrivacyPolicyDisclaimer() {
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, false)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						0)
 				.commit();
 
 		baseActivityTestRule.launchActivity(null);
@@ -87,7 +90,9 @@ public class PrivacyPolicyDisclaimerTest {
 	public void testHidePrivacyPolicyDisclaimer() {
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, true)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						UiTestUtils.getResourcesString(R.string.dialog_privacy_policy_text)
+						.hashCode())
 				.commit();
 
 		baseActivityTestRule.launchActivity(null);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/LanguagePickerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/LanguagePickerTest.java
@@ -34,6 +34,7 @@ import org.catrobat.catroid.testsuites.annotations.Cat;
 import org.catrobat.catroid.testsuites.annotations.Level;
 import org.catrobat.catroid.ui.SettingsActivity;
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.DontGenerateDefaultProjectActivityTestRule;
 import org.junit.After;
 import org.junit.Before;
@@ -49,7 +50,7 @@ import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 
-import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_VERSION;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 
@@ -60,7 +61,7 @@ public class LanguagePickerTest {
 	public DontGenerateDefaultProjectActivityTestRule<SettingsActivity> baseActivityTestRule = new
 			DontGenerateDefaultProjectActivityTestRule<>(SettingsActivity.class, false, false);
 
-	private boolean bufferedPrivacyPolicyPreferenceSetting;
+	private int bufferedPrivacyPolicyPreferenceSetting;
 
 	private static final Locale ARABICLOCALE = new Locale("ar");
 	private static final Locale DEUTSCHLOCALE = Locale.GERMAN;
@@ -71,11 +72,13 @@ public class LanguagePickerTest {
 				.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext());
 
 		bufferedPrivacyPolicyPreferenceSetting = sharedPreferences
-				.getBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, false);
+				.getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0);
 
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, true)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						UiTestUtils.getResourcesString(R.string.dialog_privacy_policy_text)
+						.hashCode())
 				.commit();
 		baseActivityTestRule.launchActivity(null);
 	}
@@ -84,7 +87,8 @@ public class LanguagePickerTest {
 	public void tearDown() {
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, bufferedPrivacyPolicyPreferenceSetting)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						bufferedPrivacyPolicyPreferenceSetting)
 				.commit();
 
 		SettingsFragment.removeLanguageSharedPreference(InstrumentationRegistry.getTargetContext());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/RTLMainMenuTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/rtl/RTLMainMenuTest.java
@@ -30,10 +30,12 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.view.View;
 
+import org.catrobat.catroid.R;
 import org.catrobat.catroid.testsuites.annotations.Cat;
 import org.catrobat.catroid.testsuites.annotations.Level;
 import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.DontGenerateDefaultProjectActivityTestRule;
 import org.junit.After;
 import org.junit.Before;
@@ -48,7 +50,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
-import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_VERSION;
 import static org.catrobat.catroid.uiespresso.util.UiTestUtils.getResources;
 
 @RunWith(AndroidJUnit4.class)
@@ -58,7 +60,7 @@ public class RTLMainMenuTest {
 	public DontGenerateDefaultProjectActivityTestRule<MainMenuActivity> baseActivityTestRule = new
 			DontGenerateDefaultProjectActivityTestRule<>(MainMenuActivity.class, false, false);
 
-	private boolean bufferedPrivacyPolicyPreferenceSetting;
+	private int bufferedPrivacyPolicyPreferenceSetting;
 
 	private static final Locale ARABIC_LOCALE = new Locale("ar");
 	private static final Locale GERMAN_LOCALE = Locale.GERMAN;
@@ -71,11 +73,13 @@ public class RTLMainMenuTest {
 				.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext());
 
 		bufferedPrivacyPolicyPreferenceSetting = sharedPreferences
-				.getBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, false);
+				.getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0);
 
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, true)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						UiTestUtils.getResourcesString(R.string.dialog_privacy_policy_text)
+						.hashCode())
 				.commit();
 	}
 
@@ -83,7 +87,8 @@ public class RTLMainMenuTest {
 	public void tearDown() {
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, bufferedPrivacyPolicyPreferenceSetting)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						bufferedPrivacyPolicyPreferenceSetting)
 				.commit();
 		SettingsFragment.removeLanguageSharedPreference(InstrumentationRegistry.getTargetContext());
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/AboutDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/AboutDialogTest.java
@@ -31,6 +31,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.testsuites.annotations.Cat;
 import org.catrobat.catroid.testsuites.annotations.Level;
 import org.catrobat.catroid.ui.MainMenuActivity;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.DontGenerateDefaultProjectActivityTestRule;
 import org.junit.After;
 import org.junit.Before;
@@ -47,7 +48,7 @@ import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_VERSION;
 
 @RunWith(AndroidJUnit4.class)
 public class AboutDialogTest {
@@ -56,7 +57,7 @@ public class AboutDialogTest {
 	public DontGenerateDefaultProjectActivityTestRule<MainMenuActivity> baseActivityTestRule = new
 			DontGenerateDefaultProjectActivityTestRule<>(MainMenuActivity.class, true, false);
 
-	private boolean bufferedPrivacyPolicyPreferenceSetting;
+	private int bufferedPrivacyPolicyPreferenceSetting;
 
 	@Before
 	public void setUp() throws Exception {
@@ -64,11 +65,13 @@ public class AboutDialogTest {
 				.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext());
 
 		bufferedPrivacyPolicyPreferenceSetting = sharedPreferences
-				.getBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, false);
+				.getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0);
 
 		sharedPreferences
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, true)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						UiTestUtils.getResourcesString(R.string.dialog_privacy_policy_text)
+								.hashCode())
 				.commit();
 		baseActivityTestRule.launchActivity(null);
 	}
@@ -77,7 +80,8 @@ public class AboutDialogTest {
 	public void tearDown() {
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, bufferedPrivacyPolicyPreferenceSetting)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						bufferedPrivacyPolicyPreferenceSetting)
 				.commit();
 	}
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/OrientationDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/OrientationDialogTest.java
@@ -33,6 +33,7 @@ import org.catrobat.catroid.testsuites.annotations.Cat;
 import org.catrobat.catroid.testsuites.annotations.Level;
 import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.ui.ProjectActivity;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.DontGenerateDefaultProjectActivityTestRule;
 import org.junit.After;
 import org.junit.Before;
@@ -51,7 +52,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.isEnabled;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_VERSION;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_CAST_GLOBALLY_ENABLED;
 import static org.catrobat.catroid.uiespresso.util.UiTestUtils.assertCurrentActivityIsInstanceOf;
 import static org.hamcrest.Matchers.allOf;
@@ -65,7 +66,7 @@ public class OrientationDialogTest {
 			DontGenerateDefaultProjectActivityTestRule<>(MainMenuActivity.class, true, false);
 
 	private boolean bufferedChromeCastSetting;
-	private boolean bufferedPrivacyPolicyPreferenceSetting;
+	private int bufferedPrivacyPolicyPreferenceSetting;
 
 	@Before
 	public void setUp() throws Exception {
@@ -76,12 +77,14 @@ public class OrientationDialogTest {
 				.getBoolean(SETTINGS_CAST_GLOBALLY_ENABLED, false);
 
 		bufferedPrivacyPolicyPreferenceSetting = sharedPreferences
-				.getBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, false);
+				.getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0);
 
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
 				.putBoolean(SETTINGS_CAST_GLOBALLY_ENABLED, true)
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, true)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						UiTestUtils.getResourcesString(R.string.dialog_privacy_policy_text)
+						.hashCode())
 				.commit();
 
 		baseActivityTestRule.launchActivity(null);
@@ -92,7 +95,8 @@ public class OrientationDialogTest {
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
 				.putBoolean(SETTINGS_CAST_GLOBALLY_ENABLED, bufferedChromeCastSetting)
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, bufferedPrivacyPolicyPreferenceSetting)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						bufferedPrivacyPolicyPreferenceSetting)
 				.commit();
 	}
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/TermsOfUseDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/TermsOfUseDialogTest.java
@@ -31,6 +31,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.testsuites.annotations.Cat;
 import org.catrobat.catroid.testsuites.annotations.Level;
 import org.catrobat.catroid.ui.MainMenuActivity;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.DontGenerateDefaultProjectActivityTestRule;
 import org.junit.After;
 import org.junit.Before;
@@ -49,7 +50,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_VERSION;
 import static org.hamcrest.Matchers.allOf;
 
 @RunWith(AndroidJUnit4.class)
@@ -59,7 +60,7 @@ public class TermsOfUseDialogTest {
 	public DontGenerateDefaultProjectActivityTestRule<MainMenuActivity> baseActivityTestRule = new
 			DontGenerateDefaultProjectActivityTestRule<>(MainMenuActivity.class, true, false);
 
-	private boolean bufferedPrivacyPolicyPreferenceSetting;
+	private int bufferedPrivacyPolicyPreferenceSetting;
 
 	@Before
 	public void setUp() throws Exception {
@@ -67,11 +68,13 @@ public class TermsOfUseDialogTest {
 				.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext());
 
 		bufferedPrivacyPolicyPreferenceSetting = sharedPreferences
-				.getBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, false);
+				.getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0);
 
 		sharedPreferences
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, true)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						UiTestUtils.getResourcesString(R.string.dialog_privacy_policy_text)
+						.hashCode())
 				.commit();
 		baseActivityTestRule.launchActivity(null);
 	}
@@ -80,7 +83,8 @@ public class TermsOfUseDialogTest {
 	public void tearDown() {
 		PreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, bufferedPrivacyPolicyPreferenceSetting)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						bufferedPrivacyPolicyPreferenceSetting)
 				.commit();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/common/SharedPreferenceKeys.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/SharedPreferenceKeys.java
@@ -29,7 +29,8 @@ public final class SharedPreferenceKeys {
 	}
 
 	public static final String ACCESSIBILITY_PROFILE_PREFERENCE_KEY = "AccessibilityProfile";
-	public static final String AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY = "AgreedToPrivacyPolicy";
+	public static final String AGREED_TO_PRIVACY_POLICY_VERSION =
+			"AgreedToCurrentPrivacyPolicy";
 
 	public static final String DEVICE_LANGUAGE = "deviceLanguage";
 	public static final String LANGUAGE_TAG_KEY = "applicationLanguage";

--- a/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -63,7 +63,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import static org.catrobat.catroid.common.FlavoredConstants.DEFAULT_ROOT_DIRECTORY;
-import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_VERSION;
 
 public class MainMenuActivity extends BaseCastActivity implements
 		ProjectLoadTask.ProjectLoadListener {
@@ -79,10 +79,11 @@ public class MainMenuActivity extends BaseCastActivity implements
 		PreferenceManager.setDefaultValues(this, R.xml.preferences, true);
 		ScreenValueHandler.updateScreenWidthAndHeight(this);
 
-		boolean hasUserAgreedToPrivacyPolicy = PreferenceManager.getDefaultSharedPreferences(this)
-				.getBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, false);
-
-		if (hasUserAgreedToPrivacyPolicy) {
+		int oldPrivacyPolicyHash = PreferenceManager.getDefaultSharedPreferences(this)
+						.getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0);
+		int currentPrivacyPolicyHash = getResources().getString(R.string.dialog_privacy_policy_text)
+						.hashCode();
+		if (oldPrivacyPolicyHash == currentPrivacyPolicyHash) {
 			loadContent();
 		} else {
 			setContentView(R.layout.privacy_policy_view);
@@ -92,7 +93,9 @@ public class MainMenuActivity extends BaseCastActivity implements
 	public void handleAgreedToPrivacyPolicyButton(View view) {
 		PreferenceManager.getDefaultSharedPreferences(this)
 				.edit()
-				.putBoolean(AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY, true)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION, getResources()
+						.getString(R.string.dialog_privacy_policy_text)
+						.hashCode())
 				.commit();
 		loadContent();
 	}


### PR DESCRIPTION
 When User updates PocketCode the AGREED_TO_PRIVACY_POLICY_PREFERENCE_KEY is already set to true so need additional check with the versionCode which is changed in each release