### PR TITLE
CATROID-730 - RegEx Assistant-Button functionality

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorRegexDetectionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorRegexDetectionTest.java
@@ -23,6 +23,9 @@
 
 package org.catrobat.catroid.uiespresso.formulaeditor;
 
+import android.content.Intent;
+import android.net.Uri;
+
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.bricks.SetVariableBrick;
@@ -37,14 +40,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.espresso.intent.Intents;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
 import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+import static org.hamcrest.Matchers.allOf;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasData;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -91,7 +99,6 @@ public class FormulaEditorRegexDetectionTest {
 
 		onView(withText(R.string.formula_editor_dialog_change_regular_expression)).check(matches(isDisplayed()));
 	}
-
 	@Test
 	public void testRegexFunctionFirstParamAssistantButton() {
 
@@ -100,6 +107,24 @@ public class FormulaEditorRegexDetectionTest {
 		prepareUntilButton(editorFunction);
 
 		onView(withText(R.string.assistant)).check(matches(isDisplayed()));
+	}
+	@Test
+	public void testRegexFunctionAssistantButtonLinkToWikiPageOnClick() {
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_regex,
+				R.string.formula_editor_function_regex_parameter);
+		prepareUntilButton(editorFunction);
+
+		Intents.init();
+
+		try {
+			onView(withText(R.string.assistant)).perform(click());
+
+			intended(allOf(
+					hasAction(Intent.ACTION_VIEW),
+					hasData(Uri.parse("https://catrob.at/regex"))));
+		} finally {
+			Intents.release();
+		}
 	}
 
 	// Cant implement ui selection of second param.

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -30,7 +30,6 @@ import android.location.LocationManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.Settings;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -73,6 +72,7 @@ import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
 import org.catrobat.catroid.userbrick.UserDefinedBrickInput;
 import org.catrobat.catroid.utils.SnackbarUtil;
 import org.catrobat.catroid.utils.ToastUtil;
+import org.catrobat.catroid.web.WebpageUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -388,15 +388,15 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		int titleId = R.string.formula_editor_dialog_change_regular_expression;
 
 		builder.setNeutralButton(R.string.assistant,
-				(DialogInterface.OnClickListener) (dialog, textInput) -> regexTesting());
+				(DialogInterface.OnClickListener) (dialog, textInput) -> openWikiPage());
 
 		builder.setTitle(titleId)
 				.setNegativeButton(R.string.cancel, null)
 				.show();
 	}
 
-	private void regexTesting() {
-		Log.i("REGEX BUTTON", "Button Press detected");
+	private void openWikiPage() {
+		WebpageUtils.openWikiPage(getContext());
 	}
 
 	private void showNewStringDialog() {


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-730

- ADD open wikipage functionality on assistant button in ABC-Button dialog
- ADD UI-test for assistant button in ABC-Button dialog

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
