### PR TITLE
CATROID-217 Show list of user bricks

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/BricksHelpUrlTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/BricksHelpUrlTest.java
@@ -27,6 +27,7 @@ import android.util.Log;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.content.bricks.UserDefinedBrick;
 import org.catrobat.catroid.ui.fragment.CategoryBricksFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -447,6 +448,9 @@ public class BricksHelpUrlTest {
 		String category = new CategoryBricksFactory().getBrickCategory(brick, false,
 				InstrumentationRegistry.getInstrumentation().getTargetContext());
 		String brickHelpUrl = brick.getHelpUrl(category);
+		if (brick instanceof UserDefinedBrick) {
+			brickHelpUrl = brick.getHelpUrl("Your bricks");
+		}
 		assertEquals(brickToHelpUrlMapping.get(simpleName), brickHelpUrl);
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -90,8 +90,7 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 	private List<NfcTagData> nfcTagList = new ArrayList<>();
 	private List<UserVariable> userVariables = new ArrayList<>();
 	private List<UserList> userLists = new ArrayList<>();
-
-	private transient List<UserDefinedBrick> userDefinedBrickList = new ArrayList<>();
+	private transient List<Brick> userDefinedBrickList = new ArrayList<>();
 
 	private transient ActionFactory actionFactory = new ActionFactory();
 
@@ -136,7 +135,7 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 		return allBricks;
 	}
 
