### PR TITLE
CATROID-857 Change Dialog for exiting Visual Placement

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/intents/visualplacement/VisualPlacementActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/intents/visualplacement/VisualPlacementActivityTest.java
@@ -113,7 +113,7 @@ public class VisualPlacementActivityTest {
 	@Test
 	public void testResultWhenDiscarded() {
 		Espresso.pressBack();
-		onView(withText(R.string.cancel))
+		onView(withText(R.string.discard))
 				.perform(click());
 
 		Assert.assertTrue(baseActivityTestRule.getActivity().isFinishing());

--- a/catroid/src/main/java/org/catrobat/catroid/visualplacement/VisualPlacementActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/visualplacement/VisualPlacementActivity.java
@@ -419,7 +419,7 @@ public class VisualPlacementActivity extends BaseCastActivity implements View.On
 				.setTitle(R.string.formula_editor_discard_changes_dialog_title)
 				.setMessage(R.string.formula_editor_discard_changes_dialog_message)
 				.setPositiveButton(R.string.save, this)
-				.setNegativeButton(R.string.cancel, this)
+				.setNegativeButton(R.string.discard, this)
 				.setCancelable(true)
 				.show();
 	}

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="cancel">Cancel</string>
     <string name="save">Save</string>
 
+    <string name="discard">Discard</string>
+
     <string name="next">Next</string>
 
     <string name="ok">OK</string>


### PR DESCRIPTION
Jira Ticket :- https://jira.catrob.at/browse/CATROID-857
When the user taps the back arrow in the "Visual Placement editor" it ask if you want to change the changes or cancel the action. "Cancel" suggests that you get back to the editing view but the changes are just discarded and the activity gets closed. So the "Cancel" button should be renamed to "Discard".

Changes Made
"Cancel" button is renamed to "Discard"

Screenshot
<img src= "https://user-images.githubusercontent.com/70067211/103666210-54ba8580-4f9a-11eb-8f4f-51f0d9aa4579.png" width="350" height="700" />


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
