### PR TITLE
CATROID-458:Crash while creating a new Actor

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionPolygonCreationTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionPolygonCreationTask.java
@@ -24,20 +24,24 @@
 package org.catrobat.catroid.sensing;
 
 import android.os.Process;
+import android.util.Log;
 
 import org.catrobat.catroid.common.LookData;
 
 public class CollisionPolygonCreationTask implements Runnable {
-
 	private LookData lookdata;
-
+	private static final String TAG = CollisionPolygonCreationTask.class.getSimpleName();
 	public CollisionPolygonCreationTask(LookData lookdata) {
+
 		this.lookdata = lookdata;
 	}
-
 	@Override
 	public void run() {
 		android.os.Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
-		lookdata.getCollisionInformation().loadCollisionPolygon();
+		try {
+			lookdata.getCollisionInformation().loadCollisionPolygon();
+		} catch (NullPointerException exception) {
+			Log.e(TAG, "Image format not supported ");
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -264,6 +264,14 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 		}
 	}
 
+	public void imgFormatNotSupportedDialog() {
+
+		AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this).setMessage(getString(R.string.Image_format_not_supported)).setPositiveButton(getString(R.string.ok), (dialog1, which) -> dialog1.cancel());
+
+		AlertDialog alertDialog = alertDialogBuilder.create();
+		alertDialog.show();
+	}
+
 	public void addSpriteFromUri(final Uri uri) {
 		final Scene currentScene = ProjectManager.getInstance().getCurrentlyEditedScene();
 
@@ -295,12 +303,15 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 					currentScene.addSprite(sprite);
 					try {
 						File imageDirectory = new File(currentScene.getDirectory(), IMAGE_DIRECTORY_NAME);
-						File file = StorageOperations
-								.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
-
+						File file = StorageOperations.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
 						LookData lookData = new LookData(textInput, file);
-						sprite.getLookList().add(lookData);
-						lookData.getCollisionInformation().calculate();
+						if (lookData.getImageMimeType() == null) {
+							imgFormatNotSupportedDialog();
+							currentScene.removeSprite(sprite);
+						} else {
+							sprite.getLookList().add(lookData);
+							lookData.getCollisionInformation().calculate();
+						}
 					} catch (IOException e) {
 						Log.e(TAG, Log.getStackTraceString(e));
 					}

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -538,7 +538,7 @@
     <string name="nfc_tag_name_label">NFC tag name</string>
     <string name="string_label">Text</string>
     <string name="data_label">Name</string>
-
+    <string name="Image_format_not_supported">Image format not supported</string>
     <!-- Details -->
     <string name="project_details">Last access: %s, size: %s</string>
     <string name="last_access_today">today, %s</string>


### PR DESCRIPTION
Crash while creating a new Actor . Ticket Fixed is https://jira.catrob.at/browse/CATROID-458  

**Summary**
 **Previous Behavior** While choosing a picture from the device it was possible to select a svg graphic which crashed the creation of the actor and it jumped back to the main menu
**Current Behavior** If you select file which cannot be decoded by Bitmap Factory (svg file etc) then it will popup message "Image format not supported" without crashing application and will remain on the same menu.  
**Branch** develop

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
