### PR TITLE
CATROID-708 - Reg Expr Assistant Button implementation

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CategoryListFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CategoryListFragmentTest.java
@@ -1,0 +1,120 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment;
+
+import android.view.View;
+import android.widget.TextView;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.bricks.ChangeSizeByNBrick;
+import org.catrobat.catroid.testsuites.annotations.Cat;
+import org.catrobat.catroid.testsuites.annotations.Level;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
+import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.hamcrest.Matcher;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.FORMULA_EDITOR_TEXT_FIELD_MATCHER;
+import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+@Category({Cat.AppUi.class, Level.Smoke.class})
+@RunWith(AndroidJUnit4.class)
+public class CategoryListFragmentTest {
+
+	@Rule
+	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
+			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+
+	private static Integer whenBrickPosition = 0;
+	private static Integer changeSizeBrickPosition = 1;
+
+	@Before
+	public void setUp() {
+		Script script = BrickTestUtils.createProjectAndGetStartScript("RegexAssistantButtonTest");
+		script.addBrick(new ChangeSizeByNBrick(0));
+		baseActivityTestRule.launchActivity();
+
+		onBrickAtPosition(whenBrickPosition).checkShowsText(R.string.brick_when_started);
+		onBrickAtPosition(changeSizeBrickPosition).checkShowsText(R.string.brick_change_size_by);
+		onBrickAtPosition(changeSizeBrickPosition).onChildView(withId(R.id.brick_change_size_by_edit_text))
+				.perform(click());
+	}
+
+	@Test
+	public void testRegexButtonImplementation() {
+		String regularExpressionAssistant =
+				"\t\t\t\t\t" + UiTestUtils.getResourcesString(R.string.formula_editor_function_regex_assistant);
+
+		String formulaEditorTextFieldBeforeButtonClick = getFormulaEditorText(FORMULA_EDITOR_TEXT_FIELD_MATCHER);
+
+		//Tests if button exists
+		onFormulaEditor()
+				.performOpenCategory(FormulaEditorWrapper.Category.FUNCTIONS)
+				.performOnItemWithText(regularExpressionAssistant, click());
+
+		//Test if button doesn't change formula editor textfield
+		Assert.assertEquals(formulaEditorTextFieldBeforeButtonClick, getFormulaEditorText(FORMULA_EDITOR_TEXT_FIELD_MATCHER));
+	}
+
+	String getFormulaEditorText(final Matcher<View> matcher) {
+		final String[] stringHolder = {null};
+		onView(matcher).perform(new ViewAction() {
+			@Override
+			public Matcher<View> getConstraints() {
+				return isAssignableFrom(TextView.class);
+			}
+
+			@Override
+			public String getDescription() {
+				return "getting text from a TextView";
+			}
+
+			@Override
+			public void perform(UiController uiController, View view) {
+				TextView tv = (TextView) view; //Save, because of check in getConstraints()
+				stringHolder[0] = tv.getText().toString();
+			}
+		});
+		return stringHolder[0];
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/CategoryListRVAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/CategoryListRVAdapter.java
@@ -59,8 +59,12 @@ public class CategoryListRVAdapter extends RecyclerView.Adapter<ViewHolder> {
 		public @CategoryListItemType int type;
 
 		public CategoryListItem(int nameResId, String text, @CategoryListItemType int type) {
+			if (nameResId == R.string.formula_editor_function_regex_assistant) {
+				this.text = "\t\t\t\t\t" + text;
+			} else {
+				this.text = text;
+			}
 			this.nameResId = nameResId;
-			this.text = text;
 			this.type = type;
 		}
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
@@ -116,10 +116,10 @@ public class CategoryListFragment extends Fragment implements CategoryListRVAdap
 			R.string.formula_editor_function_max_parameter, R.string.formula_editor_function_min_parameter);
 	private static final List<Integer> STRING_FUNCTIONS = Arrays.asList(R.string.formula_editor_function_length,
 			R.string.formula_editor_function_letter, R.string.formula_editor_function_join,
-			R.string.formula_editor_function_regex);
+			R.string.formula_editor_function_regex, R.string.formula_editor_function_regex_assistant);
 	private static final List<Integer> STRING_PARAMS = Arrays.asList(R.string.formula_editor_function_length_parameter,
 			R.string.formula_editor_function_letter_parameter, R.string.formula_editor_function_join_parameter,
-			R.string.formula_editor_function_regex_parameter);
+			R.string.formula_editor_function_regex_parameter, R.string.formula_editor_function_no_parameter);
 	private static final List<Integer> LIST_FUNCTIONS = Arrays.asList(R.string.formula_editor_function_number_of_items,
 			R.string.formula_editor_function_list_item, R.string.formula_editor_function_contains,
 			R.string.formula_editor_function_index_of_item);
@@ -273,6 +273,8 @@ public class CategoryListFragment extends Fragment implements CategoryListRVAdap
 			case CategoryListRVAdapter.DEFAULT:
 				if (LIST_FUNCTIONS.contains(item.nameResId)) {
 					onUserListFunctionSelected(item);
+				} else if (R.string.formula_editor_function_regex_assistant == item.nameResId) {
+					getActivity().onBackPressed();
 				} else {
 					addResourceToActiveFormulaInFormulaEditor(item);
 					getActivity().onBackPressed();

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1757,6 +1757,8 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_join_parameter">(\'hello\',\' world\')</string>
     <string name="formula_editor_function_regex">regular expression</string>
     <string name="formula_editor_function_regex_parameter">(\' an? ([^ .]+)\',\'I am a panda.\')</string>
+    <string name="formula_editor_function_regex_assistant">Regular expression
+        assistant</string>
     <string name="formula_editor_function_arduino_read_pin_value_digital">arduino digital pin</string>
     <string name="formula_editor_function_arduino_read_pin_value_analog">arduino analog pin</string>
     <string name="formula_editor_function_raspi_read_pin_value_digital">raspberry pi pin</string>


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-708
 
Implemented regex assistant button.

- add regular_expression_assistant string to string.xml
- add string to CategoryListFragment.java
- add UI-Test


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
