### PR TITLE
CATROID-504 Fix Lost changes due to reloading of projects

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
@@ -118,14 +118,18 @@ public class ProjectUploadActivity extends BaseActivity implements
 
 		setShowProgressBar(true);
 
-		Bundle bundle = getIntent().getExtras();
-		if (bundle != null) {
-			File projectDir = (File) bundle.getSerializable(PROJECT_DIR);
-			new ProjectLoadTask(projectDir, this)
-					.setListener(this)
-					.execute();
+		if (ProjectManager.getInstance().getCurrentProject() != null) {
+			proceedAfterProjectLoad();
 		} else {
-			finish();
+			Bundle bundle = getIntent().getExtras();
+			if (bundle != null) {
+				File projectDir = (File) bundle.getSerializable(PROJECT_DIR);
+				new ProjectLoadTask(projectDir, this)
+						.setListener(this)
+						.execute();
+			} else {
+				finish();
+			}
 		}
 	}
 
@@ -137,10 +141,7 @@ public class ProjectUploadActivity extends BaseActivity implements
 	@Override
 	public void onLoadFinished(boolean success) {
 		if (success) {
-			getTags();
-			project = ProjectManager.getInstance().getCurrentProject();
-			projectUploadController = createProjectUploadController();
-			verifyUserIdentity();
+			proceedAfterProjectLoad();
 		} else {
 			ToastUtil.showError(this, R.string.error_load_project);
 			setShowProgressBar(false);
@@ -148,6 +149,12 @@ public class ProjectUploadActivity extends BaseActivity implements
 		}
 	}
 
+	public void proceedAfterProjectLoad() {
+		getTags();
+		project = ProjectManager.getInstance().getCurrentProject();
+		projectUploadController = createProjectUploadController();
+		verifyUserIdentity();
+	}
 	private void onCreateView() {
 		int thumbnailWidth = getResources().getDimensionPixelSize(R.dimen.project_thumbnail_width);
 		int thumbnailHeight = getResources().getDimensionPixelSize(R.dimen.project_thumbnail_height);


### PR DESCRIPTION
Ticket :- https://jira.catrob.at/projects/CATROID/issues/CATROID-504

The Bug was Caused due to Reloading of Current Project in ProjectUploadActivity, When the project is reloaded the project variable is assigned a new reference, whereas the other variables like currentlyEditedScene, etc still refer to the old project reference Scene. So when the ProjectUploadActivity finishes and the ProjectActivity and corresponding fragments resume the variable don't point to correct reference.

The ProjectUploadActivity has been modified to not load the projects when it is already loaded(which is the case when the ProjectUploadActivity is launched from ProjectActivity)