### PR TITLE
Fix Typo in Registration Dialog

### DIFF
--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -956,7 +956,7 @@
     <string name="error_session_expired">Session expired, please log in.</string>
     <string name="sign_in_with_google">Sign in with Google</string>
     <string name="error_register_empty_username">Empty username</string>
-    <string name="error_register_username_as_email">Email address cannot be used as user names</string>
+    <string name="error_register_username_as_email">Email address cannot be used as username</string>
     <string name="error_register_invalid_username">Username should only contain letters (a–z), numbers (0–9),
         dashes (-), underscores (_), and periods (.).</string>
     <string name="error_register_username_start_with">Username should not start with dashes (-), underscores (_), or


### PR DESCRIPTION
**Description:**
Corrected typo in string in strings.xml, referenced in RegistrationDialogFragment.java.

**Before:**
Email address cannot be used as user names

**After:**
Email address cannot be used as username

**File:**
catroid\src\main\res\values\strings.xml

**Screenshot for Change:**
![image](https://user-images.githubusercontent.com/30703644/77759646-e2a23100-7056-11ea-90ed-a2bf5cc26e11.png)

