### PR TITLE
CATROID-805 Pen down and stamp ignored for clones

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/PenActor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/PenActor.java
@@ -61,7 +61,7 @@ public class PenActor extends Actor {
 	@Override
 	public void draw(Batch batch, float parentAlpha) {
 		buffer.begin();
-		for (Sprite sprite : ProjectManager.getInstance().getCurrentlyPlayingScene().getSpriteList()) {
+		for (Sprite sprite : StageActivity.stageListener.getSpritesFromStage()) {
 			PenConfiguration pen = sprite.penConfiguration;
 			pen.drawLinesForSprite(screenRatio);
 		}
@@ -85,7 +85,7 @@ public class PenActor extends Actor {
 	public void stampToFrameBuffer() {
 		bufferBatch.begin();
 		buffer.begin();
-		for (Sprite sprite : ProjectManager.getInstance().getCurrentlyPlayingScene().getSpriteList()) {
+		for (Sprite sprite : StageActivity.stageListener.getSpritesFromStage()) {
 			PenConfiguration pen = sprite.penConfiguration;
 			if (pen.hasStamp()) {
 				sprite.look.draw(bufferBatch, 1.0f);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SpriteController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SpriteController.java
@@ -143,6 +143,12 @@ public class SpriteController {
 			sprite.look.setLookData(sprite.getLookList().get(currentLookDataIndex));
 		}
 		spriteToCopy.look.copyTo(sprite.look);
+
+		if (spriteToCopy.penConfiguration.isPenDown()) {
+			sprite.penConfiguration.setPenDown(true);
+			sprite.penConfiguration.addQueue();
+		}
+
 		return sprite;
 	}
 


### PR DESCRIPTION
Cloned sprites are not added to the currently playing scene which was used for getting the sprites and then drawing.
Fixed the bug by using the sprites of the sprite list contained in the stage listener(Which also performs the cloning process).
Also contains a fix that when the pen is down and the sprite is cloned, that the pen is also down for the cloned sprite.

https://jira.catrob.at/browse/CATROID-805

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
