### PR TITLE
CATROID-690: Import of Project Screen crashes

### DIFF
--- a/catroid/config/lint-baseline.xml
+++ b/catroid/config/lint-baseline.xml
@@ -36,6 +36,22 @@
 
     <issue
         id="UnusedAttribute"
+        severity="Warning"
+        message="Attribute `requestLegacyExternalStorage` is only used in API level 29 and higher (current min is 21)"
+        category="Correctness"
+        priority="6"
+        summary="Attribute unused on older versions"
+        explanation="This check finds attributes set in XML files that were introduced in a version newer than the oldest version targeted by your application (with the `minSdkVersion` attribute).&#xA;&#xA;This is not an error; the application will simply ignore the attribute. However, if the attribute is important to the appearance or functionality of your application, you should consider finding an alternative way to achieve the same result with only available attributes, and then you can optionally create a copy of the layout in a layout-vNN folder which will be used on API NN or higher where you can take advantage of the newer attribute.&#xA;&#xA;Note: This check does not only apply to attributes. For example, some tags can be unused too, such as the new `&lt;tag>` element in layouts introduced in API 21."
+        errorLine1="        android:requestLegacyExternalStorage=&quot;true&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src\main\AndroidManifest.xml"
+            line="94"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
         message="Attribute `drawableTint` is only used in API level 23 and higher (current min is 21)"
         errorLine1="            android:drawableTint=&quot;@drawable/stage_dialog_color_selector&quot;"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">

--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -91,6 +91,7 @@
         android:label="${appName}"
         android:theme="@style/Catroid"
         android:supportsRtl="true"
+        android:requestLegacyExternalStorage="true"
         tools:replace="android:label,android:allowBackup"
         android:usesCleartextTraffic="true">
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/filepicker/FilePickerActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/filepicker/FilePickerActivity.java
@@ -26,6 +26,7 @@ package org.catrobat.catroid.ui.filepicker;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 
 import org.catrobat.catroid.R;
@@ -35,7 +36,7 @@ import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import androidx.appcompat.widget.Toolbar;
@@ -75,7 +76,7 @@ public class FilePickerActivity extends BaseActivity implements ListProjectFiles
 
 	private void getFiles() {
 		new RequiresPermissionTask(PERMISSIONS_REQUEST_IMPORT_FROM_EXTERNAL_STORAGE,
-				Arrays.asList(READ_EXTERNAL_STORAGE),
+				Collections.singletonList(READ_EXTERNAL_STORAGE),
 				R.string.runtime_permission_general) {
 
 			@Override
@@ -89,10 +90,16 @@ public class FilePickerActivity extends BaseActivity implements ListProjectFiles
 	private List<File> getStorageRoots() {
 		List<File> rootDirs = new ArrayList<>();
 		for (File externalFilesDir : getExternalFilesDirs(null)) {
-			String path = externalFilesDir.getAbsolutePath();
-			String packageName = getApplicationContext().getPackageName();
-			path = path.replaceAll("/Android/data/" + packageName + "/files", "");
-			rootDirs.add(new File(path));
+			try {
+				String path = externalFilesDir.getAbsolutePath();
+				Log.e(TAG, externalFilesDir.canRead() + " Path: " + path);
+				String packageName = getApplicationContext().getPackageName();
+				path = path.replaceAll("/Android/data/" + packageName + "/files", "");
+				rootDirs.add(new File(path));
+			} catch (Exception e) {
+				// needed for APIs 21 & 22
+				Log.e(TAG, "externalFilesDir is null" + e.getMessage());
+			}
 		}
 		return rootDirs;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/filepicker/ListProjectFilesTask.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/filepicker/ListProjectFilesTask.java
@@ -54,13 +54,16 @@ public class ListProjectFilesTask extends AsyncTask<File, Void, List<File>> {
 	}
 
 	private static void findProjectFiles(File dir, List<File> projectFiles) {
-		for (File file : dir.listFiles()) {
-			if (file.isDirectory()) {
-				findProjectFiles(file, projectFiles);
-			}
+		// this check will prevent a future crash on android 11
+		if (dir.canRead() && dir.listFiles() != null) {
+			for (File file : dir.listFiles()) {
+				if (file.isDirectory()) {
+					findProjectFiles(file, projectFiles);
+				}
 
-			if (file.getName().endsWith(CATROBAT_EXTENSION)) {
-				projectFiles.add(file);
+				if (file.getName().endsWith(CATROBAT_EXTENSION)) {
+					projectFiles.add(file);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**this fixes the bug for APIs from 21 to 29.
for Android 11 (API 30) the current implementation of import projects is going to be deprecated and needs to be changed.**

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
