### PR TITLE
CATROID-500 Fix variable interpretation in WebRequestBrick

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/ActionFactory.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/ActionFactory.java
@@ -1312,7 +1312,6 @@ public class ActionFactory extends Actions {
 		WebRequestAction action = action(WebRequestAction.class);
 		action.setSprite(sprite);
 		action.setFormula(variableFormula);
-		action.interpretUrl();
 		action.setUserVariable(userVariable);
 		action.setWebConnectionFactory(new WebConnectionFactory());
 		return action;

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/WebRequestAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/WebRequestAction.java
@@ -46,7 +46,6 @@ public class WebRequestAction extends Action implements WebConnection.WebRequest
 
 	private Sprite sprite;
 	private Formula formula;
-	private String url;
 	private UserVariable userVariable;
 	private WebConnectionFactory webConnectionFactory;
 
@@ -80,14 +79,6 @@ public class WebRequestAction extends Action implements WebConnection.WebRequest
 		this.webConnectionFactory = webConnectionFactory;
 	}
 
-	public void interpretUrl() {
-		try {
-			url = formula.interpretString(sprite);
-		} catch (InterpretationException interpretationException) {
-			Log.d(getClass().getSimpleName(), "Couldn't interpret formula", interpretationException);
-		}
-	}
-
 	@Override
 	public boolean act(float delta) {
 		if (userVariable == null) {
@@ -96,6 +87,17 @@ public class WebRequestAction extends Action implements WebConnection.WebRequest
 
 		if (requestStatus == NOT_SENT) {
 			requestStatus = WAITING;
+			String url = "";
+			try {
+				if (formula != null) {
+					url = formula.interpretString(sprite);
+				}
+			} catch (InterpretationException interpretationException) {
+				Log.e(getClass().getSimpleName(),
+						"formula interpretation in web request brick failed",
+						interpretationException);
+			}
+
 			webConnection = webConnectionFactory.createWebConnection(url, this);
 			if (!StageActivity.stageListener.webConnectionHolder.addConnection(webConnection)) {
 				userVariable.setValue(ERROR_TOO_MANY_REQUESTS);


### PR DESCRIPTION
Moved the interpretation of the input formula of the WebRequestBrick
from the ActionFactory to the action, so that the formula is
interpreted at run-time.

[CATROID-500](https://jira.catrob.at/browse/CATROID-500)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
