### PR TITLE
CATROID-579 Fix incorrect behaviour of Pen Bricks

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PenDownActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PenDownActionTest.java
@@ -1,0 +1,109 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.actions;
+
+import android.graphics.PointF;
+
+import com.badlogic.gdx.scenes.scene2d.Action;
+import com.badlogic.gdx.utils.Queue;
+
+import org.catrobat.catroid.content.ActionFactory;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class PenDownActionTest {
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	private static final float X_MOVEMENT = 100.0f;
+	private static final float Y_MOVEMENT = 50.0f;
+	private Formula xMovement = new Formula(X_MOVEMENT);
+	private Formula yMovement = new Formula(Y_MOVEMENT);
+	private Sprite sprite;
+
+	@Before
+	public void setUp() throws Exception {
+		sprite = new Sprite("testSprite");
+	}
+
+	@Test
+	public void testNullSprite() {
+		ActionFactory factory = new ActionFactory();
+		Action action = factory.createPenDownAction(null);
+		exception.expect(NullPointerException.class);
+		action.act(1.0f);
+	}
+
+	@Test
+	public void testSaveOnePositionChange() {
+		assertEquals(0f, sprite.look.getXInUserInterfaceDimensionUnit());
+		assertEquals(0f, sprite.look.getYInUserInterfaceDimensionUnit());
+
+		sprite.getActionFactory().createPenDownAction(sprite).act(1.0f);
+		sprite.getActionFactory().createChangeXByNAction(sprite, xMovement).act(1.0f);
+
+		Queue<Queue<PointF>> positions = sprite.penConfiguration.getPositions();
+		assertEquals(0f, positions.first().removeFirst().x);
+		assertEquals(X_MOVEMENT, positions.first().removeFirst().x);
+	}
+
+	@Test
+	public void testSimultaneousPositionChangeXY() {
+		assertEquals(0f, sprite.look.getXInUserInterfaceDimensionUnit());
+		assertEquals(0f, sprite.look.getYInUserInterfaceDimensionUnit());
+
+		sprite.getActionFactory().createPenDownAction(sprite).act(1.0f);
+		sprite.getActionFactory().createPlaceAtAction(sprite, xMovement, yMovement).act(1.0f);
+
+		Queue<Queue<PointF>> positions = sprite.penConfiguration.getPositions();
+		assertEquals(0f, positions.first().removeFirst().x);
+		assertEquals(X_MOVEMENT, positions.first().first().x);
+		assertEquals(Y_MOVEMENT, positions.first().removeFirst().y);
+	}
+
+	@Test
+	public void testMultiplePenDownActions() {
+		assertEquals(0f, sprite.look.getXInUserInterfaceDimensionUnit());
+		assertEquals(0f, sprite.look.getYInUserInterfaceDimensionUnit());
+
+		sprite.getActionFactory().createPenDownAction(sprite).act(1.0f);
+		sprite.getActionFactory().createPenDownAction(sprite).act(1.0f);
+
+		Queue<Queue<PointF>> positions = sprite.penConfiguration.getPositions();
+		assertEquals(0f, positions.first().removeFirst().x);
+		assertTrue(positions.first().isEmpty());
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PenUpActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PenUpActionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.actions;
+
+import android.graphics.PointF;
+
+import com.badlogic.gdx.scenes.scene2d.Action;
+import com.badlogic.gdx.utils.Queue;
+
+import org.catrobat.catroid.content.ActionFactory;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class PenUpActionTest {
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	private static final float X_MOVEMENT = 100.0f;
+	private Formula xMovement = new Formula(X_MOVEMENT);
+
+	private Sprite sprite;
+
+	@Before
+	public void setUp() throws Exception {
+		sprite = new Sprite("testSprite");
+	}
+
+	@Test
+	public void testNullSprite() {
+		ActionFactory factory = new ActionFactory();
+		Action action = factory.createPenUpAction(null);
+		exception.expect(NullPointerException.class);
+		action.act(1.0f);
+	}
+
+	@Test
+	public void testSaveMultiplePositionChangesWithPenUpActionBetween() {
+		assertEquals(0f, sprite.look.getXInUserInterfaceDimensionUnit());
+		assertEquals(0f, sprite.look.getYInUserInterfaceDimensionUnit());
+
+		sprite.getActionFactory().createPenDownAction(sprite).act(1.0f);
+		sprite.getActionFactory().createChangeXByNAction(sprite, xMovement).act(1.0f);
+
+		sprite.getActionFactory().createPenUpAction(sprite).act(1.0f);
+		sprite.getActionFactory().createChangeXByNAction(sprite, xMovement).act(1.0f);
+
+		sprite.getActionFactory().createPenDownAction(sprite).act(1.0f);
+		sprite.getActionFactory().createChangeXByNAction(sprite, xMovement).act(1.0f);
+
+		Queue<Queue<PointF>> positions = sprite.penConfiguration.getPositions();
+		assertEquals(0f, positions.first().removeFirst().x);
+		assertEquals(X_MOVEMENT, positions.first().removeFirst().x);
+		assertEquals(X_MOVEMENT, positions.first().removeFirst().x);
+		positions.removeFirst();
+		assertEquals(X_MOVEMENT * 2, positions.first().removeFirst().x);
+		assertEquals(X_MOVEMENT * 3, positions.first().removeFirst().x);
+	}
+
+	@Test
+	public void testMultiplePenUpActions() {
+		assertEquals(0f, sprite.look.getXInUserInterfaceDimensionUnit());
+		assertEquals(0f, sprite.look.getYInUserInterfaceDimensionUnit());
+
+		sprite.getActionFactory().createPenDownAction(sprite).act(1.0f);
+		sprite.getActionFactory().createPenUpAction(sprite).act(1.0f);
+		sprite.getActionFactory().createPenUpAction(sprite).act(1.0f);
+
+		Queue<Queue<PointF>> positions = sprite.penConfiguration.getPositions();
+		assertEquals(0f, positions.first().removeFirst().x);
+		assertEquals(0f, positions.first().removeFirst().x);
+		assertTrue(positions.first().isEmpty());
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -66,6 +66,7 @@ public class Look extends Image {
 	public static final float DEGREE_UI_OFFSET = 90.0f;
 	private static final float COLOR_SCALE = 200.0f;
 	private boolean lookVisible = true;
+	private boolean simultaneousMovementXY = false;
 	protected LookData lookData;
 	protected Sprite sprite;
 	protected float alpha = 1f;
@@ -200,6 +201,15 @@ public class Look extends Image {
 		}
 	}
 
+	@Override
+	protected void positionChanged() {
+		if (sprite != null && sprite.penConfiguration.isPenDown() && !simultaneousMovementXY) {
+			float x = getXInUserInterfaceDimensionUnit();
+			float y = getYInUserInterfaceDimensionUnit();
+			sprite.penConfiguration.addPosition(new PointF(x, y));
+		}
+	}
+
 	public void startThread(EventThread threadToBeStarted) {
 		if (scheduler != null) {
 			scheduler.startThread(threadToBeStarted);
@@ -315,8 +325,18 @@ public class Look extends Image {
 	}
 
 	public void setPositionInUserInterfaceDimensionUnit(float x, float y) {
+		adjustSimultaneousMovementXY(x, y);
 		setXInUserInterfaceDimensionUnit(x);
+		adjustSimultaneousMovementXY(this.getX(), y);
 		setYInUserInterfaceDimensionUnit(y);
+	}
+
+	private void adjustSimultaneousMovementXY(float x, float y) {
+		if (x != this.getX() && y != this.getY()) {
+			simultaneousMovementXY = true;
+		} else {
+			simultaneousMovementXY = false;
+		}
 	}
 
 	public void changeXInUserInterfaceDimensionUnit(float changeX) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/PenConfiguration.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/PenConfiguration.java
@@ -1,0 +1,125 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.content;
+
+import android.graphics.PointF;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.utils.Queue;
+
+import org.catrobat.catroid.common.BrickValues;
+import org.catrobat.catroid.stage.StageActivity;
+
+public class PenConfiguration {
+
+	private Queue<Queue<PointF>> positions = new Queue<>();
+	private boolean penDown = false;
+	private double penSize = BrickValues.PEN_SIZE;
+	private PenColor penColor = new PenColor(0, 0, 1, 1);
+	private boolean stamp = false;
+	private int queuesToFinish = 0;
+
+	public PenConfiguration() {
+	}
+
+	public void drawLinesForSprite(Float screenRatio) {
+
+		ShapeRenderer renderer = StageActivity.stageListener.shapeRenderer;
+		renderer.setColor(new Color(penColor.r, penColor.g, penColor.b, penColor.a));
+		renderer.begin(ShapeRenderer.ShapeType.Filled);
+
+		while (currentQueueHasJobToHandle()) {
+			drawLine(screenRatio, renderer);
+			updateQueues();
+		}
+
+		renderer.end();
+	}
+
+	private boolean currentQueueHasJobToHandle() {
+		return !positions.isEmpty() && (positions.first().size > 1 || queuesToFinish > 0);
+	}
+
+	private void drawLine(Float screenRatio, ShapeRenderer renderer) {
+
+		PointF currentPosition = positions.first().removeFirst();
+		PointF nextPosition = positions.first().first();
+
+		if (currentPosition.x != nextPosition.x || currentPosition.y != nextPosition.y) {
+			Float penSize = (float) this.penSize * screenRatio;
+			renderer.circle(currentPosition.x, currentPosition.y, penSize / 2);
+			renderer.rectLine(currentPosition.x, currentPosition.y, nextPosition.x, nextPosition.y,
+					penSize);
+			renderer.circle(nextPosition.x, nextPosition.y, penSize / 2);
+		}
+	}
+
+	private void updateQueues() {
+		if (queuesToFinish > 0 && positions.first().size <= 1) {
+			positions.removeFirst();
+			queuesToFinish--;
+		}
+	}
+
+	public void addQueue() {
+		positions.addLast(new Queue<>());
+	}
+
+	public void addPosition(PointF position) {
+		positions.last().addLast(position);
+	}
+
+	public void incrementQueuesToFinish() {
+		queuesToFinish++;
+	}
+
+	public void setPenDown(boolean penDown) {
+		this.penDown = penDown;
+	}
+
+	public boolean isPenDown() {
+		return penDown;
+	}
+
+	public void setPenSize(double penSize) {
+		this.penSize = penSize;
+	}
+
+	public void setPenColor(PenColor penColor) {
+		this.penColor = penColor;
+	}
+
+	public void setStamp(boolean stamp) {
+		this.stamp = stamp;
+	}
+
+	public boolean hasStamp() {
+		return stamp;
+	}
+
+	public Queue<Queue<PointF>> getPositions() {
+		return positions;
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -23,7 +23,6 @@
 package org.catrobat.catroid.content;
 
 import android.content.Context;
-import android.graphics.PointF;
 import android.util.Log;
 
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -33,7 +32,6 @@ import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 
 import org.catrobat.catroid.CatroidApplication;
 import org.catrobat.catroid.ProjectManager;
-import org.catrobat.catroid.common.BrickValues;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.common.Nameable;
@@ -518,14 +516,6 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 		for (Script script : scriptList) {
 			script.deselectElements(elements);
 		}
-	}
-
-	public class PenConfiguration {
-		public boolean penDown = false;
-		public double penSize = BrickValues.PEN_SIZE;
-		public PenColor penColor = new PenColor(0, 0, 1, 1);
-		public PointF previousPoint = null;
-		public boolean stamp = false;
 	}
 
 	public boolean toBeConverted() {

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/PenDownAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/PenDownAction.java
@@ -22,6 +22,8 @@
  */
 package org.catrobat.catroid.content.actions;
 
+import android.graphics.PointF;
+
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 
 import org.catrobat.catroid.content.Sprite;
@@ -32,7 +34,17 @@ public class PenDownAction extends TemporalAction {
 
 	@Override
 	protected void update(float delta) {
-		this.sprite.penConfiguration.penDown = true;
+
+		if (this.sprite.penConfiguration.isPenDown()) {
+			return;
+		}
+
+		this.sprite.penConfiguration.addQueue();
+		this.sprite.penConfiguration.addPosition(
+				new PointF(this.sprite.look.getXInUserInterfaceDimensionUnit(),
+						this.sprite.look.getYInUserInterfaceDimensionUnit())
+		);
+		this.sprite.penConfiguration.setPenDown(true);
 	}
 
 	public void setSprite(Sprite sprite) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/PenUpAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/PenUpAction.java
@@ -22,6 +22,8 @@
  */
 package org.catrobat.catroid.content.actions;
 
+import android.graphics.PointF;
+
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction;
 
 import org.catrobat.catroid.content.Sprite;
@@ -32,7 +34,17 @@ public class PenUpAction extends TemporalAction {
 
 	@Override
 	protected void update(float delta) {
-		this.sprite.penConfiguration.penDown = false;
+
+		if (!this.sprite.penConfiguration.isPenDown()) {
+			return;
+		}
+
+		this.sprite.penConfiguration.setPenDown(false);
+		this.sprite.penConfiguration.addPosition(
+				new PointF(this.sprite.look.getXInUserInterfaceDimensionUnit(),
+						this.sprite.look.getYInUserInterfaceDimensionUnit())
+		);
+		this.sprite.penConfiguration.incrementQueuesToFinish();
 	}
 
 	public void setSprite(Sprite sprite) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/SetPenColorAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/SetPenColorAction.java
@@ -47,7 +47,7 @@ public class SetPenColorAction extends TemporalAction {
 			int newBlue = blue == null ? 0 : blue.interpretInteger(sprite);
 			Color color = new Color();
 			Color.argb8888ToColor(color, android.graphics.Color.argb(0xFF, newRed, newGreen, newBlue));
-			sprite.penConfiguration.penColor = new PenColor(color.r, color.g, color.b, color.a);
+			sprite.penConfiguration.setPenColor(new PenColor(color.r, color.g, color.b, color.a));
 		} catch (InterpretationException interpretationException) {
 			Log.d(getClass().getSimpleName(), "Formula interpretation for this specific Brick failed.", interpretationException);
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/SetPenSizeAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/SetPenSizeAction.java
@@ -39,7 +39,7 @@ public class SetPenSizeAction extends TemporalAction {
 	protected void update(float delta) {
 		try {
 			Float newSize = penSize == null ? Float.valueOf(0f) : penSize.interpretFloat(sprite);
-			sprite.penConfiguration.penSize = newSize;
+			sprite.penConfiguration.setPenSize(newSize);
 		} catch (InterpretationException interpretationException) {
 			Log.d(getClass().getSimpleName(), "Formula interpretation for this specific Brick failed.", interpretationException);
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/StampAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/StampAction.java
@@ -33,7 +33,7 @@ public class StampAction extends TemporalAction {
 
 	@Override
 	protected void update(float delta) {
-		this.sprite.penConfiguration.stamp = true;
+		this.sprite.penConfiguration.setStamp(true);
 		StageActivity.stageListener.getPenActor().stampToFrameBuffer();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/stage/PenActor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/PenActor.java
@@ -24,11 +24,9 @@
 package org.catrobat.catroid.stage;
 
 import android.content.res.Resources;
-import android.graphics.PointF;
 import android.util.DisplayMetrics;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -36,11 +34,11 @@ import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.PenConfiguration;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.XmlHeader;
 
@@ -64,7 +62,8 @@ public class PenActor extends Actor {
 	public void draw(Batch batch, float parentAlpha) {
 		buffer.begin();
 		for (Sprite sprite : ProjectManager.getInstance().getCurrentlyPlayingScene().getSpriteList()) {
-			drawLinesForSprite(sprite);
+			PenConfiguration pen = sprite.penConfiguration;
+			pen.drawLinesForSprite(screenRatio);
 		}
 		buffer.end();
 
@@ -87,40 +86,14 @@ public class PenActor extends Actor {
 		bufferBatch.begin();
 		buffer.begin();
 		for (Sprite sprite : ProjectManager.getInstance().getCurrentlyPlayingScene().getSpriteList()) {
-			Sprite.PenConfiguration pen = sprite.penConfiguration;
-			if (pen.stamp) {
+			PenConfiguration pen = sprite.penConfiguration;
+			if (pen.hasStamp()) {
 				sprite.look.draw(bufferBatch, 1.0f);
-				pen.stamp = false;
+				pen.setStamp(false);
 			}
 		}
 		buffer.end();
 		bufferBatch.end();
-	}
-
-	private void drawLinesForSprite(Sprite sprite) {
-		float x = sprite.look.getXInUserInterfaceDimensionUnit();
-		float y = sprite.look.getYInUserInterfaceDimensionUnit();
-		Sprite.PenConfiguration pen = sprite.penConfiguration;
-
-		if (pen.previousPoint == null) {
-			pen.previousPoint = new PointF(x, y);
-			return;
-		}
-
-		ShapeRenderer renderer = StageActivity.stageListener.shapeRenderer;
-		renderer.setColor(new Color(pen.penColor.r, pen.penColor.g, pen.penColor.b, pen.penColor.a));
-		renderer.begin(ShapeRenderer.ShapeType.Filled);
-
-		if (pen.penDown && (pen.previousPoint.x != x || pen.previousPoint.y != y)) {
-			Float penSize = (float) pen.penSize * screenRatio;
-			renderer.circle(pen.previousPoint.x, pen.previousPoint.y, penSize / 2);
-			renderer.rectLine(pen.previousPoint.x, pen.previousPoint.y, x, y, penSize);
-			renderer.circle(x, y, penSize / 2);
-		}
-
-		renderer.end();
-		pen.previousPoint.x = x;
-		pen.previousPoint.y = y;
 	}
 
 	public void dispose() {


### PR DESCRIPTION
All position changes of an object are now detected and handled by the  Pen.

https://jira.catrob.at/browse/CATROID-579

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
