### PR TITLE
CATROID-427: Fix fabric logged crashes in logs on debug builds

### DIFF
--- a/catroid/src/debug/AndroidManifest.xml
+++ b/catroid/src/debug/AndroidManifest.xml
@@ -32,6 +32,7 @@
         tools:ignore="ProtectedPermissions" />
 
     <application>
+        <meta-data android:name="com.crashlytics.ApiKey" android:value="YOUR_API_KEY"/>
         <activity
             android:name=".uiespresso.ui.activity.ProjectUploadRatingDialogTest$ProjectUploadTestActivity"
             android:screenOrientation="portrait"


### PR DESCRIPTION
Fixed like proposed on [Stack Overflow](https://stackoverflow.com/questions/16932248/crashlytics-could-not-be-initialized-api-key-missing-from-androidmanifest-xml).