### PR TITLE
CATROID-600 Automatically detect API keys and warn user when uploadin…

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/ReplaceApiKeyDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/ReplaceApiKeyDialogTest.java
@@ -1,0 +1,218 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.dialog;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.util.Log;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.BackgroundRequestBrick;
+import org.catrobat.catroid.io.asynctask.ProjectSaveTask;
+import org.catrobat.catroid.uiespresso.ui.activity.ProjectUploadRatingDialogTest;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import static org.catrobat.catroid.common.Constants.CODE_XML_FILE_NAME;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_VERSION;
+import static org.catrobat.catroid.ui.ProjectUploadActivity.PROJECT_DIR;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+public class ReplaceApiKeyDialogTest {
+
+	private static final String TAG = ReplaceApiKeyDialogTest.class.getSimpleName();
+
+	@Rule
+	public BaseActivityTestRule<ProjectUploadRatingDialogTest.ProjectUploadTestActivity> activityTestRule =
+			new BaseActivityTestRule<>(ProjectUploadRatingDialogTest.ProjectUploadTestActivity.class, false, false);
+
+	private int bufferedPrivacyPolicyPreferenceSetting;
+
+	Project dummyProject;
+	String apikey = "AIzaas98d7f9a0sdf07ad0sf8a7sd09fASDf97asd9f";
+	String linkapikey = "https://catrobat.at/joke?x=AIzaas98d7f9a0sdf07ad0sf8a7sd09fASDf97asd9f/";
+	@Before
+	public void before() {
+		SharedPreferences sharedPreferences = PreferenceManager
+				.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext());
+
+		bufferedPrivacyPolicyPreferenceSetting = sharedPreferences
+				.getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0);
+
+		sharedPreferences
+				.edit()
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION, Constants.CATROBAT_TERMS_OF_USE_ACCEPTED)
+				.commit();
+	}
+
+	public void createProject(String secret) {
+		dummyProject = new Project(ApplicationProvider.getApplicationContext(), "ApiProject");
+		Scene dummyScene = new Scene("scene", dummyProject);
+		ProjectManager.getInstance().setCurrentProject(dummyProject);
+		Sprite sprite = new Sprite("sprite");
+		Script firstScript = new StartScript();
+		firstScript.addBrick(new BackgroundRequestBrick(secret));
+		dummyScene.addSprite(sprite);
+		sprite.addScript(firstScript);
+		dummyProject.addScene(dummyScene);
+		ProjectSaveTask.task(dummyProject, ApplicationProvider.getApplicationContext());
+
+		Intent intent = new Intent();
+		intent.putExtra(PROJECT_DIR, dummyProject.getDirectory());
+
+		activityTestRule.launchActivity(intent);
+	}
+
+	public void createProject(String secret1, String secret2) {
+		dummyProject = new Project(ApplicationProvider.getApplicationContext(), "ApiProject");
+		Scene dummyScene = new Scene("scene", dummyProject);
+		ProjectManager.getInstance().setCurrentProject(dummyProject);
+		Sprite sprite = new Sprite("sprite");
+		Script firstScript = new StartScript();
+		firstScript.addBrick(new BackgroundRequestBrick(secret1));
+		firstScript.addBrick(new BackgroundRequestBrick(secret2));
+		dummyScene.addSprite(sprite);
+		sprite.addScript(firstScript);
+		dummyProject.addScene(dummyScene);
+		ProjectSaveTask.task(dummyProject, ApplicationProvider.getApplicationContext());
+
+		Intent intent = new Intent();
+		intent.putExtra(PROJECT_DIR, dummyProject.getDirectory());
+
+		activityTestRule.launchActivity(intent);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())
+				.edit()
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION,
+						bufferedPrivacyPolicyPreferenceSetting)
+				.commit();
+	}
+
+	@Test
+	public void replaceApiKeyTestAPI() {
+		createProject(apikey);
+		File beforeReplace = new File(dummyProject.getDirectory(), CODE_XML_FILE_NAME);
+		String beforeReplaceCode = "";
+		try {
+			beforeReplaceCode =
+					Files.asCharSource(beforeReplace, Charsets.UTF_8).read();
+		} catch (IOException exception) {
+			Log.e(TAG, Log.getStackTraceString(exception));
+		}
+		assertTrue(beforeReplaceCode.contains(apikey));
+		onView(withText(R.string.api_replacement_dialog_accept)).perform(click());
+		File afterReplace = new File(dummyProject.getDirectory(), CODE_XML_FILE_NAME);
+		String afterReplaceCode = "";
+		try {
+			afterReplaceCode = Files.asCharSource(afterReplace, Charsets.UTF_8).read();
+		} catch (IOException exception) {
+			Log.e(TAG, Log.getStackTraceString(exception));
+		}
+		assertFalse(afterReplaceCode.contains(apikey));
+	}
+
+	@Test
+	public void replaceApiKeyTestLinkAPI() {
+		createProject(linkapikey);
+		File beforeReplace = new File(dummyProject.getDirectory(), CODE_XML_FILE_NAME);
+		String beforeReplaceCode = "";
+		try {
+			beforeReplaceCode = Files.asCharSource(beforeReplace, Charsets.UTF_8).read();
+		} catch (IOException exception) {
+			Log.e(TAG, Log.getStackTraceString(exception));
+		}
+		assertTrue(beforeReplaceCode.contains(linkapikey));
+		onView(withText(R.string.api_replacement_dialog_accept)).perform(click());
+		File afterReplace = new File(dummyProject.getDirectory(), CODE_XML_FILE_NAME);
+		String afterReplaceCode = "";
+		try {
+			afterReplaceCode = Files.asCharSource(afterReplace, Charsets.UTF_8).read();
+		} catch (IOException exception) {
+			Log.e(TAG, Log.getStackTraceString(exception));
+		}
+		assertFalse(afterReplaceCode.contains(linkapikey));
+	}
+
+	@Test
+	public void replaceApiKeyTestLoadBackup() {
+		createProject(linkapikey, apikey);
+
+		File beforeReplace = new File(dummyProject.getDirectory(), CODE_XML_FILE_NAME);
+		String beforeReplaceCode = "";
+		try {
+			beforeReplaceCode = Files.asCharSource(beforeReplace, Charsets.UTF_8).read();
+		} catch (IOException exception) {
+			Log.e(TAG, Log.getStackTraceString(exception));
+		}
+		assertTrue(beforeReplaceCode.contains(linkapikey));
+		onView(withText(R.string.api_replacement_dialog_accept)).perform(click());
+		File afterReplace = new File(dummyProject.getDirectory(), CODE_XML_FILE_NAME);
+		String afterReplaceCode = "";
+		try {
+			afterReplaceCode =
+					Files.asCharSource(afterReplace, Charsets.UTF_8).read();
+		} catch (IOException exception) {
+			Log.e(TAG, Log.getStackTraceString(exception));
+		}
+		assertFalse(afterReplaceCode.contains(linkapikey));
+		onView(withText(R.string.cancel)).perform(click());
+
+		File reloaded = new File(dummyProject.getDirectory(), CODE_XML_FILE_NAME);
+		String reloadedCode = "";
+		try {
+			reloadedCode = Files.asCharSource(reloaded, Charsets.UTF_8).read();
+		} catch (IOException exception) {
+			Log.e(TAG, Log.getStackTraceString(exception));
+		}
+		assertTrue(reloadedCode.contains(linkapikey));
+	}
+}
+

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
@@ -106,7 +106,7 @@ public class ProjectUploadActivity extends BaseActivity implements
 	private static final String LOOK_REQUEST_BRICK = "LookRequestBrick";
 	private static final String OPEN_URL_BRICK = "OpenUrlBrick";
 	private static final String WIKI_URL = "<a href='https://catrob.at/webbricks'>"
