### PR TITLE
Empty formulas are now correctly displayed, if the ShowVariable brick is used

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -236,7 +236,6 @@ public final class Constants {
 	public static final int Z_INDEX_FIRST_SPRITE = Z_INDEX_BACKGROUND + Z_INDEX_NUMBER_VIRTUAL_LAYERS + 1;
 
 	public static final String NO_VARIABLE_SELECTED = "No variable set";
-	public static final String NO_VALUE_SET = "No value set";
 	public static final int SAY_BRICK = 0;
 	public static final int THINK_BRICK = 1;
 	public static final int MAX_STRING_LENGTH_BUBBLES = 16;

--- a/catroid/src/main/java/org/catrobat/catroid/stage/ShowTextActor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/ShowTextActor.java
@@ -124,11 +124,12 @@ public class ShowTextActor extends Actor {
 			for (UserVariable variable : variableList) {
 				if (variable.getName().equals(variableToShow.getName())) {
 					String variableValue = variable.getValue().toString();
+					if (variableValue.isEmpty()) {
+						continue;
+					}
 					if (variable.getVisible()) {
 						if (isNumberAndInteger(variableValue)) {
 							drawText(batch, variableValueWithoutDecimal, xPosition, yPosition, color);
-						} else if (variableValue.isEmpty()) {
-							drawText(batch, Constants.NO_VALUE_SET, xPosition, yPosition, color);
 						} else {
 							drawText(batch, variableValue, xPosition, yPosition, color);
 						}


### PR DESCRIPTION
With this update the ShowVariable brick are now correctly displaying empty variables/formulas as such instead of the predefined text "No value set". 

Examples: 
The formula "5" still results in "5". 
The formula "" now results in "", instead of "No value set".  