### PR TITLE
CATROID-656 Adjusted Assert Messages

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/catrobattestrunner/CatrobatTestRunnerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/catrobattestrunner/CatrobatTestRunnerTest.java
@@ -96,12 +96,12 @@ public class CatrobatTestRunnerTest {
 	@Test
 	public void testFailListDoubleNotEqual() throws Exception {
 		exception.expectMessage("AssertUserListError\n"
-				+ "position: 1\n"
+				+ "position: 2\n"
 				+ "expected: <1.1>\n"
 				+ "actual:   <1.2>\n"
 				+ "deviation: --^\n"
 				+ "\n"
-				+ "position: 2\n"
+				+ "position: 3\n"
 				+ "expected: <5.2>\n"
 				+ "actual:   <5>\n"
 				+ "deviation: -^\n");
@@ -111,12 +111,12 @@ public class CatrobatTestRunnerTest {
 	@Test
 	public void testFailListStringNotEqual() throws Exception {
 		exception.expectMessage("AssertUserListError\n"
-				+ "position: 0\n"
+				+ "position: 1\n"
 				+ "expected: <first String>\n"
 				+ "actual:   <second String>\n"
 				+ "deviation: ^\n"
 				+ "\n"
-				+ "position: 1\n"
+				+ "position: 2\n"
 				+ "expected: <second String>\n"
 				+ "actual:   <first String>\n"
 				+ "deviation: ^\n");
@@ -126,12 +126,12 @@ public class CatrobatTestRunnerTest {
 	@Test
 	public void testFailListMismatchingTypes() throws Exception {
 		exception.expectMessage("AssertUserListError\n"
-				+ "position: 0\n"
+				+ "position: 1\n"
 				+ "expected: <first String>\n"
 				+ "actual:   <125.0>\n"
 				+ "deviation: ^\n"
 				+ "\n"
-				+ "position: 1\n"
+				+ "position: 2\n"
 				+ "expected: <12.3>\n"
 				+ "actual:   <second String>\n"
 				+ "deviation: ^\n");
@@ -141,26 +141,26 @@ public class CatrobatTestRunnerTest {
 	@Test
 	public void testFailParamMismatch() throws Exception {
 		exception.expectMessage("Failed Tests:\n\n"
-				+ "[2] actual = 1.0\n"
+				+ "[3] actual = 1.0\n"
 				+ "expected: <1.1>\n"
 				+ "actual:   <1.0>\n"
 				+ "deviation: --^\n\n"
-				+ "[3] actual = String\n"
+				+ "[4] actual = String\n"
 				+ "expected: <123>\n"
 				+ "actual:   <String>\n"
 				+ "deviation: ^\n\n"
-				+ "[4] actual = 345\n"
+				+ "[5] actual = 345\n"
 				+ "expected: <Test String>\n"
 				+ "actual:   <345>\n"
 				+ "deviation: ^\n\n"
-				+ "[5] actual = Actual\n"
+				+ "[6] actual = Actual\n"
 				+ "expected: <Expected>\n"
 				+ "actual:   <Actual>\n"
 				+ "deviation: ^\n\n\n"
 				+ "Succeeded Tests:\n\n"
-				+ "[0] actual = 5.0\n"
+				+ "[1] actual = 5.0\n"
 				+ "5.0 == 5\n\n"
-				+ "[1] actual = 3\n"
+				+ "[2] actual = 3\n"
 				+ "3 == 3.0");
 		testAsset("testFailParamMismatch.catrobat", "catrobatTestRunnerTests/fail");
 	}
@@ -169,14 +169,14 @@ public class CatrobatTestRunnerTest {
 	public void testFailParamStringNotEqual() throws Exception {
 		exception.expectMessage("ParameterizedAssertError\n"
 				+ "Failed Tests:\n\n"
-				+ "[1] firstPart = puppy | secondPart = naughty\n"
+				+ "[2] firstPart = puppy | secondPart = naughty\n"
 				+ "expected: <puppy is not naughty>\n"
 				+ "actual:   <puppy is naughty>\n"
 				+ "deviation: ----------^\n\n\n"
 				+ "Succeeded Tests:\n\n"
-				+ "[0] firstPart = kitty | secondPart = cute\n"
+				+ "[1] firstPart = kitty | secondPart = cute\n"
 				+ "kitty is cute == kitty is cute\n\n"
-				+ "[2] firstPart = octopus | secondPart = intelligent\n"
+				+ "[3] firstPart = octopus | secondPart = intelligent\n"
 				+ "octopus is intelligent == octopus is intelligent");
 		testAsset("testFailParamStringNotEqual.catrobat", "catrobatTestRunnerTests/fail");
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/AssertUserListAction.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/AssertUserListAction.kt
@@ -81,7 +81,7 @@ class AssertUserListAction : AssertAction() {
         expected: Any
     ): String {
         val indicator = generateIndicator(actual, expected)
-        return "position: $listPosition\n" +
+        return "position: ${listPosition + 1}\n" +
             "expected: <$expected>\n" +
             "actual:   <$actual>\n" +
             "deviation: $indicator\n\n"

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/RepeatParameterizedAction.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/RepeatParameterizedAction.kt
@@ -87,7 +87,7 @@ class RepeatParameterizedAction : RepeatAction() {
     }
 
     private fun initParameter(): Boolean = parameterizedData?.let {
-        it.currentParameters = "[${it.currentPosition}] "
+        it.currentParameters = "[${it.currentPosition + 1}] "
 
         for ((userList, userVariable) in parameters) {
             val data = userList.value

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/BrickBaseType.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/BrickBaseType.java
@@ -194,6 +194,7 @@ public abstract class BrickBaseType implements Brick {
 			position = getPositionInScript();
 			scriptName = getScript().getClass().getSimpleName();
 		}
+		position += 2;
 		return "Brick at position " + position + "\nin \"" + scriptName + "\"";
 	}
 }


### PR DESCRIPTION
Position counter of AssertUserList and ParameterizedTest now start with 1
Statically added 2 to the Position in script to start at 1 and also include the script header

https://jira.catrob.at/browse/CATROID-656

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