-		+ "https://catrob.at/webbricks</a>";
+			+ "https://catrob.at/webbricks</a>";
 	private static final String PROGRAM_NAME_START_TAG = "<programName>";
 	private static final String PROGRAM_NAME_END_TAG = "</programName>";
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
@@ -33,7 +33,9 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.text.Editable;
+import android.text.Html;
 import android.text.TextWatcher;
+import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -43,11 +45,14 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.google.android.material.textfield.TextInputLayout;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.exceptions.ProjectException;
 import org.catrobat.catroid.io.ProjectAndSceneScreenshotLoader;
 import org.catrobat.catroid.io.asynctask.ProjectLoadTask;
 import org.catrobat.catroid.io.asynctask.ProjectRenameTask;
@@ -63,12 +68,18 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import androidx.appcompat.app.AlertDialog;
 
+import static org.catrobat.catroid.common.Constants.CODE_XML_FILE_NAME;
 import static org.catrobat.catroid.common.Constants.EXTRA_PROJECT_ID;
 import static org.catrobat.catroid.common.Constants.PLAY_STORE_PAGE_LINK;
 import static org.catrobat.catroid.common.Constants.SHARE_PROJECT_URL;
@@ -90,8 +101,21 @@ public class ProjectUploadActivity extends BaseActivity implements
 
 	public static final int MAX_NUMBER_OF_TAGS_CHECKED = 3;
 	public static final String NUMBER_OF_UPLOADED_PROJECTS = "number_of_uploaded_projects";
