### PR TITLE
Catroid-499 Send web request _ and store answer in _" brick should be in red Data category of bricks

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickCategoryTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickCategoryTest.java
@@ -310,8 +310,7 @@ public class BrickCategoryTest {
 						StopScriptBrick.class,
 						CloneBrick.class,
 						DeleteThisCloneBrick.class,
-						WhenClonedBrick.class,
-						WebRequestBrick.class)},
+						WhenClonedBrick.class)},
 				{"Data", Arrays.asList(SetVariableBrick.class,
 						ChangeVariableBrick.class,
 						ShowTextBrick.class,
@@ -326,9 +325,9 @@ public class BrickCategoryTest {
 						ReplaceItemInUserListBrick.class,
 						WriteListOnDeviceBrick.class,
 						ReadListFromDeviceBrick.class,
+						WebRequestBrick.class,
 						AskBrick.class,
-						AskSpeechBrick.class,
-						WebRequestBrick.class)},
+						AskSpeechBrick.class)},
 				{"Lego NXT", Arrays.asList(LegoNxtMotorTurnAngleBrick.class,
 						LegoNxtMotorStopBrick.class,
 						LegoNxtMotorMoveBrick.class,
@@ -384,7 +383,8 @@ public class BrickCategoryTest {
 				{"Testing", Arrays.asList(AssertEqualsBrick.class,
 						WaitTillIdleBrick.class,
 						TapAtBrick.class,
-						FinishStageBrick.class)},
+						FinishStageBrick.class,
+						WebRequestBrick.class)},
 		});
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/EmbroideryPatternManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/EmbroideryPatternManager.java
@@ -23,11 +23,11 @@
 
 package org.catrobat.catroid.embroidery;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public interface EmbroideryPatternManager {
 	void addStitchCommand(StitchCommand stitchCommand);
-	ArrayList<StitchPoint> getEmbroideryPatternList();
+	List<StitchPoint> getEmbroideryPatternList();
 	EmbroideryStream getEmbroideryStream();
 	boolean validPatternExists();
 	void clear();

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -116,7 +116,6 @@ public class StageListener implements ApplicationListener {
 	private int screenshotHeight;
 	private int screenshotX;
 	private int screenshotY;
-	private byte[] screenshot = null;
 
 	private Project project;
 	private Scene scene;
@@ -130,9 +129,7 @@ public class StageListener implements ApplicationListener {
 	private Viewport viewPort;
 	public ShapeRenderer shapeRenderer;
 	private PenActor penActor;
-	private EmbroideryActor embroideryActor;
 	public EmbroideryPatternManager embroideryPatternManager;
-	private float screenRatio;
 	public WebConnectionHolder webConnectionHolder;
 
 	private List<Sprite> sprites;
@@ -201,6 +198,8 @@ public class StageListener implements ApplicationListener {
 
 		physicsWorld = scene.resetPhysicsWorld();
 		sprites = new ArrayList<>(scene.getSpriteList());
+
+		embroideryPatternManager = new DSTPatternManager();
 		initActors(sprites);
 
 		passepartout = new Passepartout(SCREEN_WIDTH, SCREEN_HEIGHT, maximizeViewPortWidth, maximizeViewPortHeight, virtualWidth, virtualHeight);
@@ -208,8 +207,6 @@ public class StageListener implements ApplicationListener {
 
 		axes = new Texture(Gdx.files.internal("stage/red_pixel.bmp"));
 		FaceDetectionHandler.resumeFaceDetection();
-
-		embroideryPatternManager = new DSTPatternManager();
 	}
 
 	public void setPaused(boolean paused) {
@@ -271,8 +268,8 @@ public class StageListener implements ApplicationListener {
 		stage.addActor(penActor);
 		penActor.setZIndex(Z_LAYER_PEN_ACTOR);
 
-		screenRatio = calculateScreenRatio();
-		embroideryActor = new EmbroideryActor(screenRatio);
+		float screenRatio = calculateScreenRatio();
+		EmbroideryActor embroideryActor = new EmbroideryActor(screenRatio, embroideryPatternManager, shapeRenderer);
 		stage.addActor(embroideryActor);
 		embroideryActor.setZIndex(Z_LAYER_EMBROIDERY_ACTOR);
 	}
@@ -369,14 +366,14 @@ public class StageListener implements ApplicationListener {
 		stage.addListener(inputListener);
 	}
 
-	public void menuResume() {
+	void menuResume() {
 		if (reloadProject) {
 			return;
 		}
 		paused = false;
 	}
 
-	public void menuPause() {
+	void menuPause() {
 		if (finished || reloadProject) {
 			return;
 		}
@@ -562,7 +559,7 @@ public class StageListener implements ApplicationListener {
 		}
 
 		if (makeScreenshot) {
-			screenshot = ScreenUtils
+			byte[] screenshot = ScreenUtils
 					.getFrameBufferPixels(screenshotX, screenshotY, screenshotWidth, screenshotHeight, true);
 			makeScreenshot = false;
 			screenshotSaver.saveScreenshotAndNotify(

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
@@ -342,9 +342,6 @@ public class CategoryBricksFactory {
 		if (SettingsFragment.isNfcSharedPreferenceEnabled(context)) {
 			controlBrickList.add(new SetNfcTagBrick(context.getString(R.string.brick_set_nfc_tag_default_value)));
 		}
-		if (BuildConfig.FEATURE_WEBREQUEST_BRICK_ENABLED) {
-			controlBrickList.add(new WebRequestBrick(context.getString(R.string.brick_web_request_default_value)));
-		}
 
 		return controlBrickList;
 	}
@@ -518,12 +515,12 @@ public class CategoryBricksFactory {
 				BrickValues.REPLACE_ITEM_IN_USERLIST_INDEX));
 		dataBrickList.add(new WriteListOnDeviceBrick());
 		dataBrickList.add(new ReadListFromDeviceBrick());
-		dataBrickList.add(new AskBrick(context.getString(R.string.brick_ask_default_question)));
-		dataBrickList.add(new AskSpeechBrick(context.getString(R.string.brick_ask_speech_default_question)));
-
 		if (BuildConfig.FEATURE_WEBREQUEST_BRICK_ENABLED) {
 			dataBrickList.add(new WebRequestBrick(context.getString(R.string.brick_web_request_default_value)));
 		}
+		dataBrickList.add(new AskBrick(context.getString(R.string.brick_ask_default_question)));
+		dataBrickList.add(new AskSpeechBrick(context.getString(R.string.brick_ask_speech_default_question)));
+
 		return dataBrickList;
 	}
 
@@ -683,6 +680,9 @@ public class CategoryBricksFactory {
 					}
 				}
 			}
+		}
+		if (BuildConfig.FEATURE_WEBREQUEST_BRICK_ENABLED) {
+			assertionsBrickList.add(new WebRequestBrick());
 		}
 
 		return assertionsBrickList;

--- a/catroid/src/main/res/layout/brick_web_request.xml
+++ b/catroid/src/main/res/layout/brick_web_request.xml
@@ -38,9 +38,9 @@
 
     <org.catrobat.catroid.ui.BrickLayout
         android:id="@+id/brick_web_request_layout"
-        style="@style/BrickContainer.Control.Medium">
+        style="@style/BrickContainer.UserVariables.Medium">
 
-        <include layout="@layout/icon_brick_category_control" />
+        <include layout="@layout/icon_brick_category_data" />
 
         <TextView
             style="@style/BrickText.SingleLine"

--- a/catroid/src/test/java/org/catrobat/catroid/stage/EmbroideryActorCircleTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/stage/EmbroideryActorCircleTest.java
@@ -1,0 +1,118 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.stage;
+
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+
+import org.catrobat.catroid.embroidery.EmbroideryPatternManager;
+import org.catrobat.catroid.embroidery.StitchPoint;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.verification.VerificationMode;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+public class EmbroideryActorCircleTest {
+	@Parameters(name = "{0}")
+	public static Iterable<Object[]> data() {
+		return asList(new Object[][] {
+				{"Test JumpPoint after ChangePoint", asList(getChangePointMock(), getJumpPointMock()), false, true},
+				{"Test Connecting Points", asList(getConnectingPointMock(), getConnectingPointMock()), true, true},
+				{"Test Changing Points", asList(getChangePointMock(), getChangePointMock()), false, true},
+				{"Test ChangePoint after JumpPoint", asList(getJumpPointMock(), getChangePointMock()), false, true},
+				{"Test JumpPoint after ConnectingPoint", asList(getConnectingPointMock(), getJumpPointMock()), true, true},
+				{"Test Jumping Points", asList(getJumpPointMock(), getJumpPointMock()), false, true},
+		});
+	}
+
+	@Parameter
+	public String name;
+
+	@Parameter(1)
+	public List<StitchPoint> stitchPoints;
+
+	@Parameter(2)
+	public boolean firstPointDrawn;
+
+	@Parameter(3)
+	public boolean secondPointDrawn;
+
+	private EmbroideryActor embroideryActorSpy;
+
+	@Before
+	public void setUp() throws Exception {
+		EmbroideryPatternManager embroideryPatternManager = mock(EmbroideryPatternManager.class);
+		when(embroideryPatternManager.getEmbroideryPatternList()).thenReturn(stitchPoints);
+		ShapeRenderer renderer = mock(ShapeRenderer.class);
+		embroideryActorSpy = spy(new EmbroideryActor(1.0f, embroideryPatternManager, renderer));
+	}
+
+	@Test
+	public void testDraw() {
+		embroideryActorSpy.draw(mock(Batch.class), 1.0F);
+
+		VerificationMode mode = firstPointDrawn ? times(1) : never();
+		verify(embroideryActorSpy, mode).drawCircle(stitchPoints.get(0));
+	}
+
+	@Test
+	public void testSecondCircleDrawn() {
+		embroideryActorSpy.draw(mock(Batch.class), 1.0F);
+
+		verify(embroideryActorSpy, times(1)).drawCircle(stitchPoints.get(1));
+	}
+
+	private static StitchPoint getJumpPointMock() {
+		StitchPoint mock = mock(StitchPoint.class);
+		when(mock.isJumpPoint()).thenReturn(true);
+		return mock;
+	}
+
+	private static StitchPoint getChangePointMock() {
+		StitchPoint mock = mock(StitchPoint.class);
+		when(mock.isColorChangePoint()).thenReturn(true);
+		return mock;
+	}
+
+	private static StitchPoint getConnectingPointMock() {
+		StitchPoint mock = mock(StitchPoint.class);
+		when(mock.isConnectingPoint()).thenReturn(true);
+		return mock;
+	}
+}

--- a/catroid/src/test/java/org/catrobat/catroid/stage/EmbroideryActorLineTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/stage/EmbroideryActorLineTest.java
@@ -1,0 +1,105 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.stage;
+
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+
+import org.catrobat.catroid.embroidery.EmbroideryPatternManager;
+import org.catrobat.catroid.embroidery.StitchPoint;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.verification.VerificationMode;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+public class EmbroideryActorLineTest {
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> data() {
+		return asList(new Object[][] {
+				{"Test Connecting Points", asList(getConnectingPointMock(), getConnectingPointMock()), true},
+				{"Test Changing Points", asList(getChangePointMock(), getChangePointMock()), false},
+				{"Test Jumping Points", asList(getJumpPointMock(), getJumpPointMock()), true},
+				{"Test Jumping Point after Connecting Point", asList(getConnectingPointMock(), getJumpPointMock()), true},
+				{"Test Changing Point after Connecting Point", asList(getConnectingPointMock(), getChangePointMock()), false}
+		});
+	}
+
+	@Parameterized.Parameter
+	public String name;
+
+	@Parameterized.Parameter(1)
+	public List<StitchPoint> stitchPoints;
+
+	@Parameterized.Parameter(2)
+	public Boolean expectedLineDrawn;
+
+	private EmbroideryActor embroideryActorSpy;
+
+	@Before
+	public void setUp() throws Exception {
+		EmbroideryPatternManager embroideryPatternManager = mock(EmbroideryPatternManager.class);
+		when(embroideryPatternManager.getEmbroideryPatternList()).thenReturn(stitchPoints);
+		ShapeRenderer renderer = mock(ShapeRenderer.class);
+		embroideryActorSpy = spy(new EmbroideryActor(1.0f, embroideryPatternManager, renderer));
+	}
+
+	@Test
+	public void testDraw() {
+		embroideryActorSpy.draw(mock(Batch.class), 1.0F);
+
+		VerificationMode mode = expectedLineDrawn ? times(1) : never();
+		verify(embroideryActorSpy, mode).drawLine(stitchPoints.get(0), stitchPoints.get(1));
+	}
+
+	private static StitchPoint getJumpPointMock() {
+		StitchPoint mock = mock(StitchPoint.class);
+		when(mock.isJumpPoint()).thenReturn(true);
+		return mock;
+	}
+
+	private static StitchPoint getChangePointMock() {
+		StitchPoint mock = mock(StitchPoint.class);
+		when(mock.isColorChangePoint()).thenReturn(true);
+		return mock;
+	}
+
+	private static StitchPoint getConnectingPointMock() {
+		StitchPoint mock = mock(StitchPoint.class);
+		when(mock.isConnectingPoint()).thenReturn(true);
+		return mock;
+	}
+}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CloneBrickUpdateVariableTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CloneBrickUpdateVariableTest.java
@@ -69,8 +69,8 @@ public class CloneBrickUpdateVariableTest {
 				{"HideTextBrick", new HideTextBrick()},
 				{"ShowTextBrick", new ShowTextBrick()},
 				{"ShowTextColorSizeAlignmentBrick", new ShowTextColorSizeAlignmentBrick()},
-				{"WebRequestBrick", new WebRequestBrick()},
 				{"ReadVariableFromDeviceBrick", new ReadVariableFromDeviceBrick()},
+				{"WebRequestBrick", new WebRequestBrick()},
 				{"WriteVariableOnDeviceBrick", new WriteVariableOnDeviceBrick()},
 		});
 	}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CloneBrickUpdateVariableTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CloneBrickUpdateVariableTest.java
@@ -70,7 +70,6 @@ public class CloneBrickUpdateVariableTest {
 				{"ShowTextBrick", new ShowTextBrick()},
 				{"ShowTextColorSizeAlignmentBrick", new ShowTextColorSizeAlignmentBrick()},
 				{"ReadVariableFromDeviceBrick", new ReadVariableFromDeviceBrick()},
-				{"WebRequestBrick", new WebRequestBrick()},
 				{"WriteVariableOnDeviceBrick", new WriteVariableOnDeviceBrick()},
 		});
 	}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CloneBrickUpdateVariableTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CloneBrickUpdateVariableTest.java
@@ -69,6 +69,7 @@ public class CloneBrickUpdateVariableTest {
 				{"HideTextBrick", new HideTextBrick()},
 				{"ShowTextBrick", new ShowTextBrick()},
 				{"ShowTextColorSizeAlignmentBrick", new ShowTextColorSizeAlignmentBrick()},
+				{"WebRequestBrick", new WebRequestBrick()},
 				{"ReadVariableFromDeviceBrick", new ReadVariableFromDeviceBrick()},
 				{"WriteVariableOnDeviceBrick", new WriteVariableOnDeviceBrick()},
 		});

