### PR TITLE
CATROID-306 Enable delete option for UserDefinedReceiverBrick

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/DeleteUserDefinedReceiverBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/DeleteUserDefinedReceiverBrickTest.java
@@ -1,0 +1,163 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.content.brick.app;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.UserDefinedScript;
+import org.catrobat.catroid.content.bricks.IfLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.SetXBrick;
+import org.catrobat.catroid.content.bricks.UserDefinedBrick;
+import org.catrobat.catroid.content.bricks.UserDefinedReceiverBrick;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.test.utils.TestUtils;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.ui.recyclerview.controller.SpriteController;
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.catrobat.catroid.userbrick.UserDefinedBrickInput;
+import org.catrobat.catroid.userbrick.UserDefinedBrickLabel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class DeleteUserDefinedReceiverBrickTest {
+
+	@Rule
+	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
+			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION,
+			SpriteActivity.FRAGMENT_SCRIPTS);
+
+	private Sprite sprite;
+	private Sprite copiedSprite;
+
+	private UserDefinedBrick userDefinedBrickToDelete;
+	private UserDefinedBrick differentUserDefinedBrick;
+	private SetXBrick setXBrick;
+	private IfLogicBeginBrick ifLogicBrick;
+
+	private int indexStartScript = 2;
+	private int indexBrickToDelete = 0;
+
+	@After
+	public void tearDown() throws IOException {
+		TestUtils.deleteProjects(DeleteUserDefinedReceiverBrickTest.class.getSimpleName());
+	}
+
+	@Before
+	public void setUp() throws IOException, CloneNotSupportedException {
+		createProject(DeleteUserDefinedReceiverBrickTest.class.getSimpleName());
+		baseActivityTestRule.launchActivity();
+		onBrickAtPosition(0).performDeleteBrick();
+	}
+
+	@Test
+	public void testRemoveFromYourBrickCategory() {
+		assertFalse(sprite.getUserDefinedBrickList().contains(userDefinedBrickToDelete));
+	}
+	@Test
+	public void testDeletionInCurrentSpriteOnly() {
+		assertTrue(copiedSprite.containsUserDefinedBrickWithSameUserData(userDefinedBrickToDelete));
+		UserDefinedBrick userDefinedBrick = (UserDefinedBrick) copiedSprite.getScript(indexStartScript).getBrickList().get(indexBrickToDelete);
+		assertTrue(userDefinedBrick.isUserDefinedBrickDataEqual(userDefinedBrickToDelete));
+	}
+	@Test
+	public void testDeletionInNestedBricks() {
+		assertTrue(ifLogicBrick.getNestedBricks().isEmpty());
+		assertTrue(ifLogicBrick.getSecondaryNestedBricks().isEmpty());
+	}
+	@Test
+	public void testDeletionOfUserDefinedReceiverBrick() {
+		assertFalse(sprite.getScript(indexStartScript).getBrickList().contains(userDefinedBrickToDelete));
+	}
+	@Test
+	public void testDifferentUserDefinedBrickNotDeleted() {
+		assertTrue(sprite.getScript(indexStartScript).getBrickList().contains(differentUserDefinedBrick));
+	}
+
+	private void createProject(String projectName) throws IOException, CloneNotSupportedException {
+		Project project = new Project(ApplicationProvider.getApplicationContext(), projectName);
+		ProjectManager projectManager = ProjectManager.getInstance();
+
+		SpriteController controller = new SpriteController();
+
+		sprite = new Sprite("Sprite1");
+		userDefinedBrickToDelete = new UserDefinedBrick(Collections.singletonList(new UserDefinedBrickLabel("Label")));
+		differentUserDefinedBrick = new UserDefinedBrick(Collections.singletonList(new UserDefinedBrickInput("Input")));
+		setXBrick = new SetXBrick(new Formula(0));
+		ifLogicBrick = new IfLogicBeginBrick();
+		ifLogicBrick.addBrickToIfBranch(userDefinedBrickToDelete);
+		ifLogicBrick.addBrickToElseBranch(userDefinedBrickToDelete);
+
+		createUserDefinedScripts();
+		createStartScript();
+
+		Scene scene = project.getDefaultScene();
+		project.getDefaultScene().addSprite(sprite);
+
+		copiedSprite = controller.copy(sprite, project, scene);
+
+		projectManager.setCurrentProject(project);
+		projectManager.setCurrentSprite(sprite);
+	}
+
+	private void createStartScript() {
+		Script startScript = new StartScript();
+		startScript.addBrick(userDefinedBrickToDelete);
+		startScript.addBrick(differentUserDefinedBrick);
+		startScript.addBrick(ifLogicBrick);
+		sprite.addScript(startScript);
+	}
+
+	private void createUserDefinedScripts() throws CloneNotSupportedException {
+		Script scriptToDelete = new UserDefinedScript();
+		scriptToDelete.setScriptBrick(new UserDefinedReceiverBrick(userDefinedBrickToDelete));
+		sprite.addUserDefinedBrick(userDefinedBrickToDelete);
+		scriptToDelete.addBrick(setXBrick);
+
+		Script secondScript = new UserDefinedScript();
+		secondScript.setScriptBrick(new UserDefinedReceiverBrick(differentUserDefinedBrick));
+		sprite.addUserDefinedBrick(differentUserDefinedBrick);
+		secondScript.addBrick(setXBrick.clone());
+
+		sprite.addScript(scriptToDelete);
+		sprite.addScript(secondScript);
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickDataInteractionWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickDataInteractionWrapper.java
@@ -113,7 +113,8 @@ public class BrickDataInteractionWrapper extends DataInteractionWrapper {
 				BrickCoordinatesProvider.UPPER_LEFT_CORNER,
 				Press.FINGER));
 		onView(anyOf(withText(R.string.brick_context_dialog_delete_brick),
-				withText(R.string.brick_context_dialog_delete_script)))
+				withText(R.string.brick_context_dialog_delete_script),
+				withText(R.string.brick_context_dialog_delete_definition)))
 				.perform(click());
 		onView(withText(R.string.yes))
 				.perform(click());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/UserDefinedBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/UserDefinedBrickTest.java
