### PR TITLE
CATROID-610 Reopening Project loads disabled EndBricks correctly

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ForItemInUserListBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ForItemInUserListBrick.java
@@ -76,7 +76,6 @@ public class ForItemInUserListBrick extends UserDataBrick implements CompositeBr
 		for (Brick brick : loopBricks) {
 			brick.setCommentedOut(commentedOut);
 		}
-		endBrick.setCommentedOut(commentedOut);
 	}
 
 	@Override
@@ -166,6 +165,11 @@ public class ForItemInUserListBrick extends UserDataBrick implements CompositeBr
 
 		EndBrick(ForItemInUserListBrick parent) {
 			this.parent = parent;
+		}
+
+		@Override
+		public boolean isCommentedOut() {
+			return parent.isCommentedOut();
 		}
 
 		@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ForVariableFromToBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ForVariableFromToBrick.java
@@ -97,7 +97,6 @@ public class ForVariableFromToBrick extends UserVariableBrickWithFormula impleme
 		for (Brick brick : loopBricks) {
 			brick.setCommentedOut(commentedOut);
 		}
-		endBrick.setCommentedOut(commentedOut);
 	}
 
 	@Override
@@ -186,6 +185,11 @@ public class ForVariableFromToBrick extends UserVariableBrickWithFormula impleme
 
 		EndBrick(ForVariableFromToBrick parent) {
 			this.parent = parent;
+		}
+
+		@Override
+		public boolean isCommentedOut() {
+			return parent.isCommentedOut();
 		}
 
 		@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ForeverBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ForeverBrick.java
