### PR TITLE
CATROID-522 References to a local UserVariable within a Scene will be changed in all Scenes

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -404,4 +404,9 @@ public class Project implements Serializable {
 			xmlHeader.setListeningLanguageTag(SPEECH_RECOGNITION_SUPPORTED_LANGUAGES.get(0));
 		}
 	}
+
+	public boolean isGlobalVariable(UserData<?> item) {
+		return getUserVariables().contains(item) || getUserLists().contains(item)
+				|| getMultiplayerVariables().contains(item);
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.content;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.Nameable;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.BroadcastMessageBrick;
@@ -172,8 +173,12 @@ public class Scene implements Nameable, Serializable {
 	}
 
 	public void updateUserDataReferences(String oldName, String newName, UserData<?> item) {
-		for (Sprite sprite : spriteList) {
-			sprite.updateUserDataReferences(oldName, newName, item);
+		if (ProjectManager.getInstance().getCurrentProject().isGlobalVariable(item)) {
+			for (Sprite sprite : spriteList) {
+				sprite.updateUserDataReferences(oldName, newName, item);
+			}
+		} else {
+			ProjectManager.getInstance().getCurrentSprite().updateUserDataReferences(oldName, newName, item);
 		}
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickVariableUpdateTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickVariableUpdateTest.java
@@ -102,6 +102,8 @@ public class CompositeBrickVariableUpdateTest {
 		script.addBrick(compositeBrick);
 		compositeBrick.getNestedBricks().add(formulaBrick);
 
+		project.addUserVariable(userVariable);
+		project.addUserList(userList);
 		ProjectManager.getInstance().setCurrentProject(project);
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickWithSecondaryListUpdateTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickWithSecondaryListUpdateTest.java
@@ -104,6 +104,8 @@ public class CompositeBrickWithSecondaryListUpdateTest {
 		compositeBrick.getNestedBricks().add(primaryListFormulaBrick);
 		compositeBrick.getSecondaryNestedBricks().add(secondaryListFormulaBrick);
 
+		project.addUserVariable(userVariable);
+		project.addUserList(userList);
 		ProjectManager.getInstance().setCurrentProject(project);
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/UpdateVariableInFormulaBrickTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/UpdateVariableInFormulaBrickTest.java
@@ -101,6 +101,8 @@ public class UpdateVariableInFormulaBrickTest {
 		sprite.addScript(script);
 		script.addBrick(formulaBrick);
 
+		project.addUserVariable(userVariable);
+		project.addUserList(userList);
 		ProjectManager.getInstance().setCurrentProject(project);
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/UpdateVariableInFormulaScriptBrickTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/UpdateVariableInFormulaScriptBrickTest.java
@@ -98,6 +98,8 @@ public class UpdateVariableInFormulaScriptBrickTest {
 		scene.addSprite(sprite);
 		sprite.addScript(formulaBrick.getScript());
 
+		project.addUserVariable(userVariable);
+		project.addUserList(userList);
 		ProjectManager.getInstance().setCurrentProject(project);
 	}
 


### PR DESCRIPTION
The bug was caused because all user variables and lists were handled equally as global variables. This bug can be avoided by adding a check in the update user data references function if the variable or list is contained in the project arraylist(which means it is a global variable).

https://jira.catrob.at/browse/CATROID-522

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
