### PR TITLE
CATROID-865 Crash on "Delete look" and "Delete background"

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/DeleteLookBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/DeleteLookBrickTest.java
@@ -1,0 +1,120 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2018 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.content.brick.app;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.DeleteLookBrick;
+import org.catrobat.catroid.content.bricks.PaintNewLookBrick;
+import org.catrobat.catroid.test.utils.TestUtils;
+import org.catrobat.catroid.testsuites.annotations.Cat;
+import org.catrobat.catroid.testsuites.annotations.Level;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.intent.Intents;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static junit.framework.Assert.assertEquals;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+@RunWith(AndroidJUnit4.class)
+public class DeleteLookBrickTest {
+	private Sprite sprite;
+	private StartScript script;
+	private final String projectName = "DeleteLookBrickTest";
+
+	@Rule
+	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
+			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+
+	@Before
+	public void setUp() throws Exception {
+		Project project = new Project(ApplicationProvider.getApplicationContext(),
+				projectName);
+		sprite = new Sprite("testSprite");
+		script = new StartScript();
+		script.addBrick(new PaintNewLookBrick());
+		sprite.addScript(script);
+		project.getDefaultScene().addSprite(sprite);
+
+		ProjectManager.getInstance().setCurrentProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+		ProjectManager.getInstance().setCurrentlyEditedScene(project.getDefaultScene());
+
+		baseActivityTestRule.launchActivity();
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testPaintLookWithoutDelete() {
+		Intents.init();
+
+		onView(withId(R.id.button_play)).perform(click());
+		onView(withId(R.id.pocketpaint_drawing_surface_view)).perform(click());
+		pressBack();
+
+		assertEquals(1, sprite.getLookList().size());
+
+		Intents.release();
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testPaintAndDeleteLook() {
+		script.addBrick(new DeleteLookBrick());
+
+		Intents.init();
+
+		onView(withId(R.id.button_play)).perform(click());
+		onView(withId(R.id.pocketpaint_drawing_surface_view)).perform(click());
+		pressBack();
+
+		assertEquals(0, sprite.getLookList().size());
+
+		Intents.release();
+	}
+
+	@After
+	public void tearDown() throws IOException {
+		baseActivityTestRule.finishActivity();
+		TestUtils.deleteProjects(projectName);
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/LookData.java
@@ -71,6 +71,8 @@ public class LookData implements Cloneable, Nameable, Serializable {
 
 	private transient CollisionInformation collisionInformation = null;
 
+	private boolean valid = true;
+
 	public LookData() {
 	}
 
@@ -229,5 +231,13 @@ public class LookData implements Cloneable, Nameable, Serializable {
 		options.inJustDecodeBounds = true;
 		BitmapFactory.decodeFile(pathName, options);
 		return options.outMimeType;
+	}
+
+	public boolean isValid() {
+		return valid;
+	}
+
+	public void invalidate() {
+		valid = false;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/DeleteLookAction.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/DeleteLookAction.kt
@@ -47,6 +47,7 @@ class DeleteLookAction : SpriteEventAction() {
             }
             val lookDataToDelete = look?.lookData
             setNewLookData(indexOfLookData + 1)
+            lookDataToDelete?.invalidate()
             lookController.delete(lookDataToDelete)
             lookList?.removeAt(indexOfLookData)
             xstreamSerializer.saveProject(ProjectManager.getInstance().currentProject)

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionInformation.java
@@ -187,7 +187,7 @@ public class CollisionInformation {
 			collisionPolygons = createCollisionPolygonByHitbox(bitmap);
 		}
 
-		if (isCalculationThreadCancelled) {
+		if (isCalculationThreadCancelled || !lookData.isValid()) {
 			return;
 		}
 


### PR DESCRIPTION
Fixed the bug by invalidating the lookdata on deletion to prevent a use in the collision calculation after deletion of the file.
Also included a test for it.

https://jira.catrob.at/browse/CATROID-865

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