@@ -23,8 +23,6 @@
 package org.catrobat.catroid.uiespresso.ui.fragment;
 
 import org.catrobat.catroid.R;
-import org.catrobat.catroid.content.Script;
-import org.catrobat.catroid.content.bricks.GlideToBrick;
 import org.catrobat.catroid.content.bricks.UserDefinedBrick;
 import org.catrobat.catroid.test.utils.TestUtils;
 import org.catrobat.catroid.ui.SpriteActivity;
@@ -77,9 +75,7 @@ public class UserDefinedBrickTest {
 
 	@Before
 	public void setUp() throws IOException {
-		Script script =
-				BrickTestUtils.createProjectAndGetStartScript(UserDefinedBrickTest.class.getSimpleName());
-		script.addBrick(new GlideToBrick());
+		BrickTestUtils.createProjectAndGetStartScript(UserDefinedBrickTest.class.getSimpleName());
 		baseActivityTestRule.launchActivity();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/Script.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Script.java
@@ -24,7 +24,9 @@ package org.catrobat.catroid.content;
 
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
 import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.content.bricks.CompositeBrick;
 import org.catrobat.catroid.content.bricks.ScriptBrick;
+import org.catrobat.catroid.content.bricks.UserDefinedBrick;
 import org.catrobat.catroid.content.eventids.EventId;
 
 import java.io.Serializable;
@@ -126,6 +128,22 @@ public abstract class Script implements Serializable, Cloneable {
 			}
 		}
 		return false;
+	}
+
+	public void removeAllOccurrencesOfUserDefinedBrick(List<Brick> brickList, UserDefinedBrick userDefinedBrick) {
+		for (int brickIndex = 0; brickIndex < brickList.size(); brickIndex++) {
+			Brick currentBrick = brickList.get(brickIndex);
+			if (currentBrick instanceof CompositeBrick) {
+				CompositeBrick currentCompositeBrick = (CompositeBrick) currentBrick;
+				removeAllOccurrencesOfUserDefinedBrick(currentCompositeBrick.getNestedBricks(), userDefinedBrick);
+				if (currentCompositeBrick.hasSecondaryList()) {
+					removeAllOccurrencesOfUserDefinedBrick(currentCompositeBrick.getSecondaryNestedBricks(), userDefinedBrick);
+				}
+			}
+			if (currentBrick instanceof UserDefinedBrick && userDefinedBrick.isUserDefinedBrickDataEqual(currentBrick)) {
+				brickList.remove(brickIndex--);
+			}
+		}
 	}
 
 	public void addRequiredResources(final Brick.ResourcesSet resourcesSet) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -162,12 +162,19 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 		return null;
 	}
 