+	private static final String WEB_REQUEST_BRICK = "WebRequestBrick";
+	private static final String BACKGROUND_REQUEST_BRICK = "BackgroundRequestBrick";
+	private static final String LOOK_REQUEST_BRICK = "LookRequestBrick";
+	private static final String OPEN_URL_BRICK = "OpenUrlBrick";
+	private static final String WIKI_URL = "<a href='https://wiki.catrobat"
+			+ ".org/bin/view/Documentation/Web%20requests/'>https://wiki.catrobat.org/bin/view/Documentation/Web%20requests/</a>";
+	private static final String PROGRAM_NAME_START_TAG = "<programName>";
+	private static final String PROGRAM_NAME_END_TAG = "</programName>";
 
 	private Project project;
+	private String xml = "";
+	private String originalProjectName = "";
+	private String backUpXml = "";
+	File xmlFile;
+	private Matcher apiMatcher;
 
 	private AlertDialog uploadProgressDialog;
 
@@ -170,7 +194,8 @@ public class ProjectUploadActivity extends BaseActivity implements
 		notesAndCreditsInputLayout.getEditText().setText(project.getNotesAndCredits());
 
 		nameInputLayout.getEditText().addTextChangedListener(nameInputTextWatcher);
-
+		originalProjectName = project.getName();
+		checkCodeforApiKey();
 		setShowProgressBar(false);
 		setNextButtonEnabled(true);
 	}
@@ -201,6 +226,7 @@ public class ProjectUploadActivity extends BaseActivity implements
 			setScreen(notesAndCreditsScreen);
 			notesAndCreditsScreen = false;
 		} else {
+			loadBackup();
 			super.onBackPressed();
 		}
 	}
@@ -261,6 +287,99 @@ public class ProjectUploadActivity extends BaseActivity implements
 
 			showSelectTagsDialog();
 		}
