### PR TITLE
CATROID-382 Enable color picker option in formula editor

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ShowTextColorSizeAlignmentBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ShowTextColorSizeAlignmentBrickTest.java
@@ -23,48 +23,66 @@
 
 package org.catrobat.catroid.uiespresso.content.brick.app;
 
+import android.util.Log;
+
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.bricks.ShowTextColorSizeAlignmentBrick;
+import org.catrobat.catroid.test.utils.TestUtils;
 import org.catrobat.catroid.testsuites.annotations.Cat;
 import org.catrobat.catroid.testsuites.annotations.Level;
 import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.IOException;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils.createProjectAndGetStartScript;
 import static org.catrobat.catroid.uiespresso.content.brick.utils.ColorPickerInteractionWrapper.onColorPickerPresetButton;
+import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
 import static org.hamcrest.Matchers.containsString;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
+@Category({Cat.AppUi.class, Level.Smoke.class})
 @RunWith(AndroidJUnit4.class)
 public class ShowTextColorSizeAlignmentBrickTest {
+	private static final String TAG = ShowTextColorSizeAlignmentBrickTest.class.getSimpleName();
 	private int brickPosition;
 
 	@Rule
 	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
 			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
 
+	@After
+	public void tearDown() {
+		try {
+			TestUtils.deleteProjects(ShowTextColorSizeAlignmentBrickTest.class.getSimpleName());
+		} catch (IOException e) {
+			Log.e(TAG, Log.getStackTraceString(e));
+		}
+	}
+
 	@Before
 	public void setUp() {
 		brickPosition = 1;
-		createProjectAndGetStartScript("ShowTextColorSizeAlignmentBrickTest")
-				.addBrick(new ShowTextColorSizeAlignmentBrick());
+		createProjectAndGetStartScript(ShowTextColorSizeAlignmentBrickTest.class.getSimpleName())
+				.addBrick(new ShowTextColorSizeAlignmentBrick(0, 0, 100, "#000000"));
 		baseActivityTestRule.launchActivity();
 	}
 
-	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void testPickColor() {
 		onBrickAtPosition(brickPosition).checkShowsText(R.string.brick_show_variable);
@@ -80,7 +98,6 @@ public class ShowTextColorSizeAlignmentBrickTest {
 				.check(matches(withText(containsString("'#0074CD'"))));
 	}
 
-	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void testPickColorCancel() {
 		onBrickAtPosition(brickPosition).checkShowsText(R.string.brick_show_variable);
@@ -94,5 +111,30 @@ public class ShowTextColorSizeAlignmentBrickTest {
 				.perform(click());
 		onView(withId(R.id.brick_show_variable_color_size_edit_color))
 				.check(matches(withText(containsString("0"))));
+	}
+
+	@Test
+	public void testPickColorInFormulaFragment() {
+		onView(withId(R.id.brick_show_variable_color_size_edit_relative_size))
+				.perform(click());
+		onView(withId(R.id.brick_show_variable_color_size_edit_color))
+				.perform(click());
+		onView(withText(R.string.brick_context_dialog_pick_color))
+				.check(matches(isDisplayed()));
+	}
+
+	@Test
+	public void testPickColorNotShownForComplexFormula() {
+		onView(withId(R.id.brick_show_variable_color_size_edit_color))
+				.perform(click());
+		onView(withText(R.string.brick_context_dialog_formula_edit_brick))
+				.perform(click());
+		onFormulaEditor()
+				.performEnterFormula("1+2")
+				.performCloseAndSave();
+		onView(withId(R.id.brick_show_variable_color_size_edit_color))
+				.perform(click());
+		onFormulaEditor()
+				.check(matches(isDisplayed()));
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextColorSizeAlignmentBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextColorSizeAlignmentBrick.java
@@ -43,12 +43,14 @@ import org.catrobat.catroid.formulaeditor.InterpretationException;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.formulaeditor.common.Conversions;
 import org.catrobat.catroid.ui.UiUtils;
+import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
 
 import static org.catrobat.catroid.ui.SpriteActivity.EXTRA_TEXT_ALIGNMENT;
 import static org.catrobat.catroid.ui.SpriteActivity.EXTRA_TEXT_COLOR;
@@ -57,6 +59,7 @@ import static org.catrobat.catroid.utils.ShowTextUtils.ALIGNMENT_STYLE_CENTERED;
 import static org.catrobat.catroid.utils.ShowTextUtils.ALIGNMENT_STYLE_LEFT;
 import static org.catrobat.catroid.utils.ShowTextUtils.ALIGNMENT_STYLE_RIGHT;
 import static org.catrobat.catroid.utils.ShowTextUtils.convertColorToString;
+import static org.catrobat.catroid.utils.ShowTextUtils.isValidColorString;
 
 public class ShowTextColorSizeAlignmentBrick extends UserVariableBrickWithVisualPlacement {
 
@@ -93,7 +96,7 @@ public class ShowTextColorSizeAlignmentBrick extends UserVariableBrickWithVisual
 
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
-		if (view.getId() == R.id.brick_show_variable_color_size_edit_color) {
+		if (view.getId() == R.id.brick_show_variable_color_size_edit_color && isValidColorString(getColor())) {
 			ShowFormulaEditorStrategy.Callback callback = new ShowTextColorSizeAlignmentBrickCallback(view);
 			showFormulaEditorStrategy.showFormulaEditorToEditFormula(view, callback);
 		} else {
@@ -233,7 +236,12 @@ public class ShowTextColorSizeAlignmentBrick extends UserVariableBrickWithVisual
 			setFormulaWithBrickField(BrickField.COLOR, new Formula(colorString));
 
 			AppCompatActivity activity = UiUtils.getActivityFromView(view);
+			Fragment currentFragment = activity.getSupportFragmentManager().findFragmentById(R.id.fragment_container);
 			notifyDataSetChanged(activity);
+
+			if (currentFragment instanceof FormulaEditorFragment) {
+				((FormulaEditorFragment) currentFragment).updateFragmentAfterColorPicker();
+			}
 		}
 
 		@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/strategy/ShowColorPickerFormulaEditorStrategy.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/strategy/ShowColorPickerFormulaEditorStrategy.java
@@ -27,6 +27,7 @@ import android.view.View;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.ui.UiUtils;
+import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import org.catrobat.catroid.ui.recyclerview.fragment.ScriptFragment;
 import org.catrobat.paintroid.colorpicker.ColorPickerDialog;
 
@@ -43,14 +44,14 @@ public class ShowColorPickerFormulaEditorStrategy implements ShowFormulaEditorSt
 
 	@Override
 	public void showFormulaEditorToEditFormula(View view, Callback callback) {
-		if (isViewInScriptFragment(view)) {
+		if (isInCorrectFragment(view, callback)) {
 			showSelectEditDialog(view, callback);
 		} else {
 			callback.showFormulaEditor(view);
 		}
 	}
 
-	private boolean isViewInScriptFragment(View view) {
+	private boolean isInCorrectFragment(View view, Callback callback) {
 		AppCompatActivity activity = UiUtils.getActivityFromView(view);
 		if (activity == null) {
 			return false;
@@ -59,7 +60,11 @@ public class ShowColorPickerFormulaEditorStrategy implements ShowFormulaEditorSt
 		FragmentManager supportFragmentManager = activity.getSupportFragmentManager();
 		Fragment currentFragment = supportFragmentManager.findFragmentById(R.id.fragment_container);
 
-		return currentFragment instanceof ScriptFragment;
+		if (currentFragment instanceof FormulaEditorFragment) {
+			callback.showFormulaEditor(view);
+		}
+
+		return currentFragment instanceof ScriptFragment || currentFragment instanceof FormulaEditorFragment;
 	}
 
 	private void showSelectEditDialog(View view, Callback callback) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -93,6 +93,7 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	private static final int SET_FORMULA_ON_CREATE_VIEW = 0;
 	private static final int SET_FORMULA_ON_SWITCH_EDIT_TEXT = 1;
 	private static final int SET_FORMULA_ON_RETURN_FROM_VISUAL_PLACEMENT = 2;
+	private static final int SET_FORMULA_ON_RETURN_FROM_COLOR_PICKER = 3;
 	private static final int TIME_WINDOW = 2000;
 	public static final int REQUEST_GPS = 1;
 	public static final int REQUEST_PERMISSIONS_COMPUTE_DIALOG = 701;
@@ -218,6 +219,11 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	public void updateFragmentAfterVisualPlacement() {
 		updateBrickView();
 		setInputFormula(currentFormulaField, SET_FORMULA_ON_RETURN_FROM_VISUAL_PLACEMENT);
+	}
+
+	public void updateFragmentAfterColorPicker() {
+		updateBrickView();
+		setInputFormula(currentFormulaField, SET_FORMULA_ON_RETURN_FROM_COLOR_PICKER);
 	}
 
 	private void onUserDismiss() {
@@ -529,6 +535,7 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 				refreshFormulaPreviewString(formulaEditorEditText.getStringFromInternFormula());
 				break;
 			case SET_FORMULA_ON_RETURN_FROM_VISUAL_PLACEMENT:
+			case SET_FORMULA_ON_RETURN_FROM_COLOR_PICKER:
 			case SET_FORMULA_ON_SWITCH_EDIT_TEXT:
 				Formula newFormula = formulaBrick.getFormulaWithBrickField(formulaField);
 				if (currentFormula == newFormula && formulaEditorEditText.hasChanges()) {
@@ -758,10 +765,6 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 
 	public String getSelectedFormulaText() {
 		return formulaEditorEditText.getSelectedTextFromInternFormula();
-	}
-
-	public void setCurrentBrickField(Brick.FormulaField currentFormulaField) {
-		FormulaEditorFragment.currentFormulaField = currentFormulaField;
 	}
 
 	public FormulaBrick getFormulaBrick() {


### PR DESCRIPTION
The ticket specifies that following is already implemented: _Note that if the color parameter field already contained a more complex formula that would build the hex string using, e.g., join functions etc, the tap on the color parameter in the script view immediately opens the formula editor, i.e., bypassing the pop-up menu._
As this was obviously not the case it is implemented together with this ticket.

https://jira.catrob.at/browse/CATROID-382

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
