### PR TITLE
Catroid 510 - Correction of ZigZag Stitch

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/embroidery/ZigZagParametrizedTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/embroidery/ZigZagParametrizedTest.java
@@ -1,0 +1,123 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.embroidery;
+
+import org.catrobat.catroid.content.Look;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.embroidery.EmbroideryPatternManager;
+import org.catrobat.catroid.embroidery.ZigZagRunningStitch;
+import org.catrobat.catroid.stage.StageActivity;
+import org.catrobat.catroid.stage.StageListener;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+public class ZigZagParametrizedTest {
+	@Parameterized.Parameters(name = "{0}")
+	public static Iterable<Object[]> data() {
+		return asList(new Object[][] {
+				{"Test Points", 10.F, 5.F, 90.F, asList(10.0F, 20.F, 30.F), asList(2.5F, -2.5F,
+						2.5F)},
+				{"Test more Points", 5.F, 2.F, 90.F, asList(10.F, 15.F, 20.F, 25.F, 30.F),
+						asList(1.F, -1.F, 1.F, -1.F, 1.F)},
+				{"Test different length", 20.F, 5.F, 90.F, asList(10.0F, 30.F), asList(2.5F,
+						-2.5F)},
+				{"Test different width", 10.F, 10.F, 90.F, asList(10.0F, 20.F, 30.F), asList(5.0F,
+						-5.0F, 5.0F)},
+				{"Test degrees", 10.F, 10.F, 270.F, asList(10.0F, 20.F, 30.F), asList(-5.0F,
+						5.0F, -5.0F)},
+		});
+	}
+
+	@Parameterized.Parameter
+	public String name;
+
+	@Parameterized.Parameter(1)
+	public Float length;
+
+	@Parameterized.Parameter(2)
+	public Float width;
+
+	@Parameterized.Parameter(3)
+	public Float degrees;
+
+	@Parameterized.Parameter(4)
+	public List<Float> expectedstitchPointsX;
+
+	@Parameterized.Parameter(5)
+	public List<Float> expectedStitchPointsY;
+
+	private ZigZagRunningStitch zigZagRunningStitch;
+	private EmbroideryPatternManager embroideryPatternManager;
+	private Sprite sprite;
+	private Look spriteLook;
+	private ArrayList<Float> actualStitchPointsX = new ArrayList<>();
+	private ArrayList<Float> actualStitchPointsY = new ArrayList<>();
+
+	@Before
+	public void setUp() throws Exception {
+		sprite = Mockito.mock(Sprite.class);
+		spriteLook = Mockito.mock(Look.class);
+		when(spriteLook.getDirectionInUserInterfaceDimensionUnit()).thenReturn(degrees);
+		sprite.look = spriteLook;
+		embroideryPatternManager = mock(EmbroideryPatternManager.class);
+		StageActivity.stageListener = Mockito.mock(StageListener.class);
+		StageActivity.stageListener.embroideryPatternManager = embroideryPatternManager;
+		zigZagRunningStitch = new ZigZagRunningStitch(sprite, length, width);
+		zigZagRunningStitch.setListener((x, y) -> {
+			actualStitchPointsX.add(x);
+			actualStitchPointsY.add(y);
+		});
+		zigZagRunningStitch.setStartCoordinates(10, 0);
+		zigZagRunningStitch.update(30, 0);
+	}
+
+	@After
+	public void tearDown() {
+		StageActivity.stageListener = null;
+	}
+
+	@Test
+	public void testXCoordinates() {
+		Assert.assertEquals(expectedstitchPointsX, actualStitchPointsX);
+	}
+
+	@Test
+	public void testYCoordinates() {
+		Assert.assertEquals(expectedStitchPointsY, actualStitchPointsY);
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/embroidery/ZigZagRunningStitchTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/embroidery/ZigZagRunningStitchTest.java
@@ -57,9 +57,9 @@ public class ZigZagRunningStitchTest {
 		embroideryPatternManager = Mockito.mock(EmbroideryPatternManager.class);
 		StageActivity.stageListener = Mockito.mock(StageListener.class);
 		StageActivity.stageListener.embroideryPatternManager = embroideryPatternManager;
-		final int width = 5;
-		final int height = 10;
-		zigZagRunningStitch = new ZigZagRunningStitch(sprite, width, height);
+		final int length = 5;
+		final int width = 10;
+		zigZagRunningStitch = new ZigZagRunningStitch(sprite, length, width);
 	}
 
 	@After
@@ -76,7 +76,7 @@ public class ZigZagRunningStitchTest {
 	@Test
 	public void testSimpleMoveOfRunningStitch() {
 		zigZagRunningStitch.update(10, 10);
-		verify(embroideryPatternManager, times(6)).addStitchCommand(any());
+		verify(embroideryPatternManager, times(3)).addStitchCommand(any());
 	}
 
 	@Test
@@ -84,6 +84,6 @@ public class ZigZagRunningStitchTest {
 		zigZagRunningStitch.setStartCoordinates(10, 10);
 		zigZagRunningStitch.update(0, 0);
 
-		verify(embroideryPatternManager, times(6)).addStitchCommand(any());
+		verify(embroideryPatternManager, times(3)).addStitchCommand(any());
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/RunningStitchType.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/RunningStitchType.java
@@ -23,7 +23,17 @@
 
 package org.catrobat.catroid.embroidery;
 
-public interface RunningStitchType {
-	void setStartCoordinates(float x, float y);
-	void update(float currentX, float currentY);
+public abstract class RunningStitchType {
+	public abstract void setStartCoordinates(float x, float y);
+	public abstract void update(float currentX, float currentY);
+
+	float interpolate(float endValue, float startValue, float percentage) {
+		float value = Math.round(startValue + percentage * (endValue - startValue));
+		return value;
+	}
+
+	float getDistanceToPoint(float currentX, float firstX, float currentY, float firstY) {
+		double distance = Math.hypot(currentX - firstX, currentY - firstY);
+		return (float) distance;
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/SimpleRunningStitch.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/SimpleRunningStitch.java
@@ -26,7 +26,7 @@ package org.catrobat.catroid.embroidery;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.stage.StageActivity;
 
-public class SimpleRunningStitch implements RunningStitchType {
+public class SimpleRunningStitch extends RunningStitchType {
 	private Sprite sprite;
 	private int length;
 	private boolean first;
@@ -49,7 +49,7 @@ public class SimpleRunningStitch implements RunningStitchType {
 
 	@Override
 	public void update(float currentX, float currentY) {
-		float distance = getDistanceToPoint(currentX, currentY);
+		float distance = getDistanceToPoint(currentX, firstX, currentY, firstY);
 		if (distance >= length) {
 			float surplusPercentage = ((distance - (distance % length)) / distance);
 			currentX = firstX + (surplusPercentage * (currentX - firstX));
@@ -76,17 +76,5 @@ public class SimpleRunningStitch implements RunningStitchType {
 			StageActivity.stageListener.embroideryPatternManager.addStitchCommand(new DSTStitchCommand(x, y,
 					sprite.look.getZIndex(), sprite));
 		}
-	}
-
-	private float interpolate(float endValue, float startValue, float percentage) {
-		float value = Math.round(startValue + percentage * (endValue - startValue));
-		return value;
-	}
-
-	private float getDistanceToPoint(float currentX, float currentY) {
-		double xDistance = Math.pow(currentX - firstX, 2);
-		double yDistance = Math.pow(currentY - firstY, 2);
-		double difference = Math.sqrt(xDistance + yDistance);
-		return (float) difference;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/embroidery/TripleRunningStitch.java
+++ b/catroid/src/main/java/org/catrobat/catroid/embroidery/TripleRunningStitch.java
@@ -26,7 +26,7 @@ package org.catrobat.catroid.embroidery;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.stage.StageActivity;
 
-public class TripleRunningStitch implements RunningStitchType {
+public class TripleRunningStitch extends RunningStitchType {
 	private Sprite sprite;
 	private int steps;
 	private boolean first;
@@ -49,7 +49,7 @@ public class TripleRunningStitch implements RunningStitchType {
 
 	@Override
 	public void update(float currentX, float currentY) {
-		float distance = getDistanceToPoint(currentX, currentY);
+		float distance = getDistanceToPoint(currentX, firstX, currentY, firstY);
 		if (distance >= steps) {
 			float surplusPercentage = ((distance - (distance % steps)) / distance);
 			currentX = firstX + (surplusPercentage * (currentX - firstX));
@@ -84,17 +84,5 @@ public class TripleRunningStitch implements RunningStitchType {
 			previousX = x;
 			previousY = y;
 		}
-	}
-
-	private float interpolate(float endValue, float startValue, float percentage) {
-		float value = Math.round(startValue + percentage * (endValue - startValue));
-		return value;
-	}
-
-	private float getDistanceToPoint(float currentX, float currentY) {
-		double xDistance = Math.pow(currentX - firstX, 2);
-		double yDistance = Math.pow(currentY - firstY, 2);
-		double difference = Math.sqrt(xDistance + yDistance);
-		return (float) difference;
 	}
 }


### PR DESCRIPTION
The implemented ZigZag Stitch was not really a ZigZag Stitch. It was a Z Stitch. This ticket fixed it. https://jira.catrob.at/browse/CATROID-510

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ x] Include the name of the Jira ticket in the PR’s title
- [ x] Include a summary of the changes plus the relevant context
- [ x] Choose the proper base branch (*develop*)
- [ x] Confirm that the changes follow the project’s coding guidelines
- [ x] Verify that the changes generate no compiler or linter warnings
- [ x] Perform a self-review of the changes
- [ x] Verify to commit no other files than the intentionally changed ones
- [ x] Include reasonable and readable tests verifying the added or changed behavior
- [ x] Confirm that new and existing unit tests pass locally
- [ x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ x] Stick to the project’s gitflow workflow
- [ x] Verify that your changes do not have any conflicts with the base branch
- [ x] After the PR, verify that all CI checks have passed
- [ x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
