### PR TITLE
CATROID-547 Web request brick crashes for certain URLs

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/ShowTextActor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/ShowTextActor.java
@@ -38,6 +38,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.common.ScreenValues;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.ShowTextColorSizeAlignmentBrick;
 import org.catrobat.catroid.formulaeditor.UserVariable;
@@ -176,8 +177,9 @@ public class ShowTextActor extends Actor {
 		float baseline = -paint.ascent();
 		paint.setAntiAlias(true);
 
-		int canvasWidth = calculateAlignmentValuesForText(paint, text);
-		int bitmapWidth = (int) (paint.measureText(text));
+		int availableWidth = (int) Math.ceil(ScreenValues.SCREEN_WIDTH + Math.abs(posX));
+		int bitmapWidth = Math.min(availableWidth, (int) paint.measureText(text));
+		int canvasWidth = calculateAlignmentValuesForText(paint, bitmapWidth);
 		int height = (int) (baseline + paint.descent());
 
 		Bitmap bitmap = Bitmap.createBitmap(bitmapWidth, height, Bitmap.Config.ARGB_8888);
@@ -237,17 +239,17 @@ public class ShowTextActor extends Actor {
 		return textSize;
 	}
 
-	private int calculateAlignmentValuesForText(Paint paint, String text) {
+	private int calculateAlignmentValuesForText(Paint paint, int bitmapWidth) {
 		switch (alignment) {
 			case ShowTextColorSizeAlignmentBrick.ALIGNMENT_STYLE_LEFT:
 				paint.setTextAlign(Align.LEFT);
 				return 0;
 			case ShowTextColorSizeAlignmentBrick.ALIGNMENT_STYLE_RIGHT:
 				paint.setTextAlign(Align.RIGHT);
-				return (int) paint.measureText(text);
+				return bitmapWidth;
 			default:
 				paint.setTextAlign(Align.CENTER);
-				return (int) (paint.measureText(text) / 2);
+				return bitmapWidth / 2;
 		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/web/WebConnection.java
+++ b/catroid/src/main/java/org/catrobat/catroid/web/WebConnection.java
@@ -27,8 +27,6 @@ import org.catrobat.catroid.common.Constants;
 
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.net.MalformedURLException;
-import java.net.URL;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -69,22 +67,18 @@ public class WebConnection {
 
 	public synchronized void sendWebRequest() {
 		try {
-			new URL(url);
-		} catch (MalformedURLException e) {
+			Request request = new Request.Builder()
+					.url(url)
+					.header("User-Agent", USER_AGENT)
+					.build();
+			call = okHttpClient.newCall(request);
+			call.enqueue(createCallback());
+		} catch (IllegalArgumentException e) {
 			WebRequestListener listener = weakListenerReference.get();
 			if (listener != null) {
 				listener.onRequestFinished(Integer.toString(Constants.ERROR_BAD_REQUEST));
 			}
-			return;
 		}
-
-		Request request = new Request.Builder()
-				.url(url)
-				.header("User-Agent", USER_AGENT)
-				.build();
-
-		call = okHttpClient.newCall(request);
-		call.enqueue(createCallback());
 	}
 
 	private Callback createCallback() {

--- a/catroid/src/test/java/org/catrobat/catroid/test/web/WebConnectionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/web/WebConnectionTest.java
@@ -48,6 +48,23 @@ public class WebConnectionTest {
 	private static final String BASE_URL_TEST_HTTPS = "https://catroid-test.catrob.at/pocketcode/";
 
 	@Test
+	public void testSendRequestWithIncompleteURL() {
+		WebConnection webConnection = new WebConnection(null);
+		WebConnection.WebRequestListener listener = Mockito.mock(WebConnection.WebRequestListener.class);
+		webConnection.setListener(listener);
+		webConnection.setUrl("https/");
+
+		doAnswer(invocation -> {
+			assertEquals(invocation.getArgument(0), Integer.toString(Constants.ERROR_BAD_REQUEST));
+			return null;
+		}).when(listener).onRequestFinished(anyString());
+
+		webConnection.sendWebRequest();
+
+		verify(listener, times(1)).onRequestFinished(anyString());
+	}
+
+	@Test
 	public void testSendRequestWithMalformedUrl() {
 		WebConnection webConnection = new WebConnection(null);
 		WebConnection.WebRequestListener listener = Mockito.mock(WebConnection.WebRequestListener.class);


### PR DESCRIPTION
Fixes rendering crashes for long strings

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
