### PR TITLE
CATROID-458:Crash while creating a new Actor

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionPolygonCreationTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionPolygonCreationTask.java
@@ -23,21 +23,29 @@
 
 package org.catrobat.catroid.sensing;
 
+
 import android.os.Process;
+import android.util.Log;
 
 import org.catrobat.catroid.common.LookData;
 
-public class CollisionPolygonCreationTask implements Runnable {
 
+public class CollisionPolygonCreationTask implements Runnable {
 	private LookData lookdata;
+	private static final String TAG  = CollisionPolygonCreationTask.class.getSimpleName();
 
 	public CollisionPolygonCreationTask(LookData lookdata) {
 		this.lookdata = lookdata;
 	}
-
 	@Override
 	public void run() {
 		android.os.Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
-		lookdata.getCollisionInformation().loadCollisionPolygon();
-	}
+try {
+	lookdata.getCollisionInformation().loadCollisionPolygon();
+}
+catch(NullPointerException exception){
+
+	Log.e(TAG,"Image formate not supported");
+}
+		}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -266,7 +266,12 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 				break;
 		}
 	}
-
+	public void imgFormatNotSupportedDialog(){
+		AlertDialog.Builder alertDialogBuilder =  new AlertDialog.Builder(this);
+		alertDialogBuilder.setMessage(getString(R.string.Image_formate_not_supported)).setPositiveButton(getString(R.string.ok), (dialog1, which) -> dialog1.cancel());
+		AlertDialog alertDialog = alertDialogBuilder.create();
+		alertDialog.show();
+	}
 	public void addSpriteFromUri(final Uri uri) {
 		final Scene currentScene = ProjectManager.getInstance().getCurrentlyEditedScene();
 
@@ -295,18 +300,16 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 				.setTextWatcher(new NewItemTextWatcher<>(currentScene.getSpriteList()))
 				.setPositiveButton(getString(R.string.ok), (TextInputDialog.OnClickListener) (dialog, textInput) -> {
 					Sprite sprite = new Sprite(textInput);
+					currentScene.addSprite(sprite);
 					try {
 						File imageDirectory = new File(currentScene.getDirectory(), IMAGE_DIRECTORY_NAME);
 						File file = StorageOperations.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
 						LookData lookData = new LookData(textInput, file);
 						if(lookData.getImageMimeType()==null)	{
-							AlertDialog.Builder alertDialogBuilder =  new AlertDialog.Builder(this);
-							alertDialogBuilder.setMessage(getString(R.string.Image_formate_not_supported)).setPositiveButton(getString(R.string.ok), (dialog1, which) -> dialog1.cancel());
-							AlertDialog alertDialog = alertDialogBuilder.create();
-							alertDialog.show();
+							imgFormatNotSupportedDialog();
+							currentScene.removeSprite(sprite);
 						}
 						else {
-							currentScene.addSprite(sprite);
 							sprite.getLookList().add(lookData);
 							lookData.getCollisionInformation().calculate();
 						}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -24,8 +24,10 @@ package org.catrobat.catroid.ui;
 
 import android.content.ClipData;
 import android.content.ClipboardManager;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -56,6 +58,7 @@ import org.catrobat.catroid.ui.recyclerview.fragment.SpriteListFragment;
 import org.catrobat.catroid.ui.recyclerview.util.UniqueNameProvider;
 import org.catrobat.catroid.utils.ToastUtil;
 import org.catrobat.catroid.utils.Utils;
+import org.catrobat.paintroid.contract.MainActivityContracts;
 
 import java.io.File;
 import java.io.IOException;
@@ -292,15 +295,21 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 				.setTextWatcher(new NewItemTextWatcher<>(currentScene.getSpriteList()))
 				.setPositiveButton(getString(R.string.ok), (TextInputDialog.OnClickListener) (dialog, textInput) -> {
 					Sprite sprite = new Sprite(textInput);
-					currentScene.addSprite(sprite);
 					try {
 						File imageDirectory = new File(currentScene.getDirectory(), IMAGE_DIRECTORY_NAME);
-						File file = StorageOperations
-								.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
-
+						File file = StorageOperations.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
 						LookData lookData = new LookData(textInput, file);
-						sprite.getLookList().add(lookData);
-						lookData.getCollisionInformation().calculate();
+						if(lookData.getImageMimeType()==null)	{
+							AlertDialog.Builder alertDialogBuilder =  new AlertDialog.Builder(this);
+							alertDialogBuilder.setMessage(getString(R.string.Image_formate_not_supported)).setPositiveButton(getString(R.string.ok), (dialog1, which) -> dialog1.cancel());
+							AlertDialog alertDialog = alertDialogBuilder.create();
+							alertDialog.show();
+						}
+						else {
+							currentScene.addSprite(sprite);
+							sprite.getLookList().add(lookData);
+							lookData.getCollisionInformation().calculate();
+						}
 					} catch (IOException e) {
 						Log.e(TAG, Log.getStackTraceString(e));
 					}

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -538,7 +538,7 @@
     <string name="nfc_tag_name_label">NFC tag name</string>
     <string name="string_label">Text</string>
     <string name="data_label">Name</string>
-
+    <string name="Image_formate_not_supported">Image formate not supported</string>
     <!-- Details -->
     <string name="project_details">Last access: %s, size: %s</string>
     <string name="last_access_today">today, %s</string>


### PR DESCRIPTION
*Crash while creating a new Actor . Ticket Fixed is https://jira.catrob.at/browse/CATROID-458*
### Summary
***Previous Behavior***
While choosing a picture from the device it was possible to select a svg graphic which crashed the creation of the actor and it jumped back to the main menu
***Current Behavior***
If you select file which cannot be decoded by Bitmap Factory (svg file etc) then it will popup message "Image format not supported" without crashing application and will remain on the same menu.
### Branch 
develop 
###Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages ](https://github.com/Catrobat/Catroid/wiki/)of this repository.
- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ]  Choose the proper base branch (develop)
- [ ]  Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ]  Perform a self-review of the changes
- [ ]  Verify to commit no other files than the intentionally changed ones
- [ ]  Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ]  Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ]  After the PR, verify that all CI checks have passed
- [ ] Post a message in the catroid-stage or catroid-ide [Slack channel ](https://catrobat.slack.com/)and ask for a code reviewer

@PlantinumX 