### PR TITLE
Catroid-504 : Project not saving on reload

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectActivityTest.java
@@ -126,7 +126,7 @@ public class ProjectActivityTest {
 	}
 
 	@Test
-	public void ProjectNotSavedTest(){
+	public void ProjectNotSavedOnReloadFromUploadActivityTest() {
 		baseActivityTestRule.launchActivity();
 		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
 		onView(withText(R.string.upload_button)).perform(click());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectActivityTest.java
@@ -55,10 +55,12 @@ import androidx.test.platform.app.InstrumentationRegistry;
 
 import static org.hamcrest.core.AllOf.allOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.Intents.intending;
@@ -70,6 +72,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 public class ProjectActivityTest {
 
 	private static final String PROJECT_NAME = "projectName";
+	Project project;
 
 	@Rule
 	public FragmentActivityTestRule<ProjectActivity> baseActivityTestRule = new
@@ -78,7 +81,7 @@ public class ProjectActivityTest {
 
 	@Before
 	public void setUp() {
-		Project project = new Project(ApplicationProvider.getApplicationContext(), PROJECT_NAME);
+		project = new Project(ApplicationProvider.getApplicationContext(), PROJECT_NAME);
 		Sprite firstSprite = new SingleSprite("firstSprite");
 		project.getDefaultScene().addSprite(firstSprite);
 		ProjectManager.getInstance().setCurrentProject(project);
@@ -119,8 +122,19 @@ public class ProjectActivityTest {
 		intending(anyIntent()).respondWith(intentResult);
 
 		onView(withText(R.string.upload_button)).perform(click());
-
 		intended(allOf(hasComponent(ProjectUploadActivity.class.getName())));
+	}
+
+	@Test
+	public void ProjectNotSavedTest(){
+		baseActivityTestRule.launchActivity();
+		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		onView(withText(R.string.upload_button)).perform(click());
+		pressBack();
+
+		Sprite sprite = new SingleSprite("nextSprite");
+		baseActivityTestRule.getActivity().addSpriteForTesting(sprite);
+		assertTrue(ProjectManager.getInstance().getCurrentProject().getDefaultScene().getSpriteList().contains(sprite));
 	}
 
 	private SharedPreferences getDefaultSharedPreferences() {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectUploadRatingDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectUploadRatingDialogTest.java
@@ -29,6 +29,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 
+import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.SingleSprite;
@@ -90,6 +91,8 @@ public class ProjectUploadRatingDialogTest {
 
 		Intent intent = new Intent();
 		intent.putExtra(PROJECT_DIR, project.getDirectory());
+
+		ProjectManager.getInstance().setCurrentProject(project);
 
 		activityTestRule.launchActivity(intent);
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -325,8 +325,6 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 	public void addSpriteForTesting(Sprite sprite) {
 		final Scene currentScene = ProjectManager.getInstance().getCurrentlyEditedScene();
 		currentScene.addSprite(sprite);
-		Boolean bool =
-				ProjectManager.getInstance().getCurrentProject().getDefaultScene().getSpriteList().contains(sprite);
 	}
 
 	public void handleAddButton(View view) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -322,6 +322,13 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 				.show();
 	}
 
+	public void addSpriteForTesting(Sprite sprite) {
+		final Scene currentScene = ProjectManager.getInstance().getCurrentlyEditedScene();
+		currentScene.addSprite(sprite);
+		Boolean bool =
+				ProjectManager.getInstance().getCurrentProject().getDefaultScene().getSpriteList().contains(sprite);
+	}
+
 	public void handleAddButton(View view) {
 		if (getCurrentFragment() instanceof SceneListFragment) {
 			handleAddSceneButton();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
@@ -117,16 +117,7 @@ public class ProjectUploadActivity extends BaseActivity implements
 		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
 		setShowProgressBar(true);
-
-		Bundle bundle = getIntent().getExtras();
-		if (bundle != null) {
-			File projectDir = (File) bundle.getSerializable(PROJECT_DIR);
-			new ProjectLoadTask(projectDir, this)
-					.setListener(this)
-					.execute();
-		} else {
-			finish();
-		}
+		loadProjectActivity();
 	}
 
 	@NotNull
@@ -137,15 +128,19 @@ public class ProjectUploadActivity extends BaseActivity implements
 	@Override
 	public void onLoadFinished(boolean success) {
 		if (success) {
-			getTags();
-			project = ProjectManager.getInstance().getCurrentProject();
-			projectUploadController = createProjectUploadController();
-			verifyUserIdentity();
+			loadProjectActivity();
 		} else {
 			ToastUtil.showError(this, R.string.error_load_project);
 			setShowProgressBar(false);
 			finish();
 		}
+	}
+
+	public void loadProjectActivity() {
+		getTags();
+		project = ProjectManager.getInstance().getCurrentProject();
+		projectUploadController = createProjectUploadController();
+		verifyUserIdentity();
 	}
 
 	private void onCreateView() {


### PR DESCRIPTION
Jira: https://jira.catrob.at/projects/CATROID/issues/CATROID-504?filter=allopenissues

This pull request is a follow up on pull request #3519 and majorly deals only with the testing stated in the comments section of the mention Jira issue.
It opens the ProjectActivity, followed by a click on the upload button and transition to ProcjectUploadActivity and back. It then goes on to add an extra sprite that is not saved in the ProjectManager (which was the reason for it to not show up on reloading)

Credits: Pratik Kumar for finding the bug and solving it.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
