### PR TITLE
CATROID-726 Fix number recognition and rewriting

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/utils/NumberFormats.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/NumberFormats.kt
@@ -27,8 +27,8 @@ class NumberFormats private constructor() {
         @JvmStatic
         fun trimTrailingCharacters(value: String?): String {
             value ?: return ""
-            if (value.contains(".") && value.matches("[0-9.-]+".toRegex())) {
-                return value.replace("0*$".toRegex(), "").replace("\\.$".toRegex(), "")
+            if (value.contains(".") && value.matches("(-?[1-9]\\d*|0)\\.(0|\\d*[1-9]0)".toRegex())) {
+                return value.replace("0$".toRegex(), "").replace("\\.$".toRegex(), "")
             }
             return value
         }

--- a/catroid/src/test/java/org/catrobat/catroid/test/utiltests/NumberFormatsTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/utiltests/NumberFormatsTest.java
@@ -55,7 +55,14 @@ public class NumberFormatsTest {
 				{"string.1900", "string.1900"},
 				{"string0.10", "string0.10"},
 				{"Pocket", "Pocket"},
-				{"Pocket.", "Pocket."}
+				{"Pocket.", "Pocket."},
+				{"1.00", "1.00"},
+				{"-1.0", "-1"},
+				{"-0.0", "-0.0"},
+				{".0", ".0"},
+				{".", "."},
+				{"1-1.0", "1-1.0"},
+				{"1.0.0", "1.0.0"}
 		});
 	}
 


### PR DESCRIPTION
*Certain strings with a dot incorrectly recognized as numbers were incorrectly rewritten. This PR fixes the recognition and adds a few test cases.*

https://jira.catrob.at/browse/CATROID-726

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
