### PR TITLE
CATROID-765 "new..." option in "When background changes to" brick does not create background look

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/WhenBackgroundChangesToBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/WhenBackgroundChangesToBrickTest.java
@@ -1,0 +1,106 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.content.brick.app;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.LookData;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.WhenBackgroundChangesScript;
+import org.catrobat.catroid.testsuites.annotations.Cat;
+import org.catrobat.catroid.testsuites.annotations.Level;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static junit.framework.Assert.assertEquals;
+
+import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+@RunWith(AndroidJUnit4.class)
+public class WhenBackgroundChangesToBrickTest {
+	private int brickPosition;
+
+	@Rule
+	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
+			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+
+	@Before
+	public void setUp() throws Exception {
+		brickPosition = 0;
+		Project project = new Project(ApplicationProvider.getApplicationContext(),
+				"WhenBackgroundChangesToBrickTest");
+		Sprite sprite = new Sprite("testSprite");
+		Script script = new WhenBackgroundChangesScript();
+
+		sprite.addScript(script);
+		project.getDefaultScene().addSprite(sprite);
+		ProjectManager.getInstance().setCurrentProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+		ProjectManager.getInstance().setCurrentlyEditedScene(project.getDefaultScene());
+
+		baseActivityTestRule.launchActivity();
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testCreateNewBackground() {
+		onBrickAtPosition(brickPosition).checkShowsText(R.string.brick_when_background);
+
+		onBrickAtPosition(brickPosition).onSpinner(R.id.brick_when_background_spinner)
+			.performSelectNameable(R.string.new_option);
+
+		Intents.init();
+
+		onView(withId(R.id.dialog_new_look_paintroid))
+			.perform(click());
+
+		onView(withId(R.id.pocketpaint_drawing_surface_view)).perform(click());
+		pressBack();
+
+		List<LookData> lookDataList =
+				ProjectManager.getInstance().getCurrentProject().getDefaultScene().getBackgroundSprite().getLookList();
+
+		assertEquals(1, lookDataList.size());
+
+		Intents.release();
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBackgroundChangesBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/WhenBackgroundChangesBrick.java
@@ -118,6 +118,8 @@ public class WhenBackgroundChangesBrick extends BrickBaseType implements ScriptB
 		if (!(activity instanceof SpriteActivity)) {
 			return;
 		}
+		((SpriteActivity) activity).setCurrentSprite(
+				ProjectManager.getInstance().getCurrentlyEditedScene().getBackgroundSprite());
 		((SpriteActivity) activity).registerOnNewLookListener(this);
 		((SpriteActivity) activity).handleAddBackgroundButton();
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -883,4 +883,8 @@ public class SpriteActivity extends BaseActivity {
 		}
 		super.onActionModeFinished(mode);
 	}
+
+	public void setCurrentSprite(Sprite sprite) {
+		currentSprite = sprite;
+	}
 }


### PR DESCRIPTION
Fixed the bug by setting the current sprite of the sprite activity to the background sprite when adding the new background.
Also added a test for this behaviour.

https://jira.catrob.at/browse/CATROID-765

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
