### PR TITLE
CATROID-351 Correct pen brick draws in Maximize mode

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/PenActor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/PenActor.java
@@ -111,7 +111,7 @@ public class PenActor extends Actor {
 		renderer.setColor(new Color(pen.penColor.r, pen.penColor.g, pen.penColor.b, pen.penColor.a));
 		renderer.begin(ShapeRenderer.ShapeType.Filled);
 
-		if (pen.penDown && (pen.previousPoint.x != sprite.look.getX() || pen.previousPoint.y != sprite.look.getY())) {
+		if (pen.penDown && (pen.previousPoint.x != x || pen.previousPoint.y != y)) {
 			Float penSize = (float) pen.penSize * screenRatio;
 			renderer.circle(pen.previousPoint.x, pen.previousPoint.y, penSize / 2);
 			renderer.rectLine(pen.previousPoint.x, pen.previousPoint.y, x, y, penSize);

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -723,13 +723,25 @@ public class StageListener implements ApplicationListener {
 				screenshotX = 0;
 				screenshotY = 0;
 				viewPort = new ScalingViewport(Scaling.stretch, virtualWidth, virtualHeight, camera);
+				shapeRenderer.identity();
 				break;
 			case MAXIMIZE:
+				float yScale = 1.0f;
+				float xScale = 1.0f;
+				if (screenshotWidth != maxViewPortWidth && maxViewPortWidth > 0) {
+					xScale = screenshotWidth / (float) maxViewPortWidth;
+				}
+				if (screenshotHeight != maxViewPortHeight && maxViewPortHeight > 0) {
+					yScale = screenshotHeight / (float) maxViewPortHeight;
+				}
+
 				screenshotWidth = maxViewPortWidth;
 				screenshotHeight = maxViewPortHeight;
 				screenshotX = maxViewPortX;
 				screenshotY = maxViewPortY;
+
 				viewPort = new ExtendViewport(virtualWidth, virtualHeight, camera);
+				shapeRenderer.scale(xScale, yScale, 1.0f);
 				break;
 			default:
 				break;
@@ -737,6 +749,7 @@ public class StageListener implements ApplicationListener {
 		viewPort.update(SCREEN_WIDTH, SCREEN_HEIGHT, false);
 		camera.position.set(0, 0, 0);
 		camera.update();
+		shapeRenderer.updateMatrices();
 	}
 
 	private void disposeTextures() {


### PR DESCRIPTION
If you change from STRETCH mode to MAXIMIZE mode, the draws
of the pen brick are not correctly scaled. So the draws have
the wrong position.
The change of the screen mode is performed in the StageListener.
Proper scaling of the ShapeRenderer (which is used to draw) is
applied there. The scaling factor for x and y is also calculated
there.
Also changed if-query in PenActor to increase performance.
In Previous version, shapeRenderer methods were called although 
position didn't change. sprite.look.getX/Y() returns not the
centered coordinates of the actor. 

https://jira.catrob.at/browse/CATROID-351

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
