### PR TITLE
CATROID-291: Refactoring

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/TouchesEdgeTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/TouchesEdgeTest.java
@@ -23,6 +23,8 @@
 
 package org.catrobat.catroid.test.sensing;
 
+import com.badlogic.gdx.math.Rectangle;
+
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Sprite;
@@ -49,6 +51,9 @@ import static org.junit.Assert.assertThat;
 public class TouchesEdgeTest {
 	protected Project project;
 	protected Sprite sprite1;
+	private int virtualScreenWidth;
+	private int virtualScreenHeight;
+	private Rectangle screen;
 
 	@Before
 	public void setUp() throws Exception {
@@ -63,49 +68,48 @@ public class TouchesEdgeTest {
 
 		CollisionTestUtils.initializeSprite(sprite1, org.catrobat.catroid.test.R.raw.collision_donut,
 				"collision_donut.png", InstrumentationRegistry.getInstrumentation().getContext(), project);
+		virtualScreenWidth = project.getXmlHeader().virtualScreenWidth;
+		virtualScreenHeight = project.getXmlHeader().virtualScreenHeight;
+		screen = project.getScreenRectangle();
 	}
 
 	@Test
 	public void testCollisionWithRightEdge() {
 		sprite1.look.setXInUserInterfaceDimensionUnit(0);
 		sprite1.look.setYInUserInterfaceDimensionUnit(0);
-		assertThat(CollisionDetection.collidesWithEdge(sprite1.look), is(not(equalTo(1d))));
-		int virtualScreenWidth = ProjectManager.getInstance().getCurrentProject().getXmlHeader().virtualScreenWidth;
+		assertThat(CollisionDetection.collidesWithEdge(sprite1.look, screen), is(not(equalTo(1d))));
 		sprite1.look.setXInUserInterfaceDimensionUnit(sprite1.look.getXInUserInterfaceDimensionUnit()
-				+ virtualScreenWidth / 2);
-		assertEquals(1d, CollisionDetection.collidesWithEdge(sprite1.look));
+				+ virtualScreenWidth / 2f);
+		assertEquals(1d, CollisionDetection.collidesWithEdge(sprite1.look, screen));
 	}
 
 	@Test
 	public void testCollisionWithLeftEdge() {
 		sprite1.look.setXInUserInterfaceDimensionUnit(0);
 		sprite1.look.setYInUserInterfaceDimensionUnit(0);
-		assertThat(CollisionDetection.collidesWithEdge(sprite1.look), is(not(equalTo(1d))));
-		int virtualScreenWidth = ProjectManager.getInstance().getCurrentProject().getXmlHeader().virtualScreenWidth;
+		assertThat(CollisionDetection.collidesWithEdge(sprite1.look, screen), is(not(equalTo(1d))));
 		sprite1.look.setXInUserInterfaceDimensionUnit(sprite1.look.getXInUserInterfaceDimensionUnit()
-				- virtualScreenWidth / 2);
-		assertEquals(1d, CollisionDetection.collidesWithEdge(sprite1.look));
+				- virtualScreenWidth / 2f);
+		assertEquals(1d, CollisionDetection.collidesWithEdge(sprite1.look, screen));
 	}
 
 	@Test
 	public void testCollisionWithUpperEdge() {
 		sprite1.look.setXInUserInterfaceDimensionUnit(0);
 		sprite1.look.setYInUserInterfaceDimensionUnit(0);
-		assertThat(CollisionDetection.collidesWithEdge(sprite1.look), is(not(equalTo(1d))));
-		int virtualScreenHeight = ProjectManager.getInstance().getCurrentProject().getXmlHeader().virtualScreenHeight;
+		assertThat(CollisionDetection.collidesWithEdge(sprite1.look, screen), is(not(equalTo(1d))));
 		sprite1.look.setYInUserInterfaceDimensionUnit(sprite1.look.getXInUserInterfaceDimensionUnit()
-				+ virtualScreenHeight / 2);
-		assertEquals(1d, CollisionDetection.collidesWithEdge(sprite1.look));
+				+ virtualScreenHeight / 2f);
+		assertEquals(1d, CollisionDetection.collidesWithEdge(sprite1.look, screen));
 	}
 
 	@Test
 	public void testCollisionWithBottomEdge() {
 		sprite1.look.setXInUserInterfaceDimensionUnit(0);
 		sprite1.look.setYInUserInterfaceDimensionUnit(0);
-		assertThat(CollisionDetection.collidesWithEdge(sprite1.look), is(not(equalTo(1d))));
-		int virtualScreenHeight = ProjectManager.getInstance().getCurrentProject().getXmlHeader().virtualScreenHeight;
+		assertThat(CollisionDetection.collidesWithEdge(sprite1.look, screen), is(not(equalTo(1d))));
 		sprite1.look.setYInUserInterfaceDimensionUnit(sprite1.look.getXInUserInterfaceDimensionUnit()
-				- virtualScreenHeight / 2);
-		assertEquals(1d, CollisionDetection.collidesWithEdge(sprite1.look));
+				- virtualScreenHeight / 2f);
+		assertEquals(1d, CollisionDetection.collidesWithEdge(sprite1.look, screen));
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/TouchesFingerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/TouchesFingerTest.java
@@ -70,10 +70,12 @@ public class TouchesFingerTest {
 	public void testBasicOneTouchingPoint() {
 		TouchUtil.reset();
 		TouchUtil.touchDown(150, 150, 1);
-		assertEquals(1d, CollisionDetection.collidesWithFinger(sprite1.look));
+		assertEquals(1d, CollisionDetection.collidesWithFinger(
+				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()));
 		TouchUtil.touchUp(1);
 		TouchUtil.touchDown(0, 0, 1);
-		assertThat(CollisionDetection.collidesWithFinger(sprite1.look), is(not(equalTo(1d))));
+		assertThat(CollisionDetection.collidesWithFinger(
+				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()), is(not(equalTo(1d))));
 	}
 
 	@Test
@@ -82,7 +84,8 @@ public class TouchesFingerTest {
 		TouchUtil.touchDown(150, 150, 1);
 		TouchUtil.touchDown(0, 0, 2);
 		TouchUtil.touchDown(151, 151, 3);
-		assertEquals(1d, CollisionDetection.collidesWithFinger(sprite1.look));
+		assertEquals(1d, CollisionDetection.collidesWithFinger(
+				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()));
 	}
 
 	@Test
@@ -90,7 +93,8 @@ public class TouchesFingerTest {
 		TouchUtil.reset();
 		TouchUtil.touchDown(0, 0, 1);
 
-		assertThat(CollisionDetection.collidesWithFinger(sprite1.look), is(not(equalTo(1d))));
+		assertThat(CollisionDetection.collidesWithFinger(
+				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()), is(not(equalTo(1d))));
 
 		float x = sprite1.look.getXInUserInterfaceDimensionUnit();
 		float y = sprite1.look.getYInUserInterfaceDimensionUnit();
@@ -98,6 +102,7 @@ public class TouchesFingerTest {
 		sprite1.look.setXInUserInterfaceDimensionUnit(x - 150);
 		sprite1.look.setYInUserInterfaceDimensionUnit(y - 150);
 
-		assertEquals(1d, CollisionDetection.collidesWithFinger(sprite1.look));
+		assertEquals(1d, CollisionDetection.collidesWithFinger(
+				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()));
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -483,7 +483,7 @@ public final class ProjectManager implements EagerSingleton {
 	}
 
 	public Scene getCurrentlyEditedScene() {
-		if (currentlyEditedScene == null) {
+		if (currentlyEditedScene == null && project != null) {
 			currentlyEditedScene = project.getDefaultScene();
 		}
 		return currentlyEditedScene;

--- a/catroid/src/main/java/org/catrobat/catroid/common/DroneConfigPreference.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/DroneConfigPreference.java
@@ -22,6 +22,8 @@
  */
 package org.catrobat.catroid.common;
 
+import org.catrobat.catroid.utils.EnumUtils;
+
 public abstract class DroneConfigPreference {
 
 	public enum Preferences {
@@ -49,15 +51,8 @@ public abstract class DroneConfigPreference {
 		}
 
 		public static DroneConfigPreference.Preferences getPreferenceFromPreferenceCode(String preferenceCode) {
-			if (preferenceCode == null) {
-				return Preferences.FIRST;
-			}
-
-			try {
-				return valueOf(preferenceCode);
-			} catch (IllegalArgumentException e) {
-				return Preferences.FIRST;
-			}
+			Preferences preferences = EnumUtils.getEnum(Preferences.class, preferenceCode);
+			return preferences != null ? preferences : Preferences.FIRST;
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/GroupSprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/GroupSprite.java
@@ -71,18 +71,17 @@ public class GroupSprite extends Sprite {
 		}
 	}
 
-	public static List<Sprite> getSpritesFromGroupWithGroupName(String groupName) {
-		List<Sprite> result = new ArrayList<Sprite>();
-		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentlyPlayingScene().getSpriteList();
+	public static List<Sprite> getSpritesFromGroupWithGroupName(String groupName, List<Sprite> sprites) {
+		List<Sprite> result = new ArrayList<>();
 		int position = 0;
-		for (Sprite sprite : spriteList) {
+		for (Sprite sprite : sprites) {
 			if (groupName.equals(sprite.getName())) {
 				break;
 			}
 			position++;
 		}
-		for (int childPosition = position + 1; childPosition < spriteList.size(); childPosition++) {
-			Sprite spriteToCheck = spriteList.get(childPosition);
+		for (int childPosition = position + 1; childPosition < sprites.size(); childPosition++) {
+			Sprite spriteToCheck = sprites.get(childPosition);
 			if (spriteToCheck instanceof GroupItemSprite) {
 				result.add(spriteToCheck);
 			} else {
@@ -95,7 +94,8 @@ public class GroupSprite extends Sprite {
 	@Override
 	public void createCollisionPolygons() {
 		Log.i("GroupSprite", "Creating Collision Polygons for all Sprites of group!");
-		List<Sprite> groupSprites = getSpritesFromGroupWithGroupName(getName());
+		List<Sprite> spriteList = ProjectManager.getInstance().getCurrentlyPlayingScene().getSpriteList();
+		List<Sprite> groupSprites = getSpritesFromGroupWithGroupName(getName(), spriteList);
 		for (Sprite sprite : groupSprites) {
 			for (LookData lookData : sprite.getLookList()) {
 				lookData.getCollisionInformation().calculate();

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -45,6 +45,7 @@ import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.ThreadScheduler;
 import org.catrobat.catroid.content.actions.EventThread;
 import org.catrobat.catroid.content.eventids.EventId;
+import org.catrobat.catroid.sensing.CollisionInformation;
 import org.catrobat.catroid.utils.TouchUtil;
 
 import java.lang.annotation.Retention;
@@ -628,10 +629,11 @@ public class Look extends Image {
 		if (getLookData() == null) {
 			originalPolygons = new Polygon[0];
 		} else {
-			if (getLookData().getCollisionInformation().collisionPolygons == null) {
-				getLookData().getCollisionInformation().loadCollisionPolygon();
+			CollisionInformation collisionInformation = getLookData().getCollisionInformation();
+			if (collisionInformation.collisionPolygons == null) {
+				collisionInformation.loadCollisionPolygon();
 			}
-			originalPolygons = getLookData().getCollisionInformation().collisionPolygons;
+			originalPolygons = collisionInformation.collisionPolygons;
 		}
 
 		Polygon[] transformedPolygons = new Polygon[originalPolygons.length];

--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.content;
 import android.content.Context;
 import android.os.Build;
 
+import com.badlogic.gdx.math.Rectangle;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 import org.catrobat.catroid.R;
@@ -274,6 +275,12 @@ public class Project implements Serializable {
 
 	public XmlHeader getXmlHeader() {
 		return this.xmlHeader;
+	}
+
+	public Rectangle getScreenRectangle() {
+		int virtualScreenWidth = xmlHeader.virtualScreenWidth;
+		int virtualScreenHeight = xmlHeader.virtualScreenHeight;
+		return new Rectangle(-virtualScreenWidth / 2, -virtualScreenHeight / 2, virtualScreenWidth, virtualScreenHeight);
 	}
 
 	public Brick.ResourcesSet getRequiredResources() {

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendPWMValueBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ArduinoSendPWMValueBrick.java
@@ -73,7 +73,7 @@ public class ArduinoSendPWMValueBrick extends FormulaBrick {
 
 	public void updateArduinoValues994to995() {
 		Formula formula = getFormulaWithBrickField(BrickField.ARDUINO_ANALOG_PIN_VALUE);
-		FormulaElement oldFormulaElement = formula.getFormulaTree();
+		FormulaElement oldFormulaElement = formula.getRoot();
 
 		FormulaElement multiplication =
 				new FormulaElement(FormulaElement.ElementType.OPERATOR, Operators.MULT.toString(), null);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextColorSizeAlignmentBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextColorSizeAlignmentBrick.java
@@ -35,8 +35,10 @@ import org.catrobat.catroid.content.bricks.brickspinner.BrickSpinner;
 import org.catrobat.catroid.content.strategy.ShowColorPickerFormulaEditorStrategy;
 import org.catrobat.catroid.content.strategy.ShowFormulaEditorStrategy;
 import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
 import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.formulaeditor.common.Conversions;
 import org.catrobat.catroid.ui.UiUtils;
 
 import java.util.ArrayList;
@@ -203,20 +205,20 @@ public class ShowTextColorSizeAlignmentBrick extends UserVariableBrickWithFormul
 			if (!isColorBrickFieldAString()) {
 				return Color.BLACK;
 			}
-			String formulaString = getColorBrickFieldStringValue();
-			if (formulaString.length() == 7 && formulaString.matches("^#[0-9a-fA-F]+$")) {
-				return Color.parseColor(formulaString);
-			} else {
-				return Color.BLACK;
-			}
+			String stringValue = getColorBrickFieldStringValue();
+			return Conversions.tryParseColor(stringValue);
 		}
 
 		private boolean isColorBrickFieldAString() {
-			return getFormulaWithBrickField(BrickField.COLOR).getRoot().getElementType() == ElementType.STRING;
+			return getColorFormulaElement().getElementType() == ElementType.STRING;
 		}
 
 		private String getColorBrickFieldStringValue() {
-			return getFormulaWithBrickField(BrickField.COLOR).getRoot().getValue();
+			return getColorFormulaElement().getValue();
+		}
+
+		private FormulaElement getColorFormulaElement() {
+			return getFormulaWithBrickField(BrickField.COLOR).getRoot();
 		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/ev3/sensors/EV3Sensor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/ev3/sensors/EV3Sensor.java
@@ -36,6 +36,7 @@ import org.catrobat.catroid.devices.mindstorms.ev3.EV3CommandByte.EV3CommandPara
 import org.catrobat.catroid.devices.mindstorms.ev3.EV3CommandByte.EV3CommandVariableScope;
 import org.catrobat.catroid.devices.mindstorms.ev3.EV3CommandType;
 import org.catrobat.catroid.devices.mindstorms.ev3.EV3Reply;
+import org.catrobat.catroid.utils.EnumUtils;
 
 import java.util.Locale;
 
@@ -71,15 +72,8 @@ public abstract class EV3Sensor implements LegoSensor {
 		}
 
 		public static EV3Sensor.Sensor getSensorFromSensorCode(String sensorCode) {
-			if (sensorCode == null) {
-				return Sensor.NO_SENSOR;
-			}
-
-			try {
-				return valueOf(sensorCode);
-			} catch (IllegalArgumentException e) {
-				return Sensor.NO_SENSOR;
-			}
+			Sensor sensor = EnumUtils.getEnum(Sensor.class, sensorCode);
+			return sensor != null ? sensor : Sensor.NO_SENSOR;
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTSensor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mindstorms/nxt/sensors/NXTSensor.java
@@ -32,6 +32,7 @@ import org.catrobat.catroid.devices.mindstorms.nxt.CommandByte;
 import org.catrobat.catroid.devices.mindstorms.nxt.CommandType;
 import org.catrobat.catroid.devices.mindstorms.nxt.NXTError;
 import org.catrobat.catroid.devices.mindstorms.nxt.NXTReply;
+import org.catrobat.catroid.utils.EnumUtils;
 
 import java.util.Locale;
 
@@ -62,15 +63,8 @@ public abstract class NXTSensor implements LegoSensor {
 		}
 
 		public static NXTSensor.Sensor getSensorFromSensorCode(String sensorCode) {
-			if (sensorCode == null) {
-				return Sensor.NO_SENSOR;
-			}
-
-			try {
-				return valueOf(sensorCode);
-			} catch (IllegalArgumentException e) {
-				return Sensor.NO_SENSOR;
-			}
+			Sensor sensor = EnumUtils.getEnum(Sensor.class, sensorCode);
+			return sensor != null ? sensor : Sensor.NO_SENSOR;
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
@@ -26,33 +26,24 @@ import android.content.Context;
 
 import org.catrobat.catroid.CatroidApplication;
 import org.catrobat.catroid.ProjectManager;
-import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
+import org.catrobat.catroid.utils.EnumUtils;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.Serializable;
 import java.util.Set;
 
-import static org.catrobat.catroid.utils.NumberFormats.stringWithoutTrailingZero;
+import static org.catrobat.catroid.utils.NumberFormats.trimTrailingCharacters;
 
 public class Formula implements Serializable {
 
 	private static final long serialVersionUID = 1L;
+	private static final String ERROR_STRING = "ERROR";
 	private FormulaElement formulaTree;
 
 	private transient InternFormula internFormula = null;
-
-	public Object readResolve() {
-
-		if (formulaTree == null) {
-			formulaTree = new FormulaElement(ElementType.NUMBER, "0 ", null);
-		}
-
-		internFormula = new InternFormula(formulaTree.getInternTokenList());
-
-		return this;
-	}
 
 	public Formula(FormulaElement formulaElement) {
 		formulaTree = formulaElement;
@@ -61,13 +52,17 @@ public class Formula implements Serializable {
 
 	public Formula(Integer value) {
 		if (value < 0) {
-			formulaTree = new FormulaElement(ElementType.OPERATOR, Operators.MINUS.toString(), null);
-			formulaTree.setRightChild(new FormulaElement(ElementType.NUMBER, Long.toString(Math.abs((long) value)),
-					formulaTree));
-			internFormula = new InternFormula(formulaTree.getInternTokenList());
+			initInverted(Long.toString(Math.abs((long) value)));
 		} else {
-			formulaTree = new FormulaElement(ElementType.NUMBER, value.toString(), null);
-			internFormula = new InternFormula(formulaTree.getInternTokenList());
+			init(ElementType.NUMBER, value.toString());
+		}
+	}
+
+	public Formula(Double value) {
+		if (value < 0) {
+			initInverted(Double.toString(Math.abs(value)));
+		} else {
+			init(ElementType.NUMBER, value.toString());
 		}
 	}
 
@@ -75,16 +70,25 @@ public class Formula implements Serializable {
 		this(Double.valueOf(value));
 	}
 
-	public Formula(Double value) {
-		if (value < 0) {
-			formulaTree = new FormulaElement(ElementType.OPERATOR, Operators.MINUS.toString(), null);
-			formulaTree.setRightChild(new FormulaElement(ElementType.NUMBER, Double.toString(Math.abs(value)),
-					formulaTree));
-			internFormula = new InternFormula(formulaTree.getInternTokenList());
+	public Formula(String value) {
+		if (value.equalsIgnoreCase(Functions.ARDUINOANALOG.toString())) {
+			formulaTree = new FormulaElement(ElementType.SENSOR, Functions.ARDUINOANALOG.toString(), null);
+		} else if (value.equalsIgnoreCase(Functions.ARDUINODIGITAL.toString())) {
+			formulaTree = new FormulaElement(ElementType.SENSOR, Functions.ARDUINODIGITAL.toString(), null);
 		} else {
-			formulaTree = new FormulaElement(ElementType.NUMBER, value.toString(), null);
-			internFormula = new InternFormula(formulaTree.getInternTokenList());
+			init(ElementType.STRING, value);
 		}
+	}
+
+	private void init(ElementType number, String s) {
+		formulaTree = new FormulaElement(number, s, null);
+		internFormula = new InternFormula(formulaTree.getInternTokenList());
+	}
+
+	private void initInverted(String value) {
+		formulaTree = new FormulaElement(ElementType.OPERATOR, Operators.MINUS.toString(), null);
+		formulaTree.setRightChild(new FormulaElement(ElementType.NUMBER, value, formulaTree));
+		internFormula = new InternFormula(formulaTree.getInternTokenList());
 	}
 
 	public void updateCollisionFormulas(String oldName, String newName, Context context) {
@@ -94,7 +98,7 @@ public class Formula implements Serializable {
 
 	public void updateCollisionFormulasToVersion() {
 		internFormula.updateCollisionFormulaToVersion(CatroidApplication.getAppContext());
-		formulaTree.updateCollisionFormulaToVersion();
+		formulaTree.updateCollisionFormulaToVersion(ProjectManager.getInstance().getCurrentProject());
 	}
 
 	public void updateVariableName(String oldName, String newName) {
@@ -111,54 +115,48 @@ public class Formula implements Serializable {
 		return formulaTree.containsSpriteInCollision(name);
 	}
 
-	public Formula(String value) {
-		if (value.equalsIgnoreCase(Functions.ARDUINOANALOG.toString())) {
-			formulaTree = new FormulaElement(ElementType.SENSOR, Functions.ARDUINOANALOG.toString(), null);
-		} else if (value.equalsIgnoreCase(Functions.ARDUINODIGITAL.toString())) {
-			formulaTree = new FormulaElement(ElementType.SENSOR, Functions.ARDUINODIGITAL.toString(), null);
-		} else {
-			formulaTree = new FormulaElement(ElementType.STRING, value, null);
-			internFormula = new InternFormula(formulaTree.getInternTokenList());
-		}
-	}
-
-	public Boolean interpretBoolean(Sprite sprite) throws InterpretationException {
-		int result = interpretDouble(sprite).intValue();
-		return result != 0;
-	}
-
 	public Integer interpretInteger(Sprite sprite) throws InterpretationException {
-		Double returnValue = interpretDouble(sprite);
-		return returnValue.intValue();
+		return interpretDouble(sprite).intValue();
+	}
+
+	@NotNull
+	private String tryInterpretDouble(Sprite sprite) {
+		try {
+			return String.valueOf(interpretDouble(sprite));
+		} catch (InterpretationException interpretationException) {
+			return ERROR_STRING;
+		}
 	}
 
 	public Double interpretDouble(Sprite sprite) throws InterpretationException {
 		try {
-			Object returnValue = formulaTree.interpretRecursive(sprite);
-			Double doubleReturnValue;
-			if (returnValue instanceof String) {
-				doubleReturnValue = Double.valueOf((String) returnValue);
-				if (doubleReturnValue.isNaN()) {
-					throw new InterpretationException("NaN in interpretDouble()");
-				}
-				return doubleReturnValue;
-			} else {
-				doubleReturnValue = (Double) returnValue;
-				if (doubleReturnValue.isNaN()) {
-					throw new InterpretationException("NaN in interpretDouble()");
-				}
-				return (Double) returnValue;
-			}
-		} catch (ClassCastException classCastException) {
-			throw new InterpretationException("Couldn't interpret Formula.", classCastException);
-		} catch (NumberFormatException numberFormatException) {
-			throw new InterpretationException("Couldn't interpret Formula.", numberFormatException);
+			return assertNotNaN(interpretDoubleInternal(sprite));
+		} catch (ClassCastException | NumberFormatException exception) {
+			throw new InterpretationException("Couldn't interpret Formula.", exception);
 		}
 	}
 
+	@NotNull
+	private Double interpretDoubleInternal(Sprite sprite) {
+		Object o = formulaTree.interpretRecursive(sprite);
+		Double doubleReturnValue;
+		if (o instanceof String) {
+			doubleReturnValue = Double.valueOf((String) o);
+		} else {
+			doubleReturnValue = (Double) o;
+		}
+		return doubleReturnValue;
+	}
+
+	private double assertNotNaN(Double doubleReturnValue) throws InterpretationException {
+		if (doubleReturnValue.isNaN()) {
+			throw new InterpretationException("NaN in interpretDouble()");
+		}
+		return doubleReturnValue;
+	}
+
 	public Float interpretFloat(Sprite sprite) throws InterpretationException {
-		Double returnValue = interpretDouble(sprite);
-		return returnValue.floatValue();
+		return interpretDouble(sprite).floatValue();
 	}
 
 	public String interpretString(Sprite sprite) throws InterpretationException {
@@ -169,7 +167,7 @@ public class Formula implements Serializable {
 		}
 
 		String value = String.valueOf(interpretation);
-		return stringWithoutTrailingZero(value);
+		return trimTrailingCharacters(value);
 	}
 
 	public Object interpretObject(Sprite sprite) {
@@ -214,48 +212,79 @@ public class Formula implements Serializable {
 		formulaTree.addRequiredResources(requiredResourcesSet);
 	}
 
-	public String getResultForComputeDialog(Context context) {
-		Sprite sprite = ProjectManager.getInstance().getCurrentSprite();
+	public String getResultForComputeDialog(StringProvider stringProvider, Sprite sprite) {
 		ElementType type = formulaTree.getElementType();
+		Project currentProject = ProjectManager.getInstance().getCurrentProject();
+		Sprite currentSprite = ProjectManager.getInstance().getCurrentSprite();
 
 		if (formulaTree.isLogicalOperator()) {
-			boolean result;
-			try {
-				result = this.interpretBoolean(sprite);
-			} catch (InterpretationException interpretationException) {
-				return "ERROR";
-			}
-			int logicalFormulaResultIdentifier = result ? R.string.formula_editor_true : R.string.formula_editor_false;
-			return context.getString(logicalFormulaResultIdentifier);
-		} else if (type == ElementType.STRING
-				|| type == ElementType.SENSOR
-				|| (type == ElementType.FUNCTION
-				&& (Functions.getFunctionByValue(formulaTree.getValue()) == Functions.LETTER
-				|| Functions.getFunctionByValue(formulaTree.getValue()) == Functions.JOIN)
-				|| Functions.getFunctionByValue(formulaTree.getValue()) == Functions.REGEX)) {
-			try {
-				return interpretString(sprite);
-			} catch (InterpretationException interpretationException) {
-				return "ERROR";
-			}
-		} else if (formulaTree.isUserVariableWithTypeString(sprite)) {
-			Project currentProject = ProjectManager.getInstance().getCurrentProject();
-			Sprite currentSprite = ProjectManager.getInstance().getCurrentSprite();
-			UserVariable userVariable = UserDataWrapper
-					.getUserVariable(formulaTree.getValue(), currentSprite, currentProject);
-			return (String) userVariable.getValue();
+			return tryInterpretBooleanToString(stringProvider, sprite);
+		} else if (isStringInterpretableType(type, formulaTree.getValue())) {
+			return tryInterpretString(sprite);
+		} else if (isVariableWithTypeString(sprite, currentProject)) {
+			return interpretUserVariable(currentProject, currentSprite);
 		} else {
-			Double interpretationResult;
-			try {
-				interpretationResult = this.interpretDouble(sprite);
-			} catch (InterpretationException interpretationException) {
-				return "ERROR";
-			}
-			return String.valueOf(interpretationResult);
+			return tryInterpretDouble(sprite);
 		}
 	}
 
-	public FormulaElement getFormulaTree() {
-		return formulaTree;
+	private boolean isStringInterpretableType(ElementType type, String formulaValue) {
+		return type == ElementType.STRING
+				|| type == ElementType.SENSOR
+				|| type == ElementType.FUNCTION && isInterpretableFunction(formulaValue);
+	}
+
+	private boolean isInterpretableFunction(String formulaValue) {
+		Functions function = EnumUtils.getEnum(Functions.class, formulaValue);
+		return function == Functions.LETTER || function == Functions.JOIN || function == Functions.REGEX;
+	}
+
+	private boolean isVariableWithTypeString(Sprite sprite, Project currentProject) {
+		if (formulaTree.getElementType() == ElementType.USER_VARIABLE) {
+			UserVariable userVariable = UserDataWrapper.getUserVariable(formulaTree.getValue(), sprite, currentProject);
+			return userVariable.getValue() instanceof String;
+		} else {
+			return false;
+		}
+	}
+
+	private String interpretUserVariable(Project currentProject, Sprite currentSprite) {
+		UserVariable userVariable = UserDataWrapper
+				.getUserVariable(formulaTree.getValue(), currentSprite, currentProject);
+		return (String) userVariable.getValue();
+	}
+
+	private String tryInterpretString(Sprite sprite) {
+		try {
+			return interpretString(sprite);
+		} catch (InterpretationException interpretationException) {
+			return ERROR_STRING;
+		}
+	}
+
+	private String tryInterpretBooleanToString(StringProvider stringProvider, Sprite sprite) {
+		try {
+			return interpretBooleanToString(sprite, stringProvider);
+		} catch (InterpretationException interpretationException) {
+			return ERROR_STRING;
+		}
+	}
+
+	public String interpretBooleanToString(Sprite sprite, StringProvider stringProvider) throws InterpretationException {
+		boolean booleanValue = interpretBoolean(sprite);
+		return toLocalizedString(booleanValue, stringProvider);
+	}
+
+	public boolean interpretBoolean(Sprite sprite) throws InterpretationException {
+		return interpretDouble(sprite).intValue() != 0;
+	}
+
+	private String toLocalizedString(boolean value, StringProvider stringProvider) {
+		return value ? stringProvider.getTrue() : stringProvider.getFalse();
+	}
+
+	public interface StringProvider {
+		String getTrue();
+		String getFalse();
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -22,36 +22,65 @@
  */
 package org.catrobat.catroid.formulaeditor;
 
-import android.content.res.Resources;
-
 import org.catrobat.catroid.ProjectManager;
-import org.catrobat.catroid.bluetooth.base.BluetoothDevice;
-import org.catrobat.catroid.common.CatroidService;
-import org.catrobat.catroid.common.Constants;
-import org.catrobat.catroid.common.LookData;
-import org.catrobat.catroid.common.ServiceProvider;
-import org.catrobat.catroid.content.GroupSprite;
-import org.catrobat.catroid.content.Look;
 import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
-import org.catrobat.catroid.devices.arduino.Arduino;
-import org.catrobat.catroid.devices.raspberrypi.RPiSocketConnection;
-import org.catrobat.catroid.devices.raspberrypi.RaspberryPiService;
-import org.catrobat.catroid.nfc.NfcHandler;
+import org.catrobat.catroid.formulaeditor.function.ArduinoFunctionProvider;
+import org.catrobat.catroid.formulaeditor.function.BinaryFunction;
+import org.catrobat.catroid.formulaeditor.function.FormulaFunction;
+import org.catrobat.catroid.formulaeditor.function.FunctionProvider;
+import org.catrobat.catroid.formulaeditor.function.MathFunctionProvider;
+import org.catrobat.catroid.formulaeditor.function.RaspiFunctionProvider;
+import org.catrobat.catroid.formulaeditor.function.TouchFunctionProvider;
 import org.catrobat.catroid.sensing.CollisionDetection;
 import org.catrobat.catroid.stage.StageActivity;
-import org.catrobat.catroid.utils.TouchUtil;
+import org.catrobat.catroid.stage.StageListener;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.catrobat.catroid.utils.NumberFormats.stringWithoutTrailingZero;
+import androidx.annotation.Nullable;
+
+import static org.catrobat.catroid.formulaeditor.InternTokenType.BRACKET_CLOSE;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.BRACKET_OPEN;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.COLLISION_FORMULA;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.FUNCTION_NAME;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.FUNCTION_PARAMETER_DELIMITER;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.NUMBER;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.OPERATOR;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.SENSOR;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.STRING;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.USER_LIST;
+import static org.catrobat.catroid.formulaeditor.InternTokenType.USER_VARIABLE;
+import static org.catrobat.catroid.formulaeditor.common.Conversions.FALSE;
+import static org.catrobat.catroid.formulaeditor.common.Conversions.TRUE;
+import static org.catrobat.catroid.formulaeditor.common.Conversions.booleanToDouble;
+import static org.catrobat.catroid.formulaeditor.common.Conversions.convertArgumentToDouble;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementOperations.interpretOperatorEqual;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementOperations.interpretSensor;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementOperations.interpretUserList;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementOperations.interpretUserVariable;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementOperations.isInteger;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementOperations.normalizeDegeneratedDoubleValues;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementOperations.tryInterpretCollision;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementOperations.tryInterpretDoubleValue;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementOperations.tryInterpretElementRecursive;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementOperations.tryParseIntFromObject;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementResources.addFunctionResources;
+import static org.catrobat.catroid.formulaeditor.common.FormulaElementResources.addSensorsResources;
+import static org.catrobat.catroid.utils.NumberFormats.trimTrailingCharacters;
 
 public class FormulaElement implements Serializable {
 
@@ -61,17 +90,23 @@ public class FormulaElement implements Serializable {
 		OPERATOR, FUNCTION, NUMBER, SENSOR, USER_VARIABLE, USER_LIST, BRACKET, STRING, COLLISION_FORMULA
 	}
 
-	public static final Double NOT_EXISTING_USER_VARIABLE_INTERPRETATION_VALUE = 0d;
-	public static final Double NOT_EXISTING_USER_LIST_INTERPRETATION_VALUE = 0d;
-	private static final String EMPTY_USER_LIST_INTERPRETATION_VALUE = "";
-
 	private ElementType type;
 	private String value;
 	private FormulaElement leftChild = null;
 	private FormulaElement rightChild = null;
-	private transient FormulaElement parent = null;
+	private transient FormulaElement parent;
+	private transient Map<Functions, FormulaFunction> formulaFunctions;
+
+	protected FormulaElement() {
+		List<FunctionProvider> functionProviders = Arrays.asList(new ArduinoFunctionProvider(), new RaspiFunctionProvider(),
+				new MathFunctionProvider(), new TouchFunctionProvider());
+
+		formulaFunctions = new EnumMap<>(Functions.class);
+		initFunctionMap(functionProviders, formulaFunctions);
+	}
 
 	public FormulaElement(ElementType type, String value, FormulaElement parent) {
+		this();
 		this.type = type;
 		this.value = value;
 		this.parent = parent;
@@ -79,9 +114,7 @@ public class FormulaElement implements Serializable {
 
 	public FormulaElement(ElementType type, String value, FormulaElement parent, FormulaElement leftChild,
 			FormulaElement rightChild) {
-		this.type = type;
-		this.value = value;
-		this.parent = parent;
+		this(type, value, parent);
 		this.leftChild = leftChild;
 		this.rightChild = rightChild;
 
@@ -93,70 +126,98 @@ public class FormulaElement implements Serializable {
 		}
 	}
 
+	private void initFunctionMap(List<FunctionProvider> functionProviders, Map<Functions, FormulaFunction> formulaFunctions) {
+		for (FunctionProvider functionProvider : functionProviders) {
+			functionProvider.addFunctionsToMap(formulaFunctions);
+		}
+
+		formulaFunctions.put(Functions.RAND, new BinaryFunction(this::interpretFunctionRand));
+	}
+
 	public ElementType getElementType() {
 		return type;
 	}
 
 	public String getValue() {
-		return stringWithoutTrailingZero(value);
+		return trimTrailingCharacters(value);
 	}
 
 	public List<InternToken> getInternTokenList() {
-		List<InternToken> internTokenList = new LinkedList<>();
+		List<InternToken> tokens = new LinkedList<>();
 
 		switch (type) {
 			case BRACKET:
-				internTokenList.add(new InternToken(InternTokenType.BRACKET_OPEN));
-				if (rightChild != null) {
-					internTokenList.addAll(rightChild.getInternTokenList());
-				}
-				internTokenList.add(new InternToken(InternTokenType.BRACKET_CLOSE));
+				addBracketTokens(tokens, rightChild);
 				break;
 			case OPERATOR:
-				if (leftChild != null) {
-					internTokenList.addAll(leftChild.getInternTokenList());
-				}
-				internTokenList.add(new InternToken(InternTokenType.OPERATOR, this.value));
-				if (rightChild != null) {
-					internTokenList.addAll(rightChild.getInternTokenList());
-				}
+				addOperatorTokens(tokens, value);
 				break;
 			case FUNCTION:
-				internTokenList.add(new InternToken(InternTokenType.FUNCTION_NAME, value));
-				boolean functionHasParameters = false;
-				if (leftChild != null) {
-					internTokenList.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
-					functionHasParameters = true;
-					internTokenList.addAll(leftChild.getInternTokenList());
-				}
-				if (rightChild != null) {
-					internTokenList.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
-					internTokenList.addAll(rightChild.getInternTokenList());
-				}
-				if (functionHasParameters) {
-					internTokenList.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
-				}
+				addFunctionTokens(tokens, value, leftChild, rightChild);
 				break;
 			case USER_VARIABLE:
-				internTokenList.add(new InternToken(InternTokenType.USER_VARIABLE, this.value));
+				addToken(tokens, USER_VARIABLE, value);
 				break;
 			case USER_LIST:
-				internTokenList.add(new InternToken(InternTokenType.USER_LIST, this.value));
+				addToken(tokens, USER_LIST, value);
 				break;
 			case NUMBER:
-				internTokenList.add(new InternToken(InternTokenType.NUMBER, stringWithoutTrailingZero(this.value)));
+				addToken(tokens, NUMBER, trimTrailingCharacters(value));
 				break;
 			case SENSOR:
-				internTokenList.add(new InternToken(InternTokenType.SENSOR, this.value));
+				addToken(tokens, SENSOR, value);
 				break;
 			case STRING:
-				internTokenList.add(new InternToken(InternTokenType.STRING, value));
+				addToken(tokens, STRING, value);
 				break;
 			case COLLISION_FORMULA:
-				internTokenList.add(new InternToken(InternTokenType.COLLISION_FORMULA, this.value));
+				addToken(tokens, COLLISION_FORMULA, value);
 				break;
 		}
-		return internTokenList;
+		return tokens;
+	}
+
+	private void addToken(List<InternToken> tokens, InternTokenType tokenType) {
+		tokens.add(new InternToken(tokenType));
+	}
+
+	private void addToken(List<InternToken> tokens, InternTokenType tokenType, String value) {
+		tokens.add(new InternToken(tokenType, value));
+	}
+
+	private void addBracketTokens(List<InternToken> internTokenList, FormulaElement element) {
+		addToken(internTokenList, BRACKET_OPEN);
+		tryAddInternTokens(internTokenList, element);
+		addToken(internTokenList, BRACKET_CLOSE);
+	}
+
+	private void addOperatorTokens(List<InternToken> tokens, String value) {
+		tryAddInternTokens(tokens, leftChild);
+		addToken(tokens, OPERATOR, value);
+		tryAddInternTokens(tokens, rightChild);
+	}
+
+	private void addFunctionTokens(List<InternToken> tokens, String value, FormulaElement leftChild, FormulaElement rightChild) {
+		addToken(tokens, FUNCTION_NAME, value);
+		boolean functionHasParameters = false;
+		if (leftChild != null) {
+			addToken(tokens, FUNCTION_PARAMETERS_BRACKET_OPEN);
+			functionHasParameters = true;
+			tokens.addAll(leftChild.getInternTokenList());
+		}
+		if (rightChild != null) {
+			addToken(tokens, FUNCTION_PARAMETER_DELIMITER);
+			tokens.addAll(rightChild.getInternTokenList());
+		}
+		if (functionHasParameters) {
+			addToken(tokens, FUNCTION_PARAMETERS_BRACKET_CLOSE);
+		}
+	}
+
+	private void tryAddInternTokens(List<InternToken> tokens, FormulaElement child) {
+		if (child != null) {
+			tokens.addAll(child.getInternTokenList());
+		}
 	}
 
 	public FormulaElement getRoot() {
@@ -168,477 +229,245 @@ public class FormulaElement implements Serializable {
 	}
 
 	public void updateVariableReferences(String oldName, String newName) {
-		if (leftChild != null) {
-			leftChild.updateVariableReferences(oldName, newName);
-		}
-		if (rightChild != null) {
-			rightChild.updateVariableReferences(oldName, newName);
-		}
-		if (type == ElementType.USER_VARIABLE && value.equals(oldName)) {
+		tryUpdateVariableReference(leftChild, oldName, newName);
+		tryUpdateVariableReference(rightChild, oldName, newName);
+		if (matchesTypeAndName(ElementType.USER_VARIABLE, oldName)) {
 			value = newName;
 		}
 	}
 
 	public void updateListName(String oldName, String newName) {
-		if (leftChild != null) {
-			leftChild.updateVariableReferences(oldName, newName);
-		}
-		if (rightChild != null) {
-			rightChild.updateVariableReferences(oldName, newName);
-		}
-		if (type == ElementType.USER_LIST && value.equals(oldName)) {
+		tryUpdateVariableReference(leftChild, oldName, newName);
+		tryUpdateVariableReference(rightChild, oldName, newName);
+		if (matchesTypeAndName(ElementType.USER_LIST, oldName)) {
 			value = newName;
 		}
 	}
 
-	public void getVariableAndListNames(List<String> variables, List<String> lists) {
-		if (leftChild != null) {
-			leftChild.getVariableAndListNames(variables, lists);
-		}
-		if (rightChild != null) {
-			rightChild.getVariableAndListNames(variables, lists);
-		}
-		if (type == ElementType.USER_VARIABLE && !variables.contains(value)) {
-			variables.add(value);
-		}
-		if (type == ElementType.USER_LIST && !lists.contains(value)) {
-			lists.add(value);
+	private void tryUpdateVariableReference(FormulaElement element, String oldName, String newName) {
+		if (element != null) {
+			element.updateVariableReferences(oldName, newName);
 		}
 	}
 
-	public boolean containsSpriteInCollision(String name) {
-		boolean contained = false;
-		if (leftChild != null) {
-			contained |= leftChild.containsSpriteInCollision(name);
-		}
-		if (rightChild != null) {
-			contained |= rightChild.containsSpriteInCollision(name);
-		}
-		if (type == ElementType.COLLISION_FORMULA && value.equals(name)) {
-			contained = true;
-		}
-		return contained;
+	public final boolean containsSpriteInCollision(String name) {
+		return containsSpriteInCollision(leftChild, name)
+				|| containsSpriteInCollision(rightChild, name)
+				|| matchesTypeAndName(ElementType.COLLISION_FORMULA, name);
 	}
 
-	public void updateCollisionFormula(String oldName, String newName) {
+	private boolean containsSpriteInCollision(FormulaElement element, String name) {
+		return element != null && element.containsSpriteInCollision(name);
+	}
 
-		if (leftChild != null) {
-			leftChild.updateCollisionFormula(oldName, newName);
-		}
-		if (rightChild != null) {
-			rightChild.updateCollisionFormula(oldName, newName);
-		}
-		if (type == ElementType.COLLISION_FORMULA && value.equals(oldName)) {
+	public final void updateCollisionFormula(String oldName, String newName) {
+		tryUpdateCollisionFormula(leftChild, oldName, newName);
+		tryUpdateCollisionFormula(rightChild, oldName, newName);
+		if (matchesTypeAndName(ElementType.COLLISION_FORMULA, oldName)) {
 			value = newName;
 		}
 	}
 
-	public void updateCollisionFormulaToVersion() {
-		if (leftChild != null) {
-			leftChild.updateCollisionFormulaToVersion();
+	private boolean matchesTypeAndName(ElementType collisionFormula, String name) {
+		return type == collisionFormula && value.equals(name);
+	}
+
+	private void tryUpdateCollisionFormula(FormulaElement element, String oldName, String newName) {
+		if (element != null) {
+			element.updateCollisionFormula(oldName, newName);
 		}
-		if (rightChild != null) {
-			rightChild.updateCollisionFormulaToVersion();
-		}
+	}
+
+	public void updateCollisionFormulaToVersion(Project currentProject) {
+		tryUpdateCollisionFormulaToVersion(leftChild, currentProject);
+		tryUpdateCollisionFormulaToVersion(rightChild, currentProject);
 		if (type == ElementType.COLLISION_FORMULA) {
-			String secondSpriteName = CollisionDetection.getSecondSpriteNameFromCollisionFormulaString(value);
+			String secondSpriteName = CollisionDetection.getSecondSpriteNameFromCollisionFormulaString(value, currentProject);
 			if (secondSpriteName != null) {
 				value = secondSpriteName;
 			}
 		}
 	}
 
-	public Object interpretRecursive(Sprite sprite) {
+	private void tryUpdateCollisionFormulaToVersion(FormulaElement element, Project currentProject) {
+		if (element != null) {
+			element.updateCollisionFormulaToVersion(currentProject);
+		}
+	}
 
-		Object returnValue = 0d;
+	public Object interpretRecursive(Sprite sprite) {
+		Object rawReturnValue = rawInterpretRecursive(sprite);
+		return normalizeDegeneratedDoubleValues(rawReturnValue);
+	}
+
+	private Object rawInterpretRecursive(Sprite sprite) {
+		ProjectManager projectManager = ProjectManager.getInstance();
+		Project currentProject = projectManager != null ? projectManager.getCurrentProject() : null;
+		Scene currentlyPlayingScene = projectManager != null ? projectManager.getCurrentlyPlayingScene() : null;
+		Scene currentlyEditedScene = projectManager != null ? projectManager.getCurrentlyEditedScene() : null;
 
 		switch (type) {
 			case BRACKET:
-				returnValue = rightChild.interpretRecursive(sprite);
-				break;
+				return rightChild.interpretRecursive(sprite);
 			case NUMBER:
-				returnValue = value;
-				break;
+			case STRING:
+				return value;
 			case OPERATOR:
-				Operators operator = Operators.getOperatorByValue(value);
-				returnValue = interpretOperator(operator, sprite);
-				break;
+				return tryInterpretOperator(sprite, value);
 			case FUNCTION:
 				Functions function = Functions.getFunctionByValue(value);
-				returnValue = interpretFunction(function, sprite);
-				break;
+				return interpretFunction(function, sprite, currentProject);
 			case SENSOR:
-				returnValue = interpretSensor(sprite);
-				break;
+				return interpretSensor(sprite, currentlyEditedScene, currentProject, value);
 			case USER_VARIABLE:
-				returnValue = interpretUserVariable(sprite);
-				break;
+				UserVariable userVariable = UserDataWrapper.getUserVariable(value, sprite, currentProject);
+				return interpretUserVariable(userVariable);
 			case USER_LIST:
-				returnValue = interpretUserList(sprite);
-				break;
-			case STRING:
-				returnValue = value;
-				break;
+				UserList userList = UserDataWrapper.getUserList(value, sprite, currentProject);
+				return interpretUserList(userList);
 			case COLLISION_FORMULA:
-				try {
-					returnValue = interpretCollision(sprite, value);
-				} catch (Exception exception) {
-					returnValue = 0d;
-				}
+				StageListener stageListener = StageActivity.stageListener;
+				return tryInterpretCollision(sprite.look, value, currentlyPlayingScene, stageListener);
 		}
-		return normalizeDegeneratedDoubleValues(returnValue);
+		return FALSE;
 	}
 
-	private Object interpretCollision(Sprite firstSprite, String formula) {
-
-		String secondSpriteName = formula;
-		Sprite secondSprite;
-		try {
-			secondSprite = ProjectManager.getInstance().getCurrentlyPlayingScene().getSprite(secondSpriteName);
-		} catch (Resources.NotFoundException exception) {
-			return 0d;
+	@NotNull
+	private Object tryInterpretOperator(Sprite sprite, String value) {
+		Operators operator = Operators.getOperatorByValue(value);
+		if (operator == null) {
+			return false;
 		}
-		Look firstLook = firstSprite.look;
-		Look secondLook;
-		if (secondSprite instanceof GroupSprite) {
-			List<Sprite> groupSprites = GroupSprite.getSpritesFromGroupWithGroupName(secondSpriteName);
-			for (Sprite sprite : groupSprites) {
-				secondLook = sprite.look;
-				if (CollisionDetection.checkCollisionBetweenLooks(firstLook, secondLook) == 1d) {
-					return 1d;
-				}
-			}
-			return 0d;
-		}
-
-		List<Sprite> spriteAndClones = new ArrayList<>();
-		spriteAndClones.add(secondSprite);
-		if (StageActivity.stageListener != null) {
-			spriteAndClones.addAll(StageActivity.stageListener.getAllClonesOfSprite(secondSprite));
-		}
-
-		for (Sprite sprite : spriteAndClones) {
-			secondLook = sprite.look;
-			if (firstLook.equals(secondLook)) {
-				continue;
-			}
-
-			if (CollisionDetection.checkCollisionBetweenLooks(firstLook, secondLook) == 1d) {
-				return 1d;
-			}
-		}
-
-		return 0d;
+		return interpretOperator(operator, sprite);
 	}
 
-	private Object interpretUserList(Sprite sprite) {
-		Project currentProject = ProjectManager.getInstance().getCurrentProject();
-		UserList userList = UserDataWrapper.getUserList(value, sprite, currentProject);
-		if (userList == null) {
-			return NOT_EXISTING_USER_LIST_INTERPRETATION_VALUE;
-		}
-
-		List<Object> userListValues = userList.getValue();
-
-		if (userListValues.size() == 0) {
-			return EMPTY_USER_LIST_INTERPRETATION_VALUE;
-		} else if (userListValues.size() == 1) {
-			return userListValues.get(0);
-		} else {
-			return interpretMultipleItemsUserList(userListValues);
-		}
-	}
-
-	private Object interpretMultipleItemsUserList(List<Object> userListValues) {
-		List<String> userListStringValues = new ArrayList<>();
-
-		for (Object listValue : userListValues) {
-			if (listValue instanceof Double) {
-				Double doubleValueOfListItem = (Double) listValue;
-				userListStringValues.add(stringWithoutTrailingZero(String.valueOf(doubleValueOfListItem.intValue())));
-			} else if (listValue instanceof String) {
-				String stringValueOfListItem = (String) listValue;
-				userListStringValues.add(stringWithoutTrailingZero(stringValueOfListItem));
-			}
-		}
-
-		StringBuilder stringBuilder = new StringBuilder(userListStringValues.size());
-		String separator = listConsistsOfSingleCharacters(userListStringValues) ? "" : " ";
-		for (String userListStringValue : userListStringValues) {
-			stringBuilder.append(stringWithoutTrailingZero(userListStringValue));
-			stringBuilder.append(separator);
-		}
-
-		return stringBuilder.toString().trim();
-	}
-
-	private Boolean listConsistsOfSingleCharacters(List<String> userListStringValues) {
-		for (String userListStringValue : userListStringValues) {
-			if (userListStringValue.length() > 1) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	private Object interpretUserVariable(Sprite sprite) {
-		Project currentProject = ProjectManager.getInstance().getCurrentProject();
-		UserVariable userVariable = UserDataWrapper.getUserVariable(value, sprite, currentProject);
-		if (userVariable == null) {
-			return NOT_EXISTING_USER_VARIABLE_INTERPRETATION_VALUE;
-		}
-		return userVariable.getValue();
-	}
-
-	private Object interpretSensor(Sprite sprite) {
-		Sensors sensor = Sensors.getSensorByValue(value);
-		if (sensor.isObjectSensor) {
-			return interpretObjectSensor(sensor, sprite);
-		} else {
-			return SensorHandler.getSensorValue(sensor);
-		}
-	}
-
-	private Object interpretFunction(Functions function, Sprite sprite) {
-		final double defaultReturnValue = 0d;
-
-		Object left = null;
-		Object right = null;
-		Double doubleValueOfLeftChild = null;
-		Double doubleValueOfRightChild = null;
-
-		if (leftChild != null) {
-			left = leftChild.interpretRecursive(sprite);
-			if (left instanceof String) {
-				try {
-					doubleValueOfLeftChild = Double.valueOf((String) left);
-				} catch (NumberFormatException numberFormatException) {
-					//This is expected
-				}
-			} else {
-				doubleValueOfLeftChild = (Double) left;
-			}
-		}
-
-		if (rightChild != null) {
-			right = rightChild.interpretRecursive(sprite);
-			if (right instanceof String) {
-				try {
-					doubleValueOfRightChild = Double.valueOf((String) right);
-				} catch (NumberFormatException numberFormatException) {
-					//This is expected
-				}
-			} else {
-				doubleValueOfRightChild = (Double) right;
-			}
-		}
+	private Object interpretFunction(Functions function, Sprite sprite, Project currentProject) {
+		Object firstArgument = tryInterpretRecursive(leftChild, sprite);
+		Object secondArgument = tryInterpretRecursive(rightChild, sprite);
 
 		switch (function) {
-			case SIN:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.sin(Math.toRadians(doubleValueOfLeftChild));
-			case COS:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.cos(Math.toRadians(doubleValueOfLeftChild));
-			case TAN:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.tan(Math.toRadians(doubleValueOfLeftChild));
-			case LN:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.log(doubleValueOfLeftChild);
-			case LOG:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.log10(doubleValueOfLeftChild);
-			case SQRT:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.sqrt(doubleValueOfLeftChild);
-			case RAND:
-				return (doubleValueOfLeftChild == null || doubleValueOfRightChild == null) ? defaultReturnValue
-						: interpretFunctionRand(doubleValueOfLeftChild, doubleValueOfRightChild);
-			case ABS:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.abs(doubleValueOfLeftChild);
-			case ROUND:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : (double) java.lang.Math.round(doubleValueOfLeftChild);
-			case PI:
-				return java.lang.Math.PI;
-			case MOD:
-				return (doubleValueOfLeftChild == null || doubleValueOfRightChild == null) ? defaultReturnValue
-						: interpretFunctionMod(doubleValueOfLeftChild, doubleValueOfRightChild);
-			case ARCSIN:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.toDegrees(Math.asin(doubleValueOfLeftChild));
-			case ARCCOS:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.toDegrees(Math.acos(doubleValueOfLeftChild));
-			case ARCTAN:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.toDegrees(Math.atan(doubleValueOfLeftChild));
-			case ARCTAN2:
-				if (doubleValueOfLeftChild == null || doubleValueOfRightChild == null) {
-					return defaultReturnValue;
-				}
-				if ((doubleValueOfLeftChild == 0) && (doubleValueOfRightChild == 0)) {
-					return -180 + java.lang.Math.random() * 360;
-				} else {
-					return java.lang.Math.toDegrees(java.lang.Math.atan2(doubleValueOfLeftChild, doubleValueOfRightChild));
-				}
-			case EXP:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.exp(doubleValueOfLeftChild);
-			case POWER:
-				return (doubleValueOfLeftChild == null || doubleValueOfRightChild == null) ? defaultReturnValue
-						: java.lang.Math.pow(doubleValueOfLeftChild, doubleValueOfRightChild);
-			case FLOOR:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.floor(doubleValueOfLeftChild);
-			case CEIL:
-				return doubleValueOfLeftChild == null ? defaultReturnValue : java.lang.Math.ceil(doubleValueOfLeftChild);
-			case MAX:
-				return (doubleValueOfLeftChild == null || doubleValueOfRightChild == null) ? defaultReturnValue : java.lang.Math.max(doubleValueOfLeftChild,
-						doubleValueOfRightChild);
-			case MIN:
-				return (doubleValueOfLeftChild == null || doubleValueOfRightChild == null) ? defaultReturnValue : java.lang.Math.min(doubleValueOfLeftChild,
-						doubleValueOfRightChild);
-			case TRUE:
-				return 1d;
-			case FALSE:
-				return 0d;
 			case LETTER:
-				return interpretFunctionLetter(right, left);
+				return interpretFunctionLetter(firstArgument, secondArgument);
 			case LENGTH:
-				return interpretFunctionLength(left, sprite);
+				return interpretFunctionLength(firstArgument, sprite, currentProject);
 			case JOIN:
-				return interpretFunctionJoin(sprite);
+				return interpretFunctionJoin(sprite, leftChild, rightChild);
 			case REGEX:
-				return interpretFunctionRegex(sprite);
-			case ARDUINODIGITAL:
-				Arduino arduinoDigital = ServiceProvider.getService(CatroidService.BLUETOOTH_DEVICE_SERVICE).getDevice(BluetoothDevice.ARDUINO);
-				if (arduinoDigital != null && doubleValueOfLeftChild != null) {
-					if (doubleValueOfLeftChild < 0 || doubleValueOfLeftChild > 13) {
-						return defaultReturnValue;
-					}
-					return arduinoDigital.getDigitalArduinoPin(doubleValueOfLeftChild.intValue());
-				}
-				break;
-			case ARDUINOANALOG:
-				Arduino arduinoAnalog = ServiceProvider.getService(CatroidService.BLUETOOTH_DEVICE_SERVICE).getDevice(BluetoothDevice.ARDUINO);
-				if (arduinoAnalog != null && doubleValueOfLeftChild != null) {
-					if (doubleValueOfLeftChild < 0 || doubleValueOfLeftChild > 5) {
-						return defaultReturnValue;
-					}
-					return arduinoAnalog.getAnalogArduinoPin(doubleValueOfLeftChild.intValue());
-				}
-				break;
-			case RASPIDIGITAL:
-				RPiSocketConnection connection = RaspberryPiService.getInstance().connection;
-				if (doubleValueOfLeftChild != null) {
-					int pin = doubleValueOfLeftChild.intValue();
-					try {
-						return connection.getPin(pin) ? 1d : 0d;
-					} catch (Exception e) {
-						//This is expected
-					}
-				}
-				break;
-			case MULTI_FINGER_TOUCHED:
-				return (doubleValueOfLeftChild != null && TouchUtil.isFingerTouching(doubleValueOfLeftChild.intValue()))
-						? 1d : defaultReturnValue;
-			case MULTI_FINGER_X:
-				return doubleValueOfLeftChild != null ? (double) TouchUtil.getX(doubleValueOfLeftChild
-						.intValue()) : defaultReturnValue;
-			case MULTI_FINGER_Y:
-				return doubleValueOfLeftChild != null ? (double) TouchUtil.getY(doubleValueOfLeftChild.intValue())
-						: defaultReturnValue;
+				return tryInterpretFunctionRegex(sprite, leftChild, rightChild);
 			case LIST_ITEM:
-				return interpretFunctionListItem(left, sprite);
+				return interpretFunctionListItem(firstArgument, sprite, currentProject);
 			case CONTAINS:
-				return interpretFunctionContains(right, sprite);
+				return interpretFunctionContains(secondArgument, sprite, currentProject);
 			case NUMBER_OF_ITEMS:
-				return interpretFunctionNumberOfItems(left, sprite);
+				return interpretFunctionNumberOfItems(firstArgument, sprite, currentProject);
+			default:
+				return interpretFormulaFunction(function, firstArgument, secondArgument);
 		}
-		return 0d;
 	}
 
-	private Object interpretFunctionNumberOfItems(Object left, Sprite sprite) {
+	@Nullable
+	private Object tryInterpretRecursive(FormulaElement element, Sprite sprite) {
+		if (element == null) {
+			return null;
+		}
+		return element.interpretRecursive(sprite);
+	}
+
+	private Object interpretFormulaFunction(Functions function, Object firstArgument, Object secondArgument) {
+		Double firstArgumentDouble = convertArgumentToDouble(firstArgument);
+		Double secondArgumentDouble = convertArgumentToDouble(secondArgument);
+		FormulaFunction formulaFunction = formulaFunctions.get(function);
+		if (formulaFunction == null) {
+			return FALSE;
+		}
+		return formulaFunction.execute(firstArgumentDouble, secondArgumentDouble);
+	}
+
+	private Object interpretFunctionNumberOfItems(Object left, Sprite sprite, Project currentProject) {
 		if (leftChild.type == ElementType.USER_LIST) {
-			return (double) handleNumberOfItemsOfUserListParameter(sprite);
-		}
-		return interpretFunctionLength(left, sprite);
-	}
-
-	private Object interpretFunctionContains(Object right, Sprite sprite) {
-		if (leftChild.getElementType() == ElementType.USER_LIST) {
-			Project currentProject = ProjectManager.getInstance().getCurrentProject();
 			UserList userList = UserDataWrapper.getUserList(leftChild.value, sprite, currentProject);
-
-			if (userList == null) {
-				return 0d;
-			}
-
-			for (Object userListElement : userList.getValue()) {
-				if (interpretOperatorEqual(userListElement, right) == 1d) {
-					return 1d;
-				}
-			}
+			return (double) handleNumberOfItemsOfUserListParameter(userList);
 		}
-
-		return 0d;
+		return interpretFunctionLength(left, sprite, currentProject);
 	}
 
-	private Object interpretFunctionListItem(Object left, Sprite sprite) {
-		UserList userList = null;
-		if (rightChild.getElementType() == ElementType.USER_LIST) {
-			Project currentProject = ProjectManager.getInstance().getCurrentProject();
-			userList = UserDataWrapper.getUserList(rightChild.value, sprite, currentProject);
+	private int handleNumberOfItemsOfUserListParameter(UserList userList) {
+		if (userList == null) {
+			return 0;
 		}
 
+		return userList.getValue().size();
+	}
+
+	private Object interpretFunctionContains(Object right, Sprite sprite, Project currentProject) {
+		UserList userList = getUserListOfChild(leftChild, sprite, currentProject);
+		if (userList == null) {
+			return FALSE;
+		}
+
+		for (Object userListElement : userList.getValue()) {
+			if (interpretOperatorEqual(userListElement, right)) {
+				return TRUE;
+			}
+		}
+
+		return FALSE;
+	}
+
+	private Object interpretFunctionListItem(Object left, Sprite sprite, Project currentProject) {
+		if (left == null) {
+			return "";
+		}
+
+		UserList userList = getUserListOfChild(rightChild, sprite, currentProject);
 		if (userList == null) {
 			return "";
 		}
 
-		int index = 0;
-		if (left instanceof String) {
-			try {
-				Double doubleValueOfLeftChild = Double.valueOf((String) left);
-				index = doubleValueOfLeftChild.intValue();
-			} catch (NumberFormatException numberFormatexception) {
-				//This is expected
-			}
-		} else if (left != null) {
-			index = ((Double) left).intValue();
-		} else {
+		int index = tryParseIntFromObject(left) - 1;
+
+		if (index < 0 || index >= userList.getValue().size()) {
 			return "";
 		}
-
-		index--;
-
-		if (index < 0) {
-			return "";
-		} else if (index >= userList.getValue().size()) {
-			return "";
-		}
-
 		return userList.getValue().get(index);
 	}
 
-	private Object interpretFunctionJoin(Sprite sprite) {
-		return stringWithoutTrailingZero(interpretInterpretFunctionStringParameter(leftChild, sprite))
-				+ stringWithoutTrailingZero(interpretInterpretFunctionStringParameter(rightChild, sprite));
+	@Nullable
+	private UserList getUserListOfChild(FormulaElement child, Sprite sprite, Project currentProject) {
+		if (child.getElementType() != ElementType.USER_LIST) {
+			return null;
+		}
+		return UserDataWrapper.getUserList(child.value, sprite, currentProject);
 	}
 
-	private Object interpretFunctionRegex(Sprite sprite) {
+	private static String interpretFunctionJoin(Sprite sprite, FormulaElement leftChild,
+			FormulaElement rightChild) {
+		return interpretFunctionString(leftChild, sprite) + interpretFunctionString(rightChild, sprite);
+	}
+
+	private static String tryInterpretFunctionRegex(Sprite sprite, FormulaElement leftChild,
+			FormulaElement rightChild) {
 		try {
-			Pattern pattern = Pattern.compile(
-					stringWithoutTrailingZero(interpretInterpretFunctionStringParameter(leftChild, sprite)),
-					Pattern.DOTALL | Pattern.MULTILINE);
-
-			Matcher matcher = pattern.matcher(
-					stringWithoutTrailingZero(interpretInterpretFunctionStringParameter(rightChild, sprite)));
-
-			if (matcher.find()) {
-				if (matcher.groupCount() == 0) {
-					return matcher.group(0);
-				} else {
-					return matcher.group(1);
-				}
-			} else {
-				return "";
-			}
+			String left = interpretFunctionString(leftChild, sprite);
+			String right = interpretFunctionString(rightChild, sprite);
+			return interpretFunctionRegex(left, right);
 		} catch (IllegalArgumentException exception) {
 			return exception.getLocalizedMessage();
 		}
 	}
 
-	private String interpretInterpretFunctionStringParameter(FormulaElement child, Sprite sprite) {
+	private static String interpretFunctionRegex(String patternString, String matcherString) {
+		Pattern pattern = Pattern.compile(patternString, Pattern.DOTALL | Pattern.MULTILINE);
+		Matcher matcher = pattern.matcher(matcherString);
+		if (matcher.find()) {
+			int groupIndex = matcher.groupCount() == 0 ? 0 : 1;
+			return matcher.group(groupIndex);
+		} else {
+			return "";
+		}
+	}
+
+	private static String interpretFunctionString(FormulaElement child, Sprite sprite) {
 		String parameterInterpretation = "";
 		if (child != null) {
 			if (child.getElementType() == ElementType.NUMBER) {
@@ -658,103 +487,84 @@ public class FormulaElement implements Serializable {
 				parameterInterpretation += child.interpretRecursive(sprite);
 			}
 		}
-		return parameterInterpretation;
+		return trimTrailingCharacters(parameterInterpretation);
 	}
 
-	private Object interpretFunctionLength(Object left, Sprite sprite) {
+	private Object interpretFunctionLength(Object left, Sprite sprite, Project currentProject) {
 		if (leftChild == null) {
 			return 0d;
 		}
-		if (leftChild.type == ElementType.NUMBER) {
-			return (double) leftChild.value.length();
-		}
-		if (leftChild.type == ElementType.STRING) {
-			return (double) leftChild.value.length();
-		}
-		if (leftChild.type == ElementType.USER_VARIABLE) {
-			return (double) handleLengthUserVariableParameter(sprite);
-		}
-		if (leftChild.type == ElementType.USER_LIST) {
-			Project currentProject = ProjectManager.getInstance().getCurrentProject();
-			UserList userList = UserDataWrapper.getUserList(leftChild.value, sprite, currentProject);
-			if (userList == null) {
-				return 0d;
-			}
-			if (userList.getValue().size() == 0) {
-				return 0d;
-			}
-
-			Object interpretedList = leftChild.interpretRecursive(sprite);
-			if (interpretedList instanceof Double) {
-				Double interpretedListDoubleValue = (Double) interpretedList;
-				if (interpretedListDoubleValue.isNaN() || interpretedListDoubleValue.isInfinite()) {
+		switch (leftChild.type) {
+			case NUMBER:
+			case STRING:
+				return (double) leftChild.value.length();
+			case USER_VARIABLE:
+				UserVariable userVariable = UserDataWrapper.getUserVariable(leftChild.value, sprite, currentProject);
+				return (double) calculateUserVariableLength(userVariable);
+			case USER_LIST:
+				UserList userList = UserDataWrapper.getUserList(leftChild.value, sprite, currentProject);
+				return calculateUserListLength(userList, left, sprite);
+			default:
+				if (left instanceof Double && ((Double) left).isNaN()) {
 					return 0d;
 				}
-				return (double) (String.valueOf(interpretedListDoubleValue.intValue())).length();
+				return (double) (String.valueOf(left)).length();
+		}
+	}
+
+	private int calculateUserVariableLength(UserVariable userVariable) {
+		Object userVariableValue = userVariable.getValue();
+		if (userVariableValue instanceof String) {
+			return String.valueOf(userVariableValue).length();
+		} else {
+			if (isInteger((Double) userVariableValue)) {
+				return Integer.toString(((Double) userVariableValue).intValue()).length();
+			} else {
+				return Double.toString(((Double) userVariableValue)).length();
 			}
-			if (interpretedList instanceof String) {
-				String interpretedListStringValue = (String) interpretedList;
-				return (double) interpretedListStringValue.length();
+		}
+	}
+
+	private double calculateUserListLength(UserList userList, Object left, Sprite sprite) {
+		if (userList == null || userList.getValue().isEmpty()) {
+			return FALSE;
+		}
+
+		Object interpretedList = leftChild.interpretRecursive(sprite);
+		if (interpretedList instanceof Double) {
+			Double interpretedListDoubleValue = (Double) interpretedList;
+			if (interpretedListDoubleValue.isNaN() || interpretedListDoubleValue.isInfinite()) {
+				return FALSE;
 			}
+			return String.valueOf(interpretedListDoubleValue.intValue()).length();
+		}
+		if (interpretedList instanceof String) {
+			String interpretedListStringValue = (String) interpretedList;
+			return interpretedListStringValue.length();
 		}
 		if (left instanceof Double && ((Double) left).isNaN()) {
-			return 0d;
+			return FALSE;
 		}
-		return (double) (String.valueOf(left)).length();
+		return String.valueOf(left).length();
 	}
 
-	private Object interpretFunctionLetter(Object right, Object left) {
-		int index = 0;
-		if (left instanceof String) {
-			try {
-				Double doubleValueOfLeftChild = Double.valueOf((String) left);
-				index = doubleValueOfLeftChild.intValue();
-			} catch (NumberFormatException numberFormatexception) {
-				//This is expected
-			}
-		} else if (left != null) {
-			index = ((Double) left).intValue();
-		} else {
+	private Object interpretFunctionLetter(Object left, Object right) {
+		if (left == null || right == null) {
 			return "";
 		}
 
-		index--;
+		int index = tryParseIntFromObject(left) - 1;
+		String stringValueOfRight = String.valueOf(right);
 
-		if (index < 0) {
-			return "";
-		} else if (right == null || index >= String.valueOf(right).length()) {
+		if (index < 0 || index >= stringValueOfRight.length()) {
 			return "";
 		}
-		return String.valueOf(String.valueOf(right).charAt(index));
+		return String.valueOf(stringValueOfRight.charAt(index));
 	}
 
-	private Object interpretFunctionMod(Object left, Object right) {
-
-		double dividend = (Double) left;
-		double divisor = (Double) right;
-
-		if (dividend == 0 || divisor == 0) {
-			return dividend;
-		}
-
-		if (divisor > 0) {
-			while (dividend < 0) {
-				dividend += java.lang.Math.abs(divisor);
-			}
-		} else {
-			if (dividend > 0) {
-				return (dividend % divisor) + divisor;
-			}
-		}
-
-		return dividend % divisor;
-	}
-
-	private Object interpretFunctionRand(Object left, Object right) {
-		double from = (double) left;
-		double to = (double) right;
-		double low = (from <= to) ? from : to;
-		double high = (from <= to) ? to : from;
+	private double interpretFunctionRand(double from, double to) {
+		double low = Math.min(from, to);
+		double high = Math.max(from, to);
 
 		if (low == high) {
 			return low;
@@ -762,7 +572,7 @@ public class FormulaElement implements Serializable {
 
 		if (isInteger(low) && isInteger(high)
 				&& !isNumberWithDecimalPoint(leftChild) && !isNumberWithDecimalPoint(rightChild)) {
-			return low + Math.floor(Math.random() * ((high + 1) - low));
+			return Math.floor(Math.random() * ((high + 1) - low)) + low;
 		} else {
 			return (Math.random() * (high - low)) + low;
 		}
@@ -772,233 +582,64 @@ public class FormulaElement implements Serializable {
 		return element.type == ElementType.NUMBER && element.value.contains(".");
 	}
 
-	private Object interpretOperator(Operators operator, Sprite sprite) {
-
-		if (leftChild != null) { // binary operator
-			Object leftObject;
-			Object rightObject;
-			try {
-				leftObject = leftChild.interpretRecursive(sprite);
-			} catch (NumberFormatException numberFormatException) {
-				leftObject = Double.NaN;
-			}
-
-			try {
-				rightObject = rightChild.interpretRecursive(sprite);
-			} catch (NumberFormatException numberFormatException) {
-				rightObject = Double.NaN;
-			}
-
-			Double left;
-			Double right;
-
-			switch (operator) {
-				case PLUS:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left + right;
-				case MINUS:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left - right;
-				case MULT:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left * right;
-				case DIVIDE:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left / right;
-				case POW:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return java.lang.Math.pow(left, right);
-				case EQUAL:
-					return interpretOperatorEqual(leftObject, rightObject);
-				case NOT_EQUAL:
-					return interpretOperatorEqual(leftObject, rightObject) == 1d ? 0d : 1d;
-				case GREATER_THAN:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left.compareTo(right) > 0 ? 1d : 0d;
-				case GREATER_OR_EQUAL:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left.compareTo(right) >= 0 ? 1d : 0d;
-				case SMALLER_THAN:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left.compareTo(right) < 0 ? 1d : 0d;
-				case SMALLER_OR_EQUAL:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left.compareTo(right) <= 0 ? 1d : 0d;
-				case LOGICAL_AND:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return (left * right) != 0d ? 1d : 0d;
-				case LOGICAL_OR:
-					left = interpretOperator(leftObject);
-					right = interpretOperator(rightObject);
-					return left != 0d || right != 0d ? 1d : 0d;
-			}
-		} else { //unary operators
-			Object rightObject;
-			try {
-				rightObject = rightChild.interpretRecursive(sprite);
-			} catch (NumberFormatException numberFormatException) {
-				rightObject = Double.NaN;
-			}
-
-			switch (operator) {
-				case MINUS:
-					Double result = interpretOperator(rightObject);
-					return -result;
-				case LOGICAL_NOT:
-					return interpretOperator(rightObject) == 0d ? 1d : 0d;
-			}
-		}
-		return 0d;
-	}
-
-	private Object interpretObjectSensor(Sensors sensor, Sprite sprite) {
-		Object returnValue = 0d;
-		LookData lookData = sprite.look.getLookData();
-		List<LookData> lookDataList = sprite.getLookList();
-		if (lookData == null && lookDataList.size() > 0) {
-			lookData = lookDataList.get(0);
-		}
-		switch (sensor) {
-			case OBJECT_BRIGHTNESS:
-				returnValue = (double) sprite.look.getBrightnessInUserInterfaceDimensionUnit();
-				break;
-			case OBJECT_COLOR:
-				returnValue = (double) sprite.look.getColorInUserInterfaceDimensionUnit();
-				break;
-			case OBJECT_TRANSPARENCY:
-				returnValue = (double) sprite.look.getTransparencyInUserInterfaceDimensionUnit();
-				break;
-			case OBJECT_LAYER:
-				if (sprite.look.getZIndex() < 0) {
-					returnValue = (double) ProjectManager.getInstance().getCurrentlyEditedScene()
-							.getSpriteList().indexOf(sprite);
-				} else if (sprite.look.getZIndex() == 0) {
-					returnValue = 0d;
-				} else {
-					returnValue = (double) sprite.look.getZIndex() - Constants.Z_INDEX_NUMBER_VIRTUAL_LAYERS;
-				}
-				break;
-			case OBJECT_ROTATION:
-				returnValue = (double) sprite.look.getDirectionInUserInterfaceDimensionUnit();
-				break;
-			case OBJECT_SIZE:
-				returnValue = (double) sprite.look.getSizeInUserInterfaceDimensionUnit();
-				break;
-			case OBJECT_X:
-				returnValue = (double) sprite.look.getXInUserInterfaceDimensionUnit();
-				break;
-			case OBJECT_Y:
-				returnValue = (double) sprite.look.getYInUserInterfaceDimensionUnit();
-				break;
-			case OBJECT_ANGULAR_VELOCITY:
-				returnValue = (double) sprite.look.getAngularVelocityInUserInterfaceDimensionUnit();
-				break;
-			case OBJECT_X_VELOCITY:
-				returnValue = (double) sprite.look.getXVelocityInUserInterfaceDimensionUnit();
-				break;
-			case OBJECT_Y_VELOCITY:
-				returnValue = (double) sprite.look.getYVelocityInUserInterfaceDimensionUnit();
-				break;
-			case OBJECT_LOOK_NUMBER:
-			case OBJECT_BACKGROUND_NUMBER:
-				returnValue = 1.0d + ((lookData != null) ? lookDataList.indexOf(lookData) : 0);
-				break;
-			case OBJECT_LOOK_NAME:
-			case OBJECT_BACKGROUND_NAME:
-				returnValue = (lookData != null) ? lookData.getName() : "";
-				break;
-			case OBJECT_DISTANCE_TO:
-				returnValue = (double) sprite.look.getDistanceToTouchPositionInUserInterfaceDimensions();
-				break;
-			case NFC_TAG_MESSAGE:
-				returnValue = NfcHandler.getLastNfcTagMessage();
-				break;
-			case NFC_TAG_ID:
-				returnValue = NfcHandler.getLastNfcTagId();
-				break;
-			case COLLIDES_WITH_EDGE:
-				if (StageActivity.stageListener != null) {
-					returnValue = StageActivity.stageListener.firstFrameDrawn ? CollisionDetection.collidesWithEdge(sprite
-							.look) : 0d;
-				} else {
-					returnValue = 0d;
-				}
-				break;
-			case COLLIDES_WITH_FINGER:
-				returnValue = CollisionDetection.collidesWithFinger(sprite.look);
-				break;
-		}
-		return returnValue;
-	}
-
-	private Double interpretOperatorEqual(Object left, Object right) {
-		try {
-			Double tempLeft = Double.valueOf(String.valueOf(left));
-			Double tempRight = Double.valueOf(String.valueOf(right));
-			int compareResult = getCompareResult(tempLeft, tempRight);
-			if (compareResult == 0) {
-				return 1d;
-			}
-			return 0d;
-		} catch (NumberFormatException numberFormatException) {
-			int compareResult = String.valueOf(left).compareTo(String.valueOf(right));
-			if (compareResult == 0) {
-				return 1d;
-			}
-			return 0d;
-		}
-	}
-
-	private int getCompareResult(Double left, Double right) {
-		int compareResult;
-		if (left == 0 || right == 0) {
-			compareResult = ((Double) Math.abs(left)).compareTo(Math.abs(right));
+	private double interpretOperator(@NotNull Operators operator, Sprite sprite) {
+		if (leftChild != null) {
+			return interpretBinaryOperator(operator, sprite);
 		} else {
-			compareResult = left.compareTo(right);
-		}
-		return compareResult;
-	}
-
-	private Double interpretOperator(Object object) {
-		if (object instanceof String) {
-			try {
-				return Double.valueOf((String) object);
-			} catch (NumberFormatException numberFormatException) {
-				return Double.NaN;
-			}
-		} else {
-			return (Double) object;
+			return interpretUnaryOperator(operator, sprite);
 		}
 	}
 
-	private Object normalizeDegeneratedDoubleValues(Object valueToCheck) {
+	private double interpretUnaryOperator(@NotNull Operators operator, Sprite sprite) {
+		Object rightObject = tryInterpretElementRecursive(rightChild, sprite);
+		double right = tryInterpretDoubleValue(rightObject);
 
-		if (valueToCheck instanceof String || valueToCheck instanceof Character) {
-			return valueToCheck;
+		switch (operator) {
+			case MINUS:
+				return -right;
+			case LOGICAL_NOT:
+				return booleanToDouble(right == FALSE);
+			default:
+				return FALSE;
 		}
+	}
 
-		if (valueToCheck == null) {
-			return 0.0;
-		}
+	private double interpretBinaryOperator(@NotNull Operators operator, Sprite sprite) {
+		Object leftObject = tryInterpretElementRecursive(leftChild, sprite);
+		Object rightObject = tryInterpretElementRecursive(rightChild, sprite);
+		Double left = tryInterpretDoubleValue(leftObject);
+		Double right = tryInterpretDoubleValue(rightObject);
 
-		if ((Double) valueToCheck == Double.NEGATIVE_INFINITY) {
-			return -Double.MAX_VALUE;
+		switch (operator) {
+			case PLUS:
+				return left + right;
+			case MINUS:
+				return left - right;
+			case MULT:
+				return left * right;
+			case DIVIDE:
+				return left / right;
+			case POW:
+				return Math.pow(left, right);
+			case EQUAL:
+				return booleanToDouble(interpretOperatorEqual(leftObject, rightObject));
+			case NOT_EQUAL:
+				return booleanToDouble(!(interpretOperatorEqual(leftObject, rightObject)));
+			case GREATER_THAN:
+				return booleanToDouble(left.compareTo(right) > 0);
+			case GREATER_OR_EQUAL:
+				return booleanToDouble(left.compareTo(right) >= 0);
+			case SMALLER_THAN:
+				return booleanToDouble(left.compareTo(right) < 0);
+			case SMALLER_OR_EQUAL:
+				return booleanToDouble(left.compareTo(right) <= 0);
+			case LOGICAL_AND:
+				return booleanToDouble(left != FALSE && right != FALSE);
+			case LOGICAL_OR:
+				return booleanToDouble(left != FALSE || right != FALSE);
+			default:
+				return FALSE;
 		}
-		if ((Double) valueToCheck == Double.POSITIVE_INFINITY) {
-			return Double.MAX_VALUE;
-		}
-
-		return valueToCheck;
 	}
 
 	public FormulaElement getParent() {
@@ -1043,10 +684,6 @@ public class FormulaElement implements Serializable {
 		cloneThis.parent.rightChild = cloneThis;
 	}
 
-	private boolean isInteger(double value) {
-		return ((Math.abs(value) - (int) Math.abs(value)) < Double.MIN_VALUE);
-	}
-
 	public boolean isLogicalOperator() {
 		return (type == ElementType.OPERATOR) && Operators.getOperatorByValue(value).isLogicalOperator;
 	}
@@ -1057,42 +694,7 @@ public class FormulaElement implements Serializable {
 				|| (rightChild != null && rightChild.containsElement(elementType)));
 	}
 
-	public boolean isUserVariableWithTypeString(Sprite sprite) {
-		if (type == ElementType.USER_VARIABLE) {
-			Project currentProject = ProjectManager.getInstance().getCurrentProject();
-			UserVariable userVariable = UserDataWrapper.getUserVariable(value, sprite, currentProject);
-			Object userVariableValue = userVariable.getValue();
-			return userVariableValue instanceof String;
-		}
-		return false;
-	}
-
-	private int handleLengthUserVariableParameter(Sprite sprite) {
-		Project currentProject = ProjectManager.getInstance().getCurrentProject();
-		UserVariable userVariable = UserDataWrapper.getUserVariable(leftChild.value, sprite, currentProject);
-		Object userVariableValue = userVariable.getValue();
-		if (userVariableValue instanceof String) {
-			return String.valueOf(userVariableValue).length();
-		} else {
-			if (isInteger((Double) userVariableValue)) {
-				return Integer.toString(((Double) userVariableValue).intValue()).length();
-			} else {
-				return Double.toString(((Double) userVariableValue)).length();
-			}
-		}
-	}
-
-	private int handleNumberOfItemsOfUserListParameter(Sprite sprite) {
-		Project currentProject = ProjectManager.getInstance().getCurrentProject();
-		UserList userList = UserDataWrapper.getUserList(leftChild.value, sprite, currentProject);
-		if (userList == null) {
-			return 0;
-		}
-
-		return userList.getValue().size();
-	}
-
-	boolean isNumber() {
+	public boolean isNumber() {
 		if (type == ElementType.OPERATOR) {
 			Operators operator = Operators.getOperatorByValue(value);
 			return (operator == Operators.MINUS) && (leftChild == null) && rightChild.isNumber();
@@ -1102,127 +704,37 @@ public class FormulaElement implements Serializable {
 
 	@Override
 	public FormulaElement clone() {
-		FormulaElement leftChildClone = leftChild == null ? null : leftChild.clone();
-		FormulaElement rightChildClone = rightChild == null ? null : rightChild.clone();
-		return new FormulaElement(type, value == null ? "" : value, null, leftChildClone, rightChildClone);
+		FormulaElement leftChildClone = tryCloneElement(leftChild);
+		FormulaElement rightChildClone = tryCloneElement(rightChild);
+		String valueClone = value == null ? "" : value;
+		return new FormulaElement(type, valueClone, null, leftChildClone, rightChildClone);
+	}
+
+	private FormulaElement tryCloneElement(FormulaElement element) {
+		return element == null ? null : element.clone();
 	}
 
 	public void addRequiredResources(final Set<Integer> requiredResourcesSet) {
-		if (leftChild != null) {
-			leftChild.addRequiredResources(requiredResourcesSet);
+		tryAddRequiredResources(requiredResourcesSet, leftChild);
+		tryAddRequiredResources(requiredResourcesSet, rightChild);
+
+		switch (type) {
+			case FUNCTION:
+				addFunctionResources(requiredResourcesSet, Functions.getFunctionByValue(value));
+				break;
+			case SENSOR:
+				addSensorsResources(requiredResourcesSet, Sensors.getSensorByValue(value));
+				break;
+			case COLLISION_FORMULA:
+				requiredResourcesSet.add(Brick.COLLISION);
+				break;
+			default:
 		}
-		if (rightChild != null) {
-			rightChild.addRequiredResources(requiredResourcesSet);
-		}
-		if (type == ElementType.FUNCTION) {
-			Functions functions = Functions.getFunctionByValue(value);
-			switch (functions) {
-				case ARDUINOANALOG:
-				case ARDUINODIGITAL:
-					requiredResourcesSet.add(Brick.BLUETOOTH_SENSORS_ARDUINO);
-					break;
-				case RASPIDIGITAL:
-					requiredResourcesSet.add(Brick.SOCKET_RASPI);
-					break;
-			}
-		}
-		if (type == ElementType.SENSOR) {
-			Sensors sensor = Sensors.getSensorByValue(value);
-			switch (sensor) {
-				case X_ACCELERATION:
-				case Y_ACCELERATION:
-				case Z_ACCELERATION:
-					requiredResourcesSet.add(Brick.SENSOR_ACCELERATION);
-					break;
+	}
 
-				case X_INCLINATION:
-				case Y_INCLINATION:
-					requiredResourcesSet.add(Brick.SENSOR_INCLINATION);
-					break;
-
-				case COMPASS_DIRECTION:
-					requiredResourcesSet.add(Brick.SENSOR_COMPASS);
-					break;
-
-				case LATITUDE:
-				case LONGITUDE:
-				case LOCATION_ACCURACY:
-				case ALTITUDE:
-					requiredResourcesSet.add(Brick.SENSOR_GPS);
-					break;
-
-				case FACE_DETECTED:
-				case FACE_SIZE:
-				case FACE_X_POSITION:
-				case FACE_Y_POSITION:
-					requiredResourcesSet.add(Brick.FACE_DETECTION);
-					break;
-
-				case NXT_SENSOR_1:
-				case NXT_SENSOR_2:
-				case NXT_SENSOR_3:
-				case NXT_SENSOR_4:
-					requiredResourcesSet.add(Brick.BLUETOOTH_LEGO_NXT);
-					break;
-
-				case EV3_SENSOR_1:
-				case EV3_SENSOR_2:
-				case EV3_SENSOR_3:
-				case EV3_SENSOR_4:
-					requiredResourcesSet.add(Brick.BLUETOOTH_LEGO_EV3);
-					break;
-
-				case PHIRO_FRONT_LEFT:
-				case PHIRO_FRONT_RIGHT:
-				case PHIRO_SIDE_LEFT:
-				case PHIRO_SIDE_RIGHT:
-				case PHIRO_BOTTOM_LEFT:
-				case PHIRO_BOTTOM_RIGHT:
-					requiredResourcesSet.add(Brick.BLUETOOTH_PHIRO);
-					break;
-
-				case DRONE_BATTERY_STATUS:
-				case DRONE_CAMERA_READY:
-				case DRONE_EMERGENCY_STATE:
-				case DRONE_FLYING:
-				case DRONE_INITIALIZED:
-				case DRONE_NUM_FRAMES:
-				case DRONE_RECORD_READY:
-				case DRONE_RECORDING:
-				case DRONE_USB_ACTIVE:
-				case DRONE_USB_REMAINING_TIME:
-					requiredResourcesSet.add(Brick.ARDRONE_SUPPORT);
-					break;
-
-				case NFC_TAG_MESSAGE:
-				case NFC_TAG_ID:
-					requiredResourcesSet.add(Brick.NFC_ADAPTER);
-					break;
-
-				case COLLIDES_WITH_EDGE:
-					requiredResourcesSet.add(Brick.COLLISION);
-					break;
-				case COLLIDES_WITH_FINGER:
-					requiredResourcesSet.add(Brick.COLLISION);
-					break;
-
-				case GAMEPAD_A_PRESSED:
-				case GAMEPAD_B_PRESSED:
-				case GAMEPAD_DOWN_PRESSED:
-				case GAMEPAD_UP_PRESSED:
-				case GAMEPAD_LEFT_PRESSED:
-				case GAMEPAD_RIGHT_PRESSED:
-					requiredResourcesSet.add(Brick.CAST_REQUIRED);
-					break;
-
-				case LOUDNESS:
-					requiredResourcesSet.add(Brick.MICROPHONE);
-					break;
-				default:
-			}
-		}
-		if (type == ElementType.COLLISION_FORMULA) {
-			requiredResourcesSet.add(Brick.COLLISION);
+	private void tryAddRequiredResources(Set<Integer> resourceSet, FormulaElement element) {
+		if (element != null) {
+			element.addRequiredResources(resourceSet);
 		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
@@ -22,6 +22,8 @@
  */
 package org.catrobat.catroid.formulaeditor;
 
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.sensing.CollisionDetection;
 
 import java.util.List;
@@ -68,7 +70,8 @@ public class InternToken {
 
 	public void updateCollisionFormulaToVersion() {
 		if (internTokenType == InternTokenType.COLLISION_FORMULA) {
-			String secondSpriteName = CollisionDetection.getSecondSpriteNameFromCollisionFormulaString(tokenStringValue);
+			Project currentProject = ProjectManager.getInstance().getCurrentProject();
+			String secondSpriteName = CollisionDetection.getSecondSpriteNameFromCollisionFormulaString(tokenStringValue, currentProject);
 			if (secondSpriteName != null) {
 				tokenStringValue = secondSpriteName;
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Operators.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Operators.java
@@ -22,7 +22,7 @@
  */
 package org.catrobat.catroid.formulaeditor;
 
-import android.util.Log;
+import org.catrobat.catroid.utils.EnumUtils;
 
 public enum Operators {
 	LOGICAL_AND(2, true), LOGICAL_OR(1, true), EQUAL(3, true), NOT_EQUAL(4, true), SMALLER_OR_EQUAL(4, true),
@@ -45,28 +45,14 @@ public enum Operators {
 	}
 
 	public int compareOperatorTo(Operators operator) {
-		int returnValue = 0;
-		if (priority > operator.priority) {
-			returnValue = 1;
-		} else if (priority == operator.priority) {
-			returnValue = 0;
-		} else if (priority < operator.priority) {
-			returnValue = -1;
-		}
-
-		return returnValue;
+		return Integer.compare(priority, operator.priority);
 	}
 
 	public static Operators getOperatorByValue(String value) {
-		try {
-			return valueOf(value);
-		} catch (IllegalArgumentException illegalArgumentException) {
-			Log.e(TAG, Log.getStackTraceString(illegalArgumentException));
-		}
-		return null;
+		return EnumUtils.getEnum(Operators.class, value);
 	}
 
 	public static boolean isOperator(String value) {
-		return getOperatorByValue(value) != null;
+		return EnumUtils.isValidEnum(Operators.class, value);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Sensors.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Sensors.java
@@ -22,7 +22,7 @@
  */
 package org.catrobat.catroid.formulaeditor;
 
-import android.util.Log;
+import org.catrobat.catroid.utils.EnumUtils;
 
 public enum Sensors {
 	X_ACCELERATION, Y_ACCELERATION, Z_ACCELERATION, COMPASS_DIRECTION, X_INCLINATION, Y_INCLINATION, LOUDNESS,
@@ -55,15 +55,10 @@ public enum Sensors {
 	}
 
 	public static boolean isSensor(String value) {
-		return getSensorByValue(value) != null;
+		return EnumUtils.isValidEnum(Sensors.class, value);
 	}
 
 	public static Sensors getSensorByValue(String value) {
-		try {
-			return valueOf(value);
-		} catch (IllegalArgumentException illegalArgumentException) {
-			Log.e(TAG, Log.getStackTraceString(illegalArgumentException));
-		}
-		return null;
+		return EnumUtils.getEnum(Sensors.class, value);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/common/Conversions.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/common/Conversions.java
@@ -1,0 +1,97 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2019 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.formulaeditor.common;
+
+import android.graphics.Color;
+
+import java.nio.ByteBuffer;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public final class Conversions {
+	public static final double TRUE = 1d;
+	public static final double FALSE = 0d;
+
+	private Conversions() {
+	}
+
+	@Nullable
+	public static Double tryParseDouble(String argument) {
+		try {
+			return Double.parseDouble(argument);
+		} catch (NumberFormatException numberFormatException) {
+			return null;
+		}
+	}
+
+	@ColorInt
+	public static int tryParseColor(String string) {
+		return tryParseColor(string, Color.BLACK);
+	}
+
+	@ColorInt
+	private static int tryParseColor(String string, int defaultValue) {
+		if (string != null && string.length() == 7 && string.matches("^#[0-9a-fA-F]+$")) {
+			return Color.parseColor(string);
+		} else {
+			return defaultValue;
+		}
+	}
+
+	@Nullable
+	public static Double convertArgumentToDouble(Object argument) {
+		if (argument == null) {
+			return null;
+		} else if (argument instanceof String) {
+			return tryParseDouble((String) argument);
+		} else {
+			return (Double) argument;
+		}
+	}
+
+	public static double booleanToDouble(boolean value) {
+		return value ? TRUE : FALSE;
+	}
+
+	public static boolean matchesColor(@NonNull ByteBuffer pixels, int color) {
+		byte[] bytes = new byte[pixels.remaining()];
+		pixels.get(bytes);
+
+		for (int i = 0; i < bytes.length; i += 4) {
+			int pixelColor = ((bytes[i] & 0xFF) << 16) | ((bytes[i + 1] & 0xFF) << 8) | bytes[i + 2] & 0xFF;
+			if (compareColors(color, pixelColor)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean compareColors(int colorA, int colorB) {
+		return (Color.red(colorA) & 0b11111000) == (Color.red(colorB) & 0b11111000)
+				&& (Color.green(colorA) & 0b11111000) == (Color.green(colorB) & 0b11111000)
+				&& (Color.blue(colorA) & 0b11110000) == (Color.blue(colorB) & 0b11110000);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/common/FormulaElementOperations.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/common/FormulaElementOperations.java
@@ -1,0 +1,359 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.formulaeditor.common;
+
+import android.content.res.Resources;
+
+import com.badlogic.gdx.math.Rectangle;
+
+import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.content.GroupSprite;
+import org.catrobat.catroid.content.Look;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.catrobat.catroid.formulaeditor.SensorHandler;
+import org.catrobat.catroid.formulaeditor.Sensors;
+import org.catrobat.catroid.formulaeditor.UserList;
+import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.nfc.NfcHandler;
+import org.catrobat.catroid.sensing.CollisionDetection;
+import org.catrobat.catroid.stage.StageActivity;
+import org.catrobat.catroid.stage.StageListener;
+import org.catrobat.catroid.utils.TouchUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.annotation.Nullable;
+
+import static org.catrobat.catroid.formulaeditor.common.Conversions.FALSE;
+import static org.catrobat.catroid.formulaeditor.common.Conversions.TRUE;
+import static org.catrobat.catroid.utils.NumberFormats.trimTrailingCharacters;
+
+public final class FormulaElementOperations {
+	private FormulaElementOperations() {
+	}
+
+	public static double getLookLayerIndex(Sprite sprite, Look look, List<Sprite> spriteList) {
+		int lookZIndex = look.getZIndex();
+		if (lookZIndex == 0) {
+			return 0;
+		} else if (lookZIndex < 0) {
+			return spriteList.indexOf(sprite);
+		} else {
+			return (double) lookZIndex - Constants.Z_INDEX_NUMBER_VIRTUAL_LAYERS;
+		}
+	}
+
+	public static boolean equalsDoubleIEEE754(double left, double right) {
+		return Double.isNaN(left) && Double.isNaN(right)
+				|| !Double.isNaN(left) && !Double.isNaN(right) && left >= right && left <= right;
+	}
+
+	public static boolean interpretOperatorEqual(Object left, Object right) {
+		String leftString = String.valueOf(left);
+		String rightString = String.valueOf(right);
+		try {
+			double tempLeft = Double.parseDouble(leftString);
+			double tempRight = Double.parseDouble(rightString);
+			return equalsDoubleIEEE754(tempLeft, tempRight);
+		} catch (NumberFormatException numberFormatException) {
+			return leftString.equals(rightString);
+		}
+	}
+
+	public static double tryInterpretDoubleValue(Object object) {
+		if (object instanceof String) {
+			try {
+				return Double.valueOf((String) object);
+			} catch (NumberFormatException numberFormatException) {
+				return Double.NaN;
+			}
+		} else {
+			return (double) object;
+		}
+	}
+
+	public static Object normalizeDegeneratedDoubleValues(Object value) {
+
+		if (value instanceof String || value instanceof Character) {
+			return value;
+		}
+
+		if (value == null) {
+			return 0.0;
+		}
+
+		if ((Double) value == Double.NEGATIVE_INFINITY) {
+			return -Double.MAX_VALUE;
+		}
+		if ((Double) value == Double.POSITIVE_INFINITY) {
+			return Double.MAX_VALUE;
+		}
+
+		return value;
+	}
+
+	public static boolean isInteger(double value) {
+		return !Double.isInfinite(value) && !Double.isNaN(value) && value == Math.rint(value);
+	}
+
+	public static double tryGetLookBackgroundNumber(LookData lookData, List<LookData> lookDataList) {
+		if (lookData == null) {
+			return 1;
+		}
+		return lookDataList.indexOf(lookData) + 1d;
+	}
+
+	public static String getLookBackgroundName(LookData lookData) {
+		if (lookData == null) {
+			return "";
+		}
+		return lookData.getName();
+	}
+
+	public static double tryCalculateCollidesWithEdge(Look look, StageListener stageListener,
+			Rectangle screen) {
+		if (stageListener == null || !stageListener.firstFrameDrawn) {
+			return FALSE;
+		}
+		return CollisionDetection.collidesWithEdge(look, screen);
+	}
+
+	public static double calculateCollidesWithFinger(Look look) {
+		return CollisionDetection.collidesWithFinger(look.getCurrentCollisionPolygon(),
+				TouchUtil.getCurrentTouchingPoints());
+	}
+
+	public static Object interpretObjectSensor(Sensors sensor, Sprite sprite,
+			Scene currentlyEditedScene, Project currentProject) {
+		Look look = sprite.look;
+		LookData lookData = look.getLookData();
+		List<LookData> lookDataList = sprite.getLookList();
+		if (lookData == null && !lookDataList.isEmpty()) {
+			lookData = lookDataList.get(0);
+		}
+		switch (sensor) {
+			case OBJECT_BRIGHTNESS:
+				return (double) look.getBrightnessInUserInterfaceDimensionUnit();
+			case OBJECT_COLOR:
+				return (double) look.getColorInUserInterfaceDimensionUnit();
+			case OBJECT_TRANSPARENCY:
+				return (double) look.getTransparencyInUserInterfaceDimensionUnit();
+			case OBJECT_LAYER:
+				return getLookLayerIndex(sprite, look, currentlyEditedScene.getSpriteList());
+			case OBJECT_ROTATION:
+				return (double) look.getDirectionInUserInterfaceDimensionUnit();
+			case OBJECT_SIZE:
+				return (double) look.getSizeInUserInterfaceDimensionUnit();
+			case OBJECT_X:
+				return (double) look.getXInUserInterfaceDimensionUnit();
+			case OBJECT_Y:
+				return (double) look.getYInUserInterfaceDimensionUnit();
+			case OBJECT_ANGULAR_VELOCITY:
+				return (double) look.getAngularVelocityInUserInterfaceDimensionUnit();
+			case OBJECT_X_VELOCITY:
+				return (double) look.getXVelocityInUserInterfaceDimensionUnit();
+			case OBJECT_Y_VELOCITY:
+				return (double) look.getYVelocityInUserInterfaceDimensionUnit();
+			case OBJECT_DISTANCE_TO:
+				return (double) look.getDistanceToTouchPositionInUserInterfaceDimensions();
+			case OBJECT_LOOK_NUMBER:
+			case OBJECT_BACKGROUND_NUMBER:
+				return tryGetLookBackgroundNumber(lookData, lookDataList);
+			case OBJECT_LOOK_NAME:
+			case OBJECT_BACKGROUND_NAME:
+				return getLookBackgroundName(lookData);
+			case NFC_TAG_MESSAGE:
+				return NfcHandler.getLastNfcTagMessage();
+			case NFC_TAG_ID:
+				return NfcHandler.getLastNfcTagId();
+			case COLLIDES_WITH_EDGE:
+				Rectangle screen = currentProject.getScreenRectangle();
+				return tryCalculateCollidesWithEdge(look, StageActivity.stageListener, screen);
+			case COLLIDES_WITH_FINGER:
+				return calculateCollidesWithFinger(look);
+			default:
+				return FALSE;
+		}
+	}
+
+	@NotNull
+	public static List<Sprite> getAllClones(Sprite sprite, StageListener stageListener) {
+		List<Sprite> spriteAndClones = new ArrayList<>();
+		spriteAndClones.add(sprite);
+		if (stageListener != null) {
+			spriteAndClones.addAll(stageListener.getAllClonesOfSprite(sprite));
+		}
+		return spriteAndClones;
+	}
+
+	public static Object interpretUserList(UserList userList) {
+		if (userList == null) {
+			return FALSE;
+		}
+
+		return interpretUserListValues(userList.getValue());
+	}
+
+	private static Object interpretUserListValues(List<Object> userListValues) {
+		if (userListValues.isEmpty()) {
+			return "";
+		} else if (userListValues.size() == 1) {
+			return userListValues.get(0);
+		} else {
+			return interpretMultipleItemsUserList(userListValues);
+		}
+	}
+
+	private static Object interpretMultipleItemsUserList(List<Object> userListValues) {
+		List<String> userListStringValues = new ArrayList<>();
+
+		for (Object listValue : userListValues) {
+			if (listValue instanceof Double) {
+				Double doubleValueOfListItem = (Double) listValue;
+				userListStringValues.add(trimTrailingCharacters(String.valueOf(doubleValueOfListItem.intValue())));
+			} else if (listValue instanceof String) {
+				String stringValueOfListItem = (String) listValue;
+				userListStringValues.add(trimTrailingCharacters(stringValueOfListItem));
+			}
+		}
+
+		StringBuilder stringBuilder = new StringBuilder(userListStringValues.size());
+		String separator = listConsistsOfSingleCharacters(userListStringValues) ? "" : " ";
+		for (String userListStringValue : userListStringValues) {
+			stringBuilder.append(trimTrailingCharacters(userListStringValue));
+			stringBuilder.append(separator);
+		}
+
+		return stringBuilder.toString().trim();
+	}
+
+	private static boolean listConsistsOfSingleCharacters(List<String> userListStringValues) {
+		for (String userListStringValue : userListStringValues) {
+			if (userListStringValue.length() > 1) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public static Object interpretUserVariable(UserVariable userVariable) {
+		if (userVariable == null) {
+			return FALSE;
+		}
+		return userVariable.getValue();
+	}
+
+	public static double interpretLookCollision(Look look, List<Look> looks) {
+		for (Look secondLook : looks) {
+			if (look.equals(secondLook)) {
+				continue;
+			}
+
+			if (CollisionDetection.checkCollisionBetweenLooks(look, secondLook) == TRUE) {
+				return TRUE;
+			}
+		}
+
+		return FALSE;
+	}
+
+	public static List<Look> toLooks(List<Sprite> sprites) {
+		List<Look> looks = new ArrayList<>(sprites.size());
+		for (Sprite sprite : sprites) {
+			looks.add(sprite.look);
+		}
+		return looks;
+	}
+
+	public static Object interpretSensor(Sprite sprite, Scene currentlyEditedScene,
+			Project currentProject, String value) {
+		Sensors sensor = Sensors.getSensorByValue(value);
+		if (sensor.isObjectSensor) {
+			return interpretObjectSensor(sensor, sprite, currentlyEditedScene, currentProject);
+		} else {
+			return SensorHandler.getSensorValue(sensor);
+		}
+	}
+
+	@Nullable
+	public static Sprite tryFindSprite(Scene scene, String spriteName) {
+		try {
+			return scene.getSprite(spriteName);
+		} catch (Resources.NotFoundException exception) {
+			return null;
+		}
+	}
+
+	public static double interpretCollision(Look firstLook, String secondSpriteName,
+			Scene currentlyPlayingScene, StageListener stageListener) {
+		Sprite secondSprite = tryFindSprite(currentlyPlayingScene, secondSpriteName);
+		if (secondSprite == null) {
+			return FALSE;
+		} else if (secondSprite instanceof GroupSprite) {
+			List<Sprite> spritesFromGroupWithGroupName = GroupSprite.getSpritesFromGroupWithGroupName(secondSpriteName, currentlyPlayingScene.getSpriteList());
+			return interpretLookCollision(firstLook, toLooks(spritesFromGroupWithGroupName));
+		} else {
+			return interpretLookCollision(firstLook, toLooks(getAllClones(secondSprite, stageListener)));
+		}
+	}
+
+	public static double tryInterpretCollision(Look firstLook, String secondSpriteName,
+			Scene currentlyPlayingScene, StageListener stageListener) {
+		try {
+			return interpretCollision(firstLook, secondSpriteName, currentlyPlayingScene, stageListener);
+		} catch (Exception e) {
+			return FALSE;
+		}
+	}
+
+	public static Object tryInterpretElementRecursive(FormulaElement element, Sprite sprite) {
+		try {
+			return element.interpretRecursive(sprite);
+		} catch (NumberFormatException numberFormatException) {
+			return Double.NaN;
+		}
+	}
+
+	public static int tryParseIntFromObject(Object value) {
+		if (value instanceof String) {
+			return tryParseIntFromString((String) value);
+		} else {
+			return ((Double) value).intValue();
+		}
+	}
+
+	private static int tryParseIntFromString(String value) {
+		try {
+			return Double.valueOf(value).intValue();
+		} catch (NumberFormatException numberFormatexception) {
+			return 0;
+		}
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/common/FormulaElementResources.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/common/FormulaElementResources.java
@@ -1,0 +1,129 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.formulaeditor.common;
+
+import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.formulaeditor.Functions;
+import org.catrobat.catroid.formulaeditor.Sensors;
+
+import java.util.Set;
+
+public final class FormulaElementResources {
+	private FormulaElementResources() {
+	}
+
+	public static void addSensorsResources(Set<Integer> resources, Sensors sensor) {
+		switch (sensor) {
+			case X_ACCELERATION:
+			case Y_ACCELERATION:
+			case Z_ACCELERATION:
+				resources.add(Brick.SENSOR_ACCELERATION);
+				break;
+			case X_INCLINATION:
+			case Y_INCLINATION:
+				resources.add(Brick.SENSOR_INCLINATION);
+				break;
+			case COMPASS_DIRECTION:
+				resources.add(Brick.SENSOR_COMPASS);
+				break;
+			case LATITUDE:
+			case LONGITUDE:
+			case LOCATION_ACCURACY:
+			case ALTITUDE:
+				resources.add(Brick.SENSOR_GPS);
+				break;
+			case FACE_DETECTED:
+			case FACE_SIZE:
+			case FACE_X_POSITION:
+			case FACE_Y_POSITION:
+				resources.add(Brick.FACE_DETECTION);
+				break;
+			case NXT_SENSOR_1:
+			case NXT_SENSOR_2:
+			case NXT_SENSOR_3:
+			case NXT_SENSOR_4:
+				resources.add(Brick.BLUETOOTH_LEGO_NXT);
+				break;
+			case EV3_SENSOR_1:
+			case EV3_SENSOR_2:
+			case EV3_SENSOR_3:
+			case EV3_SENSOR_4:
+				resources.add(Brick.BLUETOOTH_LEGO_EV3);
+				break;
+			case PHIRO_FRONT_LEFT:
+			case PHIRO_FRONT_RIGHT:
+			case PHIRO_SIDE_LEFT:
+			case PHIRO_SIDE_RIGHT:
+			case PHIRO_BOTTOM_LEFT:
+			case PHIRO_BOTTOM_RIGHT:
+				resources.add(Brick.BLUETOOTH_PHIRO);
+				break;
+			case DRONE_BATTERY_STATUS:
+			case DRONE_CAMERA_READY:
+			case DRONE_EMERGENCY_STATE:
+			case DRONE_FLYING:
+			case DRONE_INITIALIZED:
+			case DRONE_NUM_FRAMES:
+			case DRONE_RECORD_READY:
+			case DRONE_RECORDING:
+			case DRONE_USB_ACTIVE:
+			case DRONE_USB_REMAINING_TIME:
+				resources.add(Brick.ARDRONE_SUPPORT);
+				break;
+			case NFC_TAG_MESSAGE:
+			case NFC_TAG_ID:
+				resources.add(Brick.NFC_ADAPTER);
+				break;
+			case COLLIDES_WITH_EDGE:
+			case COLLIDES_WITH_FINGER:
+				resources.add(Brick.COLLISION);
+				break;
+			case GAMEPAD_A_PRESSED:
+			case GAMEPAD_B_PRESSED:
+			case GAMEPAD_DOWN_PRESSED:
+			case GAMEPAD_UP_PRESSED:
+			case GAMEPAD_LEFT_PRESSED:
+			case GAMEPAD_RIGHT_PRESSED:
+				resources.add(Brick.CAST_REQUIRED);
+				break;
+			case LOUDNESS:
+				resources.add(Brick.MICROPHONE);
+				break;
+			default:
+		}
+	}
+
+	public static void addFunctionResources(Set<Integer> resources, Functions functions) {
+		switch (functions) {
+			case ARDUINOANALOG:
+			case ARDUINODIGITAL:
+				resources.add(Brick.BLUETOOTH_SENSORS_ARDUINO);
+				break;
+			case RASPIDIGITAL:
+				resources.add(Brick.SOCKET_RASPI);
+				break;
+			default:
+		}
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/ArduinoFunctionProvider.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/ArduinoFunctionProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2019 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.formulaeditor.function;
+
+import org.catrobat.catroid.bluetooth.base.BluetoothDevice;
+import org.catrobat.catroid.common.CatroidService;
+import org.catrobat.catroid.common.ServiceProvider;
+import org.catrobat.catroid.devices.arduino.Arduino;
+import org.catrobat.catroid.formulaeditor.Functions;
+
+import java.util.Map;
+
+public class ArduinoFunctionProvider implements FunctionProvider {
+	@Override
+	public void addFunctionsToMap(Map<Functions, FormulaFunction> formulaFunctions) {
+		formulaFunctions.put(Functions.ARDUINODIGITAL, new UnaryFunction(this::interpretFunctionArduinoDigital));
+		formulaFunctions.put(Functions.ARDUINOANALOG, new UnaryFunction(this::interpretFunctionArduinoAnalog));
+	}
+
+	private double interpretFunctionArduinoAnalog(double argument) {
+		Arduino arduino = getArduino();
+		if (arduino == null || argument < 0 || argument > 5) {
+			return 0;
+		}
+		return arduino.getAnalogArduinoPin((int) argument);
+	}
+
+	private double interpretFunctionArduinoDigital(double argument) {
+		Arduino arduino = getArduino();
+		if (arduino == null || argument < 0 || argument > 13) {
+			return 0;
+		}
+		return arduino.getDigitalArduinoPin((int) argument);
+	}
+
+	private Arduino getArduino() {
+		return ServiceProvider.getService(CatroidService.BLUETOOTH_DEVICE_SERVICE).getDevice(BluetoothDevice.ARDUINO);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/BinaryFunction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/BinaryFunction.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2019 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,23 +20,31 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.catroid.formulaeditor;
 
-import org.catrobat.catroid.utils.EnumUtils;
+package org.catrobat.catroid.formulaeditor.function;
 
-public enum Functions {
+public class BinaryFunction implements FormulaFunction, BinaryFunctionAction {
+	private final BinaryFunctionAction action;
 
-	SIN, COS, TAN, LN, LOG, SQRT, RAND, ROUND, ABS, PI, MOD, ARCSIN, ARCCOS, ARCTAN, ARCTAN2, EXP, POWER, FLOOR, CEIL,
-	MAX,
-	MIN, TRUE, FALSE, LENGTH,
-	LETTER, JOIN, REGEX, LIST_ITEM, CONTAINS, NUMBER_OF_ITEMS, ARDUINOANALOG, ARDUINODIGITAL, RASPIDIGITAL,
-	MULTI_FINGER_X, MULTI_FINGER_Y, MULTI_FINGER_TOUCHED;
-
-	public static boolean isFunction(String value) {
-		return EnumUtils.isValidEnum(Functions.class, value);
+	public BinaryFunction(BinaryFunctionAction action) {
+		this.action = action;
 	}
 
-	public static Functions getFunctionByValue(String value) {
-		return EnumUtils.getEnum(Functions.class, value);
+	@Override
+	public Double execute(Double firstArgument, Double secondArgument) {
+		if (firstArgument == null || secondArgument == null) {
+			return 0d;
+		} else {
+			return action.execute(firstArgument, secondArgument);
+		}
+	}
+
+	@Override
+	public Double execute(Double... args) {
+		if (args == null || args.length < 2) {
+			return 0d;
+		} else {
+			return execute(args[0], args[1]);
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/BinaryFunctionAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/BinaryFunctionAction.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2019 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,23 +20,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.catroid.formulaeditor;
 
-import org.catrobat.catroid.utils.EnumUtils;
+package org.catrobat.catroid.formulaeditor.function;
 
-public enum Functions {
-
-	SIN, COS, TAN, LN, LOG, SQRT, RAND, ROUND, ABS, PI, MOD, ARCSIN, ARCCOS, ARCTAN, ARCTAN2, EXP, POWER, FLOOR, CEIL,
-	MAX,
-	MIN, TRUE, FALSE, LENGTH,
-	LETTER, JOIN, REGEX, LIST_ITEM, CONTAINS, NUMBER_OF_ITEMS, ARDUINOANALOG, ARDUINODIGITAL, RASPIDIGITAL,
-	MULTI_FINGER_X, MULTI_FINGER_Y, MULTI_FINGER_TOUCHED;
-
-	public static boolean isFunction(String value) {
-		return EnumUtils.isValidEnum(Functions.class, value);
-	}
-
-	public static Functions getFunctionByValue(String value) {
-		return EnumUtils.getEnum(Functions.class, value);
-	}
+public interface BinaryFunctionAction {
+	Double execute(Double firstArgument, Double secondArgument);
 }

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/FormulaFunction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/FormulaFunction.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2019 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,23 +20,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.catroid.formulaeditor;
 
-import org.catrobat.catroid.utils.EnumUtils;
+package org.catrobat.catroid.formulaeditor.function;
 
-public enum Functions {
-
-	SIN, COS, TAN, LN, LOG, SQRT, RAND, ROUND, ABS, PI, MOD, ARCSIN, ARCCOS, ARCTAN, ARCTAN2, EXP, POWER, FLOOR, CEIL,
-	MAX,
-	MIN, TRUE, FALSE, LENGTH,
-	LETTER, JOIN, REGEX, LIST_ITEM, CONTAINS, NUMBER_OF_ITEMS, ARDUINOANALOG, ARDUINODIGITAL, RASPIDIGITAL,
-	MULTI_FINGER_X, MULTI_FINGER_Y, MULTI_FINGER_TOUCHED;
-
-	public static boolean isFunction(String value) {
-		return EnumUtils.isValidEnum(Functions.class, value);
-	}
-
-	public static Functions getFunctionByValue(String value) {
-		return EnumUtils.getEnum(Functions.class, value);
-	}
+public interface FormulaFunction {
+	Double execute(Double... args);
 }

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/FunctionProvider.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/FunctionProvider.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2019 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,23 +20,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.catroid.formulaeditor;
 
-import org.catrobat.catroid.utils.EnumUtils;
+package org.catrobat.catroid.formulaeditor.function;
 
-public enum Functions {
+import org.catrobat.catroid.formulaeditor.Functions;
 
-	SIN, COS, TAN, LN, LOG, SQRT, RAND, ROUND, ABS, PI, MOD, ARCSIN, ARCCOS, ARCTAN, ARCTAN2, EXP, POWER, FLOOR, CEIL,
-	MAX,
-	MIN, TRUE, FALSE, LENGTH,
-	LETTER, JOIN, REGEX, LIST_ITEM, CONTAINS, NUMBER_OF_ITEMS, ARDUINOANALOG, ARDUINODIGITAL, RASPIDIGITAL,
-	MULTI_FINGER_X, MULTI_FINGER_Y, MULTI_FINGER_TOUCHED;
+import java.util.Map;
 
-	public static boolean isFunction(String value) {
-		return EnumUtils.isValidEnum(Functions.class, value);
-	}
-
-	public static Functions getFunctionByValue(String value) {
-		return EnumUtils.getEnum(Functions.class, value);
-	}
+public interface FunctionProvider {
+	void addFunctionsToMap(Map<Functions, FormulaFunction> formulaFunctions);
 }

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/MathFunctionProvider.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/MathFunctionProvider.java
@@ -1,0 +1,85 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2019 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.formulaeditor.function;
+
+import org.catrobat.catroid.formulaeditor.Functions;
+
+import java.util.Map;
+
+import static org.catrobat.catroid.formulaeditor.common.Conversions.FALSE;
+import static org.catrobat.catroid.formulaeditor.common.Conversions.TRUE;
+
+public class MathFunctionProvider implements FunctionProvider {
+	@Override
+	public void addFunctionsToMap(Map<Functions, FormulaFunction> formulaFunctions) {
+		formulaFunctions.put(Functions.SIN, new UnaryFunction(argument -> Math.sin(Math.toRadians(argument))));
+		formulaFunctions.put(Functions.COS, new UnaryFunction(argument -> Math.cos(Math.toRadians(argument))));
+		formulaFunctions.put(Functions.TAN, new UnaryFunction(argument -> Math.tan(Math.toRadians(argument))));
+		formulaFunctions.put(Functions.ARCTAN2, new BinaryFunction(this::interpretFunctionArcTan2));
+		formulaFunctions.put(Functions.LN, new UnaryFunction(Math::log));
+		formulaFunctions.put(Functions.LOG, new UnaryFunction(Math::log10));
+		formulaFunctions.put(Functions.SQRT, new UnaryFunction(Math::sqrt));
+		formulaFunctions.put(Functions.ABS, new UnaryFunction(Math::abs));
+		formulaFunctions.put(Functions.ROUND, new UnaryFunction(argument -> (double) Math.round(argument)));
+		formulaFunctions.put(Functions.PI, args -> Math.PI);
+		formulaFunctions.put(Functions.ARCSIN, new UnaryFunction(argument -> Math.toDegrees(Math.asin(argument))));
+		formulaFunctions.put(Functions.ARCCOS, new UnaryFunction(argument -> Math.toDegrees(Math.acos(argument))));
+		formulaFunctions.put(Functions.ARCTAN, new UnaryFunction(argument -> Math.toDegrees(Math.atan(argument))));
+		formulaFunctions.put(Functions.EXP, new UnaryFunction(Math::exp));
+		formulaFunctions.put(Functions.POWER, new BinaryFunction(Math::pow));
+		formulaFunctions.put(Functions.FLOOR, new UnaryFunction(Math::floor));
+		formulaFunctions.put(Functions.CEIL, new UnaryFunction(Math::ceil));
+		formulaFunctions.put(Functions.MAX, new BinaryFunction(Math::max));
+		formulaFunctions.put(Functions.MIN, new BinaryFunction(Math::min));
+		formulaFunctions.put(Functions.TRUE, args -> TRUE);
+		formulaFunctions.put(Functions.FALSE, args -> FALSE);
+		formulaFunctions.put(Functions.MOD, new BinaryFunction(this::interpretFunctionMod));
+	}
+
+	private double interpretFunctionMod(double dividend, double divisor) {
+		if (dividend == 0 || divisor == 0) {
+			return dividend;
+		}
+
+		if (divisor > 0) {
+			while (dividend < 0) {
+				dividend += Math.abs(divisor);
+			}
+		} else {
+			if (dividend > 0) {
+				return (dividend % divisor) + divisor;
+			}
+		}
+
+		return dividend % divisor;
+	}
+
+	private double interpretFunctionArcTan2(double firstArgument, double secondArgument) {
+		if ((firstArgument == 0) && (secondArgument == 0)) {
+			return Math.random() * 360 - 180;
+		} else {
+			return Math.toDegrees(Math.atan2(firstArgument, secondArgument));
+		}
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/RaspiFunctionProvider.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/RaspiFunctionProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2019 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.formulaeditor.function;
+
+import android.util.Log;
+
+import org.catrobat.catroid.devices.raspberrypi.RPiSocketConnection;
+import org.catrobat.catroid.devices.raspberrypi.RaspberryPiService;
+import org.catrobat.catroid.formulaeditor.Functions;
+
+import java.util.Map;
+
+public class RaspiFunctionProvider implements FunctionProvider {
+	@Override
+	public void addFunctionsToMap(Map<Functions, FormulaFunction> formulaFunctions) {
+		formulaFunctions.put(Functions.RASPIDIGITAL, new UnaryFunction(this::interpretFunctionRaspiDigital));
+	}
+
+	private double interpretFunctionRaspiDigital(Double argument) {
+		RPiSocketConnection connection = RaspberryPiService.getInstance().connection;
+		if (argument == null) {
+			return 0d;
+		}
+		try {
+			int pin = argument.intValue();
+			return booleanToDouble(connection.getPin(pin));
+		} catch (Exception e) {
+			Log.e(getClass().getSimpleName(), "RPi: exception during getPin: " + e);
+		}
+		return 0d;
+	}
+
+	private double booleanToDouble(boolean value) {
+		return value ? 1 : 0;
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/TouchFunctionProvider.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/TouchFunctionProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2019 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.formulaeditor.function;
+
+import org.catrobat.catroid.formulaeditor.Functions;
+import org.catrobat.catroid.utils.TouchUtil;
+
+import java.util.Map;
+
+public class TouchFunctionProvider implements FunctionProvider {
+	@Override
+	public void addFunctionsToMap(Map<Functions, FormulaFunction> formulaFunctions) {
+		formulaFunctions.put(Functions.MULTI_FINGER_TOUCHED, new UnaryFunction(this::interpretFunctionFingerTouched));
+		formulaFunctions.put(Functions.MULTI_FINGER_X, new UnaryFunction(this::interpretFunctionMultiFingerX));
+		formulaFunctions.put(Functions.MULTI_FINGER_Y, new UnaryFunction(this::interpretFunctionMultiFingerY));
+	}
+
+	private double interpretFunctionMultiFingerY(double argument) {
+		return TouchUtil.getY((int) argument);
+	}
+
+	private double interpretFunctionMultiFingerX(double argument) {
+		return TouchUtil.getX((int) argument);
+	}
+
+	private double interpretFunctionFingerTouched(double argument) {
+		return booleanToDouble(TouchUtil.isFingerTouching((int) argument));
+	}
+
+	private double booleanToDouble(boolean value) {
+		return value ? 1 : 0;
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/UnaryFunction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/UnaryFunction.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2019 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,23 +20,31 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.catroid.formulaeditor;
 
-import org.catrobat.catroid.utils.EnumUtils;
+package org.catrobat.catroid.formulaeditor.function;
 
-public enum Functions {
+public class UnaryFunction implements FormulaFunction, UnaryFunctionAction {
+	private final UnaryFunctionAction action;
 
-	SIN, COS, TAN, LN, LOG, SQRT, RAND, ROUND, ABS, PI, MOD, ARCSIN, ARCCOS, ARCTAN, ARCTAN2, EXP, POWER, FLOOR, CEIL,
-	MAX,
-	MIN, TRUE, FALSE, LENGTH,
-	LETTER, JOIN, REGEX, LIST_ITEM, CONTAINS, NUMBER_OF_ITEMS, ARDUINOANALOG, ARDUINODIGITAL, RASPIDIGITAL,
-	MULTI_FINGER_X, MULTI_FINGER_Y, MULTI_FINGER_TOUCHED;
-
-	public static boolean isFunction(String value) {
-		return EnumUtils.isValidEnum(Functions.class, value);
+	public UnaryFunction(UnaryFunctionAction action) {
+		this.action = action;
 	}
 
-	public static Functions getFunctionByValue(String value) {
-		return EnumUtils.getEnum(Functions.class, value);
+	@Override
+	public Double execute(Double argument) {
+		if (argument == null) {
+			return 0d;
+		} else {
+			return action.execute(argument);
+		}
+	}
+
+	@Override
+	public Double execute(Double... args) {
+		if (args == null || args.length < 1) {
+			return 0d;
+		} else {
+			return execute(args[0]);
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/UnaryFunctionAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/function/UnaryFunctionAction.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2019 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,23 +20,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.catroid.formulaeditor;
 
-import org.catrobat.catroid.utils.EnumUtils;
+package org.catrobat.catroid.formulaeditor.function;
 
-public enum Functions {
-
-	SIN, COS, TAN, LN, LOG, SQRT, RAND, ROUND, ABS, PI, MOD, ARCSIN, ARCCOS, ARCTAN, ARCTAN2, EXP, POWER, FLOOR, CEIL,
-	MAX,
-	MIN, TRUE, FALSE, LENGTH,
-	LETTER, JOIN, REGEX, LIST_ITEM, CONTAINS, NUMBER_OF_ITEMS, ARDUINOANALOG, ARDUINODIGITAL, RASPIDIGITAL,
-	MULTI_FINGER_X, MULTI_FINGER_Y, MULTI_FINGER_TOUCHED;
-
-	public static boolean isFunction(String value) {
-		return EnumUtils.isValidEnum(Functions.class, value);
-	}
-
-	public static Functions getFunctionByValue(String value) {
-		return EnumUtils.getEnum(Functions.class, value);
-	}
+public interface UnaryFunctionAction {
+	Double execute(Double argument);
 }

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionDetection.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionDetection.java
@@ -30,12 +30,11 @@ import com.badlogic.gdx.math.Polygon;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 
-import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.content.Look;
+import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
-import org.catrobat.catroid.utils.TouchUtil;
 
 import java.util.ArrayList;
 
@@ -128,10 +127,10 @@ public final class CollisionDetection {
 		return false;
 	}
 
-	public static String getSecondSpriteNameFromCollisionFormulaString(String formula) {
+	public static String getSecondSpriteNameFromCollisionFormulaString(String formula, Project currentProject) {
 
 		int indexOfSpriteInFormula = formula.length();
-		for (Scene scene : ProjectManager.getInstance().getCurrentProject().getSceneList()) {
+		for (Scene scene : currentProject.getSceneList()) {
 			for (Sprite sprite : scene.getSpriteList()) {
 				int index = formula.lastIndexOf(sprite.getName());
 				if (index > 0 && index + sprite.getName().length() == formula.length() && index
@@ -143,22 +142,19 @@ public final class CollisionDetection {
 		if (indexOfSpriteInFormula >= formula.length()) {
 			return null;
 		}
-		String secondSpriteName = formula.substring(indexOfSpriteInFormula, formula.length());
+		String secondSpriteName = formula.substring(indexOfSpriteInFormula);
 		return secondSpriteName;
 	}
 
-	public static double collidesWithEdge(Look look) {
-		int virtualScreenWidth = ProjectManager.getInstance().getCurrentProject().getXmlHeader().virtualScreenWidth;
-		int virtualScreenHeight = ProjectManager.getInstance().getCurrentProject().getXmlHeader().virtualScreenHeight;
-		Rectangle screen = new Rectangle(-virtualScreenWidth / 2, -virtualScreenHeight / 2, virtualScreenWidth,
-				virtualScreenHeight);
+	public static double collidesWithEdge(Look look, Rectangle screen) {
+		Vector2 firstPoint = new Vector2();
+		Vector2 secondPoint = new Vector2();
 		//check if any line of the collision polygons intersects with the screen boundary
 		for (Polygon polygon : look.getCurrentCollisionPolygon()) {
-			for (int i = 0; i < polygon.getTransformedVertices().length - 4; i += 2) {
-				Vector2 firstPoint = new Vector2(polygon.getTransformedVertices()[i],
-						polygon.getTransformedVertices()[i + 1]);
-				Vector2 secondPoint = new Vector2(polygon.getTransformedVertices()[i + 2],
-						polygon.getTransformedVertices()[i + 3]);
+			float[] transformedVertices = polygon.getTransformedVertices();
+			for (int i = 0; i < transformedVertices.length - 4; i += 2) {
+				firstPoint.set(transformedVertices[i], transformedVertices[i + 1]);
+				secondPoint.set(transformedVertices[i + 2], transformedVertices[i + 3]);
 
 				//if the line crosses the screen boarder, a collision is detected
 				if (screen.contains(firstPoint) ^ screen.contains(secondPoint)) {
@@ -169,7 +165,7 @@ public final class CollisionDetection {
 		return 0d;
 	}
 
-	public static double collidesWithFinger(Look look) {
+	public static double collidesWithFinger(Polygon[] currentCollisionPolygon, ArrayList<PointF> touchingPoints) {
 		/*The touching points are expanded to circles with Constants.COLLISION_WITH_FINGER_TOUCH_RADIUS
 		to simulate the real touching area of the finger (which is not only a point, but a small area)
 		To improve performance first check if the circle is contained in the bounding box of that polygon
@@ -183,7 +179,6 @@ public final class CollisionDetection {
 		  | |___| |
 		  |_______|
 		*/
-		ArrayList<PointF> touchingPoints = TouchUtil.getCurrentTouchingPoints();
 		Vector2 start = new Vector2();
 		Vector2 end = new Vector2();
 		Vector2 center = new Vector2();
@@ -192,7 +187,7 @@ public final class CollisionDetection {
 		for (PointF point : touchingPoints) {
 			center.set(point.x, point.y);
 			int containedIn = 0;
-			for (Polygon polygon : look.getCurrentCollisionPolygon()) {
+			for (Polygon polygon : currentCollisionPolygon) {
 				Rectangle boundingRectangle = polygon.getBoundingRectangle();
 				boundingRectangle.x -= touchRadius;
 				boundingRectangle.y -= touchRadius;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ScratchProgramDetailsActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ScratchProgramDetailsActivity.java
@@ -66,7 +66,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.RecyclerView;
 
-import static org.catrobat.catroid.utils.NumberFormats.humanFriendlyFormattedShortNumber;
+import static org.catrobat.catroid.utils.NumberFormats.toMetricPostfixNotation;
 
 public class ScratchProgramDetailsActivity extends BaseActivity implements
 		FetchScratchProgramDetailsTask.ScratchProgramListTaskDelegate,
@@ -95,7 +95,7 @@ public class ScratchProgramDetailsActivity extends BaseActivity implements
 
 		setContentView(R.layout.activity_scratch_project_details);
 
-		setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+		setSupportActionBar(findViewById(R.id.toolbar));
 		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 		String scratchConverter = getString(R.string.main_menu_scratch_converter);
 		SpannableString scratchConverterBeta = new SpannableString(scratchConverter
@@ -270,11 +270,11 @@ public class ScratchProgramDetailsActivity extends BaseActivity implements
 		}
 
 		((TextView) findViewById(R.id.scratch_project_favorites_text))
-				.setText(humanFriendlyFormattedShortNumber(programData.getFavorites()));
+				.setText(toMetricPostfixNotation(programData.getFavorites()));
 		((TextView) findViewById(R.id.scratch_project_loves_text))
-				.setText(humanFriendlyFormattedShortNumber(programData.getLoves()));
+				.setText(toMetricPostfixNotation(programData.getLoves()));
 		((TextView) findViewById(R.id.scratch_project_views_text))
-				.setText(humanFriendlyFormattedShortNumber(programData.getViews()));
+				.setText(toMetricPostfixNotation(programData.getViews()));
 
 		TextView dateSharedView = findViewById(R.id.date_shared_view);
 		TextView dateModifiedView = findViewById(R.id.date_modified_view);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/ListRVAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/ListRVAdapter.java
@@ -35,7 +35,7 @@ import org.catrobat.catroid.ui.recyclerview.viewholder.ListVH;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.catrobat.catroid.utils.NumberFormats.stringWithoutTrailingZero;
+import static org.catrobat.catroid.utils.NumberFormats.trimTrailingCharacters;
 
 public class ListRVAdapter extends RVAdapter<UserList> {
 
@@ -59,7 +59,7 @@ public class ListRVAdapter extends RVAdapter<UserList> {
 
 		List<String> userList = new ArrayList<>();
 		for (Object userListItem : item.getValue()) {
-			userList.add(stringWithoutTrailingZero(userListItem.toString()));
+			userList.add(trimTrailingCharacters(userListItem.toString()));
 		}
 
 		listVH.spinner.setAdapter(new UserListValuesAdapter(holder.itemView.getContext(), userList));

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/VariableRVAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/VariableRVAdapter.java
@@ -33,7 +33,7 @@ import org.catrobat.catroid.ui.recyclerview.viewholder.VariableVH;
 
 import java.util.List;
 
-import static org.catrobat.catroid.utils.NumberFormats.stringWithoutTrailingZero;
+import static org.catrobat.catroid.utils.NumberFormats.trimTrailingCharacters;
 
 public class VariableRVAdapter extends RVAdapter<UserVariable> {
 
@@ -54,6 +54,6 @@ public class VariableRVAdapter extends RVAdapter<UserVariable> {
 		UserVariable item = items.get(position);
 		VariableVH variableVH = (VariableVH) holder;
 		variableVH.title.setText(item.getName());
-		variableVH.value.setText(stringWithoutTrailingZero(item.getValue().toString()));
+		variableVH.value.setText(trimTrailingCharacters(item.getValue().toString()));
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/utils/EnumUtils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/EnumUtils.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2019 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,23 +20,33 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.catroid.formulaeditor;
 
-import org.catrobat.catroid.utils.EnumUtils;
+package org.catrobat.catroid.utils;
 
-public enum Functions {
-
-	SIN, COS, TAN, LN, LOG, SQRT, RAND, ROUND, ABS, PI, MOD, ARCSIN, ARCCOS, ARCTAN, ARCTAN2, EXP, POWER, FLOOR, CEIL,
-	MAX,
-	MIN, TRUE, FALSE, LENGTH,
-	LETTER, JOIN, REGEX, LIST_ITEM, CONTAINS, NUMBER_OF_ITEMS, ARDUINOANALOG, ARDUINODIGITAL, RASPIDIGITAL,
-	MULTI_FINGER_X, MULTI_FINGER_Y, MULTI_FINGER_TOUCHED;
-
-	public static boolean isFunction(String value) {
-		return EnumUtils.isValidEnum(Functions.class, value);
+public final class EnumUtils {
+	private EnumUtils() {
 	}
 
-	public static Functions getFunctionByValue(String value) {
-		return EnumUtils.getEnum(Functions.class, value);
+	public static <E extends Enum<E>> boolean isValidEnum(Class<E> clazz, String name) {
+		if (name == null) {
+			return false;
+		}
+		try {
+			Enum.valueOf(clazz, name);
+		} catch (IllegalArgumentException e) {
+			return false;
+		}
+		return true;
+	}
+
+	public static <E extends Enum<E>> E getEnum(Class<E> clazz, String name) {
+		if (name == null) {
+			return null;
+		}
+		try {
+			return Enum.valueOf(clazz, name);
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/utils/NumberFormats.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/NumberFormats.java
@@ -30,7 +30,7 @@ public final class NumberFormats {
 	}
 	public static final String TAG = NumberFormats.class.getSimpleName();
 
-	public static String stringWithoutTrailingZero(String value) {
+	public static String trimTrailingCharacters(String value) {
 		if (value == null) {
 			value = "";
 		}
@@ -40,15 +40,14 @@ public final class NumberFormats {
 		return value;
 	}
 
-	public static String humanFriendlyFormattedShortNumber(final int number) {
-		if (number < 1_000) {
-			return Integer.toString(number);
-		} else if (number < 10_000) {
-			return Integer.toString(number / 1_000) + (number % 1_000 > 100 ? "."
-					+ Integer.toString((number % 1_000) / 100) : "") + "k";
-		} else if (number < 1_000_000) {
-			return Integer.toString(number / 1_000) + "k";
+	public static String toMetricPostfixNotation(int number) {
+		if (number >= 1_000_000) {
+			return number / 1_000_000 + "M";
+		} else if (number >= 10_000) {
+			return number / 1_000 + (number % 1_000 > 100 ? "." + (number % 1_000) / 100 : "") + "k";
+		} else if (number >= 1_000) {
+			return number / 1_000 + "k";
 		}
-		return Integer.toString(number / 1_000_000) + "M";
+		return Integer.toString(number);
 	}
 }

--- a/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/FormulaEditorDataListAdapterArraysValueTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/FormulaEditorDataListAdapterArraysValueTest.java
@@ -58,11 +58,11 @@ public class FormulaEditorDataListAdapterArraysValueTest {
 		createProject();
 
 		UserVariable userVariable = new UserVariable(userVarName);
-		userVariable.setValue(NumberFormats.stringWithoutTrailingZero("1.0"));
+		userVariable.setValue(NumberFormats.trimTrailingCharacters("1.0"));
 		UserList userList = new UserList(userListName);
-		userList.addListItem(NumberFormats.stringWithoutTrailingZero("1.0"));
-		userList.addListItem(NumberFormats.stringWithoutTrailingZero("1.0"));
-		userList.addListItem(NumberFormats.stringWithoutTrailingZero("1.05"));
+		userList.addListItem(NumberFormats.trimTrailingCharacters("1.0"));
+		userList.addListItem(NumberFormats.trimTrailingCharacters("1.0"));
+		userList.addListItem(NumberFormats.trimTrailingCharacters("1.05"));
 		project.addUserList(userList);
 		project.addUserVariable(userVariable);
 	}

--- a/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/FormulaElementTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/FormulaElementTest.java
@@ -23,8 +23,6 @@
 
 package org.catrobat.catroid.test.formulaeditor;
 
-import org.catrobat.catroid.ProjectManager;
-import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
 import org.catrobat.catroid.formulaeditor.Functions;
@@ -32,7 +30,6 @@ import org.catrobat.catroid.formulaeditor.InternFormulaParser;
 import org.catrobat.catroid.formulaeditor.InternToken;
 import org.catrobat.catroid.formulaeditor.InternTokenType;
 import org.catrobat.catroid.formulaeditor.Operators;
-import org.catrobat.catroid.test.MockUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -49,11 +46,10 @@ import static org.catrobat.catroid.test.formulaeditor.FormulaEditorTestUtil.asse
 
 @RunWith(JUnit4.class)
 public class FormulaElementTest {
-
 	@Test
 	public void testGetInternTokenList() {
 
-		List<InternToken> internTokenList = new LinkedList<InternToken>();
+		List<InternToken> internTokenList = new LinkedList<>();
 		internTokenList.add(new InternToken(InternTokenType.BRACKET_OPEN));
 		internTokenList.add(new InternToken(InternTokenType.OPERATOR, Operators.MINUS.name()));
 		internTokenList.add(new InternToken(InternTokenType.NUMBER, "1"));
@@ -73,18 +69,14 @@ public class FormulaElementTest {
 
 	@Test
 	public void testInterpretNonExistingUserVariable() {
-		Project project = new Project(MockUtil.mockContextForProject(), "testProject");
-		ProjectManager.getInstance().setCurrentProject(project);
 		FormulaElement formulaElement = new FormulaElement(ElementType.USER_VARIABLE, "notExistingUserVariable", null);
-		assertEquals(FormulaElement.NOT_EXISTING_USER_VARIABLE_INTERPRETATION_VALUE, formulaElement.interpretRecursive(null));
+		assertEquals(0d, formulaElement.interpretRecursive(null));
 	}
 
 	@Test
 	public void testInterpretNonExistingUserList() {
-		Project project = new Project(MockUtil.mockContextForProject(), "testProject");
-		ProjectManager.getInstance().setCurrentProject(project);
 		FormulaElement formulaElement = new FormulaElement(ElementType.USER_LIST, "notExistingUserList", null);
-		assertEquals(FormulaElement.NOT_EXISTING_USER_LIST_INTERPRETATION_VALUE, formulaElement.interpretRecursive(null));
+		assertEquals(0d, formulaElement.interpretRecursive(null));
 	}
 
 	@Test

--- a/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/FormulaTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/FormulaTest.java
@@ -23,8 +23,12 @@
 
 package org.catrobat.catroid.test.formulaeditor;
 
+import android.content.Context;
+
+import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.Formula.StringProvider;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
 import org.catrobat.catroid.formulaeditor.Functions;
@@ -36,7 +40,7 @@ import org.catrobat.catroid.formulaeditor.Sensors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -49,19 +53,23 @@ import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 
-@RunWith(JUnit4.class)
+@RunWith(MockitoJUnitRunner.class)
 public class FormulaTest {
 
 	private List<InternToken> internTokenList;
 
 	@Before
 	public void setUp() {
-		internTokenList = new LinkedList<InternToken>();
+		internTokenList = new LinkedList<>();
+		if (ProjectManager.getInstance() == null) {
+			new ProjectManager(mock(Context.class));
+		}
 	}
 
 	@Test
-	public void resourceWithSensorsvariationTest() {
+	public void resourceWithSensorsVariationTest() {
 		Formula formula0 = new Formula(new FormulaElement(ElementType.SENSOR, Sensors.FACE_DETECTED.name(), null));
 		Brick.ResourcesSet resourcesSet = new Brick.ResourcesSet();
 		formula0.addRequiredResources(resourcesSet);
@@ -208,7 +216,8 @@ public class FormulaTest {
 		FormulaElement joinFunctionFormulaElement = new FormulaElement(ElementType.FUNCTION,
 				Functions.JOIN.name(), null, helloStringFormulaElement, worldStringFormulaElement);
 		Formula joinFormula = new Formula(joinFunctionFormulaElement);
-		String computeDialogResult = joinFormula.getResultForComputeDialog(null);
+		StringProvider stringProvider = mock(StringProvider.class);
+		String computeDialogResult = joinFormula.getResultForComputeDialog(stringProvider, null);
 		assertEquals("helloworld", computeDialogResult);
 	}
 
@@ -219,7 +228,8 @@ public class FormulaTest {
 		FormulaElement letterFunctionFormulaElement = new FormulaElement(ElementType.FUNCTION,
 				Functions.LETTER.name(), null, indexFormulaElement, helloStringFormulaElement);
 		Formula letterFormula = new Formula(letterFunctionFormulaElement);
-		String computeDialogResult = letterFormula.getResultForComputeDialog(null);
+		StringProvider stringProvider = mock(StringProvider.class);
+		String computeDialogResult = letterFormula.getResultForComputeDialog(stringProvider, null);
 		assertEquals("h", computeDialogResult);
 	}
 
@@ -231,7 +241,8 @@ public class FormulaTest {
 		FormulaElement regexFunctionFormulaElement = new FormulaElement(ElementType.FUNCTION,
 				Functions.REGEX.name(), null, regexStringFormulaElement, iamanelephantStringFormulaElement);
 		Formula regexFormula = new Formula(regexFunctionFormulaElement);
-		String computeDialogResult = regexFormula.getResultForComputeDialog(null);
+		StringProvider stringProvider = mock(StringProvider.class);
+		String computeDialogResult = regexFormula.getResultForComputeDialog(stringProvider, null);
 		assertEquals("elephant", computeDialogResult);
 	}
 
@@ -242,7 +253,8 @@ public class FormulaTest {
 		bracketOpenFormulaElement.replaceElement(
 				new FormulaElement(FormulaElement.ElementType.BRACKET, null, null, null, numberFormulaElement));
 		Formula bracketWrappedFormula = new Formula(bracketOpenFormulaElement);
-		String computeDialogResult = bracketWrappedFormula.getResultForComputeDialog(null);
+		StringProvider stringProvider = mock(StringProvider.class);
+		String computeDialogResult = bracketWrappedFormula.getResultForComputeDialog(stringProvider, null);
 		assertEquals("1.0", computeDialogResult);
 	}
 }

--- a/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/parser/ParserTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/parser/ParserTest.java
@@ -22,7 +22,6 @@
  */
 package org.catrobat.catroid.test.formulaeditor.parser;
 
-import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.Functions;
@@ -31,10 +30,10 @@ import org.catrobat.catroid.formulaeditor.InternToken;
 import org.catrobat.catroid.formulaeditor.InternTokenType;
 import org.catrobat.catroid.formulaeditor.Operators;
 import org.catrobat.catroid.test.formulaeditor.FormulaEditorTestUtil;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -43,32 +42,10 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 
-@RunWith(JUnit4.class)
+@RunWith(MockitoJUnitRunner.class)
 public class ParserTest {
-
-	private static final float LOOK_ALPHA = 50f;
-	private static final float LOOK_Y_POSITION = 23.4f;
-	private static final float LOOK_X_POSITION = 5.6f;
-	private static final float LOOK_BRIGHTNESS = 70f;
-	private static final float LOOK_COLOR = 0f;
-	private static final float LOOK_SCALE = 90.3f;
-	private static final float LOOK_ROTATION = 30.7f;
-	private static final int LOOK_ZPOSITION = 3;
+	@Mock
 	private Sprite testSprite;
-
-	@Before
-	public void setUp() {
-		testSprite = new SingleSprite("sprite");
-		testSprite.look.setXInUserInterfaceDimensionUnit(LOOK_X_POSITION);
-		testSprite.look.setYInUserInterfaceDimensionUnit(LOOK_Y_POSITION);
-		testSprite.look.setTransparencyInUserInterfaceDimensionUnit(LOOK_ALPHA);
-		testSprite.look.setBrightnessInUserInterfaceDimensionUnit(LOOK_BRIGHTNESS);
-		testSprite.look.setColorInUserInterfaceDimensionUnit(LOOK_COLOR);
-		testSprite.look.setScaleX(LOOK_SCALE);
-		testSprite.look.setScaleY(LOOK_SCALE);
-		testSprite.look.setRotation(LOOK_ROTATION);
-		testSprite.look.setZIndex(LOOK_ZPOSITION);
-	}
 
 	@Test
 	public void testNumbers() {
@@ -94,7 +71,7 @@ public class ParserTest {
 
 	@Test
 	public void testBracket() {
-		List<InternToken> internTokenList = new LinkedList<InternToken>();
+		List<InternToken> internTokenList = new LinkedList<>();
 
 		internTokenList.add(new InternToken(InternTokenType.BRACKET_OPEN));
 		internTokenList.add(new InternToken(InternTokenType.NUMBER, "1"));
@@ -114,7 +91,7 @@ public class ParserTest {
 		assertNotNull(parseTree);
 		assertEquals(9.0, parseTree.interpretRecursive(testSprite));
 
-		internTokenList = new LinkedList<InternToken>();
+		internTokenList = new LinkedList<>();
 
 		internTokenList.add(new InternToken(InternTokenType.OPERATOR, Operators.MINUS.name()));
 		internTokenList.add(new InternToken(InternTokenType.BRACKET_OPEN));
@@ -141,7 +118,7 @@ public class ParserTest {
 
 	@Test
 	public void testEmptyInput() {
-		List<InternToken> internTokenList = new LinkedList<InternToken>();
+		List<InternToken> internTokenList = new LinkedList<>();
 
 		InternFormulaParser internParser = new InternFormulaParser(internTokenList);
 		FormulaElement parseTree = internParser.parseFormula();
@@ -152,7 +129,7 @@ public class ParserTest {
 
 	@Test
 	public void testFuctionalAndSimpleBracketsCorrection() {
-		List<InternToken> internTokenList = new LinkedList<InternToken>();
+		List<InternToken> internTokenList = new LinkedList<>();
 
 		internTokenList.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.ABS.name()));
 		internTokenList.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));

--- a/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/parser/ParserTestOperators.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/parser/ParserTestOperators.java
@@ -22,7 +22,6 @@
  */
 package org.catrobat.catroid.test.formulaeditor.parser;
 
-import org.catrobat.catroid.content.SingleSprite;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
 import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType;
@@ -32,10 +31,10 @@ import org.catrobat.catroid.formulaeditor.InternToken;
 import org.catrobat.catroid.formulaeditor.InternTokenType;
 import org.catrobat.catroid.formulaeditor.Operators;
 import org.catrobat.catroid.test.formulaeditor.FormulaEditorTestUtil;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -43,17 +42,13 @@ import java.util.List;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 
-@RunWith(JUnit4.class)
+@RunWith(MockitoJUnitRunner.class)
 public class ParserTestOperators {
 
+	@Mock
 	private Sprite testSprite;
 	private static final Double TRUE = 1d;
 	private static final Double FALSE = 0d;
-
-	@Before
-	public void setUp() {
-		testSprite = new SingleSprite("sprite");
-	}
 
 	@Test
 	public void testOperatorChain() {

--- a/catroid/src/test/java/org/catrobat/catroid/test/utiltests/NumberFormatsTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/utiltests/NumberFormatsTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.test.utiltests;
 
+import org.catrobat.catroid.utils.NumberFormats;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -33,35 +34,34 @@ import androidx.annotation.IdRes;
 
 import static junit.framework.Assert.assertEquals;
 
-import static org.catrobat.catroid.utils.NumberFormats.stringWithoutTrailingZero;
-
 @RunWith(Parameterized.class)
 public class NumberFormatsTest {
-
 	@Parameterized.Parameter
-	public @IdRes String name;
+	public @IdRes String input;
 	@Parameterized.Parameter(1)
-	public @IdRes String stringWithoutTrailingZero;
+	public @IdRes String expected;
 
 	@Parameterized.Parameters(name = "{0}")
 	public static Iterable<Object[]> data() {
 		return Arrays.asList(new Object[][]{
-				{"0", stringWithoutTrailingZero(String.valueOf(0))},
-				{"8", stringWithoutTrailingZero(String.valueOf(8))},
-				{"-120", stringWithoutTrailingZero(String.valueOf(-120))},
-				{"0", stringWithoutTrailingZero(String.valueOf(0.0))},
-				{"0.5", stringWithoutTrailingZero(String.valueOf(0.5))},
-				{"0.7", stringWithoutTrailingZero(String.valueOf(0.70))},
-				{"0.103", stringWithoutTrailingZero(String.valueOf(0.1030))},
-				{"15.05", stringWithoutTrailingZero(String.valueOf(15.050))},
-				{"string.1900", stringWithoutTrailingZero("string.1900")},
-				{"Pocket", stringWithoutTrailingZero("Pocket")}
+				{"0", "0"},
+				{"8", "8"},
+				{"-120", "-120"},
+				{"0.0", "0"},
+				{"0.5", "0.5"},
+				{"0.70", "0.7"},
+				{"0.1030", "0.103"},
+				{"15.050", "15.05"},
+				{"string.1900", "string.1900"},
+				{"string0.10", "string0.10"},
+				{"Pocket", "Pocket"},
+				{"Pocket.", "Pocket."}
 		});
 	}
 
 	@Test
-	public void testStringWithoutTrailingZero() {
-		assertEquals(stringWithoutTrailingZero, name);
+	public void testTrimTrailingCharacters() {
+		assertEquals(expected, NumberFormats.trimTrailingCharacters(input));
 	}
 }
 


### PR DESCRIPTION
This refactoring is necessary for CATROID-291

* Create a `EnumUtils` helper class to avoid code duplications among enums.
* Simplify readability of `NumberFormatsTest` by fixating the expected output
* `FormulaElement`
  * Move access to static variables from within functions into parameters
  * Move common functions into a `common` package to reduce code duplication
    and enhance readability
  * Add a `function` package and move all function interpretation into classes following the open-closed principle
  * Split up many functions to improve readability
  * Simplify many functions
* `Formula`
  * Simplify many functions by reducing the number of concerns per function
* `CollisionDetection`
  * Improve memory consumption by reducing the number of memory allocations in loops
* Hide direct references to android context in wrappers
* Rename functions to be more precise
* Replace some class instances with mocks in tests where possible