### PR TITLE
CATROID-534 NFC Tag cannot not be added twice

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/NfcTagListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/NfcTagListFragment.java
@@ -38,6 +38,7 @@ import org.catrobat.catroid.nfc.NfcHandler;
 import org.catrobat.catroid.ui.recyclerview.adapter.NfcTagAdapter;
 import org.catrobat.catroid.utils.ToastUtil;
 
+import java.util.Iterator;
 import java.util.List;
 
 import androidx.annotation.PluralsRes;
@@ -105,7 +106,17 @@ public class NfcTagListFragment extends RecyclerViewFragment<NfcTagData> {
 					.getUniqueNameInNameables(getString(R.string.default_tag_name), adapter.getItems());
 			item.setName(name);
 			item.setNfcTagUid(uid);
-			adapter.add(item);
+			Iterator<NfcTagData> it = adapter.getItems().iterator();
+			boolean duplicate = false;
+			while (it.hasNext() && !duplicate) {
+				String nextUid = it.next().getNfcTagUid();
+				if (nextUid.equals(uid)) {
+					duplicate = true;
+				}
+			}
+			if (!duplicate) {
+				adapter.add(item);
+			}
 		} else {
 			Log.e(TAG, "NFC Tag does not have a UID.");
 		}


### PR DESCRIPTION
*Please enter a short description of your pull request and add a reference to the Jira ticket.*
When creating the NFC tag list, if the user tries to scan the same NFC tag twice, it will not be added on the list as a new one:  https://jira.catrob.at/browse/CATROID-534
### Your checklist for this pull request:
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