@@ -33,8 +33,6 @@ import org.catrobat.catroid.content.actions.ScriptSequenceAction;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.VisibleForTesting;
-
 public class ForeverBrick extends BrickBaseType implements CompositeBrick {
 
 	private transient EndBrick endBrick = new EndBrick(this);
@@ -42,11 +40,6 @@ public class ForeverBrick extends BrickBaseType implements CompositeBrick {
 	private List<Brick> loopBricks = new ArrayList<>();
 
 	public ForeverBrick() {
-	}
-
-	@VisibleForTesting
-	public EndBrick getEndBrick() {
-		return endBrick;
 	}
 
 	@Override
@@ -74,7 +67,6 @@ public class ForeverBrick extends BrickBaseType implements CompositeBrick {
 		for (Brick brick : loopBricks) {
 			brick.setCommentedOut(commentedOut);
 		}
-		endBrick.setCommentedOut(commentedOut);
 	}
 
 	@Override
@@ -168,6 +160,11 @@ public class ForeverBrick extends BrickBaseType implements CompositeBrick {
 
 		EndBrick(ForeverBrick parent) {
 			this.parent = parent;
+		}
+
+		@Override
+		public boolean isCommentedOut() {
+			return parent.isCommentedOut();
 		}
 
 		@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfLogicBeginBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfLogicBeginBrick.java
@@ -58,16 +58,6 @@ public class IfLogicBeginBrick extends FormulaBrick implements CompositeBrick {
 		setFormulaWithBrickField(BrickField.IF_CONDITION, formula);
 	}
 
-	@VisibleForTesting
-	public ElseBrick getElseBrick() {
-		return elseBrick;
-	}
-
-	@VisibleForTesting
-	public EndBrick getEndBrick() {
-		return endBrick;
-	}
-
 	@Override
 	public boolean hasSecondaryList() {
 		return true;
@@ -97,11 +87,9 @@ public class IfLogicBeginBrick extends FormulaBrick implements CompositeBrick {
 		for (Brick brick : ifBranchBricks) {
 			brick.setCommentedOut(commentedOut);
 		}
-		elseBrick.setCommentedOut(commentedOut);
 		for (Brick brick : elseBranchBricks) {
 			brick.setCommentedOut(commentedOut);
 		}
-		endBrick.setCommentedOut(commentedOut);
 	}
 
 	@Override
@@ -242,6 +230,11 @@ public class IfLogicBeginBrick extends FormulaBrick implements CompositeBrick {
 		}
 
 		@Override
+		public boolean isCommentedOut() {
+			return parent.isCommentedOut();
+		}
+
+		@Override
 		public boolean consistsOfMultipleParts() {
 			return true;
 		}
@@ -281,6 +274,11 @@ public class IfLogicBeginBrick extends FormulaBrick implements CompositeBrick {
 
 		EndBrick(IfLogicBeginBrick ifBrick) {
 			parent = ifBrick;
+		}
+
+		@Override
+		public boolean isCommentedOut() {
+			return parent.isCommentedOut();
 		}
 
 		@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfThenLogicBeginBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/IfThenLogicBeginBrick.java
@@ -37,8 +37,6 @@ import org.catrobat.catroid.formulaeditor.Formula;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.VisibleForTesting;
-
 public class IfThenLogicBeginBrick extends FormulaBrick implements CompositeBrick {
 
 	private static final long serialVersionUID = 1L;
@@ -54,11 +52,6 @@ public class IfThenLogicBeginBrick extends FormulaBrick implements CompositeBric
 	public IfThenLogicBeginBrick(Formula formula) {
 		this();
 		setFormulaWithBrickField(Brick.BrickField.IF_CONDITION, formula);
-	}
-
-	@VisibleForTesting
-	public EndBrick getEndBrick() {
-		return endBrick;
 	}
 
 	@Override
@@ -86,7 +79,6 @@ public class IfThenLogicBeginBrick extends FormulaBrick implements CompositeBric
 		for (Brick brick : ifBranchBricks) {
 			brick.setCommentedOut(commentedOut);
 		}
-		endBrick.setCommentedOut(commentedOut);
 	}
 
 	@Override
@@ -188,6 +180,11 @@ public class IfThenLogicBeginBrick extends FormulaBrick implements CompositeBric
 
 		EndBrick(IfThenLogicBeginBrick parent) {
 			this.parent = parent;
+		}
+
+		@Override
+		public boolean isCommentedOut() {
+			return parent.isCommentedOut();
 		}
 
 		@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroIfLogicBeginBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroIfLogicBeginBrick.java
@@ -53,16 +53,6 @@ public class PhiroIfLogicBeginBrick extends BrickBaseType implements CompositeBr
 	private List<Brick> ifBranchBricks = new ArrayList<>();
 	private List<Brick> elseBranchBricks = new ArrayList<>();
 
-	@VisibleForTesting
-	public ElseBrick getElseBrick() {
-		return elseBrick;
-	}
-
-	@VisibleForTesting
-	public EndBrick getEndBrick() {
-		return endBrick;
-	}
-
 	@Override
 	public boolean hasSecondaryList() {
 		return true;
@@ -92,11 +82,9 @@ public class PhiroIfLogicBeginBrick extends BrickBaseType implements CompositeBr
 		for (Brick brick : ifBranchBricks) {
 			brick.setCommentedOut(commentedOut);
 		}
-		elseBrick.setCommentedOut(commentedOut);
 		for (Brick brick : elseBranchBricks) {
 			brick.setCommentedOut(commentedOut);
 		}
-		endBrick.setCommentedOut(commentedOut);
 	}
 
 	@Override
@@ -256,6 +244,11 @@ public class PhiroIfLogicBeginBrick extends BrickBaseType implements CompositeBr
 		}
 
 		@Override
+		public boolean isCommentedOut() {
+			return parent.isCommentedOut();
+		}
+
+		@Override
 		public boolean consistsOfMultipleParts() {
 			return true;
 		}
@@ -295,6 +288,11 @@ public class PhiroIfLogicBeginBrick extends BrickBaseType implements CompositeBr
 
 		EndBrick(PhiroIfLogicBeginBrick ifBrick) {
 			parent = ifBrick;
+		}
+
+		@Override
+		public boolean isCommentedOut() {
+			return parent.isCommentedOut();
 		}
 
 		@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatBrick.java
@@ -42,8 +42,6 @@ import org.catrobat.catroid.utils.Utils;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.VisibleForTesting;
-
 public class RepeatBrick extends FormulaBrick implements CompositeBrick {
 
 	private transient EndBrick endBrick = new EndBrick(this);
@@ -57,11 +55,6 @@ public class RepeatBrick extends FormulaBrick implements CompositeBrick {
 	public RepeatBrick(Formula condition) {
 		this();
 		setFormulaWithBrickField(Brick.BrickField.TIMES_TO_REPEAT, condition);
-	}
-
-	@VisibleForTesting
-	public EndBrick getEndBrick() {
-		return endBrick;
 	}
 
 	@Override
@@ -89,7 +82,6 @@ public class RepeatBrick extends FormulaBrick implements CompositeBrick {
 		for (Brick brick : loopBricks) {
 			brick.setCommentedOut(commentedOut);
 		}
-		endBrick.setCommentedOut(commentedOut);
 	}
 
 	@Override
@@ -207,6 +199,11 @@ public class RepeatBrick extends FormulaBrick implements CompositeBrick {
 
 		EndBrick(RepeatBrick parent) {
 			this.parent = parent;
+		}
+
+		@Override
+		public boolean isCommentedOut() {
+			return parent.isCommentedOut();
 		}
 
 		@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatUntilBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/RepeatUntilBrick.java
@@ -34,12 +34,9 @@ import org.catrobat.catroid.formulaeditor.Formula;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.annotation.VisibleForTesting;
-
 public class RepeatUntilBrick extends FormulaBrick implements CompositeBrick {
 
 	private transient EndBrick endBrick = new EndBrick(this);
-
 	private List<Brick> loopBricks = new ArrayList<>();
 
 	public RepeatUntilBrick() {
@@ -49,11 +46,6 @@ public class RepeatUntilBrick extends FormulaBrick implements CompositeBrick {
 	public RepeatUntilBrick(Formula condition) {
 		this();
 		setFormulaWithBrickField(BrickField.REPEAT_UNTIL_CONDITION, condition);
-	}
-
-	@VisibleForTesting
-	public EndBrick getEndBrick() {
-		return endBrick;
 	}
 
 	@Override
@@ -81,7 +73,6 @@ public class RepeatUntilBrick extends FormulaBrick implements CompositeBrick {
 		for (Brick brick : loopBricks) {
 			brick.setCommentedOut(commentedOut);
 		}
-		endBrick.setCommentedOut(commentedOut);
 	}
 
 	@Override
@@ -177,6 +168,11 @@ public class RepeatUntilBrick extends FormulaBrick implements CompositeBrick {
 
 		EndBrick(RepeatUntilBrick parent) {
 			this.parent = parent;
+		}
+
+		@Override
+		public boolean isCommentedOut() {
+			return parent.isCommentedOut();
 		}
 
 		@Override


### PR DESCRIPTION
Endbricks now solely use the enabled/disabled state of their parents to keep their state when reopening the project.

JIRA: https://jira.catrob.at/browse/CATROID-610

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
