### PR TITLE
Catroid 737 - Added list of feature functionality to regular expression assistant window

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/RegularExpressionAssistantDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/RegularExpressionAssistantDialogTest.java
@@ -62,27 +62,53 @@ public class RegularExpressionAssistantDialogTest {
 		script.addBrick(new ChangeSizeByNBrick(0));
 		baseActivityTestRule.launchActivity();
 
+		onBrickAtPosition(1).onChildView(withId(R.id.brick_change_size_by_edit_text)).perform(click());
+	}
+
+	private void clickOnAssistantInFunctionList() {
 		String regularExpressionAssistant =
 				"\t\t\t\t\t" + UiTestUtils.getResourcesString(R.string.formula_editor_function_regex_assistant);
-
-		onBrickAtPosition(1).onChildView(withId(R.id.brick_change_size_by_edit_text)).perform(click());
 		onFormulaEditor().performOpenCategory(FormulaEditorWrapper.Category.FUNCTIONS).performSelect(regularExpressionAssistant);
 	}
 
 	@Test
 	public void testDialogTitle() {
+		clickOnAssistantInFunctionList();
 		onView(withText(R.string.formula_editor_dialog_regular_expression_assistant_title)).check(matches(isDisplayed()));
 	}
 
 	@Test
 	public void testCancelButton() {
+		clickOnAssistantInFunctionList();
 		onView(withText(R.string.cancel)).check(matches(isDisplayed()));
 	}
 
 	@Test (expected = NoMatchingViewException.class)
 	public void testCancelButtonFunctionality() {
+		clickOnAssistantInFunctionList();
 		onView(withText(R.string.cancel)).perform(click());
 
 		onView(withText(R.string.cancel)).check(matches(isDisplayed()));
+	}
+
+	@Test //refactor to wiki button or html extract once they are implemented
+	public void testIsDummyFeatureInList() {
+		//setup
+		clickOnAssistantInFunctionList();
+
+		//test
+		onView(withText(R.string.formula_editor_function_regex_assistant_dummy)).check(matches(isDisplayed()));
+	}
+
+	@Test //refactor to wiki button or html extract once they are implemented
+	public void testDoesDummyOpenCorrectDialog() {
+		//setup
+		clickOnAssistantInFunctionList();
+
+		//test
+		onView(withText(R.string.formula_editor_function_regex_assistant_dummy)).perform(click()); //clicke auf dummy
+		String nameOfDummyDialog =
+				UiTestUtils.getResourcesString(R.string.formula_editor_function_regex_assistant_dummy) + "Dialog";
+		onView(withText(nameOfDummyDialog)).check(matches(isDisplayed()));
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/RegularExpressionAssistantDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/RegularExpressionAssistantDialog.java
@@ -1,0 +1,81 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.ui.dialogs.regexassistant;
+
+import android.content.Context;
+import android.content.DialogInterface;
+
+import org.catrobat.catroid.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.appcompat.app.AlertDialog;
+
+public class RegularExpressionAssistantDialog {
+
+	static List<RegularExpressionFeature> listOfFeatures;
+	List<String> namesOfFeatures;
+	Context context;
+
+	public RegularExpressionAssistantDialog(Context context) {
+		this.context = context;
+		createListOfFeatures();
+	}
+
+	public void createAssistant() {
+		AlertDialog.Builder builder = new AlertDialog.Builder(context);
+
+		builder.setView(R.layout.dialog_regular_expression_assistant);
+		builder.setTitle(R.string.formula_editor_dialog_regular_expression_assistant_title);
+		builder.setNegativeButton(R.string.cancel, null);
+
+		buildListOfFeatures(builder);
+
+		AlertDialog dialog = builder.create();
+
+		dialog.show();
+	}
+
+	private void buildListOfFeatures(AlertDialog.Builder builder) {
+		namesOfFeatures = new ArrayList<>();
+		for (RegularExpressionFeature rf : listOfFeatures) {
+			namesOfFeatures.add(context.getString(rf.getTitleId()));
+		}
+
+		builder.setItems(namesOfFeatures.toArray(new String[0]),
+				new DialogInterface.OnClickListener() {
+					@Override
+						public void onClick(DialogInterface dialog, int indexInList) {
+							listOfFeatures.get(indexInList).openDialog(context);
+						}
+				});
+	}
+
+	private void createListOfFeatures() {
+		listOfFeatures = new ArrayList<>();
+
+		listOfFeatures.add(new RegularExpressionFeatureDummy(R.string.formula_editor_function_regex_assistant_dummy));
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/RegularExpressionFeature.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/RegularExpressionFeature.java
@@ -21,24 +21,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.catroid.ui.dialogs;
+package org.catrobat.catroid.ui.dialogs.regexassistant;
 
 import android.content.Context;
 
-import org.catrobat.catroid.R;
+public abstract class RegularExpressionFeature {
 
-import androidx.appcompat.app.AlertDialog;
+	int titleId;
 
-public class RegularExpressionAssistantDialog {
-	public void createAssistant(Context context) {
-		AlertDialog.Builder builder = new AlertDialog.Builder(context);
+	public abstract void openDialog(Context context);
 
-		builder.setView(R.layout.dialog_regular_expression_assistant);
-		builder.setTitle(R.string.formula_editor_dialog_regular_expression_assistant_title);
-		builder.setNegativeButton(R.string.cancel, null);
-
-		AlertDialog dialog = builder.create();
-
-		dialog.show();
+	public int getTitleId() {
+		return titleId;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/RegularExpressionFeatureDummy.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/RegularExpressionFeatureDummy.java
@@ -1,0 +1,43 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.ui.dialogs.regexassistant;
+
+import android.app.AlertDialog;
+import android.content.Context;
+
+import org.catrobat.catroid.R;
+
+public class RegularExpressionFeatureDummy extends RegularExpressionFeature {
+
+	public RegularExpressionFeatureDummy(int titleId) {
+		this.titleId = titleId;
+	}
+
+	public void openDialog(Context context) {
+		AlertDialog.Builder builder = new AlertDialog.Builder(context);
+		builder.setTitle(context.getString(titleId) + "Dialog");
+		builder.setView(R.layout.dialog_regular_expression_assistant);
+		builder.show();
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
@@ -42,7 +42,7 @@ import org.catrobat.catroid.devices.mindstorms.nxt.sensors.NXTSensor;
 import org.catrobat.catroid.formulaeditor.SensorHandler;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.ui.dialogs.LegoSensorPortConfigDialog;
-import org.catrobat.catroid.ui.dialogs.RegularExpressionAssistantDialog;
+import org.catrobat.catroid.ui.dialogs.regexassistant.RegularExpressionAssistantDialog;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import org.catrobat.catroid.ui.recyclerview.adapter.CategoryListRVAdapter;
 import org.catrobat.catroid.ui.recyclerview.adapter.CategoryListRVAdapter.CategoryListItem;
@@ -339,7 +339,7 @@ public class CategoryListFragment extends Fragment implements CategoryListRVAdap
 	}
 
 	private void openRegularExpressionAssistant() {
-		new RegularExpressionAssistantDialog().createAssistant(getContext());
+		new RegularExpressionAssistantDialog(getContext()).createAssistant();
 	}
 
 	private void showNewUserListDialog(CategoryListItem categoryListItem, List<UserList> projectUserList, List<UserList> spriteUserList,

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1765,6 +1765,7 @@ needs read and write access to it. You can always change permissions through you
         assistant</string>
     <string name="formula_editor_dialog_regular_expression_assistant_title">Regular
         expression assistant</string>
+    <string name="formula_editor_function_regex_assistant_dummy">RegexDummy</string>
     <string name="formula_editor_function_arduino_read_pin_value_digital">arduino digital pin</string>
     <string name="formula_editor_function_arduino_read_pin_value_analog">arduino analog pin</string>
     <string name="formula_editor_function_raspi_read_pin_value_digital">raspberry pi pin</string>


### PR DESCRIPTION
Catroid 737 - Added list of feature functionality to regular expression assistant window
https://jira.catrob.at/browse/CATROID-737

-Add internal list functionality to add new assistant window features
-Add UI-tests testing the display and opening of the corresponding dialog
-Add datastructure for assistant features
-Add dummy class for testing purposes

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
