### PR TITLE
CATROID-542 Introduce multiplayer variables setting and UI to create it

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -171,6 +171,7 @@ android {
         buildConfigField "boolean", "FEATURE_SCRATCH_CONVERTER_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_USERBRICKS_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_WEBREQUEST_BRICK_ENABLED", "true"
+        buildConfigField "boolean", "FEATURE_MULTIPLAYER_VARIABLES_ENABLED", "true"
         resValue "string", "FEATURE_ARDUINO_PREFERENCES_ENABLED", "false"
         resValue "string", "FEATURE_PHIRO_PREFERENCES_ENABLED", "false"
         resValue "string", "FEATURE_RASPI_PREFERENCES_ENABLED", "false"
@@ -255,6 +256,7 @@ android {
             buildConfigField "boolean", "FEATURE_POCKETMUSIC_ENABLED", "false"
             buildConfigField "boolean", "FEATURE_USERBRICKS_ENABLED", "false"
             buildConfigField "boolean", "FEATURE_WEBREQUEST_BRICK_ENABLED", "false"
+            buildConfigField "boolean", "FEATURE_MULTIPLAYER_VARIABLES_ENABLED", "false"
             resValue "string", "SNACKBAR_HINTS_ENABLED", "true"
         }
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/VariableBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/VariableBrickTest.java
@@ -31,6 +31,7 @@ import org.catrobat.catroid.runner.Flaky;
 import org.catrobat.catroid.testsuites.annotations.Cat;
 import org.catrobat.catroid.testsuites.annotations.Level;
 import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
 import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
 import org.junit.Before;
@@ -39,13 +40,18 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.hamcrest.Matchers.not;
 
 import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
@@ -109,5 +115,37 @@ public class VariableBrickTest {
 
 		onBrickAtPosition(setBrickPosition).onSpinner(R.id.change_variable_spinner)
 				.checkShowsText(variableName);
+	}
+
+	@Category({Cat.AppUi.class, Level.Functional.class})
+	@Test
+	public void testMultiplayerVariableScopeIsVisibleWithEnabledPreference() {
+		SettingsFragment.setMultiplayerVariablesPreferenceEnabled(
+				ApplicationProvider.getApplicationContext(), true);
+
+		onBrickAtPosition(setBrickPosition).onVariableSpinner(R.id.set_variable_spinner)
+				.perform(click());
+
+		onView(withText(R.string.new_option))
+				.perform(click());
+
+		onView(withId(R.id.multiplayer))
+				.check(matches(isDisplayed()));
+	}
+
+	@Category({Cat.AppUi.class, Level.Functional.class})
+	@Test
+	public void testMultiplayerVariableScopeIsNotVisibleWithDisabledPreference() {
+		SettingsFragment.setMultiplayerVariablesPreferenceEnabled(
+				ApplicationProvider.getApplicationContext(), false);
+
+		onBrickAtPosition(setBrickPosition).onVariableSpinner(R.id.set_variable_spinner)
+				.perform(click());
+
+		onView(withText(R.string.new_option))
+				.perform(click());
+
+		onView(withId(R.id.multiplayer))
+				.check(matches(not(isDisplayed())));
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorMultiplayerVariablesTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorMultiplayerVariablesTest.java
@@ -1,0 +1,128 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.formulaeditor;
+
+import android.view.View;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.bricks.ChangeSizeByNBrick;
+import org.catrobat.catroid.testsuites.annotations.Cat;
+import org.catrobat.catroid.testsuites.annotations.Level;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+import static org.hamcrest.CoreMatchers.not;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+public class FormulaEditorMultiplayerVariablesTest {
+	@Rule
+	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
+			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION,
+			SpriteActivity.FRAGMENT_SCRIPTS);
+
+	@Before
+	public void setUp() throws Exception {
+		Script script = BrickTestUtils.createProjectAndGetStartScript(
+				FormulaEditorMultiplayerVariablesTest.class.getSimpleName());
+		script.addBrick(new ChangeSizeByNBrick(0));
+
+		baseActivityTestRule.launchActivity();
+
+		onView(withId(R.id.brick_change_size_by_edit_text))
+				.perform(click());
+
+		onFormulaEditor()
+				.performOpenDataFragment();
+	}
+
+	@Category({Cat.AppUi.class, Level.Functional.class})
+	@Test
+	public void testMultiplayerScopeIsVisibleWithEnabledPreference() {
+		testMultiplayerScopeVisibility(true);
+	}
+
+	@Category({Cat.AppUi.class, Level.Functional.class})
+	@Test
+	public void testMultiplayerScopeIsNotVisibleWithDisabledPreference() {
+		testMultiplayerScopeVisibility(false);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testCannotSelectMultiplayerAndListTogether() {
+		SettingsFragment.setMultiplayerVariablesPreferenceEnabled(
+				ApplicationProvider.getApplicationContext(), true);
+		onView(withId(R.id.button_add))
+				.perform(click());
+
+		onView(withId(R.id.multiplayer))
+				.perform(click());
+		onView(withId(R.id.make_list))
+				.check(matches(not(isEnabled())));
+
+		onView(withId(R.id.global))
+				.perform(click());
+		onView(withId(R.id.make_list))
+				.perform(click());
+		onView(withId(R.id.multiplayer))
+				.check(matches(not(isEnabled())));
+
+		onView(withId(R.id.make_list))
+				.perform(click());
+		onView(withId(R.id.multiplayer))
+				.check(matches(isEnabled()));
+	}
+
+	private void testMultiplayerScopeVisibility(boolean isMultiplayerEnabled) {
+		SettingsFragment.setMultiplayerVariablesPreferenceEnabled(
+				ApplicationProvider.getApplicationContext(), isMultiplayerEnabled);
+
+		onView(withId(R.id.button_add))
+				.perform(click());
+
+		Matcher<View> expectedMultiplayerRadioButtonVisibility = isMultiplayerEnabled
+				? isDisplayed()
+				: not(isDisplayed());
+
+		onView(withId(R.id.multiplayer))
+				.check(matches(expectedMultiplayerRadioButtonVisibility));
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorVariableScopeTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorVariableScopeTest.java
@@ -47,7 +47,7 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
-public class FormularEditorVariableScopeTest {
+public class FormulaEditorVariableScopeTest {
 
 	@Rule
 	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsFragmentTest.java
@@ -61,6 +61,7 @@ import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTING
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_EV3_SHOW_SENSOR_INFO_BOX_DISABLED;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MULTIPLAYER_VARIABLES_ENABLED;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_ARDUINO_BRICKS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_HINTS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_NFC_BRICKS;
@@ -93,7 +94,7 @@ public class SettingsFragmentTest {
 			SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED,
 			SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED, SETTINGS_MINDSTORMS_EV3_SHOW_SENSOR_INFO_BOX_DISABLED,
 			SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS, PARROT_JUMPING_SUMO_SCREEN_KEY,
-			SETTINGS_SHOW_RASPI_BRICKS,
+			SETTINGS_SHOW_RASPI_BRICKS, SETTINGS_MULTIPLAYER_VARIABLES_ENABLED,
 			SETTINGS_CAST_GLOBALLY_ENABLED));
 	private Map<String, Boolean> initialSettings = new HashMap<>();
 
@@ -141,6 +142,7 @@ public class SettingsFragmentTest {
 		checkPreference(R.string.preference_title_enable_hints, SETTINGS_SHOW_HINTS);
 		checkPreference(R.string.preference_title_enable_crash_reports, SETTINGS_CRASH_REPORTS);
 		checkPreference(R.string.preference_title_cast_feature_globally_enabled, SETTINGS_CAST_GLOBALLY_ENABLED);
+		checkPreference(R.string.preference_title_multiplayer_variables_enabled, SETTINGS_MULTIPLAYER_VARIABLES_ENABLED);
 	}
 
 	@Category({Cat.AppUi.class, Level.Functional.class, Cat.Quarantine.class})

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/brickspinner/UserVariableBrickTextInputDialogBuilder.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/brickspinner/UserVariableBrickTextInputDialogBuilder.java
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.content.bricks.brickspinner;
 
 import android.app.Dialog;
+import android.view.View;
 import android.widget.RadioButton;
 
 import org.catrobat.catroid.R;
@@ -33,6 +34,7 @@ import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.ui.recyclerview.dialog.TextInputDialog;
 import org.catrobat.catroid.ui.recyclerview.dialog.textwatcher.NewItemTextWatcher;
 import org.catrobat.catroid.ui.recyclerview.fragment.ScriptFragment;
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -66,7 +68,14 @@ public class UserVariableBrickTextInputDialogBuilder extends TextInputDialog.Bui
 				});
 
 		setTitle(R.string.formula_editor_variable_dialog_title);
-		setView(R.layout.dialog_new_user_data);
+
+		View dialogView = View.inflate(activity, R.layout.dialog_new_user_data, null);
+		if (SettingsFragment.isMultiplayerVariablesPreferenceEnabled(activity.getApplicationContext())) {
+			RadioButton multiplayerRadioButton = dialogView.findViewById(R.id.multiplayer);
+			multiplayerRadioButton.setVisibility(View.VISIBLE);
+		}
+		setView(dialogView);
+
 		setNegativeButton(R.string.cancel, (dialog, which) -> spinner.setSelection(currentUserVariable));
 		setOnCancelListener(dialog -> spinner.setSelection(currentUserVariable));
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -704,10 +704,19 @@ public class SpriteActivity extends BaseActivity {
 
 	public void handleAddUserDataButton() {
 		View view = View.inflate(this, R.layout.dialog_new_user_data, null);
-		CheckBox makeListCheckBox = view.findViewById(R.id.make_list);
-		RadioButton addToProjectUserDataRadioButton = view.findViewById(R.id.global);
 
+		CheckBox makeListCheckBox = view.findViewById(R.id.make_list);
 		makeListCheckBox.setVisibility(View.VISIBLE);
+
+		RadioButton multiplayerRadioButton = view.findViewById(R.id.multiplayer);
+		if (SettingsFragment.isMultiplayerVariablesPreferenceEnabled(getApplicationContext())) {
+			multiplayerRadioButton.setVisibility(View.VISIBLE);
+			multiplayerRadioButton.setOnCheckedChangeListener((buttonView, isChecked) -> {
+				makeListCheckBox.setEnabled(!isChecked);
+			});
+		}
+
+		RadioButton addToProjectUserDataRadioButton = view.findViewById(R.id.global);
 
 		List<UserData> variables = new ArrayList<>();
 		variables.addAll(currentProject.getUserVariables());
@@ -757,6 +766,7 @@ public class SpriteActivity extends BaseActivity {
 				alertDialog.setTitle(getString(R.string.formula_editor_variable_dialog_title));
 				textWatcher.setScope(variables);
 			}
+			multiplayerRadioButton.setEnabled(!checked);
 		});
 
 		alertDialog.show();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -53,6 +53,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
 
 import static org.catrobat.catroid.CatroidApplication.defaultSystemLanguage;
@@ -74,6 +75,7 @@ public class SettingsFragment extends PreferenceFragment {
 	public static final String SETTINGS_SHOW_NFC_BRICKS = "setting_nfc_bricks";
 	public static final String SETTINGS_PARROT_AR_DRONE_CATROBAT_TERMS_OF_SERVICE_ACCEPTED_PERMANENTLY = "setting_parrot_ar_drone_catrobat_terms_of_service_accepted_permanently";
 	public static final String SETTINGS_CAST_GLOBALLY_ENABLED = "setting_cast_globally_enabled";
+	public static final String SETTINGS_MULTIPLAYER_VARIABLES_ENABLED = "setting_multiplayer_variables_enabled";
 	public static final String SETTINGS_SHOW_HINTS = "setting_enable_hints";
 	public static final String SETTINGS_MULTILINGUAL = "setting_multilingual";
 	public static final String SETTINGS_PARROT_JUMPING_SUMO_CATROBAT_TERMS_OF_SERVICE_ACCEPTED_PERMANENTLY =
@@ -141,7 +143,7 @@ public class SettingsFragment extends PreferenceFragment {
 			screen.removePreference(arduinoPreference);
 		}
 
-		if ((!BuildConfig.FEATURE_CAST_ENABLED)) {
+		if (!BuildConfig.FEATURE_CAST_ENABLED) {
 			CheckBoxPreference globalCastPreference = (CheckBoxPreference) findPreference(SETTINGS_CAST_GLOBALLY_ENABLED);
 			globalCastPreference.setEnabled(false);
 			screen.removePreference(globalCastPreference);
@@ -157,6 +159,13 @@ public class SettingsFragment extends PreferenceFragment {
 			CheckBoxPreference crashlyticsPreference = (CheckBoxPreference) findPreference(SETTINGS_CRASH_REPORTS);
 			crashlyticsPreference.setEnabled(false);
 			screen.removePreference(crashlyticsPreference);
+		}
+
+		if (!BuildConfig.FEATURE_MULTIPLAYER_VARIABLES_ENABLED) {
+			CheckBoxPreference multiplayerPreference =
+					(CheckBoxPreference) findPreference(SETTINGS_MULTIPLAYER_VARIABLES_ENABLED);
+			multiplayerPreference.setEnabled(false);
+			screen.removePreference(multiplayerPreference);
 		}
 	}
 
@@ -399,6 +408,17 @@ public class SettingsFragment extends PreferenceFragment {
 		getSharedPreferences(context).edit()
 				.putBoolean(SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED, true)
 				.apply();
+	}
+
+	@VisibleForTesting
+	public static void setMultiplayerVariablesPreferenceEnabled(Context context, boolean value) {
+		getSharedPreferences(context).edit()
+				.putBoolean(SETTINGS_MULTIPLAYER_VARIABLES_ENABLED, value)
+				.apply();
+	}
+
+	public static boolean isMultiplayerVariablesPreferenceEnabled(Context context) {
+		return getBooleanSharedPreference(false, SETTINGS_MULTIPLAYER_VARIABLES_ENABLED, context);
 	}
 
 	private void setLanguage() {

--- a/catroid/src/main/res/layout/dialog_new_user_data.xml
+++ b/catroid/src/main/res/layout/dialog_new_user_data.xml
@@ -64,6 +64,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/new_data_for_this_sprite_only" />
+
+            <RadioButton
+                android:id="@+id/multiplayer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/new_data_for_connected_devices"
+                android:visibility="gone" />
         </RadioGroup>
 
         <CheckBox

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -190,6 +190,10 @@
     <string name="preference_raspi_port">Raspberry Pi port</string>
     <!--  -->
 
+    <string name="preference_title_multiplayer_variables_enabled">Multiplayer extension</string>
+    <string name="preference_description_multiplayer_variables_enabled">Allow the app to use
+        multiplayer variables shared via Bluetooth</string>
+
     <!-- Scratch Converter activity -->
     <string name="beta">BETA</string>
     <string name="error_scratch_program_not_accessible_any_more">Whoops! The project seems to have disappeared
@@ -719,6 +723,8 @@
     <!-- NewDataDialog -->
     <string name="new_data_for_all_sprites">For all actors, objects, and clones in all scenes</string>
     <string name="new_data_for_this_sprite_only">For this actor, object, or one of its clones only</string>
+    <string name="new_data_for_connected_devices">For all actors, objects, and clones in all scenes of projects
+        on connected multiplayer devices</string>
 
 
     <!-- Backpack -->

--- a/catroid/src/main/res/xml/preferences.xml
+++ b/catroid/src/main/res/xml/preferences.xml
@@ -33,6 +33,12 @@
 
     <CheckBoxPreference
         android:defaultValue="false"
+        android:key="setting_multiplayer_variables_enabled"
+        android:summary="@string/preference_description_multiplayer_variables_enabled"
+        android:title="@string/preference_title_multiplayer_variables_enabled" />
+
+    <CheckBoxPreference
+        android:defaultValue="false"
         android:key="setting_embroidery_bricks"
         android:summary="@string/preference_description_embroidery_bricks"
         android:title="@string/preference_title_enable_embroidery_bricks" />


### PR DESCRIPTION
[CATROID-542](https://jira.catrob.at/browse/CATROID-542) 
- Add multiplayer variables feature flag
- Add multiplayer extension preference to settings screen
- Add multiplayer scope to "New variable" dialogs
- Fix typo in FormulaEditorVariableScopeTest class name

This is the first step of implementing Bluetooth multiplayer feature. This PR adds only the base - feature flag, item in settings and the UI for multiplayer variables in "New variable" dialogs (bot in the Data category in formula editor and by pressing "new..." on a brick).

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
