### PR TITLE
CATROID-551 Assert brick behavior differs from equality sign in formula

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/AssertEqualsAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/AssertEqualsAction.java
@@ -63,9 +63,9 @@ public class AssertEqualsAction extends Action {
 
 	private boolean equalValues(String actual, String expected) {
 		try {
-			return Double.valueOf(actual).equals(Double.valueOf(expected));
+			return actual.equals(expected) || Double.parseDouble(actual) == Double.parseDouble(expected);
 		} catch (NumberFormatException numberFormatException) {
-			return actual.equals(expected);
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Fixes behavior where assert brick would not consider -0 and 0 to be equal

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