+	}
+
+	private void checkCodeforApiKey() {
+		String regex = "<value>.*?((?=[A-Za-z]+[0-9]|[0-9]+[A-Za-z])[A-Za-z0-9]{24,45})";
+		xmlFile = new File(project.getDirectory(), CODE_XML_FILE_NAME);
+
+		try {
+			xml = Files.asCharSource(xmlFile, Charsets.UTF_8).read();
+			backUpXml = xml;
+		} catch (IOException exception) {
+			Log.e(TAG, Log.getStackTraceString(exception));
+		}
+		if (xml.contains(WEB_REQUEST_BRICK) || xml.contains(BACKGROUND_REQUEST_BRICK) || xml.contains(LOOK_REQUEST_BRICK) || xml.contains(OPEN_URL_BRICK)) {
+			Pattern apiPattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+			apiMatcher = apiPattern.matcher(xml);
+			if (apiMatcher.find()) {
+				showApiReplacementDialog(Objects.requireNonNull(apiMatcher.group(1)));
+			}
+		}
+	}
+
+	private void apiKeyFound() {
+		if (apiMatcher.find(apiMatcher.end())) {
+			showApiReplacementDialog(Objects.requireNonNull(apiMatcher.group(1)));
+		}
+	}
+
+	private void replaceSecret(String secret) {
+		xml = xml.replaceAll(secret, getString(R.string.api_replacement));
+		try {
+			FileOutputStream stream = new FileOutputStream(xmlFile);
+			stream.write(xml.getBytes(StandardCharsets.UTF_8));
+			stream.close();
+		} catch (IOException exception) {
+			Log.e(TAG, Log.getStackTraceString(exception));
+		}
+		reloadProject();
+		apiKeyFound();
+	}
+
+	private void reloadProject() {
+		try {
+			ProjectManager.getInstance().loadProject(project.getDirectory());
+			project = ProjectManager.getInstance().getCurrentProject();
+		} catch (ProjectException exception) {
+			Log.e(TAG, Log.getStackTraceString(exception));
+		}
+	}
+
+	private void loadBackup() {
+		String currentName = project.getName();
+		if (!currentName.equals(originalProjectName)) {
+			String toReplace = PROGRAM_NAME_START_TAG + originalProjectName + PROGRAM_NAME_END_TAG;
+			String replaceWith = PROGRAM_NAME_START_TAG + currentName + PROGRAM_NAME_END_TAG;
+			xmlFile = new File(project.getDirectory(), CODE_XML_FILE_NAME);
+			backUpXml = backUpXml.replace(toReplace, replaceWith);
+		}
+		try {
+			FileOutputStream stream = new FileOutputStream(xmlFile);
+			stream.write(backUpXml.getBytes(StandardCharsets.UTF_8));
+			stream.close();
+		} catch (IOException exception) {
+			Log.e(TAG, Log.getStackTraceString(exception));
+		}
+		reloadProject();
+	}
+
+	private void showApiReplacementDialog(String secret) {
+		View view = View.inflate(this, R.layout.dialog_replace_api_key, null);
+		TextView warningText = view.findViewById(R.id.replace_api_key_warning);
+		warningText.setMovementMethod(LinkMovementMethod.getInstance());
+		String warningURL = getString(R.string.api_replacement_dialog_warning,
+				WIKI_URL);
+		warningText.setText(Html.fromHtml(warningURL));
+		AlertDialog alertDialog = new AlertDialog.Builder(this)
+				.setTitle(R.string.warning)
+				.setView(view)
+				.setPositiveButton(getString(R.string.api_replacement_dialog_accept), (dialog, which) -> {
+					replaceSecret(secret);
+				})
+				.setNegativeButton(getText(R.string.api_replacement_dialog_neutral), (dialog, which) -> {
+					apiKeyFound();
+				})
+				.setNeutralButton(getText(R.string.cancel), (dialog, which) -> {
+					loadBackup();
+					finish();
+				})
+				.setCancelable(false)
+				.create();
+
+		alertDialog.show();
+		TextView keyField = alertDialog.findViewById(R.id.replace_api_key);
+		keyField.setText(secret);
 	}
 
 	private void showSelectTagsDialog() {
@@ -332,8 +451,11 @@ public class ProjectUploadActivity extends BaseActivity implements
 		uploadProgressDialog = new AlertDialog.Builder(this)
 				.setTitle(getString(R.string.upload_project_dialog_title))
 				.setView(R.layout.dialog_upload_project_progress)
-				.setPositiveButton(R.string.progress_upload_dialog_show_program, null)
+				.setPositiveButton(R.string.progress_upload_dialog_show_program, (dialog, which) -> {
+					loadBackup();
+				})
 				.setNegativeButton(R.string.done, (dialog, which) -> {
+					loadBackup();
 					finish();
 				})
 				.setCancelable(false)
@@ -377,6 +499,7 @@ public class ProjectUploadActivity extends BaseActivity implements
 			Intent intent = new Intent(this, WebViewActivity.class);
 			intent.putExtra(WebViewActivity.INTENT_PARAMETER_URL, projectUrl);
 			startActivity(intent);
+			loadBackup();
 			finish();
 		});
 		positiveButton.setEnabled(true);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectUploadActivity.java
