### PR TITLE
CATROID-511 Refactor distance calculations to use standard Java math …

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -55,13 +55,9 @@ import androidx.annotation.VisibleForTesting;
 
 public class Look extends Image {
 
-	public float getDistanceToTouchPositionInUserInterfaceDimensions() {
-		int touchIndex = TouchUtil.getLastTouchIndex();
-
-		return (float) Math.hypot((TouchUtil.getX(touchIndex) - getXInUserInterfaceDimensionUnit()),
-				(TouchUtil.getY(touchIndex) - getYInUserInterfaceDimensionUnit()));
-	}
-
+	@Retention(RetentionPolicy.SOURCE)
+	@IntDef({ROTATION_STYLE_LEFT_RIGHT_ONLY, ROTATION_STYLE_ALL_AROUND, ROTATION_STYLE_NONE})
+	public @interface RotationStyle {}
 	public static final int ROTATION_STYLE_LEFT_RIGHT_ONLY = 0;
 	public static final int ROTATION_STYLE_ALL_AROUND = 1;
 	public static final int ROTATION_STYLE_NONE = 2;
@@ -308,9 +304,11 @@ public class Look extends Image {
 		setY(y - getHeight() / 2f);
 	}
 
-	@Retention(RetentionPolicy.SOURCE)
-	@IntDef({ROTATION_STYLE_LEFT_RIGHT_ONLY, ROTATION_STYLE_ALL_AROUND, ROTATION_STYLE_NONE})
-	public @interface RotationStyle {
+	public float getDistanceToTouchPositionInUserInterfaceDimensions() {
+		int touchIndex = TouchUtil.getLastTouchIndex();
+
+		return (float) Math.hypot((TouchUtil.getX(touchIndex) - getXInUserInterfaceDimensionUnit()),
+				(TouchUtil.getY(touchIndex) - getYInUserInterfaceDimensionUnit()));
 	}
 
 	public float getAngularVelocityInUserInterfaceDimensionUnit() {

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -55,9 +55,13 @@ import androidx.annotation.VisibleForTesting;
 
 public class Look extends Image {
 
-	@Retention(RetentionPolicy.SOURCE)
-	@IntDef({ROTATION_STYLE_LEFT_RIGHT_ONLY, ROTATION_STYLE_ALL_AROUND, ROTATION_STYLE_NONE})
-	public @interface RotationStyle {}
+	public float getDistanceToTouchPositionInUserInterfaceDimensions() {
+		int touchIndex = TouchUtil.getLastTouchIndex();
+
+		return (float) Math.hypot((TouchUtil.getX(touchIndex) - getXInUserInterfaceDimensionUnit()),
+				(TouchUtil.getY(touchIndex) - getYInUserInterfaceDimensionUnit()));
+	}
+
 	public static final int ROTATION_STYLE_LEFT_RIGHT_ONLY = 0;
 	public static final int ROTATION_STYLE_ALL_AROUND = 1;
 	public static final int ROTATION_STYLE_NONE = 2;
@@ -304,12 +308,9 @@ public class Look extends Image {
 		setY(y - getHeight() / 2f);
 	}
 
-	public float getDistanceToTouchPositionInUserInterfaceDimensions() {
-		int touchIndex = TouchUtil.getLastTouchIndex();
-
-		return (float)
-				Math.sqrt(Math.pow((TouchUtil.getX(touchIndex) - getXInUserInterfaceDimensionUnit()), 2)
-						+ Math.pow((TouchUtil.getY(touchIndex) - getYInUserInterfaceDimensionUnit()), 2));
+	@Retention(RetentionPolicy.SOURCE)
+	@IntDef({ROTATION_STYLE_LEFT_RIGHT_ONLY, ROTATION_STYLE_ALL_AROUND, ROTATION_STYLE_NONE})
+	public @interface RotationStyle {
 	}
 
 	public float getAngularVelocityInUserInterfaceDimensionUnit() {

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
@@ -368,10 +368,6 @@ public class CollisionInformation {
 				- (point.y - lineStart.y) * (lineEnd.x - lineStart.x)) / normalLength;
 	}
 
-	private static float pointToPointDistance(PointF p1, PointF p2) {
-		return (float) Math.hypot(p1.x - p2.x, p1.y - p2.y);
-	}
-
 	public static ArrayList<PointF> simplifyPolygon(ArrayList<PointF> points, int start, int end, float epsilon) {
 		//Ramer-Douglas-Peucker Algorithm
 		float dmax = 0f;

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
@@ -167,7 +167,7 @@ public class CollisionInformation {
 				if (pointToPointDistance(simplified.get(0), simplified.get(simplified.size() - 1)) < epsilon) {
 					simplified.remove(simplified.size() - 1);
 				}
-				
+
 				if (simplified.size() < 3) {
 					continue;
 				}
@@ -371,8 +371,8 @@ public class CollisionInformation {
 
 	private static float pointToPointDistance(PointF p1, PointF p2) {
 		return (float) Math.hypot(p1.x - p2.x, p1.y - p2.y);
-	}	
-	
+	}
+
 	public static ArrayList<PointF> simplifyPolygon(ArrayList<PointF> points, int start, int end, float epsilon) {
 		//Ramer-Douglas-Peucker Algorithm
 		float dmax = 0f;

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
@@ -164,9 +164,10 @@ public class CollisionInformation {
 				ArrayList<PointF> points = getPointsFromPolygonVertices(boundingPolygon.get(i));
 				ArrayList<PointF> simplified = simplifyPolygon(points, 0, points.size() - 1, epsilon);
 
-				if (Math.hypot(simplified.get(0).x - simplified.get(simplified.size() - 1).x, simplified.get(0).y - simplified.get(simplified.size() - 1).y) < epsilon) {
+				if (pointToPointDistance(simplified.get(0), simplified.get(simplified.size() - 1)) < epsilon) {
 					simplified.remove(simplified.size() - 1);
 				}
+				
 				if (simplified.size() < 3) {
 					continue;
 				}
@@ -368,6 +369,10 @@ public class CollisionInformation {
 				- (point.y - lineStart.y) * (lineEnd.x - lineStart.x)) / normalLength;
 	}
 
+	private static float pointToPointDistance(PointF p1, PointF p2) {
+		return (float) Math.hypot(p1.x - p2.x, p1.y - p2.y);
+	}	
+	
 	public static ArrayList<PointF> simplifyPolygon(ArrayList<PointF> points, int start, int end, float epsilon) {
 		//Ramer-Douglas-Peucker Algorithm
 		float dmax = 0f;

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
@@ -164,10 +164,9 @@ public class CollisionInformation {
 				ArrayList<PointF> points = getPointsFromPolygonVertices(boundingPolygon.get(i));
 				ArrayList<PointF> simplified = simplifyPolygon(points, 0, points.size() - 1, epsilon);
 
-				if (pointToPointDistance(simplified.get(0), simplified.get(simplified.size() - 1)) < epsilon) {
+				if (Math.hypot(simplified.get(0).x - simplified.get(simplified.size() - 1).x, simplified.get(0).y - simplified.get(simplified.size() - 1).y) < epsilon) {
 					simplified.remove(simplified.size() - 1);
 				}
-
 				if (simplified.size() < 3) {
 					continue;
 				}
@@ -370,7 +369,7 @@ public class CollisionInformation {
 	}
 
 	private static float pointToPointDistance(PointF p1, PointF p2) {
-		return (float) Math.sqrt(((p1.x - p2.x) * (p1.x - p2.x) + (p1.y - p2.y) * (p1.y - p2.y)));
+		return (float) Math.hypot(p1.x - p2.x, p1.y - p2.y);
 	}
 
 	public static ArrayList<PointF> simplifyPolygon(ArrayList<PointF> points, int start, int end, float epsilon) {

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/sprite/LookTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/sprite/LookTest.java
@@ -206,12 +206,9 @@ public class LookTest {
 		float vectorX = pointBx - pointAx;
 		float vectorY = pointBy - pointAy;
 
-		double squareX = (float) Math.pow(vectorX, 2);
-		double squareY = (float) Math.pow(vectorY, 2);
+		float hypotOfScalar = (float) Math.hypot(vectorX, vectorY);
 
-		float squareRootOfScalar = (float) Math.sqrt(squareX + squareY);
-
-		assertEquals(touchPosition, squareRootOfScalar);
+		assertEquals(touchPosition, hypotOfScalar);
 	}
 
 	@Test


### PR DESCRIPTION
Instead of using our own implementation based on the Pythagorean theorem to calculate 
distances, use the standard math functions from Java.

### Your checklist for this pull request

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

Signed-off-by: abdelaty <abdelaty.mohammedmagdi@gmail.com>