### PR TITLE
CATROID-643: fix StandaloneSignedRelease build

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -296,7 +296,9 @@ android {
             resValue "string", "FEATURE_RASPI_PREFERENCES_ENABLED", "true"
         }
         standalone {
-            applicationIdSuffix '.standalone'
+            if (!project.hasProperty('packageName')) {
+                applicationIdSuffix '.standalone'
+            }
             versionCode 1
             versionName '1.0'
 

--- a/catroid/gradle/standalone_apk_tasks.gradle
+++ b/catroid/gradle/standalone_apk_tasks.gradle
@@ -52,6 +52,9 @@ task standalonePreparation() {
      */
     if (project.hasProperty('download')) {
         project.ext.projectId = project['suffix']
+        if (project.hasProperty('packageName')) {
+            project.ext.appId = project['packageName']
+        }
         project.ext.appId += '.' + project['suffix']
         project.ext.manifestAppIcon = '@drawable/icon'
         project.ext.appZipFile = new File(makeAppsCache().absolutePath + '/' + project.ext.projectId + '.zip')
@@ -221,7 +224,7 @@ def messUpIntentFilters() {
 */
 
 tasks.whenTaskAdded { task ->
-    if (task.name == 'preStandaloneDebugBuild') {
+    if (task.name == 'preStandaloneDebugBuild' || task.name == 'preStandaloneSignedReleaseBuild') {
         task.dependsOn 'standalonePreparation'
     } else if (task.name == 'assembleStandaloneDebug') {
         task.finalizedBy 'standaloneCleanup'


### PR DESCRIPTION
* the project folder is missing in the built apk file
* right now the package name of the apk is org.catrobat.{projectId}.standalone, which must be pre-defined during the build to something like com.mydomain.{projectName}

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
