### PR TITLE
CATROID-725 Added context sensitive regular expression editor dialog

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorRegexDetectionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorRegexDetectionTest.java
@@ -1,0 +1,142 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.formulaeditor;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.bricks.SetVariableBrick;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
+import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+@RunWith(AndroidJUnit4.class)
+public class FormulaEditorRegexDetectionTest {
+
+	@Rule
+	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
+			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+
+	@Before
+	public void setUp() {
+		Script script = BrickTestUtils.createProjectAndGetStartScript(
+				"FormulaEditorRegExDetectionTest");
+		script.addBrick(new SetVariableBrick(0));
+		baseActivityTestRule.launchActivity();
+	}
+
+	@Test
+	public void testNonRegexFunctionChangeText() {
+
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_join,
+				R.string.formula_editor_function_join_parameter);
+		prepareUntilButton(editorFunction);
+
+		onView(withText(R.string.formula_editor_dialog_change_text)).check(matches(isDisplayed()));
+	}
+
+	@Test (expected = NoMatchingViewException.class)
+	public void testNonRegexFunctionNoAssistantButton() {
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_join,
+				R.string.formula_editor_function_join_parameter);
+		prepareUntilButton(editorFunction);
+		onView(withText(R.string.assistant)).check(matches(isDisplayed()));
+	}
+
+	@Test
+	public void testRegexFunctionFirstParamChangeRegexText() {
+
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_regex,
+				R.string.formula_editor_function_regex_parameter);
+		prepareUntilButton(editorFunction);
+
+		onView(withText(R.string.formula_editor_dialog_change_regular_expression)).check(matches(isDisplayed()));
+	}
+
+	@Test
+	public void testRegexFunctionFirstParamAssistantButton() {
+
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_regex,
+				R.string.formula_editor_function_regex_parameter);
+		prepareUntilButton(editorFunction);
+
+		onView(withText(R.string.assistant)).check(matches(isDisplayed()));
+	}
+
+	// Cant implement ui selection of second param.
+	// Functionality is still covered by unit test
+	//@Test
+	public void testRegexFunctionSecondParamChangeText() {
+
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_regex,
+				R.string.formula_editor_function_regex_parameter);
+
+		prepareUntilButton(editorFunction);
+		//select 2nd param.
+		onView(withText(R.string.formula_editor_dialog_change_text)).check(matches(isDisplayed()));
+	}
+
+	// Cant implement ui selection of second param.
+	// Functionality is still covered by unit test
+	//@Test (expected = NoMatchingViewException.class)
+	public void testRegexFunctionSecondParamNoAssistantButton() {
+
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_regex,
+				R.string.formula_editor_function_regex_parameter);
+
+		prepareUntilButton(editorFunction);
+		//select 2nd param.
+		onView(withText(R.string.assistant)).check(matches(isDisplayed()));
+	}
+
+	private void prepareUntilButton(String nameOfFunction) {
+		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text)).perform(click());
+		onFormulaEditor().performOpenCategory(FormulaEditorWrapper.Category.FUNCTIONS).performSelect(nameOfFunction);
+		onFormulaEditor().performClickOn(FormulaEditorWrapper.Control.TEXT);
+	}
+
+	private String getFunctionEntryName(int functionName, int paramName) {
+		String functionString = UiTestUtils.getResourcesString(functionName);
+		String paramString = UiTestUtils.getResourcesString(paramName);
+		return functionString + paramString;
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
@@ -273,6 +273,10 @@ public class FormulaEditorEditText extends EditText implements OnTouchListener {
 		return internFormula.getSelectedText();
 	}
 
+	public boolean isSelectedTokenFirstParamOfRegularExpression() {
+		return internFormula.isSelectedTokenFirstParamOfRegularExpression();
+	}
+
 	public void overrideSelectedText(String string) {
 		internFormula.overrideSelectedText(string, context);
 		history.push(new UndoState(internFormula.getInternFormulaState(),

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
@@ -966,6 +966,60 @@ public class InternFormula {
 		return null;
 	}
 
+	public boolean isSelectedTokenFirstParamOfRegularExpression() {
+
+		boolean isFirstParamInRegularExpression = false;
+
+		if (internFormulaTokenSelection != null) {
+			int indexOfSelectedTokenInTokenSelection = internFormulaTokenSelection.getStartIndex();
+
+			if (indexOfSelectedTokenInTokenSelection >= 2) {
+
+				isFirstParamInRegularExpression =
+						isSelectedTokenTypeString(indexOfSelectedTokenInTokenSelection)
+								&& isTokenBeforeSelectedTypeBracketOpen(indexOfSelectedTokenInTokenSelection)
+								&& isTwoTokensBeforeSelectedAFunctionAndNamedRegex(indexOfSelectedTokenInTokenSelection);
+			}
+		}
+		return isFirstParamInRegularExpression;
+	}
+
+	private boolean isSelectedTokenTypeString(int index) {
+		boolean isStringOrFunction = true;
+
+		InternTokenType typeFunction = InternTokenType.FUNCTION_NAME;
+		InternTokenType typeString = InternTokenType.STRING;
+
+		InternTokenType selectedTokenType = internTokenFormulaList.get(index).getInternTokenType();
+
+		if (!(selectedTokenType == typeString || selectedTokenType == typeFunction)) {
+			isStringOrFunction = false;
+		}
+		return isStringOrFunction;
+	}
+
+	private boolean isTokenBeforeSelectedTypeBracketOpen(int index) {
+		boolean isBracket = true;
+		InternTokenType typeBracketOpen = InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN;
+		if (!(internTokenFormulaList.get(index - 1).getInternTokenType()
+				== typeBracketOpen)) {
+			isBracket = false;
+		}
+		return isBracket;
+	}
+
+	private boolean isTwoTokensBeforeSelectedAFunctionAndNamedRegex(int index) {
+		boolean isRegex = true;
+		InternTokenType typeFunctionName = InternTokenType.FUNCTION_NAME;
+		String stringOfRegularExpression = Functions.REGEX.name();
+		InternToken functionToken = internTokenFormulaList.get(index - 2);
+		if (!(functionToken.getInternTokenType() == typeFunctionName
+				&& functionToken.getTokenStringValue().equals(stringOfRegularExpression))) {
+			isRegex = false;
+		}
+		return isRegex;
+	}
+
 	public String getSelectedText() {
 		InternToken token = getSelectedToken();
 		if (token == null) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -23,12 +23,14 @@
 package org.catrobat.catroid.ui.fragment;
 
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Rect;
 import android.location.LocationManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.Settings;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -327,7 +329,11 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 							endFormulaEditor();
 							return true;
 						case R.id.formula_editor_keyboard_string:
-							showNewStringDialog();
+							if (isSelectedTextFirstParamOfRegularExpression()) {
+								showNewRegexAssistantDialog();
+							} else {
+								showNewStringDialog();
+							}
 							return true;
 						case R.id.formula_editor_keyboard_delete:
 							formulaEditorEditText.handleKeyEvent(view.getId(), "");
@@ -364,6 +370,33 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	public void onStop() {
 		super.onStop();
 		((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(actionBarTitleBuffer);
+	}
+
+	private boolean isSelectedTextFirstParamOfRegularExpression() {
+		return getFormulaEditorEditText().isSelectedTokenFirstParamOfRegularExpression();
+	}
+
+	private void showNewRegexAssistantDialog() {
+		String selectedFormulaText = getSelectedFormulaText();
+
+		TextInputDialog.Builder builder = new TextInputDialog.Builder(getContext());
+
+		builder.setHint(getString(R.string.string_label))
+				.setText(selectedFormulaText)
+				.setPositiveButton(getString(R.string.ok), (TextInputDialog.OnClickListener) (dialog, textInput) -> addString(textInput));
+
+		int titleId = R.string.formula_editor_dialog_change_regular_expression;
+
+		builder.setNeutralButton(R.string.assistant,
+				(DialogInterface.OnClickListener) (dialog, textInput) -> regexTesting());
+
+		builder.setTitle(titleId)
+				.setNegativeButton(R.string.cancel, null)
+				.show();
+	}
+
+	private void regexTesting() {
+		Log.i("REGEX BUTTON", "Button Press detected");
 	}
 
 	private void showNewStringDialog() {

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="done">Done</string>
     <string name="close">Close</string>
 
+    <string name= "assistant">Assistant</string>
+
     <string name="yes">Yes</string>
     <string name="no">No</string>
 
@@ -1913,6 +1915,8 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_discard_changes_dialog_title">Save changes?</string>
     <string name="formula_editor_new_string_name">New text</string>
     <string name="formula_editor_dialog_change_text">Change text</string>
+    <string name="formula_editor_dialog_change_regular_expression">Change regular
+        expression</string>
     <string name="formula_editor_fragment_data_current_items">current items</string>
     <string name="formula_editor_data_dialog_is_list">Make it a list</string>
     <string name="formula_editor_sensor_face_detected">face is visible</string>

--- a/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/InternFormulaRegexDetectionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/InternFormulaRegexDetectionTest.java
@@ -1,0 +1,215 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.formulaeditor;
+
+import android.content.Context;
+
+import org.catrobat.catroid.formulaeditor.Functions;
+import org.catrobat.catroid.formulaeditor.InternFormula;
+import org.catrobat.catroid.formulaeditor.InternToken;
+import org.catrobat.catroid.formulaeditor.InternTokenType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.assertFalse;
+
+@RunWith(JUnit4.class)
+public class InternFormulaRegexDetectionTest {
+
+	private InternFormula internFormula;
+
+	@Test
+	public void testEmptyFormula() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = 0;
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertFalse("EmptyList should not be inside a regular expression",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+
+	@Test
+	public void testFormulaWithoutRegex() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.JOIN.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
+		internTokens.add(new InternToken(InternTokenType.STRING, "Hello"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "World"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = internFormula.getExternFormulaString().indexOf("Hello") + 1;
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertFalse("Formula without a regular expression cannot have a first regex param",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+
+	@Test
+	public void testFormulaWithNoBracketInFrontOfSelection() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.REGEX.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "Hello"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "World"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = internFormula.getExternFormulaString().indexOf("Hello") + 1;
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertFalse("If there is not bracket in front then this cant be the first param",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+
+	@Test
+	public void testRegexFormulaWithSelectedFirstParamNotString() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.REGEX.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
+		internTokens.add(new InternToken(InternTokenType.USER_VARIABLE, "Hello"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "World"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = internFormula.getExternFormulaString().indexOf("Hello") + 1;
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertFalse("If there is not bracket in front then this cant be the first param",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+
+	@Test
+	public void testCorrectRegexWithFirstParamSelected() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.REGEX.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
+		internTokens.add(new InternToken(InternTokenType.STRING, "Hello"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "World"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = internFormula.getExternFormulaString().indexOf("Hello") + 1;
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertTrue("First param in regex should be found",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+
+	@Test
+	public void testCorrectRegexWithSecondParamSelected() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.REGEX.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
+		internTokens.add(new InternToken(InternTokenType.STRING, "Hello"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "World"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = internFormula.getExternFormulaString().indexOf("World") + 1;
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertFalse("Second param in regex should not be found",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+
+	@Test
+	public void testCorrectRegexWithFirstParamOtherFunctionSelected() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.REGEX.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.JOIN.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
+		internTokens.add(new InternToken(InternTokenType.STRING, "FirstParam"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "SecondParam"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "World"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = 7; // since te extern string is "null( null( 'FirstParam',
+		// 'SecondParam' ), 'World' ) we want to click the join function, which is the second
+		// null, that is at index 6-9, so we click on index 7 because there is no option for us
+		// to find the correct index otherwise.
+
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertTrue("Function in first param of regular expression should be found as first param",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+
+	@Test
+	public void testCorrectRegexWithFirstParamOfInnerFunctionSelected() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.REGEX.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.JOIN.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
+		internTokens.add(new InternToken(InternTokenType.STRING, "FirstParam"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "SecondParam"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "World"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = internFormula.getExternFormulaString().indexOf("FirstParam") + 1;
+
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertFalse("First Param of inner function is not the first param of outer regular "
+						+ "expression",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+}


### PR DESCRIPTION
CATROID-725 Added context sensitive regular expression editor dialog. If first param of a regular expression is selected, an extended dialog option is shown. The dialog shown has the title "Change regular expression" and has a "Assistant" button without implemented functionality.
https://jira.catrob.at/browse/CATROID-725

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
