### PR TITLE
CATROID-637 Exit Community (open app in browser)

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -111,6 +111,9 @@ public final class Constants {
 	private static final String WEB_TEST_URL = BuildConfig.WEB_TEST_URL;
 	public static final String MAIN_URL_HTTPS = BuildConfig.WEB_TEST_FLAG ? WEB_TEST_URL : MAIN_URL_PRODUCTION;
 
+	// Default "flavor" in the web which equals "pocketcode"
+	public static final String BASE_APP_URL_HTTPS = MAIN_URL_HTTPS + "/app/";
+
 	public static final String SHARE_PROGRAM_URL = BASE_URL_HTTPS + "/program/";
 
 	public static final String CATROBAT_ABOUT_URL = "https://www.catrobat.org/";

--- a/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/WebViewActivity.java
@@ -158,7 +158,8 @@ public class WebViewActivity extends AppCompatActivity {
 				webViewLoadingDialog.setCanceledOnTouchOutside(false);
 				webViewLoadingDialog.setProgressStyle(android.R.style.Widget_ProgressBar_Small);
 				webViewLoadingDialog.show();
-			} else if (allowGoBack && urlClient.equals(FlavoredConstants.BASE_URL_HTTPS)) {
+			} else if (allowGoBack && (urlClient.equals(FlavoredConstants.BASE_URL_HTTPS)
+					|| urlClient.equals(Constants.BASE_APP_URL_HTTPS))) {
 				allowGoBack = false;
 				onBackPressed();
 			}


### PR DESCRIPTION
When the app is opened from the browser, there is a high chance
the user was browsing the ShareCommunity platform under the "app" flavor
which is basically the same as "pocketcode".

  - add "app" url constant
  - "app" index route closes web-view, similar to "pocketcode" index route

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
