### PR TITLE
CATROID-864 Show keyboard for TextInputDialogs

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/ViewUtils.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ViewUtils.kt
@@ -1,0 +1,50 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:JvmName("ViewUtils")
+
+package org.catrobat.catroid.ui
+
+import android.app.Activity
+import android.content.Context
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+
+private const val WAIT_TIME: Long = 100
+
+fun View?.showKeyboard() {
+    this?.let {
+        val inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        it.postDelayed(Runnable {
+            it.requestFocus()
+            inputMethodManager.showSoftInput(it, 0)
+        }, WAIT_TIME)
+    }
+}
+
+fun View?.hideKeyboard() {
+    this?.let {
+        val inputMethodManager = context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(it.windowToken, 0)
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/HtmlExtractorInputDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/regexassistant/HtmlExtractorInputDialog.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -32,6 +32,7 @@ import android.text.Editable;
 import com.google.android.material.textfield.TextInputLayout;
 
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.ui.ViewUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -119,40 +120,38 @@ public final class HtmlExtractorInputDialog extends AlertDialog {
 		public androidx.appcompat.app.AlertDialog create() {
 			final androidx.appcompat.app.AlertDialog alertDialog = super.create();
 
-			alertDialog.setOnShowListener(new OnShowListener() {
+			alertDialog.setOnShowListener(dialog -> {
+				TextInputLayout textInputLayout = alertDialog.findViewById(R.id.input);
+				textInputLayout.setHint(keywordHint);
+				textInputLayout.getEditText().setText(keyword);
+				textInputLayout.getEditText().selectAll();
 
-				@Override
-				public void onShow(DialogInterface dialog) {
-					TextInputLayout textInputLayout = alertDialog.findViewById(R.id.input);
-					textInputLayout.setHint(keywordHint);
-					textInputLayout.getEditText().setText(keyword);
-					textInputLayout.getEditText().selectAll();
+				TextInputLayout textInputLayout1 = alertDialog.findViewById(R.id.input1);
+				textInputLayout1.setHint(htmlHint);
+				textInputLayout1.getEditText().setText(htmlText);
+				textInputLayout1.getEditText().selectAll();
 
-					TextInputLayout textInputLayout1 = alertDialog.findViewById(R.id.input1);
-					textInputLayout1.setHint(htmlHint);
-					textInputLayout1.getEditText().setText(htmlText);
-					textInputLayout1.getEditText().selectAll();
+				if (textWatcherKeyword != null) {
+					textInputLayout.getEditText().addTextChangedListener(textWatcherKeyword);
+					textWatcherKeyword.setInputLayout(textInputLayout);
+					textWatcherKeyword.setAlertDialog(alertDialog);
+					String error = textWatcherKeyword
+							.validateInput(textInputLayout.getEditText().getText().toString(), getContext());
 
-					if (textWatcherKeyword != null) {
-						textInputLayout.getEditText().addTextChangedListener(textWatcherKeyword);
-						textWatcherKeyword.setInputLayout(textInputLayout);
-						textWatcherKeyword.setAlertDialog(alertDialog);
-						String error = textWatcherKeyword
-								.validateInput(textInputLayout.getEditText().getText().toString(), getContext());
-
-						alertDialog.getButton(androidx.appcompat.app.AlertDialog.BUTTON_POSITIVE).setEnabled(error == null);
-					}
-
-					if (textWatcherHtml != null) {
-						textInputLayout.getEditText().addTextChangedListener(textWatcherHtml);
-						textWatcherHtml.setInputLayout(textInputLayout1);
-						textWatcherHtml.setAlertDialog(alertDialog);
-						String error = textWatcherHtml
-								.validateInput(textInputLayout.getEditText().getText().toString(), getContext());
-
-						alertDialog.getButton(androidx.appcompat.app.AlertDialog.BUTTON_POSITIVE).setEnabled(error == null);
-					}
+					alertDialog.getButton(androidx.appcompat.app.AlertDialog.BUTTON_POSITIVE).setEnabled(error == null);
 				}
+
+				if (textWatcherHtml != null) {
+					textInputLayout.getEditText().addTextChangedListener(textWatcherHtml);
+					textWatcherHtml.setInputLayout(textInputLayout1);
+					textWatcherHtml.setAlertDialog(alertDialog);
+					String error = textWatcherHtml
+							.validateInput(textInputLayout.getEditText().getText().toString(), getContext());
+
+					alertDialog.getButton(androidx.appcompat.app.AlertDialog.BUTTON_POSITIVE).setEnabled(error == null);
+				}
+
+				ViewUtils.showKeyboard(textInputLayout.getEditText());
 			});
 
 			return alertDialog;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/TextInputDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/TextInputDialog.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -27,10 +27,12 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.text.Editable;
+import android.widget.EditText;
 
 import com.google.android.material.textfield.TextInputLayout;
 
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.ui.ViewUtils;
 import org.catrobat.catroid.ui.recyclerview.dialog.textwatcher.InputWatcher;
 
 import androidx.annotation.NonNull;
@@ -72,14 +74,11 @@ public final class TextInputDialog extends AlertDialog {
 			return this;
 		}
 
-		public Builder setPositiveButton(String text, final OnClickListener listener) {
-			setPositiveButton(text, new DialogInterface.OnClickListener() {
-				@Override
-				public void onClick(DialogInterface dialog, int which) {
-					TextInputLayout textInputLayout = ((Dialog) dialog).findViewById(R.id.input);
-					String text = textInputLayout.getEditText().getText().toString();
-					listener.onPositiveButtonClick(dialog, text);
-				}
+		public Builder setPositiveButton(String buttonText, final OnClickListener listener) {
+			setPositiveButton(buttonText, (DialogInterface.OnClickListener) (dialog, which) -> {
+				TextInputLayout textInputLayout = ((Dialog) dialog).findViewById(R.id.input);
+				String text = textInputLayout.getEditText().getText().toString();
+				listener.onPositiveButtonClick(dialog, text);
 			});
 			return this;
 		}
@@ -88,23 +87,21 @@ public final class TextInputDialog extends AlertDialog {
 		public AlertDialog create() {
 			final AlertDialog alertDialog = super.create();
 
-			alertDialog.setOnShowListener(new OnShowListener() {
-				@Override
-				public void onShow(DialogInterface dialog) {
-					TextInputLayout textInputLayout = alertDialog.findViewById(R.id.input);
-					textInputLayout.setHint(hint);
-					textInputLayout.getEditText().setText(text);
-					textInputLayout.getEditText().selectAll();
+			alertDialog.setOnShowListener(dialog -> {
+				TextInputLayout textInputLayout = alertDialog.findViewById(R.id.input);
+				EditText editText = textInputLayout.getEditText();
+				textInputLayout.setHint(hint);
+				editText.setText(text);
+				editText.selectAll();
 
-					if (textWatcher != null) {
-						textInputLayout.getEditText().addTextChangedListener(textWatcher);
-						textWatcher.setInputLayout(textInputLayout);
-						textWatcher.setButton(alertDialog.getButton(AlertDialog.BUTTON_POSITIVE));
-						textWatcher.setContext(getContext());
-					}
+				if (textWatcher != null) {
+					textInputLayout.getEditText().addTextChangedListener(textWatcher);
+					textWatcher.setInputLayout(textInputLayout);
+					textWatcher.setButton(alertDialog.getButton(AlertDialog.BUTTON_POSITIVE));
+					textWatcher.setContext(getContext());
 				}
+				ViewUtils.showKeyboard(editText);
 			});
-
 			return alertDialog;
 		}
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/LoginDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/LoginDialogFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -40,6 +40,7 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.FlavoredConstants;
 import org.catrobat.catroid.transfers.LoginTask;
+import org.catrobat.catroid.ui.ViewUtils;
 import org.catrobat.catroid.ui.WebViewActivity;
 import org.catrobat.catroid.web.ServerCalls;
 
@@ -135,24 +136,12 @@ public class LoginDialogFragment extends DialogFragment implements LoginTask.OnL
 			}
 		});
 
-		alertDialog.setOnShowListener(new DialogInterface.OnShowListener() {
-			@Override
-			public void onShow(DialogInterface dialog) {
-				alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
-				alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
-					@Override
-					public void onClick(View view) {
-						onLoginButtonClick();
-					}
-				});
+		alertDialog.setOnShowListener(dialog -> {
+			alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+			alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(buttonView -> onLoginButtonClick());
+			alertDialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener(buttonView -> onPasswordForgottenButtonClick());
 
-				alertDialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener(new View.OnClickListener() {
-					@Override
-					public void onClick(View view) {
-						onPasswordForgottenButtonClick();
-					}
-				});
-			}
+			ViewUtils.showKeyboard(usernameEditText);
 		});
 
 		return alertDialog;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/RegistrationDialogFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/login/RegistrationDialogFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -24,7 +24,6 @@ package org.catrobat.catroid.ui.recyclerview.dialog.login;
 
 import android.app.Dialog;
 import android.content.DialogInterface;
-import android.content.DialogInterface.OnShowListener;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.InputType;
@@ -43,6 +42,7 @@ import org.catrobat.catroid.transfers.CheckEmailAvailableTask;
 import org.catrobat.catroid.transfers.CheckUserNameAvailableTask;
 import org.catrobat.catroid.transfers.RegistrationTask;
 import org.catrobat.catroid.transfers.RegistrationTask.OnRegistrationListener;
+import org.catrobat.catroid.ui.ViewUtils;
 import org.catrobat.catroid.utils.DeviceSettingsProvider;
 import org.catrobat.catroid.utils.ToastUtil;
 import org.catrobat.catroid.utils.Utils;
@@ -238,17 +238,10 @@ public class RegistrationDialogFragment extends DialogFragment implements OnRegi
 			emailInputLayout.setErrorEnabled(false);
 		}
 
-		alertDialog.setOnShowListener(new OnShowListener() {
-			@Override
-			public void onShow(DialogInterface dialog) {
-				alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
-				alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
-					@Override
-					public void onClick(View view) {
-						onRegisterButtonClick();
-					}
-				});
-			}
+		alertDialog.setOnShowListener(dialog -> {
+			alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+			alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(buttonView -> onRegisterButtonClick());
+			ViewUtils.showKeyboard(userNameEditText);
 		});
 		return alertDialog;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/scratchconverter/ScratchSearchResultsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/scratchconverter/ScratchSearchResultsFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -45,6 +45,7 @@ import org.catrobat.catroid.common.ScratchSearchResult;
 import org.catrobat.catroid.scratchconverter.ConversionManager;
 import org.catrobat.catroid.transfers.SearchScratchProgramsTask;
 import org.catrobat.catroid.ui.ScratchProgramDetailsActivity;
+import org.catrobat.catroid.ui.ViewUtils;
 import org.catrobat.catroid.ui.recyclerview.adapter.RVAdapter;
 import org.catrobat.catroid.ui.recyclerview.adapter.ScratchProgramAdapter;
 import org.catrobat.catroid.ui.recyclerview.viewholder.CheckableVH;
@@ -99,7 +100,9 @@ public class ScratchSearchResultsFragment extends Fragment implements
 
 		@Override
 		public boolean onQueryTextChange(String newText) {
-			if (newText.length() > 1) {
+			if (newText.isEmpty()) {
+				searchTaskDelegate.startSearch(null);
+			} else {
 				searchTaskDelegate.startSearch(newText);
 			}
 			return false;
@@ -242,7 +245,14 @@ public class ScratchSearchResultsFragment extends Fragment implements
 	@Override
 	public void onResume() {
 		super.onResume();
+		ViewUtils.showKeyboard(searchView);
 		searchTaskDelegate.startSearch(null);
+	}
+
+	@Override
+	public void onPause() {
+		super.onPause();
+		ViewUtils.hideKeyboard(getView());
 	}
 
 	@Override


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-864

- Fixed bug of Scratch2Catrobat search view, where the results of the old search persisted even if no more character was within the textfield.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