-	public List<UserDefinedBrick> getUserDefinedBrickList() {
+	public List<Brick> getUserDefinedBrickList() {
 		return userDefinedBrickList;
 	}
 
@@ -450,7 +449,7 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 	}
 
 	public static boolean doesUserBrickAlreadyExist(UserDefinedBrick userDefinedBrick, Sprite sprite) {
-		for (UserDefinedBrick alreadyDefinedBrick : sprite.getUserDefinedBrickList()) {
+		for (Brick alreadyDefinedBrick : sprite.getUserDefinedBrickList()) {
 			if (alreadyDefinedBrick.equals(userDefinedBrick)) {
 				return true;
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserDefinedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserDefinedBrick.java
@@ -24,10 +24,8 @@
 package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
-import android.text.method.ScrollingMovementMethod;
 import android.view.ContextThemeWrapper;
 import android.view.View;
-import android.widget.ScrollView;
 import android.widget.TextView;
 
 import org.catrobat.catroid.R;
@@ -50,12 +48,13 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
 public class UserDefinedBrick extends BrickBaseType {
+	private static final long serialVersionUID = 1L;
+
 	public static final String USER_BRICK_BUNDLE_ARGUMENT = "user_brick";
 	public static final String ADD_INPUT_OR_LABEL_BUNDLE_ARGUMENT = "addInputOrLabel";
 	public static final boolean INPUT = true;
 	public static final boolean LABEL = false;
 
-	private ScrollView scrollbar;
 	private List<UserBrickData> userBrickDataList;
 	private BrickLayout userBrickContentLayout;
 	public TextView currentUserDataEditText;
@@ -116,7 +115,6 @@ public class UserDefinedBrick extends BrickBaseType {
 	public View getView(Context context) {
 		super.getView(context);
 		userBrickContentLayout = view.findViewById(R.id.brick_user_brick);
-		scrollbar = view.findViewById(R.id.user_brick_scrollbar);
 		boolean isAddInputFragment = false;
 		boolean isAddLabelFragment = false;
 
@@ -146,8 +144,6 @@ public class UserDefinedBrick extends BrickBaseType {
 			addTextViewForUserData(context, new StringOption(defaultText), LABEL);
 		}
 
-		scrollbar.post(this::scrollToBottom);
-
 		return view;
 	}
 
@@ -155,19 +151,13 @@ public class UserDefinedBrick extends BrickBaseType {
 
 		TextView userDataTextView;
 		if (isInputOrLabel) {
-			userDataTextView = new TextView(new ContextThemeWrapper(context, R.style.MultilineBrickEditText));
+			userDataTextView = new TextView(new ContextThemeWrapper(context, R.style.BrickEditText));
 		} else {
-			userDataTextView = new TextView(new ContextThemeWrapper(context, R.style.MultilineBrickText));
+			userDataTextView = new TextView(new ContextThemeWrapper(context, R.style.BrickText));
 		}
-		userDataTextView.setMovementMethod(new ScrollingMovementMethod());
 		userDataTextView.setText(text.getName());
 		currentUserDataEditText = userDataTextView;
 		userBrickContentLayout.addView(userDataTextView);
-	}
-
-	public void scrollToBottom() {
-		scrollbar.scrollTo(0,
-				scrollbar.getChildAt(scrollbar.getChildCount() - 1).getBottom());
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddBrickFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddBrickFragment.java
@@ -31,8 +31,6 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.ListView;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
@@ -144,12 +142,7 @@ public class AddBrickFragment extends ListFragment {
 			listIndexToFocus = -1;
 		}
 
-		getListView().setOnItemClickListener(new ListView.OnItemClickListener() {
-			@Override
-			public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-				addBrickToScript(adapter.getItem(position));
-			}
-		});
+		getListView().setOnItemClickListener((parent, view, position, id) -> addBrickToScript(adapter.getItem(position)));
 	}
 
 	public void addBrickToScript(Brick brickToAdd) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddUserBrickFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddUserBrickFragment.java
@@ -34,6 +34,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.LinearLayout;
+import android.widget.ScrollView;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
@@ -63,6 +64,7 @@ public class AddUserBrickFragment extends Fragment {
 	private UserDefinedBrick userDefinedBrick;
 	private View userBrickView;
 	private LinearLayout userBrickSpace;
+	private ScrollView scrollView;
 
 	private MenuItem confirmItem;
 
@@ -80,6 +82,7 @@ public class AddUserBrickFragment extends Fragment {
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		View view = inflater.inflate(R.layout.fragment_add_new_user_brick, container, false);
 		userBrickSpace = view.findViewById(R.id.user_brick_space);
+		scrollView = view.findViewById(R.id.fragment_add_new_user_brick);
 
 		addLabel = view.findViewById(R.id.button_add_label);
 		addInput = view.findViewById(R.id.button_add_input);
@@ -96,12 +99,11 @@ public class AddUserBrickFragment extends Fragment {
 				userBrickSpace.addView(userBrickView);
 			}
 		}
-
 		AppCompatActivity activity = (AppCompatActivity) getActivity();
 		if (activity != null) {
 			ActionBar actionBar = activity.getSupportActionBar();
 			if (actionBar != null) {
-				actionBar.setTitle(R.string.brick_add_new_user_brick);
+				actionBar.setTitle(R.string.category_user_bricks);
 			}
 		}
 
@@ -253,6 +255,7 @@ public class AddUserBrickFragment extends Fragment {
 			userDefinedBrick.addLabel(input);
 		}
 		updateBrickView();
+		scrollView.post(() -> scrollView.fullScroll(View.FOCUS_DOWN));
 	}
 
 	private void updateBrickView() {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddUserDataToUserBrickFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddUserDataToUserBrickFragment.java
@@ -37,6 +37,7 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.LinearLayout;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import com.google.android.material.textfield.TextInputEditText;
@@ -64,6 +65,7 @@ public class AddUserDataToUserBrickFragment extends Fragment {
 	private AppCompatActivity activity;
 	private TextInputEditText addUserDataUserBrickEditText;
 	private TextInputLayout addUserDataUserBrickTextLayout;
+	private ScrollView scrollView;
 
 	private MenuItem nextItem;
 
@@ -74,6 +76,7 @@ public class AddUserDataToUserBrickFragment extends Fragment {
 	public View onCreateView(@NotNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		View view = inflater.inflate(R.layout.fragment_add_user_data_to_user_brick, container, false);
 		LinearLayout userBrickSpace = view.findViewById(R.id.user_brick_space);
+		scrollView = view.findViewById(R.id.fragment_add_user_data_to_user_brick);
 
 		Bundle arguments = getArguments();
 		if (arguments != null) {
@@ -103,14 +106,14 @@ public class AddUserDataToUserBrickFragment extends Fragment {
 
 		activity = (AppCompatActivity) getActivity();
 		if (activity != null) {
-			getActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE | WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+			showStandardSystemKeyboard();
 			ActionBar actionBar = activity.getSupportActionBar();
 			if (actionBar != null) {
-				activity.getSupportActionBar().setTitle("Your Bricks");
+				activity.getSupportActionBar().setTitle(R.string.category_user_bricks);
 			}
 		}
 
-		userDefinedBrick.scrollToBottom();
+		view.findViewById(R.id.bottom_constraint).requestFocus();
 
 		setHasOptionsMenu(true);
 
@@ -173,7 +176,7 @@ public class AddUserDataToUserBrickFragment extends Fragment {
 
 	private void showStandardSystemKeyboard() {
 		if (activity != null) {
-			activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE | WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+			activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
 		}
 	}
 
@@ -222,7 +225,6 @@ public class AddUserDataToUserBrickFragment extends Fragment {
 
 		@Override
 		public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-			userDefinedBrick.scrollToBottom();
 		}
 
 		@Override
@@ -230,6 +232,9 @@ public class AddUserDataToUserBrickFragment extends Fragment {
 			userBrickTextView.setText(editable.toString());
 			if (isAddInput()) {
 				String error = validateName(editable.toString());
+				if (error != null) {
+					scrollView.post(() -> scrollView.fullScroll(View.FOCUS_DOWN));
+				}
 				addUserDataUserBrickTextLayout.setError(error);
 				setNextItemEnabled(error == null);
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
@@ -186,7 +186,6 @@ import org.catrobat.catroid.content.bricks.TurnLeftBrick;
 import org.catrobat.catroid.content.bricks.TurnLeftSpeedBrick;
 import org.catrobat.catroid.content.bricks.TurnRightBrick;
 import org.catrobat.catroid.content.bricks.TurnRightSpeedBrick;
-import org.catrobat.catroid.content.bricks.UserDefinedBrick;
 import org.catrobat.catroid.content.bricks.VibrationBrick;
 import org.catrobat.catroid.content.bricks.WaitBrick;
 import org.catrobat.catroid.content.bricks.WaitTillIdleBrick;
@@ -349,9 +348,11 @@ public class CategoryBricksFactory {
 	}
 
 	private List<Brick> setupUserBricksCategoryList() {
-		List<Brick> userdDefinedBrickList = new ArrayList<>();
-		userdDefinedBrickList.add(new UserDefinedBrick());
-		return userdDefinedBrickList;
+		Sprite currentSprite = ProjectManager.getInstance().getCurrentSprite();
+		if (currentSprite != null) {
+			return currentSprite.getUserDefinedBrickList();
+		}
+		return new ArrayList<>();
 	}
 
 	private List<Brick> setupChromecastCategoryList(Context context) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/UserBrickListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/UserBrickListFragment.java
@@ -23,21 +23,24 @@
 
 package org.catrobat.catroid.ui.fragment;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
 
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.UserDefinedBrick;
+import org.catrobat.catroid.ui.adapter.PrototypeBrickAdapter;
 import org.catrobat.catroid.ui.recyclerview.fragment.ScriptFragment;
 
-import androidx.annotation.NonNull;
+import java.util.List;
+
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.ListFragment;
 
 public class UserBrickListFragment extends ListFragment implements View.OnClickListener {
@@ -48,6 +51,7 @@ public class UserBrickListFragment extends ListFragment implements View.OnClickL
 	private ScriptFragment scriptFragment;
 
 	private ImageButton addUserBrickButton;
+	private PrototypeBrickAdapter adapter;
 
 	public static UserBrickListFragment newInstance(ScriptFragment scriptFragment) {
 		UserBrickListFragment fragment = new UserBrickListFragment();
@@ -72,9 +76,11 @@ public class UserBrickListFragment extends ListFragment implements View.OnClickL
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		View view = inflater.inflate(R.layout.fragment_user_brick_list, container, false);
-		setHasOptionsMenu(true);
+
 		addUserBrickButton = view.findViewById(R.id.button_add_user_brick);
 		addUserBrickButton.setOnClickListener(this);
+
+		setupUserDefinedBrickListView();
 
 		AppCompatActivity activity = (AppCompatActivity) getActivity();
 		if (activity != null) {
@@ -88,6 +94,24 @@ public class UserBrickListFragment extends ListFragment implements View.OnClickL
 	}
 
 	@Override
+	public void onStart() {
+		super.onStart();
+		getListView().setOnItemClickListener((parent, view, position, id) -> { });
+	}
+
+	private void setupUserDefinedBrickListView() {
+		Context context = getActivity();
+		CategoryBricksFactory categoryBricksFactory = new CategoryBricksFactory();
+
+		if (context != null) {
+			List<Brick> brickList =
+					categoryBricksFactory.getBricks(getString(R.string.category_user_bricks), false, context);
+			adapter = new PrototypeBrickAdapter(brickList);
+			setListAdapter(adapter);
+		}
+	}
+
+	@Override
 	public void onClick(View v) {
 		AddUserBrickFragment addUserBrickFragment =
 				AddUserBrickFragment.newInstance(scriptFragment);
@@ -97,25 +121,12 @@ public class UserBrickListFragment extends ListFragment implements View.OnClickL
 		bundle.putSerializable(UserDefinedBrick.USER_BRICK_BUNDLE_ARGUMENT, userDefinedBrick);
 		addUserBrickFragment.setArguments(bundle);
 
-		getFragmentManager().beginTransaction()
-				.add(R.id.fragment_container, addUserBrickFragment, AddUserBrickFragment.TAG)
-				.addToBackStack(AddUserBrickFragment.TAG)
-				.commit();
-	}
-
-	@Override
-	public void onPrepareOptionsMenu(@NonNull Menu menu) {
-		super.onPrepareOptionsMenu(menu);
-
-		((AppCompatActivity) getActivity())
-				.getSupportActionBar().setTitle(R.string.category_user_bricks);
-	}
-
-	@Override
-	public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
-		super.onCreateOptionsMenu(menu, inflater);
-
-		((AppCompatActivity) getActivity())
-				.getSupportActionBar().setTitle(R.string.category_user_bricks);
+		FragmentManager fragmentManager = getFragmentManager();
+		if (fragmentManager != null) {
+			fragmentManager.beginTransaction()
+					.add(R.id.fragment_container, addUserBrickFragment, AddUserBrickFragment.TAG)
+					.addToBackStack(AddUserBrickFragment.TAG)
+					.commit();
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/BrickAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/BrickAdapter.java
@@ -31,7 +31,6 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.BaseAdapter;
 
-import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -114,9 +113,6 @@ public class BrickAdapter extends BaseAdapter implements
 		itemView.setAlpha(viewStateManager.isEnabled(position) ? 1 : DISABLED_BRICK_ALPHA);
 
 		View brickViewContainer = ((ViewGroup) itemView).getChildAt(1);
-		if (brickViewContainer.getId() == R.id.user_brick_scrollbar) {
-			brickViewContainer = ((ViewGroup) brickViewContainer).getChildAt(0);
-		}
 		Drawable background = brickViewContainer.getBackground();
 
 		if (item.isCommentedOut()) {

--- a/catroid/src/main/res/layout/brick_user_brick.xml
+++ b/catroid/src/main/res/layout/brick_user_brick.xml
@@ -35,19 +35,12 @@
         android:gravity="center_vertical"
         android:visibility="gone"/>
 
-    <ScrollView
-        android:id="@+id/user_brick_scrollbar"
-        android:layout_marginTop="10dp"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/brick_height_medium"
-        android:layout_marginBottom="10dp">
         <org.catrobat.catroid.ui.BrickLayout
             android:id="@+id/brick_user_brick"
             style="@style/BrickContainer.Userbrick.Medium"
-            android:layout_height="@dimen/brick_height_medium"
             app:userDefinedBrick="true"
             android:layout_width="match_parent">
             <include layout="@layout/icon_brick_category_look"/>
         </org.catrobat.catroid.ui.BrickLayout>
-    </ScrollView>
+
 </LinearLayout>

--- a/catroid/src/main/res/layout/fragment_add_new_user_brick.xml
+++ b/catroid/src/main/res/layout/fragment_add_new_user_brick.xml
@@ -24,29 +24,36 @@
 
 
 <!-- Overdraw lint warning is ignored - fragments need refactoring -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/fragment_add_new_user_brick"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/app_background"
-    android:orientation="vertical"
     tools:ignore="Overdraw">
 
     <LinearLayout
-        android:id="@+id/user_brick_space"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"/>
+        android:orientation="vertical">
 
-    <Button
-        android:id="@+id/button_add_label"
-        android:text="@string/brick_user_defined_add_label"
-        style="@style/Button"/>
+        <LinearLayout
+            android:id="@+id/user_brick_space"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="10dp"
+            android:layout_marginTop="10dp"
+            android:orientation="vertical"/>
 
-    <Button
-        android:id="@+id/button_add_input"
-        android:text="@string/brick_user_defined_add_input"
-        style="@style/Button" />
+        <Button
+            android:id="@+id/button_add_label"
+            android:text="@string/brick_user_defined_add_label"
+            style="@style/Button"/>
 
-</LinearLayout>
+        <Button
+            android:id="@+id/button_add_input"
+            android:text="@string/brick_user_defined_add_input"
+            style="@style/Button" />
+
+    </LinearLayout>
+</ScrollView>

--- a/catroid/src/main/res/layout/fragment_add_user_data_to_user_brick.xml
+++ b/catroid/src/main/res/layout/fragment_add_user_data_to_user_brick.xml
@@ -24,49 +24,60 @@
 
 
 <!-- Overdraw lint warning is ignored - fragments need refactoring -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/fragment_add_user_data_to_user_brick"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@color/app_background"
-    android:orientation="vertical"
-    android:clickable="true"
-    android:focusable="true"
     tools:ignore="Overdraw">
 
-
     <LinearLayout
-        android:id="@+id/user_brick_space"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"/>
+        android:orientation="vertical">
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"
-        android:id="@+id/brick_user_defined_add_user_data_description"
-        android:textSize="?attr/x_large"
-        android:color="@color/accent"/>
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="5dp"
-        android:layout_marginRight="5dp">
+        <LinearLayout
+            android:id="@+id/user_brick_space"
+            android:layout_marginBottom="10dp"
+            android:layout_marginTop="10dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"/>
+
+        <TextView
+            android:id="@+id/brick_user_defined_add_user_data_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:layout_marginRight="10dp"
+            android:textSize="?attr/x_large"
+            android:color="@color/accent"/>
+
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/user_data_user_brick_text_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginLeft="5dp"
+            android:layout_marginRight="5dp"
+            android:layout_marginBottom="10dp"
             app:errorEnabled="true">
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/user_data_user_brick_edit_field"
                 android:layout_width="match_parent"
+                android:singleLine="true"
                 android:layout_height="wrap_content"
                 android:textSize="?attr/x_large"
                 android:selectAllOnFocus="true"/>
         </com.google.android.material.textfield.TextInputLayout>
-    </ScrollView>
-</LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/bottom_constraint"
+            android:focusableInTouchMode="true"
+            android:focusable="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"/>
+    </LinearLayout>
+</ScrollView>

--- a/catroid/src/main/res/layout/fragment_user_brick_list.xml
+++ b/catroid/src/main/res/layout/fragment_user_brick_list.xml
@@ -33,7 +33,7 @@
               android:orientation="vertical"
               tools:ignore="Overdraw" >
 
-    <org.catrobat.catroid.ui.dragndrop.BrickListView
+    <ListView
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1061,7 +1061,6 @@
     <!-- User Defined Bricks -->
     <string name="brick_user_defined_add_label">Add label</string>
     <string name="brick_user_defined_add_input">Add input</string>
-    <string name="brick_add_new_user_brick">Add new brick</string>
 
     <string name="brick_user_defined_add_input_description">Add input for this brick:</string>
     <string name="brick_user_defined_add_label_description">Add label for this brick:</string>

--- a/catroid/src/main/res/values/styles.xml
+++ b/catroid/src/main/res/values/styles.xml
@@ -149,7 +149,8 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">60dp</item>
         <item name="android:layout_marginLeft">10dp</item>
-        <item name="android:layout_marginTop">20dp</item>
+        <item name="android:layout_marginTop">10dp</item>
+        <item name="android:layout_marginBottom">10dp</item>
         <item name="android:layout_marginRight">10dp</item>
         <item name="android:background">@drawable/button_background_selector</item>
         <item name="android:fontFamily">sans-serif</item>
@@ -164,18 +165,7 @@
         <item name="android:textSize">?attr/large</item>
         <item name="android:textColor">@color/solid_white</item>
         <item name="android:textStyle">bold</item>
-    </style>
-
-    <style name="MultilineBrickText">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:textSize">?attr/large</item>
-        <item name="android:textColor">@color/solid_white</item>
-        <item name="android:textStyle">bold</item>
-        <item name="android:maxLines">3</item>
-        <item name="android:scrollbars">vertical</item>
-        <item name="android:gravity">bottom</item>
-        <item name="android:paddingEnd">@dimen/material_design_spacing_small</item>
+        <item name="android:singleLine">true</item>
     </style>
 
     <style name="BrickText.SingleLine">
@@ -200,19 +190,6 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:singleLine">true</item>
         <item name="android:ellipsize">end</item>
-    </style>
-
-    <style name="MultilineBrickEditText" parent="Widget.AppCompat.EditText">
-        <item name="android:textSize">?attr/large</item>
-        <item name="backgroundTint">@color/solid_white</item>
-        <item name="android:focusable">false</item>
-        <item name="android:focusableInTouchMode">false</item>
-        <item name="android:clickable">false</item>
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">match_parent</item>
-        <item name="android:maxLines">3</item>
-        <item name="android:scrollbars">vertical</item>
-        <item name="android:gravity">bottom</item>
     </style>
 
     <style name="BrickContainer">

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/AddUserBrickTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/AddUserBrickTest.java
@@ -23,9 +23,8 @@
 
 package org.catrobat.catroid.test.content.bricks;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
-
 import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.UserDefinedBrick;
 import org.catrobat.catroid.content.bricks.brickspinner.StringOption;
 import org.catrobat.catroid.userbrick.UserBrickData;
@@ -39,6 +38,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertSame;
@@ -52,36 +52,36 @@ public class AddUserBrickTest {
 	public static Iterable<Object[]> data() {
 		return asList(new Object[][] {
 				{"SpriteBrickEmpty",
-						Arrays.asList(new UserBrickData[]{defaultInput}),
+						Collections.singletonList(defaultInput),
 						new ArrayList<>(),
 						false},
 				{"SameUserInputs",
-						Arrays.asList(new UserBrickData[]{defaultInput}),
-						Arrays.asList(new UserBrickData[]{defaultInput}),
+						Collections.singletonList(defaultInput),
+						Collections.singletonList(defaultInput),
 						true},
 				{"SameUserLabels",
-						Arrays.asList(new UserBrickData[]{defaultLabel}),
-						Arrays.asList(new UserBrickData[]{defaultLabel}),
+						Collections.singletonList(defaultLabel),
+						Collections.singletonList(defaultLabel),
 						true},
 				{"DifferentLabelsWhitespaces",
-						Arrays.asList(new UserBrickData[]{new UserBrickLabel(new StringOption(" "))}),
-						Arrays.asList(new UserBrickData[]{new UserBrickLabel(new StringOption(""))}),
+						Collections.singletonList(new UserBrickLabel(new StringOption(" "))),
+						Collections.singletonList(new UserBrickLabel(new StringOption(""))),
 						false},
 				{"DifferentAmountOfUserInput",
-						Arrays.asList(new UserBrickData[]{defaultInput, differentInput}),
-						Arrays.asList(new UserBrickData[]{defaultInput}),
+						asList(defaultInput, differentInput),
+						Collections.singletonList(defaultInput),
 						false},
 				{"DifferentAmountOfUserData",
-						Arrays.asList(new UserBrickData[]{defaultLabel, defaultInput}),
-						Arrays.asList(new UserBrickData[]{defaultInput}),
+						asList(defaultLabel, defaultInput),
+						Collections.singletonList(defaultInput),
 						false},
 				{"SameUserDataWithDifferentInput",
-						Arrays.asList(new UserBrickData[]{defaultLabel, defaultInput, defaultLabel}),
-						Arrays.asList(new UserBrickData[]{defaultLabel, differentInput, defaultLabel}),
+						asList(defaultLabel, defaultInput, defaultLabel),
+						asList(defaultLabel, differentInput, defaultLabel),
 						true},
 				{"DifferentUserLabelsWithDifferentInput",
-						Arrays.asList(new UserBrickData[]{defaultLabel, defaultInput, differentLabel}),
-						Arrays.asList(new UserBrickData[]{defaultLabel, differentInput, defaultLabel}),
+						asList(defaultLabel, defaultInput, differentLabel),
+						asList(defaultLabel, differentInput, defaultLabel),
 						false},
 		});
 	}
@@ -107,7 +107,7 @@ public class AddUserBrickTest {
 	private static UserBrickInput differentInput = new UserBrickInput(new StringOption("DifferentInput"));
 
 	private UserDefinedBrick brickToTest;
-	private List<UserDefinedBrick> userDefinedBrickListOfSprite;
+	private List<Brick> userDefinedBrickListOfSprite;
 
 	@Before
 	public void setUp() throws Exception {


### PR DESCRIPTION
- Implement ListFragment to show the already defined UserBricks
- As it is not possible to make ScrollViews inside ListViews the Layout of a UserBrick was refactored according to https://jira.catrob.at/browse/CATROID-573. This makes it possible that a UserDefinedBrick can consist of more lines now.
- InputFields and Labels of UserDefinedBricks are also adapted to the previously mentioned ticket. Thus, if they get longer than one line the text is displayed with dots.
- As discussed with @BeinhAlex a testcase will be added with ticket https://jira.catrob.at/browse/CATROID-219
 
https://jira.catrob.at/browse/CATROID-217

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
