### PR TITLE
CATROID-652 Front Camera is always activated

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/camera/FaceDetector.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/camera/FaceDetector.kt
@@ -45,14 +45,16 @@ import org.catrobat.catroid.stage.StageActivity
 import kotlin.math.roundToInt
 
 object FaceDetector : ImageAnalysis.Analyzer {
-    private val detectionClient = FaceDetection.getClient(
-        FaceDetectorOptions.Builder()
-            .setClassificationMode(FaceDetectorOptions.CLASSIFICATION_MODE_ALL)
-            .enableTracking()
-            .build()
-    )
-    private val sensorListeners = mutableSetOf<SensorCustomEventListener>()
     private const val MAX_FACE_SIZE = 100
+    private val sensorListeners = mutableSetOf<SensorCustomEventListener>()
+    private val detectionClient by lazy {
+        FaceDetection.getClient(
+            FaceDetectorOptions.Builder()
+                .setClassificationMode(FaceDetectorOptions.CLASSIFICATION_MODE_ALL)
+                .enableTracking()
+                .build()
+        )
+    }
 
     @JvmStatic
     fun addListener(listener: SensorCustomEventListener) {


### PR DESCRIPTION
Creates face detection client on demand to avoid unneccessary camera access. Issue is most apparent on devices with pop-up camera (eg. Xiaomi Mi 9T Pro).

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
