### PR TITLE
CATROID-636: Migrate to AndroidX (targetSdkVersion 29)

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -132,12 +132,12 @@ jacocoAndroidUnitTestReport {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
 
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         applicationId appId
         testInstrumentationRunner 'org.catrobat.catroid.runner.UiTestApplicationRunner'
         versionCode 78

--- a/catroid/proguard-project.txt
+++ b/catroid/proguard-project.txt
@@ -19,11 +19,6 @@
 #   public *;
 #}
 
-
-# The official support library.
--keep class android.support.v4.app.** { *; }
--keep interface android.support.v4.app.** { *; }
-
 # Library JARs
 -keep class com.thoughtworks.xstream.** { *; }
 -keep interface com.thoughtworks.xstream.** { *; }

--- a/catroid/src/main/java/org/catrobat/catroid/CatroidApplication.java
+++ b/catroid/src/main/java/org/catrobat/catroid/CatroidApplication.java
@@ -65,7 +65,7 @@ public class CatroidApplication extends Application implements HasActivityInject
 	DispatchingAndroidInjector<Activity> dispatchingActivityInjector;
 	protected AppComponent appComponents;
 
-	@TargetApi(28)
+	@TargetApi(29)
 	@Override
 	public void onCreate() {
 		super.onCreate();

--- a/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickAddCategoryTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickAddCategoryTest.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.test.robolectric.bricks;
 
 import android.app.Activity;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.widget.ListAdapter;
 
@@ -44,6 +45,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -65,6 +67,7 @@ import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTING
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_RASPI_BRICKS;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.P})
 public class BrickAddCategoryTest {
 
 	private SpriteActivity activity;

--- a/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickSingleFormulaFieldTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickSingleFormulaFieldTest.java
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.test.robolectric.bricks;
 
 import android.app.Activity;
+import android.os.Build;
 import android.view.View;
 import android.widget.TextView;
 
@@ -143,7 +144,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
-@Config(sdk = {25})
+@Config(sdk = {Build.VERSION_CODES.P})
 public class BrickSingleFormulaFieldTest {
 
 	private SpriteActivity activity;

--- a/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickSpinnerDefaultValueTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickSpinnerDefaultValueTest.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.test.robolectric.bricks;
 
 import android.app.Activity;
 import android.content.Context;
+import android.os.Build;
 import android.view.View;
 import android.widget.Spinner;
 
@@ -67,6 +68,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -76,6 +78,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.P})
 public class BrickSpinnerDefaultValueTest {
 
 	private CategoryBricksFactory categoryBricksFactory;

--- a/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickSpinnerTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickSpinnerTest.java
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.test.robolectric.bricks;
 
 import android.app.Activity;
+import android.os.Build;
 import android.view.View;
 import android.widget.Spinner;
 
@@ -81,6 +82,7 @@ import org.mockito.Mockito;
 import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -99,6 +101,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.P})
 public class BrickSpinnerTest {
 
 	private SpriteActivity activity;

--- a/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickStringSpinnerDefaultValueTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickStringSpinnerDefaultValueTest.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.test.robolectric.bricks;
 
 import android.app.Activity;
 import android.content.Context;
+import android.os.Build;
 import android.view.View;
 import android.widget.Spinner;
 
@@ -60,6 +61,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -69,6 +71,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.P})
 public class BrickStringSpinnerDefaultValueTest {
 
 	private CategoryBricksFactory categoryBricksFactory;

--- a/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickStringSpinnerTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickStringSpinnerTest.java
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.test.robolectric.bricks;
 
 import android.app.Activity;
+import android.os.Build;
 import android.view.View;
 import android.widget.Spinner;
 
@@ -63,6 +64,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -80,6 +82,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.P})
 public class BrickStringSpinnerTest {
 
 	private SpriteActivity activity;

--- a/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BroadcastBrickTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BroadcastBrickTest.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.test.robolectric.bricks;
 
 import android.app.Activity;
 import android.content.DialogInterface;
+import android.os.Build;
 import android.view.View;
 import android.widget.Spinner;
 
@@ -46,6 +47,7 @@ import org.mockito.Mockito;
 import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -56,6 +58,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.P})
 public class BroadcastBrickTest {
 
 	private static final String INITAL_MESSAGE = "initialMessage";

--- a/catroid/src/test/java/org/catrobat/catroid/test/robolectric/formulaeditor/FormulaEditorEditTextGenericTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/robolectric/formulaeditor/FormulaEditorEditTextGenericTest.java
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.test.robolectric.formulaeditor;
 
 import android.app.Activity;
+import android.os.Build;
 import android.os.SystemClock;
 import android.view.MotionEvent;
 import android.view.View;
@@ -46,6 +47,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 
@@ -54,6 +56,7 @@ import androidx.annotation.IdRes;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(sdk = {Build.VERSION_CODES.P})
 public class FormulaEditorEditTextGenericTest {
 
 	@ParameterizedRobolectricTestRunner.Parameters(name = "{0}" + "-Test")


### PR DESCRIPTION
* Migrate to AndroidX (targetSdkVersion 29)
* set config annotations with sdk 28 for robolectric tests, cause android Q(Api 29) isn't yet supported by robolectric

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