@@ -105,8 +105,8 @@ public class ProjectUploadActivity extends BaseActivity implements
 	private static final String BACKGROUND_REQUEST_BRICK = "BackgroundRequestBrick";
 	private static final String LOOK_REQUEST_BRICK = "LookRequestBrick";
 	private static final String OPEN_URL_BRICK = "OpenUrlBrick";
-	private static final String WIKI_URL = "<a href='https://wiki.catrobat"
-			+ ".org/bin/view/Documentation/Web%20requests/'>https://wiki.catrobat.org/bin/view/Documentation/Web%20requests/</a>";
+	private static final String WIKI_URL = "<a href='https://catrob.at/webbricks'>"
+		+ "https://catrob.at/webbricks</a>";
 	private static final String PROGRAM_NAME_START_TAG = "<programName>";
 	private static final String PROGRAM_NAME_END_TAG = "</programName>";
 

--- a/catroid/src/main/res/layout/dialog_replace_api_key.xml
+++ b/catroid/src/main/res/layout/dialog_replace_api_key.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2020 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingEnd="@dimen/dialog_content_area_padding"
+    android:paddingStart="@dimen/dialog_content_area_padding"
+    android:paddingTop="@dimen/dialog_content_area_padding_top">
+
+         <TextView
+             android:id="@+id/replace_api_key_warning"
+             android:layout_width="wrap_content"
+             android:layout_height="wrap_content"
+             android:layout_marginBottom="@dimen/material_design_spacing_x_large"/>
+         <TextView
+             android:id="@+id/replace_api_key"
+             android:layout_width="match_parent"
+             android:layout_height="wrap_content"
+             android:background="#FFFFFF"
+             android:paddingLeft="24pt"
+             android:paddingRight="24pt"
+             android:paddingTop="14pt"
+             android:paddingBottom="14pt"
+             android:textColor="#000000"/>
+</LinearLayout>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -81,6 +81,16 @@
         You may also report the project on its page on the Catrobat community platform in case
         you are sure that it is harmful.</string>
 
+    <!-- Replace Api dialog -->
+    <string name="api_replacement_dialog_neutral">Upload without change</string>
+    <string name="api_replacement_dialog_accept">Upload with keys replaced</string>
+    <string name="api_replacement_dialog_warning">The project contains bricks that access the
+        web, and also seems to contain API keys. Please see %1s why
+        uploading these keys can be dangerous.</string>
+    <string name="api_replacement">insert API key here</string>
+    <!-- -->
+
+
     <!-- Login/Logout Mechanism -->
     <string name="loading_check_oauth_token">Checking login data…</string>
     <string name="loading_google_exchange_code">Exchanging Google login data…</string>


### PR DESCRIPTION
The "Send web request" and "Get image from" bricks may require API keys for certain web services. These keys belong to the persons that acquired those keys, maybe had to pay money for them, register with their credit card, etc to get them.

To remind users that uploading such projects is dangerous, Catroid shall try to detect API keys and warn the user that it detected them, and offer to replace the ones it could identify in the scripts during the upload (but not in the local copy).
https://jira.catrob.at/browse/CATROID-600
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
