### PR TITLE
CATROID-621 removed limitation of suffix from ReadVariableFromFileBrick

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/ReadVariableFromFileAction.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/ReadVariableFromFileAction.kt
@@ -44,7 +44,7 @@ class ReadVariableFromFileAction : EventAction() {
         }
 
         var fileName = Utils.sanitizeFileName(formula!!.interpretString(sprite))
-        if (!fileName.endsWith(".txt")) {
+        if (!fileName.contains(Regex("\\.\\w+$"))) {
             fileName += ".txt"
         }
 


### PR DESCRIPTION
if no suffix is provided it will still append '.txt'

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
