### PR TITLE
CATROID-439 - StageActivity onDestroy crashes when no current project

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageActivity.java
@@ -130,7 +130,9 @@ public class StageActivity extends AndroidApplication implements PermissionHandl
 
 	@Override
 	protected void onDestroy() {
-		StageLifeCycleController.stageDestroy(this);
+		if (ProjectManager.getInstance().getCurrentProject() != null) {
+			StageLifeCycleController.stageDestroy(this);
+		}
 		super.onDestroy();
 	}
 


### PR DESCRIPTION
currently second highest crash in play console, again cascading crash after an actual crash for some other reason.
