### PR TITLE
CATROID-19 Enable undo of single brick deletion

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickDataInteractionWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickDataInteractionWrapper.java
@@ -116,8 +116,6 @@ public class BrickDataInteractionWrapper extends DataInteractionWrapper {
 				withText(R.string.brick_context_dialog_delete_script),
 				withText(R.string.brick_context_dialog_delete_definition)))
 				.perform(click());
-		onView(withText(R.string.yes))
-				.perform(click());
 	}
 
 	public void performEditFormula() {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/actionbar/ActionBarUndoSpinnerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/actionbar/ActionBarUndoSpinnerTest.java
@@ -136,8 +136,6 @@ public class ActionBarUndoSpinnerTest {
 				.performSelectNameable(secondItem);
 		onView(withId(R.id.menu_undo))
 				.perform(click());
-		onBrickAtPosition(brickPosition)
-				.onSpinner(brickSpinnerViewId).checkShowsText(firstItem);
 		onView(withId(R.id.menu_undo)).check(doesNotExist());
 	}
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/UndoTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/UndoTest.java
@@ -1,0 +1,132 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.bricks.IfLogicBeginBrick;
+import org.catrobat.catroid.content.bricks.SetXBrick;
+import org.catrobat.catroid.io.XstreamSerializer;
+import org.catrobat.catroid.test.utils.TestUtils;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.catrobat.catroid.WaitForConditionAction.waitFor;
+import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.junit.Assert.assertEquals;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+@RunWith(Parameterized.class)
+public class UndoTest {
+
+	private final long waitThreshold = 5000;
+
+	@Rule
+	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
+			FragmentActivityTestRule<>(SpriteActivity.class,
+			SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{"SingleScript", 0},
+				{"CompositeBrick", 1},
+				{"SingleBrick", 2},
+		});
+	}
+
+	@Parameterized.Parameter
+	public String name;
+
+	@Parameterized.Parameter(1)
+	public int brickPosition;
+
+	String initialProject;
+
+	@After
+	public void tearDown() throws IOException {
+		TestUtils.deleteProjects(UndoTest.class.getSimpleName());
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		createProject();
+		baseActivityTestRule.launchActivity();
+	}
+
+	@Test
+	public void testUndoSpinnerActionVisible() {
+		onBrickAtPosition(brickPosition)
+				.performDeleteBrick();
+
+		onView(withId(R.id.menu_undo))
+				.perform(waitFor(isDisplayed(), waitThreshold));
+	}
+
+	@Test
+	public void testUndo() {
+		onBrickAtPosition(brickPosition).performDeleteBrick();
+
+		onView(withId(R.id.menu_undo))
+				.perform(click());
+
+		onView(withId(R.id.menu_undo))
+				.check(doesNotExist());
+
+		String projectAfterUndo = getProjectAsXmlString();
+		assertEquals(projectAfterUndo, initialProject);
+	}
+
+	public String getProjectAsXmlString() {
+		return XstreamSerializer.getInstance().getXmlAsStringFromProject(ProjectManager.getInstance().getCurrentProject());
+	}
+
+	private void createProject() {
+		Script script = BrickTestUtils.createProjectAndGetStartScript(UndoTest.class.getSimpleName());
+		IfLogicBeginBrick compositeBrick = new IfLogicBeginBrick();
+		compositeBrick.addBrickToIfBranch(new SetXBrick());
+		compositeBrick.addBrickToElseBranch(new SetXBrick());
+		script.addBrick(compositeBrick);
+
+		XstreamSerializer.getInstance().saveProject(ProjectManager.getInstance().getCurrentProject());
+		initialProject = getProjectAsXmlString();
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -515,6 +515,21 @@ public final class ProjectManager {
 		currentSprite = sprite;
 	}
 
+	public boolean setCurrentSceneAndSprite(String sceneName, String spriteName) {
+		for (Scene scene : project.getSceneList()) {
+			if (scene.getName().equals(sceneName)) {
+				setCurrentlyEditedScene(scene);
+				for (Sprite sprite : scene.getSpriteList()) {
+					if (sprite.getName().equals(spriteName)) {
+						currentSprite = sprite;
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
 	public void setCurrentlyEditedScene(Scene scene) {
 		currentlyEditedScene = scene;
 		currentlyPlayingScene = scene;

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -51,6 +51,7 @@ public final class Constants {
 	public static final String CODE_XML_FILE_NAME = "code.xml";
 	public static final String PERMISSIONS_FILE_NAME = "permissions.txt";
 	public static final String TMP_CODE_XML_FILE_NAME = "tmp_" + CODE_XML_FILE_NAME;
+	public static final String UNDO_CODE_XML_FILE_NAME = "undo_" + CODE_XML_FILE_NAME;
 
 	public static final String DEVICE_VARIABLE_JSON_FILENAME = "DeviceVariables.json";
 	public static final String DEVICE_LIST_JSON_FILENAME = "DeviceLists.json";

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/brickspinner/BrickSpinner.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/brickspinner/BrickSpinner.java
@@ -35,7 +35,6 @@ import android.widget.TextView;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Nameable;
-import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.ui.UiUtils;
 import org.catrobat.catroid.ui.recyclerview.fragment.ScriptFragment;
 
@@ -53,8 +52,6 @@ public class BrickSpinner<T extends Nameable> implements AdapterView.OnItemSelec
 	private BrickSpinnerAdapter adapter;
 	private Integer spinnerid;
 	private T previousItem;
-	private T undoItem;
-	boolean wasUndo;
 
 	private OnItemSelectedListener<T> onItemSelectedListener;
 
@@ -65,7 +62,6 @@ public class BrickSpinner<T extends Nameable> implements AdapterView.OnItemSelec
 		spinner.setAdapter(adapter);
 		spinner.setSelection(0);
 		spinner.setOnItemSelectedListener(this);
-		wasUndo = false;
 	}
 
 	public void setOnItemSelectedListener(OnItemSelectedListener<T> onItemSelectedListener) {
@@ -79,8 +75,6 @@ public class BrickSpinner<T extends Nameable> implements AdapterView.OnItemSelec
 		if (onItemSelectedListener == null || item == null) {
 			return;
 		}
-
-		showUndo(view, false);
 
 		if (item.getClass().equals(NewOption.class)) {
 			return;
@@ -96,12 +90,10 @@ public class BrickSpinner<T extends Nameable> implements AdapterView.OnItemSelec
 	}
 
 	private void onSelectionChanged(View view, Nameable item) {
-		if (previousItem != null && previousItem != item && !wasUndo) {
-			showUndo(view, true);
-			undoItem = previousItem;
+		if (previousItem != null && previousItem != item) {
+			showUndo(view);
 		}
 		previousItem = (T) item;
-		wasUndo = false;
 	}
 
 	@Override
@@ -144,11 +136,6 @@ public class BrickSpinner<T extends Nameable> implements AdapterView.OnItemSelec
 		}
 	}
 
-	public void undoSelection() {
-		setSelection(undoItem);
-		wasUndo = true;
-	}
-
 	private int consolidateSpinnerSelection(int position) {
 		if (position == -1) {
 			if (adapter.containsNewOption()) {
@@ -174,20 +161,28 @@ public class BrickSpinner<T extends Nameable> implements AdapterView.OnItemSelec
 		}
 	}
 
-	private void showUndo(View view, boolean visible) {
+	private void showUndo(View view) {
+		ScriptFragment scriptFragment = getScriptFragment(view);
+		if (scriptFragment.copyProjectForUndoOption()) {
+			scriptFragment.showUndo(true);
+			scriptFragment.setUndoBrickPosition();
+		}
+	}
+
+	private ScriptFragment getScriptFragment(View view) {
 		FragmentActivity activity = null;
 		if (view != null) {
 			activity = UiUtils.getActivityFromView(view);
 		}
 		if (activity == null) {
-			return;
+			return null;
 		}
 
 		Fragment currentFragment = activity.getSupportFragmentManager().findFragmentById(R.id.fragment_container);
-		if (currentFragment instanceof ScriptFragment && activity instanceof SpriteActivity) {
-			((ScriptFragment) currentFragment).setCurrentSpinner(this);
-			((SpriteActivity) activity).showUndoSpinnerSelection(visible);
+		if (currentFragment instanceof ScriptFragment) {
+			return (ScriptFragment) currentFragment;
 		}
+		return null;
 	}
 
 	public boolean isNewOptionSelected() {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -192,7 +192,7 @@ public class SpriteActivity extends BaseActivity {
 		return super.onCreateOptionsMenu(menu);
 	}
 
-	public void showUndoSpinnerSelection(boolean visible) {
+	public void showUndo(boolean visible) {
 		if (currentMenu != null) {
 			currentMenu.findItem(R.id.menu_undo).setVisible(visible);
 		}

--- a/catroid/src/main/res/values-af/strings.xml
+++ b/catroid/src/main/res/values-af/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-ar/strings.xml
+++ b/catroid/src/main/res/values-ar/strings.xml
@@ -379,14 +379,6 @@
         <item quantity="many">هل تريد حذف هذه النصوص البرمجية؟</item>
         <item quantity="other">هل تريد حذف هذه النصوص البرمجية؟</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="zero">هل تريد حذف هذه اللبّنة البرمجية؟</item>
-        <item quantity="one">هل تريد حذف هذه اللبّنة البرمجية؟</item>
-        <item quantity="two">هل تريد حذف هذين اللّبنتين البرمجيتين؟</item>
-        <item quantity="few">هل تريد حذف هذه اللّبنات البرمجية؟</item>
-        <item quantity="many">هل تريد حذف هذه اللّبنات البرمجية؟</item>
-        <item quantity="other">هل تريد حذف هذه اللّبنات البرمجية؟</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">اسم البرنامج</string>

--- a/catroid/src/main/res/values-az/strings.xml
+++ b/catroid/src/main/res/values-az/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-bg/strings.xml
+++ b/catroid/src/main/res/values-bg/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-bn/strings.xml
+++ b/catroid/src/main/res/values-bn/strings.xml
@@ -324,10 +324,6 @@
         <item quantity="one">এই স্ক্রিপ্ট মুছবেন?</item>
         <item quantity="other">এই স্ক্রিপ্টগুলি মুছবেন?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">এই ব্রিকটি মুছবেন?</item>
-        <item quantity="other">এই ব্রিকগুলি মুছবেন?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">প্রজেক্টের নাম</string>

--- a/catroid/src/main/res/values-bs/strings.xml
+++ b/catroid/src/main/res/values-bs/strings.xml
@@ -348,11 +348,6 @@
         <item quantity="few">Obrisati ove skripte?</item>
         <item quantity="other">Obrisati ove skripte?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Obrisati ovaj blok?</item>
-        <item quantity="few">Obrisati ove blokove?</item>
-        <item quantity="other">Obrisati ove blokove?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Naziv projekta</string>

--- a/catroid/src/main/res/values-ca/strings.xml
+++ b/catroid/src/main/res/values-ca/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-cs/strings.xml
+++ b/catroid/src/main/res/values-cs/strings.xml
@@ -367,12 +367,6 @@
         <item quantity="many">Delete these scripts?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Smazat tento blok?</item>
-        <item quantity="few">Smazat tyto bloky?</item>
-        <item quantity="many">Smazat tyto bloky?</item>
-        <item quantity="other">Smazat tyto bloky?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Název programu</string>

--- a/catroid/src/main/res/values-da/strings.xml
+++ b/catroid/src/main/res/values-da/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-de/strings.xml
+++ b/catroid/src/main/res/values-de/strings.xml
@@ -336,10 +336,6 @@
         <item quantity="one">Dieses Skript löschen?</item>
         <item quantity="other">Diese Skripte löschen?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Diesen Baustein löschen?</item>
-        <item quantity="other">Diese Bausteine löschen?</item>
-    </plurals>
     <string name="delete_definition">Definition dieses Bausteins löschen?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Projektname</string>

--- a/catroid/src/main/res/values-el/strings.xml
+++ b/catroid/src/main/res/values-el/strings.xml
@@ -337,10 +337,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-en-rAU/strings.xml
+++ b/catroid/src/main/res/values-en-rAU/strings.xml
@@ -328,10 +328,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>
     <string name="scene_name_label">Scene name</string>

--- a/catroid/src/main/res/values-en-rCA/strings.xml
+++ b/catroid/src/main/res/values-en-rCA/strings.xml
@@ -328,10 +328,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>
     <string name="scene_name_label">Scene name</string>

--- a/catroid/src/main/res/values-en-rGB/strings.xml
+++ b/catroid/src/main/res/values-en-rGB/strings.xml
@@ -328,10 +328,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>
     <string name="scene_name_label">Scene name</string>

--- a/catroid/src/main/res/values-es/strings.xml
+++ b/catroid/src/main/res/values-es/strings.xml
@@ -335,10 +335,6 @@
         <item quantity="one">¿Eliminar este script?</item>
         <item quantity="other">¿Eliminar estos scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">¿Eliminar este bloque?</item>
-        <item quantity="other">¿Eliminar estos bloques?</item>
-    </plurals>
     <string name="delete_definition">¿Eliminar la definición de este bloque?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Nombre del proyecto</string>

--- a/catroid/src/main/res/values-fa/strings.xml
+++ b/catroid/src/main/res/values-fa/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-fi/strings.xml
+++ b/catroid/src/main/res/values-fi/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-fr/strings.xml
+++ b/catroid/src/main/res/values-fr/strings.xml
@@ -337,10 +337,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-gl/strings.xml
+++ b/catroid/src/main/res/values-gl/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-gu/strings.xml
+++ b/catroid/src/main/res/values-gu/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-ha/strings.xml
+++ b/catroid/src/main/res/values-ha/strings.xml
@@ -328,10 +328,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>
     <string name="scene_name_label">Scene name</string>

--- a/catroid/src/main/res/values-hi/strings.xml
+++ b/catroid/src/main/res/values-hi/strings.xml
@@ -340,10 +340,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-hr/strings.xml
+++ b/catroid/src/main/res/values-hr/strings.xml
@@ -349,11 +349,6 @@ Ako se ne osjecate ugodno kako bi to ucinili, mozete koristiti nase besplatne we
         <item quantity="few">Delete these scripts?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Izbriši ovaj blok?</item>
-        <item quantity="few">Delete these bricks?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Naziv projekta</string>

--- a/catroid/src/main/res/values-hu/strings.xml
+++ b/catroid/src/main/res/values-hu/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-ig/strings.xml
+++ b/catroid/src/main/res/values-ig/strings.xml
@@ -326,9 +326,6 @@
     <plurals name="delete_scripts">
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-in/strings.xml
+++ b/catroid/src/main/res/values-in/strings.xml
@@ -326,9 +326,6 @@
     <plurals name="delete_scripts">
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-it/strings.xml
+++ b/catroid/src/main/res/values-it/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Elimina questo script?</item>
         <item quantity="other">Elimina questi script?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Elimina questo mattoncino?</item>
-        <item quantity="other">Elimina questi mattoncini?</item>
-    </plurals>
     <string name="delete_definition">Elimina la definizione di questo mattoncino?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Nome del programma</string>

--- a/catroid/src/main/res/values-iw/strings.xml
+++ b/catroid/src/main/res/values-iw/strings.xml
@@ -371,12 +371,6 @@
         <item quantity="many">Delete these scripts?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="two">Delete these bricks?</item>
-        <item quantity="many">Delete these bricks?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-ja/strings.xml
+++ b/catroid/src/main/res/values-ja/strings.xml
@@ -322,9 +322,6 @@
     <plurals name="delete_scripts">
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-kk/strings.xml
+++ b/catroid/src/main/res/values-kk/strings.xml
@@ -320,10 +320,6 @@
         <item quantity="one">Осы скриптті жою керек пе?</item>
         <item quantity="other">Осы скриптілерді жою керек пе?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Осы блокты жою керек пе?</item>
-        <item quantity="other">Осы блоктарды жою керек пе?</item>
-    </plurals>
     <string name="delete_definition">Осы блоктың анықтамасын жою керек пе?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Жоба атауы</string>

--- a/catroid/src/main/res/values-kn/strings.xml
+++ b/catroid/src/main/res/values-kn/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-ko/strings.xml
+++ b/catroid/src/main/res/values-ko/strings.xml
@@ -308,9 +308,6 @@
     <plurals name="delete_scripts">
         <item quantity="other">이 스크립트를 삭제하시겠습니까?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="other">이 블록을 삭제하시겠습니까?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">프로젝트 이름</string>

--- a/catroid/src/main/res/values-lt/strings.xml
+++ b/catroid/src/main/res/values-lt/strings.xml
@@ -371,12 +371,6 @@
         <item quantity="many">Delete these scripts?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="few">Delete these bricks?</item>
-        <item quantity="many">Delete these bricks?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-mk/strings.xml
+++ b/catroid/src/main/res/values-mk/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-ml/strings.xml
+++ b/catroid/src/main/res/values-ml/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-ms/strings.xml
+++ b/catroid/src/main/res/values-ms/strings.xml
@@ -326,9 +326,6 @@
     <plurals name="delete_scripts">
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-nl/strings.xml
+++ b/catroid/src/main/res/values-nl/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-no/strings.xml
+++ b/catroid/src/main/res/values-no/strings.xml
@@ -337,10 +337,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-pl/strings.xml
+++ b/catroid/src/main/res/values-pl/strings.xml
@@ -350,12 +350,6 @@
         <item quantity="many">Usunąć te skrypty?</item>
         <item quantity="other">Usunąć te skrypty?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Usunąć ten bloczek?</item>
-        <item quantity="few">Usunąć te bloczki?</item>
-        <item quantity="many">Usunąć te bloczki?</item>
-        <item quantity="other">Usunąć te bloczki?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Nazwa programu</string>

--- a/catroid/src/main/res/values-ps/strings.xml
+++ b/catroid/src/main/res/values-ps/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-pt-rBR/strings.xml
+++ b/catroid/src/main/res/values-pt-rBR/strings.xml
@@ -340,10 +340,6 @@
         <item quantity="one">Excluir esse script?</item>
         <item quantity="other">Excluir esses scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Excluir esse bloco?</item>
-        <item quantity="other">Excluir esses blocos?</item>
-    </plurals>
     <string name="delete_definition">Deletar definição desse bloco?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Nome do projeto</string>

--- a/catroid/src/main/res/values-pt/strings.xml
+++ b/catroid/src/main/res/values-pt/strings.xml
@@ -338,10 +338,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-ro/strings.xml
+++ b/catroid/src/main/res/values-ro/strings.xml
@@ -356,11 +356,6 @@
         <item quantity="few">Delete these scripts?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="few">Delete these bricks?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-ru/strings.xml
+++ b/catroid/src/main/res/values-ru/strings.xml
@@ -368,12 +368,6 @@
         <item quantity="many">Удалить эти скрипты?</item>
         <item quantity="other">Удалить эти скрипты?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Удалить этот блок?</item>
-        <item quantity="few">Удалить эти блоки?</item>
-        <item quantity="many">Удалить эти блоки?</item>
-        <item quantity="other">Удалить эти блоки?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Название проекта</string>

--- a/catroid/src/main/res/values-sd/strings.xml
+++ b/catroid/src/main/res/values-sd/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-si/strings.xml
+++ b/catroid/src/main/res/values-si/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-sk/strings.xml
+++ b/catroid/src/main/res/values-sk/strings.xml
@@ -367,12 +367,6 @@
         <item quantity="many">Delete these scripts?</item>
         <item quantity="other">Odstrániť tieto skripty?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Odstrániť tento blok?</item>
-        <item quantity="few">Odstrániť tieto bloky?</item>
-        <item quantity="many">Delete these bricks?</item>
-        <item quantity="other">Odstrániť tieto bloky?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-sl/strings.xml
+++ b/catroid/src/main/res/values-sl/strings.xml
@@ -371,12 +371,6 @@
         <item quantity="few">Delete these scripts?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="two">Delete these bricks?</item>
-        <item quantity="few">Delete these bricks?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-sq/strings.xml
+++ b/catroid/src/main/res/values-sq/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-sr-rCS/strings.xml
+++ b/catroid/src/main/res/values-sr-rCS/strings.xml
@@ -343,11 +343,6 @@
         <item quantity="few">Obriši ove skripte?</item>
         <item quantity="other">Obriši ove skripte?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Obriši ovu kocku?</item>
-        <item quantity="few">Obriši ove kocke?</item>
-        <item quantity="other">Obriši ove kocke?</item>
-    </plurals>
     <!-- Dialog Labels -->
     <string name="project_name_label">Naziv projekta</string>
     <string name="scene_name_label">Ime scene</string>

--- a/catroid/src/main/res/values-sr/strings.xml
+++ b/catroid/src/main/res/values-sr/strings.xml
@@ -333,11 +333,6 @@
         <item quantity="few">Delete these scripts?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="few">Delete these bricks?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>
     <string name="scene_name_label">Scene name</string>

--- a/catroid/src/main/res/values-sv/strings.xml
+++ b/catroid/src/main/res/values-sv/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-sw/strings.xml
+++ b/catroid/src/main/res/values-sw/strings.xml
@@ -337,10 +337,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-ta/strings.xml
+++ b/catroid/src/main/res/values-ta/strings.xml
@@ -332,10 +332,6 @@
         <item quantity="one">இந்த ஸ்கிரிப்டை நீக்கவா?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">இந்த செங்களை நீக்கவா?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">செயற்திட்டத்தின் பெயர்</string>

--- a/catroid/src/main/res/values-te/strings.xml
+++ b/catroid/src/main/res/values-te/strings.xml
@@ -341,10 +341,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-th/strings.xml
+++ b/catroid/src/main/res/values-th/strings.xml
@@ -324,10 +324,6 @@
         <item quantity="other">ลบสคริปต์นี้หรือไม่
 ลบสคริปต์เหล่านี้หรือไม่</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="other">ลบคำสั่งนี้หรือไม่
-ลบคำสั่งเหล่านี้หรือไม่</item>
-    </plurals>
     <string name="delete_definition">ลบคำจำกัดความของคำสั่งนี้หรือไม่</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">ชื่อโครงการ</string>

--- a/catroid/src/main/res/values-tr/strings.xml
+++ b/catroid/src/main/res/values-tr/strings.xml
@@ -322,10 +322,6 @@
         <item quantity="one">Bu komut dosyası silinsin mi?</item>
         <item quantity="other">Bu komut dosyaları silinsin mi?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Bu tuğla silinsin mi?</item>
-        <item quantity="other">Bu tuğlalar silinsin mi?</item>
-    </plurals>
     <string name="delete_definition">Bu tuğlanın tanımı silinsin mi?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Proje ismi</string>

--- a/catroid/src/main/res/values-tw/strings.xml
+++ b/catroid/src/main/res/values-tw/strings.xml
@@ -328,10 +328,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>
     <string name="scene_name_label">Scene name</string>

--- a/catroid/src/main/res/values-uk/strings.xml
+++ b/catroid/src/main/res/values-uk/strings.xml
@@ -371,12 +371,6 @@
         <item quantity="many">Delete these scripts?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="few">Delete these bricks?</item>
-        <item quantity="many">Delete these bricks?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-ur/strings.xml
+++ b/catroid/src/main/res/values-ur/strings.xml
@@ -338,10 +338,6 @@
         <item quantity="one">ان سکرپٹ کو  ختم کریں؟</item>
         <item quantity="other">ان سکرپٹ کو ختم کریں؟</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">ان اینٹوں کو  ختم کریں؟</item>
-        <item quantity="other">ان اینٹوں کو ختم کریں؟</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">نام پروجیکٹ</string>

--- a/catroid/src/main/res/values-vi/strings.xml
+++ b/catroid/src/main/res/values-vi/strings.xml
@@ -326,9 +326,6 @@
     <plurals name="delete_scripts">
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <string name="delete_definition">Delete the definition of this brick?</string>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>

--- a/catroid/src/main/res/values-zh-rCN/strings.xml
+++ b/catroid/src/main/res/values-zh-rCN/strings.xml
@@ -302,9 +302,6 @@
     <plurals name="delete_scripts">
         <item quantity="other">删除这些脚本？</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="other">删除这些积木吗？</item>
-    </plurals>
     <!-- Dialog Labels -->
     <string name="project_name_label">项目名称</string>
     <string name="scene_name_label">场景名称</string>

--- a/catroid/src/main/res/values-zh-rTW/strings.xml
+++ b/catroid/src/main/res/values-zh-rTW/strings.xml
@@ -313,9 +313,6 @@
     <plurals name="delete_scripts">
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>
     <string name="scene_name_label">Scene name</string>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -350,8 +350,6 @@
     <string name="am_convert">Convert</string>
     <string name="am_merge">Merge</string>
     <string name="dialog_confirm_delete">You can\'t undo this!</string>
-    <string name="dialog_confirm_delete_definition">This will also remove the brick in all
-        other scripts in which it is being used.\nYou cannot undo this!</string>
 
     <string name="list_headline_sprites">Actors and objects</string>
 
@@ -396,11 +394,6 @@
         <item quantity="one">Delete this script?</item>
         <item quantity="other">Delete these scripts?</item>
     </plurals>
-    <plurals name="delete_bricks">
-        <item quantity="one">Delete this brick?</item>
-        <item quantity="other">Delete these bricks?</item>
-    </plurals>
-    <string name="delete_definition">Delete the definition of this brick?</string>
 
     <!-- Dialog Labels -->
     <string name="project_name_label">Project name</string>


### PR DESCRIPTION
- Copy code.xml file to undo_code.xml if an undo option is available
- Replace code.xml with previously copied undo_code.xml when undo is executed
- Refactor undo of brick spinner
- Adding this functionality makes https://jira.catrob.at/browse/CATROID-142 and https://jira.catrob.at/browse/CATROID-143 work out of the box -> so these two tickets can be marked resolved as well
- Delete unused string resources of dialogs -> As there is a lint problem with deleting plurals from the default string.xml file - plural resources have been deleted from all string.xml files. This problem will be fixed with ticket https://jira.catrob.at/browse/CATROID-810 

https://jira.catrob.at/browse/CATROID-19

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
