### PR TITLE
CATROID-371 Fix the memory leak in ShowBubbleActor

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/ShowBubbleActor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/ShowBubbleActor.java
@@ -55,6 +55,10 @@ public class ShowBubbleActor extends Actor {
 	ArrayList<String> bubbleValue;
 	private Sprite sprite;
 	private int type;
+	private Pixmap pixmapLeft;
+	private Pixmap pixmapRight;
+	private Texture textureLeft;
+	private Texture textureRight;
 	private Image imageLeft;
 	private Image imageRight;
 	private Image image;
@@ -73,9 +77,20 @@ public class ShowBubbleActor extends Actor {
 		getImageForDraw().draw(batch, parentAlpha);
 	}
 
+	public void close() {
+		pixmapRight.dispose();
+		textureRight.dispose();
+		pixmapLeft.dispose();
+		textureLeft.dispose();
+	}
+
 	private void init() {
-		imageRight = new Image(new Texture(drawBubbleOnCanvas(bubbleValue, true)));
-		imageLeft = new Image(new Texture(drawBubbleOnCanvas(bubbleValue, false)));
+		pixmapRight = drawBubbleOnCanvas(bubbleValue, true);
+		textureRight = new Texture(pixmapRight);
+		imageRight = new Image(textureRight);
+		pixmapLeft = drawBubbleOnCanvas(bubbleValue, false);
+		textureLeft = new Texture(pixmapLeft);
+		imageLeft = new Image(textureLeft);
 		image = imageRight;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -793,6 +793,7 @@ public class StageListener implements ApplicationListener {
 	}
 
 	public void removeBubbleActorForSprite(Sprite sprite) {
+		getBubbleActorForSprite(sprite).close();
 		getStage().getActors().removeValue(getBubbleActorForSprite(sprite), true);
 		bubbleActorMap.remove(sprite);
 	}


### PR DESCRIPTION
Add close() method to class ShowBubbleActor and dispose
the pixmaps and textures used in the constructor to prevent
memory leaks. They (Pixmap, Texture) are holding native memory
resources if dispose is not called at the end of the lifetime.
Finally the close() method is called when BubbleActor
got removed from BubbleActorList.

https://jira.catrob.at/browse/CATROID-371

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
