### PR TITLE
CATROID-510 Correction of ZigZag Stitch

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/embroidery/ZigZagRunningStitchTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/embroidery/ZigZagRunningStitchTest.java
@@ -76,7 +76,7 @@ public class ZigZagRunningStitchTest {
 	@Test
 	public void testSimpleMoveOfRunningStitch() {
 		zigZagRunningStitch.update(10, 10);
-		verify(embroideryPatternManager, times(6)).addStitchCommand(any());
+		verify(embroideryPatternManager, times(3)).addStitchCommand(any());
 	}
 
 	@Test
@@ -84,6 +84,6 @@ public class ZigZagRunningStitchTest {
 		zigZagRunningStitch.setStartCoordinates(10, 10);
 		zigZagRunningStitch.update(0, 0);
 
-		verify(embroideryPatternManager, times(6)).addStitchCommand(any());
+		verify(embroideryPatternManager, times(3)).addStitchCommand(any());
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/RunningStitchType.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/RunningStitchType.java
@@ -23,7 +23,18 @@
 
 package org.catrobat.catroid.embroidery;
 
-public interface RunningStitchType {
-	void setStartCoordinates(float x, float y);
-	void update(float currentX, float currentY);
+public abstract class RunningStitchType {
+	abstract void setStartCoordinates(float x, float y);
+	abstract void update(float currentX, float currentY);
+
+	public float interpolate(float endValue, float startValue, float percentage) {
+		float value = Math.round(startValue + percentage * (endValue - startValue));
+		return value;
+	}
+
+
+	public float getDistanceToPoint(float currentX, float firstX, float currentY, float firstY) {
+		double distance = Math.hypot(currentX - firstX, currentY - firstY);
+		return (float) distance;
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/SimpleRunningStitch.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/SimpleRunningStitch.java
@@ -26,7 +26,7 @@ package org.catrobat.catroid.embroidery;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.stage.StageActivity;
 
-public class SimpleRunningStitch implements RunningStitchType {
+public class SimpleRunningStitch extends RunningStitchType {
 	private Sprite sprite;
 	private int length;
 	private boolean first;
@@ -49,7 +49,7 @@ public class SimpleRunningStitch implements RunningStitchType {
 
 	@Override
 	public void update(float currentX, float currentY) {
-		float distance = getDistanceToPoint(currentX, currentY);
+		float distance = getDistanceToPoint(currentX, firstX, currentY, firstY);
 		if (distance >= length) {
 			float surplusPercentage = ((distance - (distance % length)) / distance);
 			currentX = firstX + (surplusPercentage * (currentX - firstX));
@@ -76,15 +76,5 @@ public class SimpleRunningStitch implements RunningStitchType {
 			StageActivity.stageListener.embroideryPatternManager.addStitchCommand(new DSTStitchCommand(x, y,
 					sprite.look.getZIndex(), sprite));
 		}
-	}
-
-	private float interpolate(float endValue, float startValue, float percentage) {
-		float value = Math.round(startValue + percentage * (endValue - startValue));
-		return value;
-	}
-
-	private float getDistanceToPoint(float currentX, float currentY) {
-		double distance = Math.hypot(currentX - firstX, currentY - firstY);
-		return (float) distance;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/SimpleRunningStitch.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/SimpleRunningStitch.java
@@ -84,9 +84,7 @@ public class SimpleRunningStitch implements RunningStitchType {
 	}
 
 	private float getDistanceToPoint(float currentX, float currentY) {
-		double xDistance = Math.pow(currentX - firstX, 2);
-		double yDistance = Math.pow(currentY - firstY, 2);
-		double difference = Math.sqrt(xDistance + yDistance);
-		return (float) difference;
+		double distance = Math.hypot(currentX - firstX, currentY - firstY);
+		return (float) distance;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/TripleRunningStitch.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/TripleRunningStitch.java
@@ -26,7 +26,7 @@ package org.catrobat.catroid.embroidery;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.stage.StageActivity;
 
-public class TripleRunningStitch implements RunningStitchType {
+public class TripleRunningStitch extends RunningStitchType {
 	private Sprite sprite;
 	private int steps;
 	private boolean first;
@@ -49,7 +49,7 @@ public class TripleRunningStitch implements RunningStitchType {
 
 	@Override
 	public void update(float currentX, float currentY) {
-		float distance = getDistanceToPoint(currentX, currentY);
+		float distance = getDistanceToPoint(currentX, firstX, currentY, firstY);
 		if (distance >= steps) {
 			float surplusPercentage = ((distance - (distance % steps)) / distance);
 			currentX = firstX + (surplusPercentage * (currentX - firstX));
@@ -84,15 +84,5 @@ public class TripleRunningStitch implements RunningStitchType {
 			previousX = x;
 			previousY = y;
 		}
-	}
-
-	private float interpolate(float endValue, float startValue, float percentage) {
-		float value = Math.round(startValue + percentage * (endValue - startValue));
-		return value;
-	}
-
-	private float getDistanceToPoint(float currentX, float currentY) {
-		double distance = Math.hypot(currentX - firstX, currentY - firstY);
-		return (float) distance;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/TripleRunningStitch.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/TripleRunningStitch.java
@@ -92,9 +92,7 @@ public class TripleRunningStitch implements RunningStitchType {
 	}
 
 	private float getDistanceToPoint(float currentX, float currentY) {
-		double xDistance = Math.pow(currentX - firstX, 2);
-		double yDistance = Math.pow(currentY - firstY, 2);
-		double difference = Math.sqrt(xDistance + yDistance);
-		return (float) difference;
+		double distance = Math.hypot(currentX - firstX, currentY - firstY);
+		return (float) distance;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/ZigZagRunningStitch.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/ZigZagRunningStitch.java
@@ -26,7 +26,7 @@ package org.catrobat.catroid.embroidery;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.stage.StageActivity;
 
-public class ZigZagRunningStitch implements RunningStitchType {
+public class ZigZagRunningStitch extends RunningStitchType {
 	private float length;
 	private float width;
 	private Sprite sprite;
@@ -52,7 +52,7 @@ public class ZigZagRunningStitch implements RunningStitchType {
 	@Override
 	public void update(float currentX, float currentY) {
 		if (sprite != null) {
-			float distance = getDistanceToPoint(currentX, currentY);
+			float distance = getDistanceToPoint(currentX, firstX, currentY, firstY);
 			if (distance >= length) {
 				float surplusPercentage = ((distance - (distance % length)) / distance);
 				currentX = firstX + (surplusPercentage * (currentX - firstX));
@@ -90,15 +90,5 @@ public class ZigZagRunningStitch implements RunningStitchType {
 		direction *= (-1);
 		StageActivity.stageListener.embroideryPatternManager.addStitchCommand(new DSTStitchCommand(xCoord, yCoord,
 				sprite.look.getZIndex(), sprite));
-	}
-
-	private float interpolate(float endValue, float startValue, float percentage) {
-		float value = Math.round(startValue + percentage * (endValue - startValue));
-		return value;
-	}
-
-	private float getDistanceToPoint(float currentX, float currentY) {
-		double distance = Math.hypot(currentX - firstX, currentY - firstY);
-		return (float) distance;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/ZigZagRunningStitch.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/ZigZagRunningStitch.java
@@ -98,9 +98,7 @@ public class ZigZagRunningStitch implements RunningStitchType {
 	}
 
 	private float getDistanceToPoint(float currentX, float currentY) {
-		double xDistance = Math.pow(currentX - firstX, 2);
-		double yDistance = Math.pow(currentY - firstY, 2);
-		double difference = Math.sqrt(xDistance + yDistance);
-		return (float) difference;
+		double distance = Math.hypot(currentX - firstX, currentY - firstY);
+		return (float) distance;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/ZigZagRunningStitch.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/ZigZagRunningStitch.java
@@ -32,7 +32,7 @@ public class ZigZagRunningStitch implements RunningStitchType {
 	private Sprite sprite;
 	private float firstX = 0;
 	private float firstY = 0;
-	private int direction = -1;
+	private int direction = 1;
 	private boolean first = true;
 
 	public ZigZagRunningStitch(Sprite sprite, float length, float width) {
@@ -72,7 +72,6 @@ public class ZigZagRunningStitch implements RunningStitchType {
 		if (first) {
 			first = false;
 			addPointInDirection(firstX, firstY, degrees);
-			addPointInDirection(firstX, firstY, degrees);
 		}
 
 		for (int count = 1; count < interpolationCount; count++) {
@@ -80,16 +79,14 @@ public class ZigZagRunningStitch implements RunningStitchType {
 			float x = interpolate(currentX, firstX, splitFactor);
 			float y = interpolate(currentY, firstY, splitFactor);
 			addPointInDirection(x, y, degrees);
-			addPointInDirection(x, y, degrees);
 		}
 
-		addPointInDirection(currentX, currentY, degrees);
 		addPointInDirection(currentX, currentY, degrees);
 	}
 
 	private void addPointInDirection(float x, float y, float degrees) {
-		float xCoord = (float) (x + (width / 2) * Math.sin(Math.toRadians(degrees + 90)) * direction);
-		float yCoord = (float) (y + (width / 2) * Math.cos(Math.toRadians(degrees + 90)) * direction);
+		float xCoord = (float) (x - (width / 2) * Math.sin(Math.toRadians(degrees + 90)) * direction);
+		float yCoord = (float) (y - (width / 2) * Math.cos(Math.toRadians(degrees + 90)) * direction);
 		direction *= (-1);
 		StageActivity.stageListener.embroideryPatternManager.addStitchCommand(new DSTStitchCommand(xCoord, yCoord,
 				sprite.look.getZIndex(), sprite));


### PR DESCRIPTION
The implemented ZigZag Stitch was not really a ZigZag Stitch. It was a Z Stitch. This ticket fixed it. https://jira.catrob.at/browse/CATROID-510

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
