### PR TITLE
CATROID-476 Line gets drawn between successive layers

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/EmbroideryActor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/EmbroideryActor.java
@@ -54,7 +54,6 @@ public class EmbroideryActor extends Actor {
 		List<StitchPoint> stitchPoints = embroideryPatternManager.getEmbroideryPatternList();
 
 		ListIterator<StitchPoint> iterator = stitchPoints.listIterator();
-		boolean isLayerChange = false;
 
 		if (stitchPoints.size() >= 2) {
 			batch.end();
@@ -62,29 +61,25 @@ public class EmbroideryActor extends Actor {
 			shapeRenderer.setColor(Color.BLACK);
 			shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);
 
-			StitchPoint previousStitchPoint = iterator.next();
+			StitchPoint previousStitchPoint;
+			StitchPoint stitchPoint = iterator.next();
+			drawCircle(stitchPoint);
+			boolean colorChange = false;
+
 			while (iterator.hasNext()) {
-				StitchPoint stitchPoint = iterator.next();
-
-				if ((stitchPoint.isColorChangePoint()) || (previousStitchPoint.isColorChangePoint())) {
-					previousStitchPoint = stitchPoint;
-					isLayerChange = true;
-					continue;
-				}
-				if (isLayerChange && stitchPoint.isJumpPoint()) {
-					previousStitchPoint = stitchPoint;
-					continue;
-				} else {
-					isLayerChange = false;
-				}
-				if (stitchPoint.isConnectingPoint() || previousStitchPoint.isConnectingPoint()) {
-					drawCircle(previousStitchPoint);
-				}
-
-				drawLine(previousStitchPoint, stitchPoint);
 				previousStitchPoint = stitchPoint;
+				stitchPoint = iterator.next();
+
+				colorChange |= stitchPoint.isColorChangePoint();
+
+				if (!colorChange) {
+					drawLine(previousStitchPoint, stitchPoint);
+				}
+				if (stitchPoint.isConnectingPoint()) {
+					drawCircle(stitchPoint);
+					colorChange = false;
+				}
 			}
-			drawCircle(previousStitchPoint);
 			shapeRenderer.end();
 			batch.begin();
 		}

--- a/catroid/src/test/java/org/catrobat/catroid/stage/EmbroideryActorCircleTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/stage/EmbroideryActorCircleTest.java
@@ -52,12 +52,20 @@ public class EmbroideryActorCircleTest {
 	@Parameters(name = "{0}")
 	public static Iterable<Object[]> data() {
 		return asList(new Object[][] {
-				{"Test JumpPoint after ChangePoint", asList(getChangePointMock(), getJumpPointMock()), false, true},
-				{"Test Connecting Points", asList(getConnectingPointMock(), getConnectingPointMock()), true, true},
-				{"Test Changing Points", asList(getChangePointMock(), getChangePointMock()), false, true},
-				{"Test ChangePoint after JumpPoint", asList(getJumpPointMock(), getChangePointMock()), false, true},
-				{"Test JumpPoint after ConnectingPoint", asList(getConnectingPointMock(), getJumpPointMock()), true, true},
-				{"Test Jumping Points", asList(getJumpPointMock(), getJumpPointMock()), false, true},
+				{"Test ConnectingPoints", asList(getConnectingPointMock(),
+						getConnectingPointMock(), getConnectingPointMock()), true, true},
+				{"Test JumpPoints", asList(getConnectingPointMock(),
+						getJumpPointMock(), getJumpPointMock()), false, false},
+				{"Test ChangePoints", asList(getConnectingPointMock(),
+						getColorChangePointMock(), getColorChangePointMock()), false, false},
+				{"Test JumpPoint after ChangePoint", asList(getConnectingPointMock(),
+						getColorChangePointMock(), getJumpPointMock()), false, false},
+				{"Test ConnectingPoint after JumpPoint", asList(getConnectingPointMock(),
+						getJumpPointMock(), getConnectingPointMock()), false, true},
+				{"Test ChangePoint after JumpPoint", asList(getConnectingPointMock(),
+						getJumpPointMock(), getColorChangePointMock()), false, false},
+				{"Test JumpPoint after ConnectingPoint", asList(getConnectingPointMock(),
+						getConnectingPointMock(), getJumpPointMock()), true, false}
 		});
 	}
 
@@ -84,18 +92,29 @@ public class EmbroideryActorCircleTest {
 	}
 
 	@Test
-	public void testDraw() {
+	public void testFirstCircleDrawn() {
 		embroideryActorSpy.draw(mock(Batch.class), 1.0F);
-
-		VerificationMode mode = firstPointDrawn ? times(1) : never();
-		verify(embroideryActorSpy, mode).drawCircle(stitchPoints.get(0));
+		verify(embroideryActorSpy, times(1)).drawCircle(stitchPoints.get(0));
 	}
 
 	@Test
 	public void testSecondCircleDrawn() {
 		embroideryActorSpy.draw(mock(Batch.class), 1.0F);
+		VerificationMode mode = firstPointDrawn ? times(1) : never();
+		verify(embroideryActorSpy, mode).drawCircle(stitchPoints.get(1));
+	}
 
-		verify(embroideryActorSpy, times(1)).drawCircle(stitchPoints.get(1));
+	@Test
+	public void testThirdCircleDrawn() {
+		embroideryActorSpy.draw(mock(Batch.class), 1.0F);
+		VerificationMode mode = secondPointDrawn ? times(1) : never();
+		verify(embroideryActorSpy, mode).drawCircle(stitchPoints.get(2));
+	}
+
+	private static StitchPoint getConnectingPointMock() {
+		StitchPoint mock = mock(StitchPoint.class);
+		when(mock.isConnectingPoint()).thenReturn(true);
+		return mock;
 	}
 
 	private static StitchPoint getJumpPointMock() {
@@ -104,15 +123,9 @@ public class EmbroideryActorCircleTest {
 		return mock;
 	}
 
-	private static StitchPoint getChangePointMock() {
+	private static StitchPoint getColorChangePointMock() {
 		StitchPoint mock = mock(StitchPoint.class);
 		when(mock.isColorChangePoint()).thenReturn(true);
-		return mock;
-	}
-
-	private static StitchPoint getConnectingPointMock() {
-		StitchPoint mock = mock(StitchPoint.class);
-		when(mock.isConnectingPoint()).thenReturn(true);
 		return mock;
 	}
 }

--- a/catroid/src/test/java/org/catrobat/catroid/stage/EmbroideryActorLineTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/stage/EmbroideryActorLineTest.java
@@ -50,11 +50,20 @@ public class EmbroideryActorLineTest {
 	@Parameterized.Parameters(name = "{0}")
 	public static Iterable<Object[]> data() {
 		return asList(new Object[][] {
-				{"Test Connecting Points", asList(getConnectingPointMock(), getConnectingPointMock()), true},
-				{"Test Changing Points", asList(getChangePointMock(), getChangePointMock()), false},
-				{"Test Jumping Points", asList(getJumpPointMock(), getJumpPointMock()), true},
-				{"Test Jumping Point after Connecting Point", asList(getConnectingPointMock(), getJumpPointMock()), true},
-				{"Test Changing Point after Connecting Point", asList(getConnectingPointMock(), getChangePointMock()), false}
+				{"Test ConnectingPoints", asList(getConnectingPointMock(),
+						getConnectingPointMock(), getConnectingPointMock()), true, true},
+				{"Test JumpPoints", asList(getConnectingPointMock(),
+						getJumpPointMock(), getJumpPointMock()), true, true},
+				{"Test ChangePoints", asList(getConnectingPointMock(),
+						getColorChangePointMock(), getColorChangePointMock()), false, false},
+				{"Test ConnectingPoint after JumpPoint", asList(getConnectingPointMock(),
+						getJumpPointMock(), getConnectingPointMock()), true, true},
+				{"Test ConnectingPoint after ChangePoint", asList(getConnectingPointMock(),
+						getColorChangePointMock(), getConnectingPointMock()), false, false},
+				{"Test JumpPoint after ChangePoint", asList(getConnectingPointMock(),
+						getColorChangePointMock(), getJumpPointMock()), false, false},
+				{"Test ChangePoint after JumpPoint", asList(getConnectingPointMock(),
+						getJumpPointMock(), getColorChangePointMock()), true, false}
 		});
 	}
 
@@ -65,7 +74,10 @@ public class EmbroideryActorLineTest {
 	public List<StitchPoint> stitchPoints;
 
 	@Parameterized.Parameter(2)
-	public Boolean expectedLineDrawn;
+	public Boolean firstLineDrawn;
+
+	@Parameterized.Parameter(3)
+	public Boolean secondLineDrawn;
 
 	private EmbroideryActor embroideryActorSpy;
 
@@ -78,11 +90,23 @@ public class EmbroideryActorLineTest {
 	}
 
 	@Test
-	public void testDraw() {
-		embroideryActorSpy.draw(mock(Batch.class), 1.0F);
-
-		VerificationMode mode = expectedLineDrawn ? times(1) : never();
+	public void testFirstLineDrawn() {
+		embroideryActorSpy.draw(mock(Batch.class), 1f);
+		VerificationMode mode = firstLineDrawn ? times(1) : never();
 		verify(embroideryActorSpy, mode).drawLine(stitchPoints.get(0), stitchPoints.get(1));
+	}
+
+	@Test
+	public void testSecondLineDrawn() {
+		embroideryActorSpy.draw(mock(Batch.class), 1f);
+		VerificationMode mode = secondLineDrawn ? times(1) : never();
+		verify(embroideryActorSpy, mode).drawLine(stitchPoints.get(1), stitchPoints.get(2));
+	}
+
+	private static StitchPoint getConnectingPointMock() {
+		StitchPoint mock = mock(StitchPoint.class);
+		when(mock.isConnectingPoint()).thenReturn(true);
+		return mock;
 	}
 
 	private static StitchPoint getJumpPointMock() {
@@ -91,15 +115,9 @@ public class EmbroideryActorLineTest {
 		return mock;
 	}
 
-	private static StitchPoint getChangePointMock() {
+	private static StitchPoint getColorChangePointMock() {
 		StitchPoint mock = mock(StitchPoint.class);
 		when(mock.isColorChangePoint()).thenReturn(true);
-		return mock;
-	}
-
-	private static StitchPoint getConnectingPointMock() {
-		StitchPoint mock = mock(StitchPoint.class);
-		when(mock.isConnectingPoint()).thenReturn(true);
 		return mock;
 	}
 }


### PR DESCRIPTION
Fixes bug where stitches from different embroidery needles would be connected.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
