### PR TITLE
CATROID-420 Catch runtime exception in ContentResolver.

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/io/StorageOperations.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/StorageOperations.java
@@ -101,10 +101,14 @@ public final class StorageOperations {
 		String result = null;
 
 		if (uri.getScheme().equals("content")) {
-			try (Cursor cursor = contentResolver.query(uri, null, null, null, null)) {
-				if (cursor != null && cursor.moveToFirst()) {
-					result = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
+			try {
+				try (Cursor cursor = contentResolver.query(uri, null, null, null, null)) {
+					if (cursor != null && cursor.moveToFirst()) {
+						result = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
+					}
 				}
+			} catch (Exception e) {
+				Log.e(TAG, "Cannot query content resolver for filename.");
 			}
 		}
 


### PR DESCRIPTION
 - ContentResolver.query(..) seems to throw a runtime exception
   because of some security issue -> as seen in Play Console.
   This catches said exception.