### PR TITLE
 Catroid-499 Send web request _ and store answer in _" brick should be in red Data category of bricks

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickCategoryTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickCategoryTest.java
@@ -310,8 +310,7 @@ public class BrickCategoryTest {
 						StopScriptBrick.class,
 						CloneBrick.class,
 						DeleteThisCloneBrick.class,
-						WhenClonedBrick.class,
-						WebRequestBrick.class)},
+						WhenClonedBrick.class)},
 				{"Data", Arrays.asList(SetVariableBrick.class,
 						ChangeVariableBrick.class,
 						ShowTextBrick.class,
@@ -326,9 +325,9 @@ public class BrickCategoryTest {
 						ReplaceItemInUserListBrick.class,
 						WriteListOnDeviceBrick.class,
 						ReadListFromDeviceBrick.class,
+						WebRequestBrick.class,
 						AskBrick.class,
-						AskSpeechBrick.class,
-						WebRequestBrick.class)},
+						AskSpeechBrick.class)},
 				{"Lego NXT", Arrays.asList(LegoNxtMotorTurnAngleBrick.class,
 						LegoNxtMotorStopBrick.class,
 						LegoNxtMotorMoveBrick.class,
@@ -384,7 +383,8 @@ public class BrickCategoryTest {
 				{"Testing", Arrays.asList(AssertEqualsBrick.class,
 						WaitTillIdleBrick.class,
 						TapAtBrick.class,
-						FinishStageBrick.class)},
+						FinishStageBrick.class,
+						WebRequestBrick.class)},
 		});
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
@@ -273,7 +273,7 @@ public class CategoryBricksFactory {
 			return setupEmbroideryCategoryList();
 		}
 		if (category.equals(context.getString(R.string.category_assertions))) {
-			return setupAssertionsCategoryList();
+			return setupAssertionsCategoryList(context);
 		}
 
 		return Collections.emptyList();
@@ -341,9 +341,6 @@ public class CategoryBricksFactory {
 		controlBrickList.add(new WhenClonedBrick());
 		if (SettingsFragment.isNfcSharedPreferenceEnabled(context)) {
 			controlBrickList.add(new SetNfcTagBrick(context.getString(R.string.brick_set_nfc_tag_default_value)));
-		}
-		if (BuildConfig.FEATURE_WEBREQUEST_BRICK_ENABLED) {
-			controlBrickList.add(new WebRequestBrick(context.getString(R.string.brick_web_request_default_value)));
 		}
 
 		return controlBrickList;
@@ -518,12 +515,12 @@ public class CategoryBricksFactory {
 				BrickValues.REPLACE_ITEM_IN_USERLIST_INDEX));
 		dataBrickList.add(new WriteListOnDeviceBrick());
 		dataBrickList.add(new ReadListFromDeviceBrick());
-		dataBrickList.add(new AskBrick(context.getString(R.string.brick_ask_default_question)));
-		dataBrickList.add(new AskSpeechBrick(context.getString(R.string.brick_ask_speech_default_question)));
-
 		if (BuildConfig.FEATURE_WEBREQUEST_BRICK_ENABLED) {
 			dataBrickList.add(new WebRequestBrick(context.getString(R.string.brick_web_request_default_value)));
 		}
+		dataBrickList.add(new AskBrick(context.getString(R.string.brick_ask_default_question)));
+		dataBrickList.add(new AskSpeechBrick(context.getString(R.string.brick_ask_speech_default_question)));
+
 		return dataBrickList;
 	}
 
@@ -660,7 +657,7 @@ public class CategoryBricksFactory {
 		return embroideryBrickList;
 	}
 
-	private List<Brick> setupAssertionsCategoryList() {
+	private List<Brick> setupAssertionsCategoryList(Context context) {
 		List<Brick> assertionsBrickList = new ArrayList<>();
 
 		AssertEqualsBrick assertEqualsBrick = new AssertEqualsBrick();
@@ -683,6 +680,9 @@ public class CategoryBricksFactory {
 					}
 				}
 			}
+		}
+		if (BuildConfig.FEATURE_WEBREQUEST_BRICK_ENABLED) {
+			assertionsBrickList.add(new WebRequestBrick(context.getString(R.string.brick_web_request_default_value)));
 		}
 
 		return assertionsBrickList;
@@ -801,7 +801,7 @@ public class CategoryBricksFactory {
 			}
 		}
 
-		categoryBricks = setupAssertionsCategoryList();
+		categoryBricks = setupAssertionsCategoryList(context);
 		for (Brick categoryBrick : categoryBricks) {
 			if (brick.getClass().equals(categoryBrick.getClass())) {
 				category = res.getString(R.string.category_assertions);

--- a/catroid/src/main/res/layout/brick_web_request.xml
+++ b/catroid/src/main/res/layout/brick_web_request.xml
@@ -38,9 +38,9 @@
 
     <org.catrobat.catroid.ui.BrickLayout
         android:id="@+id/brick_web_request_layout"
-        style="@style/BrickContainer.Control.Medium">
+        style="@style/BrickContainer.UserVariables.Medium">
 
-        <include layout="@layout/icon_brick_category_control" />
+        <include layout="@layout/icon_brick_category_data" />
 
         <TextView
             style="@style/BrickText.SingleLine"


### PR DESCRIPTION
The WebRequestBrick is now a red DataBrick and is removed from the ControlBrickList. It's now present in the DataBrickList and in the TestingBrickList.

https://jira.catrob.at/browse/CATROID-499

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
