### PR TITLE
MAINTENANCE: Set default flavor dimension for Android Studio

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -271,7 +271,9 @@ android {
     }
 
     productFlavors {
-        catroid
+        catroid {
+            isDefault.set(true)
+        }
         createAtSchool {
             applicationIdSuffix '.createatschool'
         }


### PR DESCRIPTION
With the current version of the android gradle plugin it's now possible to set a default flavor dimension for android studio (used only at the first time you open the project).

This should fix the recurring issue we have with people having set `arduinoDebug` as default flavor by accident.

See the issue tracker for the related feature request:
https://issuetracker.google.com/issues/36988145

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title (no ticket)
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [-] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
