### PR TITLE
CATROID-761 Single undo of editing or creating a look

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/LookUndoTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/LookUndoTest.java
@@ -1,0 +1,216 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.stage;
+
+import android.Manifest;
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Environment;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.io.ResourceImporter;
+import org.catrobat.catroid.io.XstreamSerializer;
+import org.catrobat.catroid.test.utils.TestUtils;
+import org.catrobat.catroid.testsuites.annotations.Cat;
+import org.catrobat.catroid.testsuites.annotations.Level;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.hamcrest.Matcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.File;
+import java.io.IOException;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.GrantPermissionRule;
+
+import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView;
+import static org.catrobat.catroid.uiespresso.util.matchers.BundleMatchers.bundleHasExtraIntent;
+import static org.catrobat.catroid.uiespresso.util.matchers.BundleMatchers.bundleHasMatchingString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.core.AllOf.allOf;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.Intents.intending;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasCategories;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtras;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasType;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+public class LookUndoTest {
+
+	private Matcher<Intent> expectedChooserIntent;
+	private Matcher<Intent> expectedPaintNewLookIntent;
+	private final String lookFileName = "catroid_sunglasses.png";
+	private final String projectName = getClass().getSimpleName();
+	private final String spriteName = "testSprite";
+	private File imageFile;
+	private final File tmpDir = new File(
+			Environment.getExternalStorageDirectory().getAbsolutePath(), "Pocket Code Test Temp");
+
+	@Rule
+	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
+			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_LOOKS);
+
+	@Rule
+	public GrantPermissionRule runtimePermissionRule = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE, android.Manifest.permission.READ_EXTERNAL_STORAGE);
+
+	@Before
+	public void setUp() throws Exception {
+		createProject(projectName);
+
+		baseActivityTestRule.launchActivity();
+		Intents.init();
+
+		Matcher<Intent> expectedGetContentIntent = allOf(
+				hasAction("android.intent.action.GET_CONTENT"),
+				hasType("image/*"));
+
+		String chooserTitle = UiTestUtils.getResourcesString(R.string.select_look_from_gallery);
+		expectedChooserIntent = allOf(
+				hasAction("android.intent.action.CHOOSER"),
+				hasExtras(bundleHasMatchingString("android.intent.extra.TITLE", chooserTitle)),
+				hasExtras(bundleHasExtraIntent(expectedGetContentIntent)));
+
+		if (!tmpDir.exists()) {
+			tmpDir.mkdirs();
+		}
+
+		imageFile = ResourceImporter.createImageFileFromResourcesInDirectory(
+				InstrumentationRegistry.getInstrumentation().getContext().getResources(),
+				org.catrobat.catroid.test.R.drawable.catroid_banzai,
+				tmpDir,
+				lookFileName,
+				1);
+
+		Intent resultData = new Intent();
+		resultData.setData(Uri.fromFile(imageFile));
+
+		Instrumentation.ActivityResult result =
+				new Instrumentation.ActivityResult(Activity.RESULT_OK, resultData);
+
+		intending(expectedChooserIntent).respondWith(result);
+
+		expectedPaintNewLookIntent = allOf(
+				hasComponent(Constants.POCKET_PAINT_INTENT_ACTIVITY_NAME),
+				hasAction("android.intent.action.MAIN"),
+				hasCategories(hasItem(equalTo("android.intent.category.LAUNCHER"))));
+
+		Instrumentation.ActivityResult resultPaintroid = new Instrumentation.ActivityResult(Activity.RESULT_OK, null);
+
+		intending(expectedPaintNewLookIntent).respondWith(resultPaintroid);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testAddNewLook() {
+		onView(withId(R.id.menu_undo)).check(doesNotExist());  // undo shouldn't be visible
+		// adding image
+
+		onView(withId(R.id.button_add))
+				.perform(click());
+
+		onView(withId(R.id.dialog_new_look_paintroid))
+				.perform(click());
+
+		intended(expectedPaintNewLookIntent);
+
+		onRecyclerView().atPosition(0).onChildView(R.id.title_view)
+				.check(matches(withText(spriteName)));
+
+		onView(withId(R.id.menu_undo)).perform(click()); // press undo
+
+		onRecyclerView().checkHasNumberOfItems(0);
+
+		onView(withId(R.id.menu_undo)).check(doesNotExist());  // undo shouldn't be visible
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testUndoLookFromGalleryIntentTest() {
+		onView(withId(R.id.menu_undo)).check(doesNotExist()); // undo shouldn't be visible
+
+		onView(withId(R.id.button_add))
+				.perform(click());
+
+		onView(withId(R.id.dialog_new_look_gallery))
+				.perform(click());
+
+		intended(expectedChooserIntent);
+
+		onRecyclerView().atPosition(0).onChildView(R.id.title_view)
+				.check(matches(withText(lookFileName.replace(".png", ""))));
+
+		onView(withId(R.id.menu_undo)).perform(click()); // press undo
+
+		onRecyclerView().checkHasNumberOfItems(0);
+
+		onView(withId(R.id.menu_undo)).check(doesNotExist()); // undo shouldn't be visible
+	}
+
+	private void createProject(String projectName) {
+		Project project = new Project(ApplicationProvider.getApplicationContext(), projectName);
+		Sprite sprite = new Sprite(spriteName);
+
+		project.getDefaultScene().addSprite(sprite);
+		ProjectManager.getInstance().setCurrentProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+		ProjectManager.getInstance().setCurrentlyEditedScene(project.getDefaultScene());
+		XstreamSerializer.getInstance().saveProject(project);
+	}
+
+	@After
+	public void tearDown() throws IOException {
+		Intents.release();
+		baseActivityTestRule.finishActivity();
+		TestUtils.deleteProjects(projectName);
+		if (imageFile != null && imageFile.exists()) {
+			imageFile.delete();
+		}
+		if (tmpDir.exists()) {
+			tmpDir.delete();
+		}
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
@@ -23,8 +23,11 @@
 
 package org.catrobat.catroid.ui.recyclerview.fragment;
 
+import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
@@ -34,6 +37,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.ui.controller.BackpackListManager;
 import org.catrobat.catroid.ui.recyclerview.adapter.LookAdapter;
 import org.catrobat.catroid.ui.recyclerview.backpack.BackpackActivity;
@@ -41,20 +45,29 @@ import org.catrobat.catroid.ui.recyclerview.controller.LookController;
 import org.catrobat.catroid.utils.SnackbarUtil;
 import org.catrobat.catroid.utils.ToastUtil;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.PluralsRes;
 
 import static org.catrobat.catroid.common.Constants.EXTRA_PICTURE_PATH_POCKET_PAINT;
 import static org.catrobat.catroid.common.Constants.POCKET_PAINT_INTENT_ACTIVITY_NAME;
 import static org.catrobat.catroid.common.SharedPreferenceKeys.SHOW_DETAILS_LOOKS_PREFERENCE_KEY;
+import static org.catrobat.catroid.ui.SpriteActivity.EDIT_LOOK;
 
 public class LookListFragment extends RecyclerViewFragment<LookData> {
 
 	public static final String TAG = LookListFragment.class.getSimpleName();
 
 	private LookController lookController = new LookController();
+
+	private Bitmap bmp;
+	private LookData currentItem;
 
 	@Override
 	protected void initializeAdapter() {
@@ -137,6 +150,23 @@ public class LookListFragment extends RecyclerViewFragment<LookData> {
 		finishActionMode();
 	}
 
+	private void disposeItem() {
+		if (bmp != null) {
+			if (!bmp.isRecycled()) {
+				bmp.recycle();
+			}
+			bmp = null;
+			currentItem.dispose();
+			currentItem = null;
+		}
+	}
+
+	@Override
+	public void onDestroy() {
+		super.onDestroy();
+		disposeItem();
+	}
+
 	@Override
 	@PluralsRes
 	protected int getDeleteAlertTitleId() {
@@ -173,13 +203,50 @@ public class LookListFragment extends RecyclerViewFragment<LookData> {
 	}
 
 	@Override
+	public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+		super.onActivityResult(requestCode, resultCode, data);
+		if (requestCode == EDIT_LOOK) {
+			Bitmap b = BitmapFactory.decodeFile(currentItem.getFile().getAbsolutePath());
+			if (!bmp.sameAs(b)) {
+				Activity activity = getActivity();
+				if (activity instanceof SpriteActivity) {
+					((SpriteActivity) getActivity()).setUndoMenuItemVisibility(true);
+				}
+			}
+		}
+	}
+
+	public boolean undo() {
+		if (currentItem != null) {
+			try {
+				bmp.compress(Bitmap.CompressFormat.PNG, 100,
+						new FileOutputStream(new File(currentItem.getFile().getAbsolutePath())));
+			} catch (FileNotFoundException e) {
+				Log.e(TAG, Log.getStackTraceString(e));
+			}
+			currentItem.invalidateThumbnailBitmap();
+			adapter.notifyDataSetChanged();
+			disposeItem();
+			return true;
+		}
+		return false;
+	}
+
+	public void deleteItem(LookData lookData) {
+		deleteItems(Collections.singletonList(lookData));
+	}
+
+	@Override
 	public void onItemClick(LookData item) {
 		if (actionModeType != NONE) {
 			return;
 		}
 
+		currentItem = item;
+
 		item.invalidateThumbnailBitmap();
 		item.clearCollisionInformation();
+		bmp = BitmapFactory.decodeFile(item.getFile().getAbsolutePath());
 
 		Intent intent = new Intent("android.intent.action.MAIN");
 		intent.setComponent(new ComponentName(getActivity(), POCKET_PAINT_INTENT_ACTIVITY_NAME));
@@ -188,6 +255,6 @@ public class LookListFragment extends RecyclerViewFragment<LookData> {
 		intent.putExtras(bundle);
 		intent.addCategory("android.intent.category.LAUNCHER");
 
-		startActivity(intent);
+		startActivityForResult(intent, EDIT_LOOK);
 	}
 }


### PR DESCRIPTION
Ticket: https://jira.catrob.at/browse/CATROID-761

Single undo of editing or creating a look (in paintroid, or on importing from gallery / media library.)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
