### PR TITLE
CATROID-520: Add Double tap to exit from main activity

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.java
@@ -28,6 +28,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.MenuItem;
+import android.widget.Toast;
 
 import com.google.android.gms.analytics.HitBuilders;
 import com.google.android.gms.analytics.Tracker;
@@ -74,6 +75,22 @@ public abstract class BaseActivity extends AppCompatActivity implements Permissi
 					+ "recreation, finishing activity.");
 			finish();
 		}
+	}
+
+	private static final int TIME_INTERVAL = 2000; // # milliseconds, desired time passed between two back presses.
+	private long mBackPressed;
+
+	@Override
+	public void onBackPressed()
+	{
+		if (mBackPressed + TIME_INTERVAL > System.currentTimeMillis())
+		{
+			super.onBackPressed();
+			return;
+		}
+		else { Toast.makeText(getBaseContext(), "Tap back button in order to exit", Toast.LENGTH_SHORT).show(); }
+
+		mBackPressed = System.currentTimeMillis();
 	}
 
 	private void applyAccessibilityStyles() {


### PR DESCRIPTION

Most of the time when a user is interacting with your App, they are likely to click on the back button of their android device and when they do, the app closes. But it is likely to close which they might not have intended to do. Hence I suggest it would be good if double-tap is implemented.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