-	private boolean containsUserDefinedBrickWithSameUserData(UserDefinedBrick userDefinedBrick) {
+	public boolean containsUserDefinedBrickWithSameUserData(UserDefinedBrick userDefinedBrick) {
 		return getUserDefinedBrickWithSameUserData(userDefinedBrick) != null;
 	}
 
 	public void addUserDefinedBrick(UserDefinedBrick userDefinedBrick) {
 		userDefinedBrickList.add(userDefinedBrick);
+	}
+
+	public void removeUserDefinedBrick(UserDefinedBrick userDefinedBrick) {
+		for (Script script : scriptList) {
+			script.removeAllOccurrencesOfUserDefinedBrick(script.brickList, userDefinedBrick);
+		}
+		userDefinedBrickList.remove(userDefinedBrick);
 	}
 
 	public void addClonesOfUserDefinedBrickList(List<UserDefinedBrick> userDefinedBricks) {
@@ -487,8 +494,8 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 		}
 	}
 
-	public static boolean doesUserBrickAlreadyExist(UserDefinedBrick userDefinedBrick, Sprite sprite) {
-		for (Brick alreadyDefinedBrick : sprite.getUserDefinedBrickList()) {
+	public boolean doesUserBrickAlreadyExist(UserDefinedBrick userDefinedBrick) {
+		for (Brick alreadyDefinedBrick : getUserDefinedBrickList()) {
 			if (((UserDefinedBrick) alreadyDefinedBrick).isUserDefinedBrickDataEqual(userDefinedBrick)) {
 				return true;
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserDefinedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserDefinedBrick.java
@@ -142,7 +142,11 @@ public class UserDefinedBrick extends BrickBaseType {
 		return userDefinedBrickDataList.get(userDefinedBrickDataList.size() - 1) instanceof UserDefinedBrickLabel;
 	}
 
-	public boolean isUserDefinedBrickDataEqual(UserDefinedBrick other) {
+	public boolean isUserDefinedBrickDataEqual(Brick brick) {
+		if (!(brick instanceof UserDefinedBrick)) {
+			return false;
+		}
+		UserDefinedBrick other = (UserDefinedBrick) brick;
 		if (userDefinedBrickDataList.size() != other.userDefinedBrickDataList.size()) {
 			return false;
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddUserDefinedBrickFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddUserDefinedBrickFragment.java
@@ -148,7 +148,7 @@ public class AddUserDefinedBrickFragment extends Fragment {
 				userDefinedBrick.addLabel("");
 			}
 
-			if (Sprite.doesUserBrickAlreadyExist(userDefinedBrick, currentSprite)) {
+			if (currentSprite.doesUserBrickAlreadyExist(userDefinedBrick)) {
 				ToastUtil.showErrorWithColor(getContext(), R.string.brick_user_defined_already_exists, Color.RED);
 				if (brickIsEmpty) {
 					userDefinedBrick.removeLastLabel();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/BrickController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/BrickController.java
@@ -29,6 +29,8 @@ import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.ScriptBrick;
+import org.catrobat.catroid.content.bricks.UserDefinedBrick;
+import org.catrobat.catroid.content.bricks.UserDefinedReceiverBrick;
 
 import java.util.List;
 
@@ -63,6 +65,10 @@ public final class BrickController {
 	public void delete(@NonNull List<Brick> bricksToDelete, Sprite parent) {
 		for (Brick brick : bricksToDelete) {
 			Script script = brick.getScript();
+			if (brick instanceof UserDefinedReceiverBrick) {
+				UserDefinedBrick userDefinedBrick = ((UserDefinedReceiverBrick) brick).getUserDefinedBrick();
+				parent.removeUserDefinedBrick(userDefinedBrick);
+			}
 
 			if (brick instanceof ScriptBrick) {
 				parent.removeScript(script);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -45,6 +45,7 @@ import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
 import org.catrobat.catroid.content.bricks.ScriptBrick;
+import org.catrobat.catroid.content.bricks.UserDefinedReceiverBrick;
 import org.catrobat.catroid.content.bricks.VisualPlacementBrick;
 import org.catrobat.catroid.io.asynctask.ProjectSaveTask;
 import org.catrobat.catroid.ui.BottomBar;
@@ -174,7 +175,7 @@ public class ScriptFragment extends ListFragment implements
 				copy(adapter.getSelectedItems());
 				break;
 			case DELETE:
-				showDeleteAlert(adapter.getSelectedItems());
+				showDeleteAlert(adapter.getSelectedItems(), false);
 				break;
 			case COMMENT:
 				toggleComments(adapter.getSelectedItems());
@@ -468,6 +469,12 @@ public class ScriptFragment extends ListFragment implements
 	private List<Integer> getContextMenuItems(Brick brick) {
 		List<Integer> items = new ArrayList<>();
 
+		if (brick instanceof UserDefinedReceiverBrick) {
+			items.add(R.string.brick_context_dialog_delete_definition);
+			items.add(R.string.brick_context_dialog_move_definition);
+			return items;
+		}
+
 		if (brick instanceof ScriptBrick) {
 			items.add(R.string.backpack_add);
 			items.add(R.string.brick_context_dialog_copy_script);
@@ -529,7 +536,10 @@ public class ScriptFragment extends ListFragment implements
 				break;
 			case R.string.brick_context_dialog_delete_brick:
 			case R.string.brick_context_dialog_delete_script:
-				showDeleteAlert(brick.getAllParts());
+				showDeleteAlert(brick.getAllParts(), false);
+				break;
+			case R.string.brick_context_dialog_delete_definition:
+				showDeleteAlert(brick.getAllParts(), true);
 				break;
 			case R.string.brick_context_dialog_comment_in:
 			case R.string.brick_context_dialog_comment_in_script:
@@ -555,6 +565,7 @@ public class ScriptFragment extends ListFragment implements
 				break;
 			case R.string.brick_context_dialog_move_brick:
 			case R.string.brick_context_dialog_move_script:
+			case R.string.brick_context_dialog_move_definition:
 				onItemLongClick(brick, position);
 				break;
 			case R.string.brick_context_dialog_help:
@@ -645,11 +656,18 @@ public class ScriptFragment extends ListFragment implements
 		finishActionMode();
 	}
 
-	private void showDeleteAlert(List<Brick> selectedBricks) {
-		new AlertDialog.Builder(getContext())
-				.setTitle(getResources().getQuantityString(R.plurals.delete_bricks, selectedBricks.size()))
-				.setMessage(R.string.dialog_confirm_delete)
-				.setPositiveButton(R.string.yes, (dialog, id) -> delete(selectedBricks))
+	private void showDeleteAlert(List<Brick> selectedBricks, boolean isUserDefinedReceiverBrick) {
+		AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+
+		if (isUserDefinedReceiverBrick) {
+			builder.setTitle(R.string.delete_definition)
+					.setMessage(R.string.dialog_confirm_delete_definition);
+		} else {
+			builder.setTitle(getResources().getQuantityString(R.plurals.delete_bricks, selectedBricks.size()))
+					.setMessage(R.string.dialog_confirm_delete);
+		}
+
+		builder.setPositiveButton(R.string.yes, (dialog, id) -> delete(selectedBricks))
 				.setNegativeButton(R.string.no, null)
 				.setCancelable(false)
 				.show();

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -333,6 +333,8 @@
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
     <string name="dialog_confirm_delete">You can\'t undo this!</string>
+    <string name="dialog_confirm_delete_definition">This will also remove the brick in all
+        other scripts in which it is being used.\nYou cannot undo this!</string>
 
     <string name="list_headline_sprites">Actors and objects</string>
 
@@ -381,6 +383,7 @@
         <item quantity="one">Delete this brick?</item>
         <item quantity="other">Delete these bricks?</item>
     </plurals>
+    <string name="delete_definition">Delete the definition of this brick?</string>
 
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>
@@ -767,11 +770,13 @@
     <!-- Brick context dialog -->
     <string name="brick_context_dialog_move_brick">Move brick</string>
     <string name="brick_context_dialog_move_script">Move script</string>
+    <string name="brick_context_dialog_move_definition">Move this definition</string>
     <string name="brick_context_dialog_delete_brick">Delete brick</string>
     <string name="brick_context_dialog_copy_brick">Copy brick</string>
     <string name="brick_context_dialog_copy_script">Copy script</string>
     <string name="brick_context_dialog_formula_edit_brick">Edit formula</string>
     <string name="brick_context_dialog_delete_script">Delete script</string>
+    <string name="brick_context_dialog_delete_definition">Delete this definition</string>
     <string name="brick_context_dialog_comment_in">Enable brick</string>
     <string name="brick_context_dialog_comment_out">Disable brick</string>
     <string name="brick_context_dialog_highlight_brick_parts">Highlight brick parts</string>

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/UserDefinedBrickEqualityTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/UserDefinedBrickEqualityTest.java
@@ -33,8 +33,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -97,7 +98,7 @@ public class UserDefinedBrickEqualityTest {
 	@Parameterized.Parameter(3)
 	public boolean expectedOutput;
 
-	@Mock
+	@Spy
 	private Sprite spriteMock;
 
 	private static UserDefinedBrickLabel defaultLabel = new UserDefinedBrickLabel("Label");
@@ -110,8 +111,9 @@ public class UserDefinedBrickEqualityTest {
 
 	@Before
 	public void setUp() throws Exception {
-		brickToTest = new UserDefinedBrick(brickToTestBrickData);
+		MockitoAnnotations.initMocks(this);
 
+		brickToTest = new UserDefinedBrick(brickToTestBrickData);
 		UserDefinedBrick alreadyDefinedUserBrickOfSprite = new UserDefinedBrick(alreadyDefinedUserBrickOfSpriteBrickData);
 		userDefinedBrickListOfSprite = new ArrayList<>();
 		userDefinedBrickListOfSprite.add(alreadyDefinedUserBrickOfSprite);
@@ -119,8 +121,7 @@ public class UserDefinedBrickEqualityTest {
 
 	@Test
 	public void testDoesUserBrickAlreadyExist() {
-		spriteMock = Mockito.mock(Sprite.class);
 		Mockito.when(spriteMock.getUserDefinedBrickList()).thenReturn(userDefinedBrickListOfSprite);
-		assertSame(Sprite.doesUserBrickAlreadyExist(brickToTest, spriteMock), expectedOutput);
+		assertSame(spriteMock.doesUserBrickAlreadyExist(brickToTest), expectedOutput);
 	}
 }


### PR DESCRIPTION
- Add context menu items for deleting/moving UserDefinedReceiverBrick ⇨  https://jira.catrob.at/browse/CATROID-309 and https://jira.catrob.at/browse/CATROID-310 work out-of-the-box and can be closed if this PR is merged
- Multi-brick deletion from the overflow menu is handled in the same way as for one UserDefinedReceiverBrick


- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
