### PR TITLE
CATROID-820 add visual placement when no variable is selected

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorBrickViewOnClickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorBrickViewOnClickTest.java
@@ -51,6 +51,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isClickable;
 import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.isFocusable;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class FormulaEditorBrickViewOnClickTest {
@@ -74,6 +75,8 @@ public class FormulaEditorBrickViewOnClickTest {
 				.onFormulaTextField(R.id.brick_show_variable_edit_text_x)
 				.perform(click());
 
+		chooseEditFormulaDialogOption();
+
 		onView(withId(R.id.show_variable_spinner))
 				.check(matches(allOf(not(isClickable()), not(isEnabled()), not(isFocusable()))));
 	}
@@ -84,12 +87,16 @@ public class FormulaEditorBrickViewOnClickTest {
 				.onFormulaTextField(R.id.brick_show_variable_edit_text_x)
 				.perform(click());
 
+		chooseEditFormulaDialogOption();
+
 		onFormulaEditor()
 				.checkShows(showTextBrick.getFormulaWithBrickField(Brick.BrickField.X_POSITION)
 						.getTrimmedFormulaString(ApplicationProvider.getApplicationContext()));
 
 		onView(withId(R.id.brick_show_variable_edit_text_y))
 				.perform(click());
+
+		chooseEditFormulaDialogOption();
 
 		onFormulaEditor()
 				.checkShows(showTextBrick.getFormulaWithBrickField(Brick.BrickField.Y_POSITION)
@@ -100,5 +107,10 @@ public class FormulaEditorBrickViewOnClickTest {
 		Script script = BrickTestUtils.createProjectAndGetStartScript(getClass().getSimpleName());
 		showTextBrick = new ShowTextBrick(new Formula(100), new Formula(200));
 		script.addBrick(showTextBrick);
+	}
+
+	private void chooseEditFormulaDialogOption() {
+		onView(withText(R.string.brick_context_dialog_formula_edit_brick))
+				.perform(click());
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserVariableBrickWithVisualPlacement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserVariableBrickWithVisualPlacement.java
@@ -115,10 +115,6 @@ public abstract class UserVariableBrickWithVisualPlacement extends VisualPlaceme
 		builder.show();
 	}
 
-	public boolean isNewOptionSelected() {
-		return spinner.isNewOptionSelected();
-	}
-
 	@Override
 	public void onStringOptionSelected(Integer spinnerId, String string) {
 	}
@@ -139,15 +135,15 @@ public abstract class UserVariableBrickWithVisualPlacement extends VisualPlaceme
 	}
 
 	@Override
-	public boolean visualPlacementConditionsSatisfied() {
-		return super.visualPlacementConditionsSatisfied() && !this.isNewOptionSelected();
-	}
-
-	@Override
 	public Intent generateIntentForVisualPlacement(BrickField brickFieldX, BrickField brickFieldY) {
 		Intent intent = super.generateIntentForVisualPlacement(brickFieldX, brickFieldY);
-		String text = userVariable.getValue().toString();
 
+		Object variableValue = 0;
+		if (userVariable != null) {
+			variableValue = userVariable.getValue();
+		}
+
+		String text = variableValue.toString();
 		if (isNumberAndInteger(text)) {
 			text = getStringAsInteger(text);
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/VisualPlacementBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/VisualPlacementBrick.java
@@ -133,11 +133,7 @@ public abstract class VisualPlacementBrick extends FormulaBrick {
 	}
 
 	public boolean isVisualPlacement(View view) {
-		return isCorrectTextField(view) && visualPlacementConditionsSatisfied();
-	}
-
-	public boolean visualPlacementConditionsSatisfied() {
-		return areAllBrickFieldsNumbers();
+		return isCorrectTextField(view) && areAllBrickFieldsNumbers();
 	}
 
 	public boolean areAllBrickFieldsNumbers() {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -532,7 +532,7 @@ public class ScriptFragment extends ListFragment implements
 			items.add(brick.isCommentedOut()
 					? R.string.brick_context_dialog_comment_in
 					: R.string.brick_context_dialog_comment_out);
-			if (brick instanceof VisualPlacementBrick && ((VisualPlacementBrick) brick).visualPlacementConditionsSatisfied()) {
+			if (brick instanceof VisualPlacementBrick && ((VisualPlacementBrick) brick).areAllBrickFieldsNumbers()) {
 				items.add(R.string.brick_option_place_visually);
 			}
 			if (brick instanceof FormulaBrick) {

--- a/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickSingleFormulaFieldTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickSingleFormulaFieldTest.java
@@ -104,7 +104,6 @@ import org.catrobat.catroid.content.bricks.SetVelocityBrick;
 import org.catrobat.catroid.content.bricks.SetVolumeToBrick;
 import org.catrobat.catroid.content.bricks.SetXBrick;
 import org.catrobat.catroid.content.bricks.SetYBrick;
-import org.catrobat.catroid.content.bricks.ShowTextBrick;
 import org.catrobat.catroid.content.bricks.ShowTextColorSizeAlignmentBrick;
 import org.catrobat.catroid.content.bricks.SpeakAndWaitBrick;
 import org.catrobat.catroid.content.bricks.SpeakBrick;
@@ -208,10 +207,7 @@ public class BrickSingleFormulaFieldTest {
 				{SayForBubbleBrick.class.getSimpleName() + " duration", new SayForBubbleBrick(), R.id.brick_for_bubble_edit_text_duration},
 				{ThinkForBubbleBrick.class.getSimpleName() + " text", new ThinkForBubbleBrick(), R.id.brick_for_bubble_edit_text_text},
 				{ThinkForBubbleBrick.class.getSimpleName() + " duration", new ThinkForBubbleBrick(), R.id.brick_for_bubble_edit_text_duration},
-				{ShowTextBrick.class.getSimpleName() + " x", new ShowTextBrick(), R.id.brick_show_variable_edit_text_x},
-				{ShowTextBrick.class.getSimpleName() + " y", new ShowTextBrick(), R.id.brick_show_variable_edit_text_y},
-				{ShowTextColorSizeAlignmentBrick.class.getSimpleName() + " x", new ShowTextColorSizeAlignmentBrick(), R.id.brick_show_variable_color_size_edit_text_x},
-				{ShowTextColorSizeAlignmentBrick.class.getSimpleName() + " y", new ShowTextColorSizeAlignmentBrick(), R.id.brick_show_variable_color_size_edit_text_y},
+				{ShowTextColorSizeAlignmentBrick.class.getSimpleName() + " color", new ShowTextColorSizeAlignmentBrick(), R.id.brick_show_variable_color_size_edit_color},
 				{ShowTextColorSizeAlignmentBrick.class.getSimpleName() + " size", new ShowTextColorSizeAlignmentBrick(), R.id.brick_show_variable_color_size_edit_relative_size},
 				{InsertItemIntoUserListBrick.class.getSimpleName() + " value", new InsertItemIntoUserListBrick(), R.id.brick_insert_item_into_userlist_value_edit_text},
 				{InsertItemIntoUserListBrick.class.getSimpleName() + " index", new InsertItemIntoUserListBrick(), R.id.brick_insert_item_into_userlist_at_index_edit_text},


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-820

- make visual placement also available if no variable is selected (default text "0" is displayed)
- make visual placement also available if text size is not sane (default text size 1.0 is used)
- adapt testcases when FormulaEditor should be opened immediately

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
