### PR TITLE
Fix deleteProjects() call with no parameter

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/StopSoundActionTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/StopSoundActionTest.kt
@@ -29,6 +29,7 @@ import org.catrobat.catroid.content.Project
 import org.catrobat.catroid.content.SingleSprite
 import org.catrobat.catroid.content.Sprite
 import org.catrobat.catroid.io.SoundManager
+import org.catrobat.catroid.io.XstreamSerializer
 import org.catrobat.catroid.test.R
 import org.catrobat.catroid.test.utils.TestUtils
 import org.catrobat.catroid.test.utils.TestUtils.createSoundFile
@@ -50,10 +51,7 @@ class StopSoundActionTest {
 
     @Before
     fun setUp() {
-        project = Project(
-            ApplicationProvider.getApplicationContext(),
-            TestUtils.DEFAULT_TEST_PROJECT_NAME
-        )
+        project = createProject()
         soundFile = createSoundFile(project, R.raw.testsound, "soundTest.mp3")
         sprite = SingleSprite(TestUtils.DEFAULT_TEST_SPRITE_NAME)
     }
@@ -92,7 +90,15 @@ class StopSoundActionTest {
     @After
     fun tearDown() {
         soundManager.clear()
+        TestUtils.deleteProjects()
     }
 
     private fun createSoundInfo(soundFile: File) = SoundInfo().also { it.file = soundFile }
+
+    private fun createProject(): Project {
+        val newProject: Project = Project(ApplicationProvider.getApplicationContext(),
+            TestUtils.DEFAULT_TEST_PROJECT_NAME)
+        XstreamSerializer.getInstance().saveProject(newProject)
+        return newProject
+    }
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/TestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/TestUtils.java
@@ -43,6 +43,7 @@ import org.catrobat.catroid.io.XstreamSerializer;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -58,6 +59,20 @@ public final class TestUtils {
 
 	private TestUtils() {
 		throw new AssertionError();
+	}
+
+	public static void deleteProjects() throws IOException {
+		File[] filesOfRootDirectory = FlavoredConstants.DEFAULT_ROOT_DIRECTORY.listFiles();
+		if (filesOfRootDirectory == null || filesOfRootDirectory.length == 0) {
+			return;
+		}
+
+		ArrayList<String> projectFilesToDelete = new ArrayList<>();
+		for (File file : filesOfRootDirectory) {
+			projectFilesToDelete.add(file.getName());
+		}
+
+		deleteProjects(projectFilesToDelete.toArray(new String[0]));
 	}
 
 	public static void deleteProjects(String... projectNames) throws IOException {


### PR DESCRIPTION
A lot of tests are using `TestUtils.java --> deleteProjects(String... projects)` function to clear up their test setup. When calling this function without parameters, which is the case in many of those tests, nothing will happen. As discussed with @gPathpp the function should delete all Projects when calling without parameters.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