--- a/catroid/src/test/java/org/catrobat/catroid/test/stage/EmbroideryActorTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/stage/EmbroideryActorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.stage;
+
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.utils.GdxNativesLoader;
+
+import org.catrobat.catroid.content.Look;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.embroidery.DSTPatternManager;
+import org.catrobat.catroid.embroidery.DSTStitchCommand;
+import org.catrobat.catroid.stage.EmbroideryActor;
+import org.catrobat.catroid.stage.StageActivity;
+import org.catrobat.catroid.stage.StageListener;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(GdxNativesLoader.class)
+public class EmbroideryActorTest {
+	private Sprite sprite;
+	private ShapeRenderer renderer;
+	private Batch batch;
+
+	@Before
+	public void setUp() throws Exception {
+		PowerMockito.mockStatic(GdxNativesLoader.class);
+
+		sprite = Mockito.mock(Sprite.class);
+		sprite.look = Mockito.mock(Look.class);
+		batch = Mockito.mock(Batch.class);
+		StageActivity.stageListener = Mockito.mock(StageListener.class);
+		StageActivity.stageListener.embroideryPatternManager = new DSTPatternManager();
+		renderer = Mockito.mock(ShapeRenderer.class);
+		StageActivity.stageListener.shapeRenderer = renderer;
+	}
+
+	@After
+	public void tearDown() {
+		StageActivity.stageListener = null;
+	}
+
+	@Test
+	public void testDrawLine() {
+		float startX = 0.0f;
+		float startY = 0.0f;
+		float endX = 60.0f;
+		float endY = 0.0f;
+		StageActivity.stageListener.embroideryPatternManager.addStitchCommand(new DSTStitchCommand(startX,
+				startY, 1, sprite));
+		StageActivity.stageListener.embroideryPatternManager.addStitchCommand(new DSTStitchCommand(endX,
+				endY, 1, sprite));
+
+		EmbroideryActor embroideryActor = new EmbroideryActor(1.f,
+				StageActivity.stageListener.embroideryPatternManager, renderer);
+
+		embroideryActor.draw(batch, 1.f);
+		verify(renderer, times(1)).rectLine(startX, startY, endX, endY,
+				embroideryActor.getStitchSize());
+	}
+
+	@Test
+	public void testDrawLineWithCircles() {
+		float startX = 0.0f;
+		float startY = 0.0f;
+		float endX = 30.0f;
+		float endY = 0.0f;
+		StageActivity.stageListener.embroideryPatternManager.addStitchCommand(new DSTStitchCommand(startX,
+				startY, 1, sprite));
+		StageActivity.stageListener.embroideryPatternManager.addStitchCommand(new DSTStitchCommand(endX,
+				endY, 1, sprite));
+
+		EmbroideryActor embroideryActor = new EmbroideryActor(1.f,
+				StageActivity.stageListener.embroideryPatternManager, renderer);
+
+		embroideryActor.draw(batch, 1.f);
+		verify(renderer, times(1)).circle(startX, startY, embroideryActor.getStitchSize());
+		verify(renderer, times(1)).rectLine(startX, startY, endX, endY,
+				embroideryActor.getStitchSize());
+		verify(renderer, times(1)).circle(endX, endY, embroideryActor.getStitchSize());
+	}
+}


### PR DESCRIPTION
The WebRequestBrick was removed from the ControlBrickList and got changed to a DataBrick. It was also added to the TestingBrickList. Moved position in the DataBrickList also.

https://jira.catrob.at/browse/CATROID-499

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
