### PR TITLE
CATROID-511 Refactor some distance calculations

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -307,9 +307,10 @@ public class Look extends Image {
 	public float getDistanceToTouchPositionInUserInterfaceDimensions() {
 		int touchIndex = TouchUtil.getLastTouchIndex();
 
-		return (float)
-				Math.sqrt(Math.pow((TouchUtil.getX(touchIndex) - getXInUserInterfaceDimensionUnit()), 2)
-						+ Math.pow((TouchUtil.getY(touchIndex) - getYInUserInterfaceDimensionUnit()), 2));
+		float dx = TouchUtil.getX(touchIndex) - getXInUserInterfaceDimensionUnit();
+		float dy = TouchUtil.getY(touchIndex) - getYInUserInterfaceDimensionUnit();
+
+		return (float) Math.hypot(dx, dy);
 	}
 
 	public float getAngularVelocityInUserInterfaceDimensionUnit() {

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
@@ -164,7 +164,10 @@ public class CollisionInformation {
 				ArrayList<PointF> points = getPointsFromPolygonVertices(boundingPolygon.get(i));
 				ArrayList<PointF> simplified = simplifyPolygon(points, 0, points.size() - 1, epsilon);
 
-				if (pointToPointDistance(simplified.get(0), simplified.get(simplified.size() - 1)) < epsilon) {
+				float dx = simplified.get(simplified.size() - 1).x - simplified.get(0).x;
+				float dy = simplified.get(simplified.size() - 1).y - simplified.get(0).y;
+
+				if (Math.hypot(dx, dy) < epsilon) {
 					simplified.remove(simplified.size() - 1);
 				}
 
@@ -367,10 +370,6 @@ public class CollisionInformation {
 				+ (lineEnd.y - lineStart.y) * (lineEnd.y - lineStart.y));
 		return Math.abs((point.x - lineStart.x) * (lineEnd.y - lineStart.y)
 				- (point.y - lineStart.y) * (lineEnd.x - lineStart.x)) / normalLength;
-	}
-
-	private static float pointToPointDistance(PointF p1, PointF p2) {
-		return (float) Math.sqrt(((p1.x - p2.x) * (p1.x - p2.x) + (p1.y - p2.y) * (p1.y - p2.y)));
 	}
 
 	public static ArrayList<PointF> simplifyPolygon(ArrayList<PointF> points, int start, int end, float epsilon) {

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/sprite/LookTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/sprite/LookTest.java
@@ -192,29 +192,6 @@ public class LookTest {
 	}
 
 	@Test
-	public void testDistanceTo() {
-		look.setXInUserInterfaceDimensionUnit(25);
-		look.setYInUserInterfaceDimensionUnit(55);
-		float touchPosition = look.getDistanceToTouchPositionInUserInterfaceDimensions();
-
-		float pointAx = look.getXInUserInterfaceDimensionUnit();
-		float pointAy = look.getYInUserInterfaceDimensionUnit();
-		int touchIndex = TouchUtil.getLastTouchIndex();
-		float pointBx = TouchUtil.getX(touchIndex);
-		float pointBy = TouchUtil.getY(touchIndex);
-
-		float vectorX = pointBx - pointAx;
-		float vectorY = pointBy - pointAy;
-
-		double squareX = (float) Math.pow(vectorX, 2);
-		double squareY = (float) Math.pow(vectorY, 2);
-
-		float squareRootOfScalar = (float) Math.sqrt(squareX + squareY);
-
-		assertEquals(touchPosition, squareRootOfScalar);
-	}
-
-	@Test
 	public void testCloneValues() {
 		Look origin = new Look(null);
 		origin.setSizeInUserInterfaceDimensionUnit(12);


### PR DESCRIPTION
Refactored some point to point distance calculations. One testcase for the function 'getDistanceToTouchPositionInUserInterfaceDimensions()' got deleted, because it asserted always true and basically just holds the new 'hypot()'-function from the library. For the other function(s), no additional testcases were added, because there are already at least one for each edited function. 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
