### PR TITLE
CATROID-710 RegExpAssistant Button uses RegEx functionalities

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorRegexAssistantTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorRegexAssistantTest.java
@@ -21,11 +21,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.catrobat.catroid.uiespresso.ui.dialog;
+package org.catrobat.catroid.uiespresso.formulaeditor;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
-import org.catrobat.catroid.content.bricks.ChangeSizeByNBrick;
+import org.catrobat.catroid.content.bricks.SetVariableBrick;
 import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
 import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper;
@@ -36,7 +36,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
@@ -44,25 +43,37 @@ import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorW
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
-public class RegularExpressionAssistantDialogTest {
+public class FormulaEditorRegexAssistantTest {
 
 	@Rule
 	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
 			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
 
 	@Before
-	public void setUp() throws Exception {
-		Script script = BrickTestUtils.createProjectAndGetStartScript("FormulaEditorFunctionListTest");
-		script.addBrick(new ChangeSizeByNBrick(0));
+	public void setUp() {
+		Script script = BrickTestUtils.createProjectAndGetStartScript(
+				"FormulaEditorRegExDetectionTest");
+		script.addBrick(new SetVariableBrick(0)); //standard value of editor field is 123
 		baseActivityTestRule.launchActivity();
+	}
 
-		onBrickAtPosition(1).onChildView(withId(R.id.brick_change_size_by_edit_text)).perform(click());
+	@Test
+	public void testAssistantReplacesTextInFormulaEditor() {
+		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text)).perform(click());
+		clickOnAssistantInFunctionList();
+
+		onView(withText(R.string.cancel)).perform(click());
+
+		String selectedFunctionString =
+				getSelectedFunctionString(
+						UiTestUtils.getResourcesString(R.string.formula_editor_function_regex)
+								+ UiTestUtils.getResourcesString(R.string.formula_editor_function_regex_parameter));
+
+		onFormulaEditor().checkShows(selectedFunctionString);
 	}
 
 	private void clickOnAssistantInFunctionList() {
@@ -71,38 +82,12 @@ public class RegularExpressionAssistantDialogTest {
 		onFormulaEditor().performOpenCategory(FormulaEditorWrapper.Category.FUNCTIONS).performSelect(regularExpressionAssistant);
 	}
 
-	@Test
-	public void testDialogTitle() {
-		clickOnAssistantInFunctionList();
-		onView(withText(R.string.formula_editor_dialog_regular_expression_assistant_title)).check(matches(isDisplayed()));
-	}
-
-	@Test
-	public void testCancelButton() {
-		clickOnAssistantInFunctionList();
-		onView(withText(R.string.cancel)).check(matches(isDisplayed()));
-	}
-
-	@Test (expected = NoMatchingViewException.class)
-	public void testCancelButtonFunctionality() {
-		clickOnAssistantInFunctionList();
-
-		onView(withText(R.string.cancel)).perform(click());
-		onView(withText(R.string.cancel)).check(matches(isDisplayed()));
-	}
-
-	@Test
-	public void testIsHtmlExtractorInList() {
-		clickOnAssistantInFunctionList();
-
-		onView(withText(R.string.formula_editor_regex_html_extractor_dialog_title)).check(matches(isDisplayed()));
-	}
-
-	@Test
-	public void testDoesHtmlExtractorOpensCorrectDialog() {
-		clickOnAssistantInFunctionList();
-
-		onView(withText(R.string.formula_editor_regex_html_extractor_dialog_title)).perform(click()); //click on HTML Extractor
-		onView(withText(R.string.formula_editor_regex_html_extractor_dialog_title)).check(matches(isDisplayed()));
+	private String getSelectedFunctionString(String functionString) {
+		return functionString
+				.replaceAll("^(.+?)\\(", "$1( ")
+				.replace(",", " , ")
+				.replace("-", "- ")
+				.replaceAll("\\)$", " )")
+				.concat(" ");
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
@@ -282,6 +282,8 @@ public class CategoryListFragment extends Fragment implements CategoryListRVAdap
 				if (LIST_FUNCTIONS.contains(item.nameResId)) {
 					onUserListFunctionSelected(item);
 				} else if (R.string.formula_editor_function_regex_assistant == item.nameResId) {
+					addResourceToActiveFormulaInFormulaEditor(getRegularExpressionItem());
+					getActivity().onBackPressed();
 					openRegularExpressionAssistant();
 				} else {
 					addResourceToActiveFormulaInFormulaEditor(item);
@@ -336,6 +338,18 @@ public class CategoryListFragment extends Fragment implements CategoryListRVAdap
 			return;
 		}
 		addResourceToActiveFormulaInFormulaEditor(categoryListItem, projectUserList.get(projectUserList.size() - 1));
+	}
+
+	private CategoryListItem getRegularExpressionItem() {
+		CategoryListItem regexItem = null;
+
+		List<CategoryListItem> itemList = getFunctionItems();
+		for (CategoryListItem item : itemList) {
+			if (item.nameResId == R.string.formula_editor_function_regex) {
+				regexItem = item;
+			}
+		}
+		return regexItem;
 	}
 
 	private void openRegularExpressionAssistant() {


### PR DESCRIPTION
-CHANGE opening the regular expression assistant in the functions list now inserts a regular expression into the formula editor before opening the assistant dialog
-ADD UI Test checking that the correct text is inserted into the formula editor

https://jira.catrob.at/browse/CATROID-710

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
