### PR TITLE
CATROID-387 Show messages of BroadcastMessageBricks in lexicographic order

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/BroadcastBrickMessageUpdateTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/BroadcastBrickMessageUpdateTest.java
@@ -32,14 +32,17 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.BroadcastBrick;
 import org.catrobat.catroid.content.bricks.BroadcastReceiverBrick;
 import org.catrobat.catroid.content.bricks.BroadcastWaitBrick;
+import org.catrobat.catroid.test.utils.TestUtils;
 import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -47,28 +50,34 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
-import static org.catrobat.catroid.uiespresso.content.messagecontainer.BroadcastMessageBrickUtils.createNewBroadCastMessageOnBrick;
+import static org.catrobat.catroid.uiespresso.content.messagecontainer.BroadcastMessageBrickTestUtils.createNewBroadcastMessageOnBrick;
 
 @RunWith(AndroidJUnit4.class)
 public class BroadcastBrickMessageUpdateTest {
 	private String defaultMessage = "defaultMessage";
-	String message = "Oida!";
+	String message = "newAddedMessage";
 	BroadcastReceiverBrick firstBroadcastBrick;
 
 	@Rule
 	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
 			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
 
+	@After
+	public void tearDown() throws IOException {
+		baseActivityTestRule.finishActivity();
+		TestUtils.deleteProjects(BroadcastBrickMessageUpdateTest.class.getSimpleName());
+	}
+
 	@Before
 	public void setUp() throws Exception {
-		createProject(this.getClass().getSimpleName());
+		createTestProjectWithBricks(BroadcastBrickMessageUpdateTest.class.getSimpleName());
 		baseActivityTestRule.launchActivity();
 	}
 
 	@Test
 	public void testAllBroadcastBricksSpinnersShowTheNewAddedMessage() {
-		createNewBroadCastMessageOnBrick(message, firstBroadcastBrick,
-				(SpriteActivity) baseActivityTestRule.getActivity());
+		createNewBroadcastMessageOnBrick(message, firstBroadcastBrick,
+				baseActivityTestRule.getActivity());
 
 		List<String> spinnerValues = Arrays.asList(
 				UiTestUtils.getResourcesString(R.string.new_option),
@@ -92,7 +101,7 @@ public class BroadcastBrickMessageUpdateTest {
 				.checkNameableValuesAvailable(spinnerValues);
 	}
 
-	private void createProject(String projectName) {
+	private void createTestProjectWithBricks(String projectName) {
 		Project project = new Project(ApplicationProvider.getApplicationContext(), projectName);
 		Sprite sprite = new Sprite("testSprite");
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickSpinnerDataInteractionWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickSpinnerDataInteractionWrapper.java
@@ -76,7 +76,7 @@ public class BrickSpinnerDataInteractionWrapper extends DataInteractionWrapper {
 	}
 
 	public BrickSpinnerDataInteractionWrapper checkNameableValuesAvailable(List<String> stringValues) {
-		dataInteraction.check(matches(BrickSpinnerMatchers.withNamableValues(stringValues)));
+		dataInteraction.check(matches(BrickSpinnerMatchers.withNameableValues(stringValues)));
 		return new BrickSpinnerDataInteractionWrapper(dataInteraction);
 	}
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/messagecontainer/BroadcastAndWaitBrickMessageContainerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/messagecontainer/BroadcastAndWaitBrickMessageContainerTest.java
@@ -53,7 +53,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static junit.framework.TestCase.assertTrue;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
-import static org.catrobat.catroid.uiespresso.content.messagecontainer.BroadcastMessageBrickUtils.createNewBroadCastMessageOnBrick;
+import static org.catrobat.catroid.uiespresso.content.messagecontainer.BroadcastMessageBrickTestUtils.createNewBroadcastMessageOnBrick;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -93,7 +93,7 @@ public class BroadcastAndWaitBrickMessageContainerTest {
 	public void testBroadcastAndWaitBrickOmitSaveUnusedMessages() {
 		String uselessMessage = "useless";
 
-		createNewBroadCastMessageOnBrick(uselessMessage, broadcastMessageBrick,
+		createNewBroadcastMessageOnBrick(uselessMessage, broadcastMessageBrick,
 				baseActivityTestRule.getActivity());
 
 		onBrickAtPosition(broadcastAndWaitPosition)

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/messagecontainer/BroadcastMessageBrickTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/messagecontainer/BroadcastMessageBrickTestUtils.java
@@ -32,23 +32,18 @@ import org.mockito.Mockito;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.test.platform.app.InstrumentationRegistry;
 
-public final class BroadcastMessageBrickUtils {
-	private BroadcastMessageBrickUtils() {
+public final class BroadcastMessageBrickTestUtils {
+	private BroadcastMessageBrickTestUtils() {
 		throw new AssertionError();
 	}
 
-	public static void createNewBroadCastMessageOnBrick(final String message, final BroadcastMessageBrick brick,
+	public static void createNewBroadcastMessageOnBrick(final String message, final BroadcastMessageBrick brick,
 			final AppCompatActivity activity) {
 		if (!(activity instanceof SpriteActivity)) {
 			return;
 		}
 		InstrumentationRegistry.getInstrumentation().runOnMainSync(
-				new Runnable() {
-					@Override
-					public void run() {
-						brick.getOkButtonListener(activity)
-								.onPositiveButtonClick(Mockito.mock(DialogInterface.class), message);
-					}
-				});
+				() -> brick.getOkButtonListener(activity)
+						.onPositiveButtonClick(Mockito.mock(DialogInterface.class), message));
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/messagecontainer/BroadcastReceiveBrickMessageContainerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/messagecontainer/BroadcastReceiveBrickMessageContainerTest.java
@@ -54,7 +54,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static junit.framework.TestCase.assertTrue;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
-import static org.catrobat.catroid.uiespresso.content.messagecontainer.BroadcastMessageBrickUtils.createNewBroadCastMessageOnBrick;
+import static org.catrobat.catroid.uiespresso.content.messagecontainer.BroadcastMessageBrickTestUtils.createNewBroadcastMessageOnBrick;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -94,7 +94,7 @@ public class BroadcastReceiveBrickMessageContainerTest {
 		String uselessMessage = "useless";
 		int broadcastReceivePosition = 1;
 
-		createNewBroadCastMessageOnBrick(uselessMessage, broadcastMessageBrick,
+		createNewBroadcastMessageOnBrick(uselessMessage, broadcastMessageBrick,
 				(SpriteActivity) baseActivityTestRule.getActivity());
 
 		onBrickAtPosition(broadcastReceivePosition)

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/messagecontainer/BroadcastSendBrickMessageContainerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/messagecontainer/BroadcastSendBrickMessageContainerTest.java
@@ -53,7 +53,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static junit.framework.TestCase.assertTrue;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
-import static org.catrobat.catroid.uiespresso.content.messagecontainer.BroadcastMessageBrickUtils.createNewBroadCastMessageOnBrick;
+import static org.catrobat.catroid.uiespresso.content.messagecontainer.BroadcastMessageBrickTestUtils.createNewBroadcastMessageOnBrick;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -93,7 +93,7 @@ public class BroadcastSendBrickMessageContainerTest {
 		String uselessMessage = "useless";
 		int broadcastSendPosition = 1;
 
-		createNewBroadCastMessageOnBrick(uselessMessage, broadcastMessageBrick,
+		createNewBroadcastMessageOnBrick(uselessMessage, broadcastMessageBrick,
 				(SpriteActivity) baseActivityTestRule.getActivity());
 
 		onBrickAtPosition(broadcastSendPosition)

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/matchers/BrickSpinnerMatchers.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/matchers/BrickSpinnerMatchers.java
@@ -40,7 +40,7 @@ public final class BrickSpinnerMatchers {
 		throw new AssertionError();
 	}
 
-	public static Matcher<View> withNamableValues(final List<String> stringValues) {
+	public static Matcher<View> withNameableValues(final List<String> stringValues) {
 		return new TypeSafeMatcher<View>() {
 			@Override
 			protected boolean matchesSafely(View view) {
@@ -80,7 +80,7 @@ public final class BrickSpinnerMatchers {
 					return false;
 				}
 				for (int index = 0; index < spinnerAdapter.getCount(); index++) {
-					String item = (String) spinnerAdapter.getItem(index);
+					String item = ((Nameable) spinnerAdapter.getItem(index)).getName();
 					if (!item.equals(stringValues.get(index))) {
 						return false;
 					}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/BroadcastMessageBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/BroadcastMessageBrick.java
@@ -38,6 +38,7 @@ import org.catrobat.catroid.ui.recyclerview.dialog.TextInputDialog;
 import org.catrobat.catroid.ui.recyclerview.dialog.textwatcher.NonEmptyStringTextWatcher;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import androidx.annotation.Nullable;
@@ -67,15 +68,7 @@ public abstract class BroadcastMessageBrick extends BrickBaseType implements
 		List<String> messages = ProjectManager.getInstance().getCurrentProject()
 				.getBroadcastMessageContainer().getBroadcastMessages();
 
-		if (messages.isEmpty()) {
-			messages.add(context.getString(R.string.brick_broadcast_default_value));
-		}
-
-		List<Nameable> items = new ArrayList<>();
-		items.add(new NewOption(context.getString(R.string.new_option)));
-		for (String message : messages) {
-			items.add(new StringOption(message));
-		}
+		List<Nameable> items = getSortedItemListFromMessages(context, messages);
 
 		spinner = new BrickSpinner<>(R.id.brick_broadcast_spinner, view, items);
 		spinner.setOnItemSelectedListener(this);
@@ -132,5 +125,23 @@ public abstract class BroadcastMessageBrick extends BrickBaseType implements
 	@VisibleForTesting
 	public DialogInterface.OnCancelListener getCanceledListener() {
 		return dialog -> spinner.setSelection(getBroadcastMessage());
+	}
+
+	@VisibleForTesting
+	public static List<Nameable> getSortedItemListFromMessages(Context context, List<String> messages) {
+		if (messages.isEmpty()) {
+			String defaultValue = context.getString(R.string.brick_broadcast_default_value);
+			return Collections.singletonList(new StringOption(defaultValue));
+		}
+
+		Collections.sort(messages, String::compareToIgnoreCase);
+
+		List<Nameable> items = new ArrayList<>();
+		items.add(new NewOption(context.getString(R.string.new_option)));
+
+		for (String message : messages) {
+			items.add(new StringOption(message));
+		}
+		return items;
 	}
 }

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/BroadcastMessageBrickTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/BroadcastMessageBrickTest.java
@@ -1,0 +1,89 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.bricks;
+
+import android.content.Context;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.Nameable;
+import org.catrobat.catroid.content.bricks.BroadcastMessageBrick;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.eq;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
+@RunWith(Parameterized.class)
+public class BroadcastMessageBrickTest {
+
+	private static String defaultValueString = "defaultString";
+	private static String newOptionString = "newOption";
+	private Context context;
+
+	@Parameters(name = "{0}")
+	public static Iterable<Object[]> data() {
+		return asList(new Object[][] {
+				{"MultipleCharsWithDifferentCase", asList("a", "R", "x"), asList(newOptionString, "a", "R", "x")},
+				{"MultipleNumbers", asList("50", "3", "12"), asList(newOptionString, "12", "3", "50")},
+				{"WithSpecialCharacters", asList(".", "a", ":", "_b", "c"), asList(newOptionString, ".", ":", "_b", "a", "c")},
+				{"NoMessage", new ArrayList<>(), singletonList(defaultValueString)},
+		});
+	}
+
+	@Parameterized.Parameter
+	public String name;
+
+	@Parameter(1)
+	public List<String> messages;
+
+	@Parameter(2)
+	public List<String> expectedOutput;
+
+	@Before
+	public void setUp() throws Exception {
+		context = Mockito.mock(Context.class);
+		Mockito.when(context.getString(eq(R.string.brick_broadcast_default_value))).thenReturn(defaultValueString);
+		Mockito.when(context.getString(eq(R.string.new_option))).thenReturn(newOptionString);
+	}
+
+	@Test
+	public void testGetSortedItemListFromMessages() {
+		List<Nameable> output = BroadcastMessageBrick.getSortedItemListFromMessages(context, messages);
+		List<String> outputStrings = output.stream().map(Nameable::getName).collect(Collectors.toList());
+		Assert.assertThat(outputStrings, CoreMatchers.equalTo(expectedOutput));
+	}
+}


### PR DESCRIPTION
- Add a UI test for correct lexicographic order
- Rename createNewBroadcastMessageOnBrick() and withNameableValues() as there were spelling mistakes.
- Rename BroadcastMessageBrickUtils to BroadcastMessageBrickTestUtils to prevent misleading.