### PR TITLE
CATROID-867 CRITICAL: crash when tapping on = operator in Logic tab in formula editor

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorKeyboardTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorKeyboardTest.java
@@ -36,6 +36,7 @@ import org.catrobat.catroid.test.utils.TestUtils;
 import org.catrobat.catroid.testsuites.annotations.Cat;
 import org.catrobat.catroid.testsuites.annotations.Level;
 import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper;
 import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
 import org.junit.After;
@@ -96,13 +97,18 @@ public class FormulaEditorKeyboardTest {
 		onView(withId(R.id.brick_set_variable_edit_text)).perform(click());
 
 		onFormulaEditor()
-				.performEnterFormula("(1)+1-1*1/1");
+				.performEnterFormula("(1)+1-1*1/1")
+				.performOpenCategory(FormulaEditorWrapper.Category.LOGIC);
+
+		onView(withText(R.string.formula_editor_logic_equal)).perform(click());
+
+		onFormulaEditor().performEnterFormula("1");
 
 		onFormulaEditor()
 				.performCloseAndSave();
 
 		onView(withId(R.id.brick_set_variable_edit_text))
-				.check(matches(withText("( 1 ) + 1 - 1 × 1 ÷ 1 ")));
+				.check(matches(withText("( 1 ) + 1 - 1 × 1 ÷ 1 = 1 ")));
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaKeyboardAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaKeyboardAdapter.java
@@ -351,6 +351,8 @@ public class InternFormulaKeyboardAdapter {
 				return buildOperator(Operators.DIVIDE);
 			case R.string.formula_editor_operator_power:
 				return buildOperator(Operators.POW);
+			case R.string.formula_editor_logic_equal:
+				return buildOperator(Operators.EQUAL);
 			case R.string.formula_editor_logic_notequal:
 				return buildOperator(Operators.NOT_EQUAL);
 			case R.string.formula_editor_logic_lesserthan:


### PR DESCRIPTION
Ticket: https://jira.catrob.at/browse/CATROID-867

CRITICAL: crash when tapping on = operator in Logic tab in formula editor

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
