### PR TITLE
CATROID-763 Result of generated Regex is insert into first parameter

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/HtmlExtractorDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/HtmlExtractorDialogTest.java
@@ -103,19 +103,30 @@ public class HtmlExtractorDialogTest {
 		onView(withText(R.string.formula_editor_function_regex_html_extractor_not_found)).inRoot(withDecorView(not(baseActivityTestRule.getActivity().getWindow().getDecorView()))).check(matches(isDisplayed()));
 	}
 
-	@Test
-	public void testHtmlExtractorDialogFoundMessage() {
-		onView(withHint(R.string.keyword_label)).perform(typeText("Key"));
-		onView(withHint(R.string.html_label)).perform(typeText("Keyword was Found"));
-		onView(withText(R.string.ok)).perform(click());
-
-		onView(withText(R.string.formula_editor_function_regex_html_extractor_found)).inRoot(withDecorView(not(baseActivityTestRule.getActivity().getWindow().getDecorView()))).check(matches(isDisplayed()));
-	}
-
 	private void openHtmlExtractor() {
 		String regularExpressionAssistant =
 				"\t\t\t\t\t" + UiTestUtils.getResourcesString(R.string.formula_editor_function_regex_assistant);
 		onFormulaEditor().performOpenCategory(FormulaEditorWrapper.Category.FUNCTIONS).performSelect(regularExpressionAssistant);
 		onView(withText(R.string.formula_editor_regex_html_extractor_dialog_title)).perform(click()); //click on HTML Extractor
+	}
+
+	@Test
+	public void testInsertKeywordIntoEditor() {
+		String expectedText = "regular expression('(.*) ','I am a panda.')";
+
+		onView(withHint(R.string.keyword_label)).perform(typeText("Word"));
+		onView(withHint(R.string.html_label)).perform(typeText("Word Inserted"));
+		onView(withText(R.string.ok)).perform(click());
+
+		onFormulaEditor().checkShows(getSelectedFunctionString(expectedText));
+	}
+
+	private String getSelectedFunctionString(String functionString) {
+		return functionString
+				.replaceAll("^(.+?)\\(", "$1( ")
+				.replace(",", " , ")
+				.replace("-", "- ")
+				.replaceAll("\\)$", " )")
+				.concat(" ");
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/HtmlExtractorDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/HtmlExtractorDialog.java
@@ -27,12 +27,17 @@ import android.content.Context;
 import android.content.DialogInterface;
 
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import org.catrobat.catroid.utils.HtmlRegexExtractor;
+
+import androidx.fragment.app.FragmentManager;
 
 public class HtmlExtractorDialog extends RegularExpressionFeature {
 
-	public HtmlExtractorDialog() {
+	private FragmentManager fragmentManager;
+	public HtmlExtractorDialog(FragmentManager fragmentManager) {
 		this.titleId = R.string.formula_editor_regex_html_extractor_dialog_title;
+		this.fragmentManager = fragmentManager;
 	}
 
 	public void openDialog(Context context) {
@@ -43,11 +48,27 @@ public class HtmlExtractorDialog extends RegularExpressionFeature {
 			@Override
 			public void onPositiveButtonClick(DialogInterface dialog, String keywordInput, String htmlInput) {
 				HtmlRegexExtractor htmlRegexExt = new HtmlRegexExtractor(context);
-				htmlRegexExt.searchKeyword(keywordInput, htmlInput);
+				outputText(htmlRegexExt.searchKeyword(keywordInput, htmlInput));
 			}
 		});
 		builder.setTitle(R.string.formula_editor_regex_html_extractor_dialog_title);
 		builder.setNegativeButton(R.string.cancel, null);
 		builder.show();
+	}
+
+	private FormulaEditorFragment getFormulaEditorFragment() {
+		FormulaEditorFragment formulaEditorFragment = null;
+		if (fragmentManager != null) {
+			formulaEditorFragment = ((FormulaEditorFragment) fragmentManager
+					.findFragmentByTag(FormulaEditorFragment.FORMULA_EDITOR_FRAGMENT_TAG));
+		}
+		return formulaEditorFragment;
+	}
+
+	private void outputText(String text) {
+		FormulaEditorFragment formulaEditorFragment = getFormulaEditorFragment();
+		if (formulaEditorFragment != null && (!text.equals(""))) {
+			formulaEditorFragment.addString(text);
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/RegularExpressionAssistantDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/RegularExpressionAssistantDialog.java
@@ -33,15 +33,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.FragmentManager;
 
 public class RegularExpressionAssistantDialog {
 
 	static List<RegularExpressionFeature> listOfFeatures;
 	List<String> namesOfFeatures;
 	Context context;
+	FragmentManager fragmentManager;
 
-	public RegularExpressionAssistantDialog(Context context) {
+	public RegularExpressionAssistantDialog(Context context, FragmentManager fragmentManager) {
 		this.context = context;
+		this.fragmentManager = fragmentManager;
 		createListOfFeatures();
 	}
 
@@ -77,7 +80,7 @@ public class RegularExpressionAssistantDialog {
 	private void createListOfFeatures() {
 		listOfFeatures = new ArrayList<>();
 		if (BuildConfig.FEATURE_REGULAR_EXPRESSION_ASSISTANT_ENABLED) {
-			listOfFeatures.add(new HtmlExtractorDialog());
+			listOfFeatures.add(new HtmlExtractorDialog(fragmentManager));
 			listOfFeatures.add(new JsonExtractorDialog());
 		}
 		listOfFeatures.add(new WikiWebPage());

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -396,7 +396,7 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	}
 
 	private void openAssistantDialog() {
-		new RegularExpressionAssistantDialog(getContext()).createAssistant();
+		new RegularExpressionAssistantDialog(getContext(), getFragmentManager()).createAssistant();
 	}
 
 	private void showNewStringDialog() {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
@@ -355,7 +355,7 @@ public class CategoryListFragment extends Fragment implements CategoryListRVAdap
 	}
 
 	private void openRegularExpressionAssistant() {
-		new RegularExpressionAssistantDialog(getContext()).createAssistant();
+		new RegularExpressionAssistantDialog(getContext(), getFragmentManager()).createAssistant();
 	}
 
 	private void showNewUserListDialog(CategoryListItem categoryListItem, List<UserList> projectUserList, List<UserList> spriteUserList,

--- a/catroid/src/main/java/org/catrobat/catroid/utils/HtmlRegexExtractor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/HtmlRegexExtractor.java
@@ -38,20 +38,17 @@ public class HtmlRegexExtractor {
 		this.context = context;
 	}
 
-	public void searchKeyword(String keyword, String text) {
+	public String searchKeyword(String keyword, String text) {
 		String keywordFound = findKeyword(keyword, text);
 		String regexFound = htmlToRegexConverter(keywordFound, text);
 		if (regexFound == null) {
 			showError();
+			return "";
 		} else {
-			showSuccess();
+			return regexFound;
 		}
 	}
 
-	private void showSuccess() {
-		ToastUtil.showSuccess(context,
-				R.string.formula_editor_function_regex_html_extractor_found);
-	}
 	private void showError() {
 		ToastUtil.showError(context,
 				R.string.formula_editor_function_regex_html_extractor_not_found);

--- a/catroid/src/main/java/org/catrobat/catroid/utils/HtmlRegexExtractor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/HtmlRegexExtractor.java
@@ -27,19 +27,117 @@ import android.content.Context;
 
 import org.catrobat.catroid.R;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import androidx.annotation.VisibleForTesting;
+
 public class HtmlRegexExtractor {
 	private Context context;
 	public HtmlRegexExtractor(Context context) {
 		this.context = context;
 	}
-	public void searchKeyword(String search, String text) {
-		int index = text.indexOf(search);
-		if (index >= 0) {
-			ToastUtil.showSuccess(context,
-					R.string.formula_editor_function_regex_html_extractor_found);
+
+	public void searchKeyword(String keyword, String text) {
+		String keywordFound = findKeyword(keyword, text);
+		String regexFound = htmlToRegexConverter(keywordFound, text);
+		if (regexFound == null) {
+			showError();
 		} else {
-			ToastUtil.showError(context,
-					R.string.formula_editor_function_regex_html_extractor_not_found);
+			showSuccess();
 		}
+	}
+
+	private void showSuccess() {
+		ToastUtil.showSuccess(context,
+				R.string.formula_editor_function_regex_html_extractor_found);
+	}
+	private void showError() {
+		ToastUtil.showError(context,
+				R.string.formula_editor_function_regex_html_extractor_not_found);
+	}
+
+	@VisibleForTesting
+	public String findKeyword(String keyword, String text) {
+		if (keyword.equals("")) {
+			return null;
+		}
+		if (text.indexOf(keyword) >= 0) {
+			return keyword;
+		} else {
+			return findKeywordWithHtmlBetweenWordsInText(keyword, text);
+		}
+	}
+
+	private String findKeywordWithHtmlBetweenWordsInText(String keyword, String text) {
+		String[] splittedKeyword = keyword.split(" ");
+		String regex = Pattern.quote(splittedKeyword[0]);
+
+		for (int i = 1; i < splittedKeyword.length; i++) {
+			regex += ".*?" + Pattern.quote(splittedKeyword[i]);
+		}
+		return findShortestOccurrenceInText(regex, text);
+	}
+
+	private String findShortestOccurrenceInText(String regex, String text) {
+		Matcher m = Pattern.compile(regex).matcher(text);
+
+		String shortestOccurrence = null;
+		int lastIndex = -1;
+		while (m.find(lastIndex + 1)) {
+			String found = m.group();
+			if (shortestOccurrence == null || shortestOccurrence.length() > found.length()) {
+				shortestOccurrence = found;
+				lastIndex = m.start();
+			}
+		}
+		return shortestOccurrence;
+	}
+
+	public String htmlToRegexConverter(String keyword, String htmlText) {
+		int keywordIndex;
+		String regex;
+
+		if (keyword != null) {
+			keywordIndex = htmlText.indexOf(keyword);
+			if (keyword.equals(htmlText)) {
+				regex = "(.*)";
+			} else {
+				regex = "(.*)";
+				int distance = 0;
+				do {
+					distance++;
+
+					String beforeKeyword = "";
+					int beforeKeywordIndex = keywordIndex - distance;
+					if (beforeKeywordIndex >= 0) {
+						beforeKeyword = String.valueOf(htmlText.charAt(beforeKeywordIndex));
+					}
+
+					String afterKeyword = "";
+					int afterKeywordIndex = keywordIndex + keyword.length() + distance - 1;
+					if (afterKeywordIndex < htmlText.length()) {
+						afterKeyword =
+								String.valueOf(htmlText.charAt(afterKeywordIndex));
+					}
+
+					regex = beforeKeyword + regex + afterKeyword;
+				} while (!matchesUniquely(regex, htmlText, keyword));
+			}
+		} else {
+			regex = null;
+		}
+		return regex;
+	}
+	private boolean matchesUniquely(String pattern, String text, String expectedMatch) {
+		int counter = 0;
+		Matcher matcher = Pattern.compile(pattern).matcher(text);
+
+		String matched = null;
+		while (matcher.find()) {
+			matched = matcher.group(1);
+			counter++;
+		}
+		return counter == 1 && expectedMatch.equals(matched);
 	}
 }

--- a/catroid/src/test/java/org/catrobat/catroid/test/ui/regexassistant/HtmlRegexExtractorTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/ui/regexassistant/HtmlRegexExtractorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.ui.regexassistant;
+
+import android.app.Activity;
+
+import org.catrobat.catroid.utils.HtmlRegexExtractor;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class HtmlRegexExtractorTest {
+
+	@Before
+	public void setUp() {
+		Activity context = new Activity();
+		htmlExtractor = new HtmlRegexExtractor(context);
+	}
+	private HtmlRegexExtractor htmlExtractor;
+
+	@Test
+	public void testFindKeywordWithEmptyKeyword() {
+		assertNull(htmlExtractor.findKeyword("", "abc"));
+	}
+
+	@Test
+	public void testFindKeywordWithWrongKeyword() {
+		assertNull(htmlExtractor.findKeyword("def", "abc"));
+	}
+
+	@Test
+	public void testFindOneKeywordInLongWord() {
+		assertEquals("abc", htmlExtractor.findKeyword("abc", "abcdefg"));
+	}
+
+	@Test
+	public void testFindKeywordInSentence() {
+		assertEquals("abc", htmlExtractor.findKeyword("abc", "Wer are looking for the abc "
+				+ "statement in long text"));
+	}
+
+	@Test
+	public void testFindKeywordInSentenceWithSpaceInKeywordAndTextWithNBSP() {
+		assertEquals("ab&nbsp;c", htmlExtractor.findKeyword("ab c", "Wer are looking for "
+				+ "the "
+				+ "ab&nbsp;c statement in long text"));
+	}
+
+	@Test
+	public void testKeywordWithNonBreakingSpace() {
+		assertEquals("Key&nbsp;Word", htmlExtractor.findKeyword("Key Word", "Key&nbsp;Word"));
+	}
+
+	@Test
+	public void testKeywordWithTag() {
+		assertEquals("Key <i>Word", htmlExtractor.findKeyword("Key Word", "Key "
+				+ "<i>Word</i>"));
+	}
+
+	@Test
+	public void testFalseKeywordOrder() {
+		assertNull(htmlExtractor.findKeyword("Key Word", "Word Key"));
+	}
+
+	@Test
+	public void testRegexAsKeyword() {
+		assertNull("A regular expression should not be found inside a html text that "
+						+ "doesn't contain it literally",
+				htmlExtractor.findKeyword("[A-Z]", "ABCDE"));
+	}
+
+	@Test
+	public void testRegexAsKeywordAndInText() {
+		assertEquals("[A-Z]", htmlExtractor.findKeyword("[A-Z]", "[A-Z]+.*"));
+	}
+
+	@Test
+	public void testFindKeywordSmallestOccurrence() {
+		assertEquals("Hello&nbsp;World", htmlExtractor.findKeyword("Hello World",
+				"Hello Banana Animal Text Hello&nbsp;World Ape"));
+	}
+
+	@Test
+	public void testCreateRegexWithOneCharContext() {
+		assertEquals("b(.*)e", htmlExtractor.htmlToRegexConverter("cd", "abcdefg"));
+	}
+
+	@Test
+	public void testCreateRegexWithKeywordAtStart() {
+		assertEquals("(.*)c", htmlExtractor.htmlToRegexConverter("ab", "abcdefg"));
+	}
+
+	@Test
+	public void testCreateRegexWithKeywordAtEnd() {
+		assertEquals("d(.*)", htmlExtractor.htmlToRegexConverter("efg", "abcdefg"));
+	}
+
+	@Test
+	public void testCreateRegexWithDuplicateKeywordFirstOccurrence1CharContext() {
+		assertEquals("ab(.*)defga", htmlExtractor.htmlToRegexConverter("KEY", "abKEYdefgadKEYdefg"));
+	}
+
+	@Test
+	public void testCreateRegexWith2CharContext() {
+		assertEquals("yb(.*)de", htmlExtractor.htmlToRegexConverter("KEY", "abcdefg ybKEYdefg"));
+	}
+
+	@Test
+	public void testCreateRegexWhereKeywordEqualsHtmlText() {
+		assertEquals("(.*)", htmlExtractor.htmlToRegexConverter("abcdefg", "abcdefg"));
+	}
+
+	@Test
+	public void testCreateRegexPostfixInKeyword() {
+		assertEquals("(.*)b", htmlExtractor.htmlToRegexConverter("abc", "abcbc"));
+	}
+
+	@Test
+	public void testCreateRegexOutOfBoundsAfter2CharContext() {
+		assertEquals("b(.*)ba", htmlExtractor.htmlToRegexConverter("abc", "babcbabcb"));
+	}
+	@Test
+	public void testFirstKeyBordersOnSecondKey() {
+		assertEquals("baaaa(.*)aaaaK", htmlExtractor.htmlToRegexConverter("KEY",
+				"baaaaKEYaaaaKEYaaaa"));
+	}
+	@Test
+	public void testCreateRegexWhereTextOnlyKeywords() {
+		assertEquals("(.*)aa", htmlExtractor.htmlToRegexConverter("a", "aaa"));
+	}
+}


### PR DESCRIPTION
CATROID-763 Result of generated Regex is insert into first parameter

- Insert the created regular expression from 4.5.1/Ticket 762 into the first param of the already existent regular expression
- HtmlExtractorDialogTest: UI Test for inserted text into first parameter
- HtmlExtractorDialog: String from keyword is insert into first parameter

https://jira.catrob.at/browse/CATROID-763

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
