### PR TITLE
CATROID-885 Make rename option single choice

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/PlaySoundAndWaitBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/PlaySoundAndWaitBrickTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -63,14 +63,13 @@ import androidx.test.rule.GrantPermissionRule;
 import static org.catrobat.catroid.common.Constants.SOUND_DIRECTORY_NAME;
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
 import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.openActionBar;
 import static org.catrobat.catroid.uiespresso.util.actions.TabActionsKt.selectTabAtPosition;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.instanceOf;
 
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
@@ -188,7 +187,7 @@ public class PlaySoundAndWaitBrickTest {
 	private void deleteSound(int position) {
 		onView(withId(R.id.tab_layout))
 				.perform(selectTabAtPosition(SpriteActivity.FRAGMENT_SOUNDS));
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.delete))
 				.perform(click());
 		onRecyclerView().atPosition(position)
@@ -208,13 +207,10 @@ public class PlaySoundAndWaitBrickTest {
 	private void renameSound(int position, String oldName, String newName) {
 		onView(withId(R.id.tab_layout))
 				.perform(selectTabAtPosition(SpriteActivity.FRAGMENT_SOUNDS));
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename))
 				.perform(click());
 		onRecyclerView().atPosition(position)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm))
 				.perform(click());
 
 		onView(withText(R.string.rename_sound_dialog)).inRoot(isDialog())

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/PlaySoundBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/PlaySoundBrickTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -59,13 +59,12 @@ import androidx.test.rule.GrantPermissionRule;
 import static org.catrobat.catroid.common.Constants.SOUND_DIRECTORY_NAME;
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
 import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.openActionBar;
 import static org.catrobat.catroid.uiespresso.util.actions.TabActionsKt.selectTabAtPosition;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.instanceOf;
 
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.replaceText;
@@ -99,12 +98,10 @@ public class PlaySoundBrickTest {
 	private void renameSound(int position, String newSoundName) {
 		onView(withId(R.id.tab_layout))
 				.perform(selectTabAtPosition(SpriteActivity.FRAGMENT_SOUNDS));
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename))
 				.perform(click());
 		onRecyclerView().atPosition(position)
-				.performCheckItem();
-		onView(withId(R.id.confirm))
 				.perform(click());
 		onView(allOf(withText(soundName), isDisplayed(), instanceOf(EditText.class)))
 				.perform(replaceText(newSoundName));
@@ -116,7 +113,7 @@ public class PlaySoundBrickTest {
 	private void deleteSound(int position) {
 		onView(withId(R.id.tab_layout))
 				.perform(selectTabAtPosition(SpriteActivity.FRAGMENT_SOUNDS));
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.delete))
 				.perform(click());
 		onRecyclerView().atPosition(position)

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectActivityTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectActivityTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -53,13 +53,12 @@ import androidx.test.espresso.intent.Intents;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.openActionBar;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.intent.Intents.intended;
@@ -117,7 +116,7 @@ public class ProjectActivityTest {
 		Instrumentation.ActivityResult intentResult = new Instrumentation.ActivityResult(Activity.RESULT_OK, intent);
 
 		baseActivityTestRule.launchActivity();
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 
 		intending(anyIntent()).respondWith(intentResult);
 
@@ -128,7 +127,7 @@ public class ProjectActivityTest {
 	@Test
 	public void projectNotSavedOnReloadFromUploadActivityTest() {
 		baseActivityTestRule.launchActivity();
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.upload_button)).perform(click());
 		pressBack();
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameLookTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameLookTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -52,15 +52,15 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME;
+import static org.catrobat.catroid.uiespresso.ui.actionbar.utils.ActionModeWrapper.onActionMode;
 import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.openActionBar;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -70,6 +70,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
+@Category({Cat.AppUi.class, Level.Smoke.class})
 @RunWith(AndroidJUnit4.class)
 public class RenameLookTest {
 
@@ -88,16 +89,13 @@ public class RenameLookTest {
 		baseActivityTestRule.launchActivity();
 	}
 
-	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void renameLookTest() {
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename)).perform(click());
 
 		onRecyclerView().atPosition(0)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm)).perform(click());
+				.perform(click());
 
 		onView(withText(R.string.rename_look_dialog)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
@@ -115,16 +113,13 @@ public class RenameLookTest {
 		onView(withText(newLookName)).check(matches(isDisplayed()));
 	}
 
-	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void cancelRenameLookTest() {
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename)).perform(click());
 
 		onRecyclerView().atPosition(0)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm)).perform(click());
+				.perform(click());
 
 		onView(withText(R.string.rename_look_dialog)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
@@ -139,16 +134,13 @@ public class RenameLookTest {
 		onView(withText(oldLookName)).check(matches(isDisplayed()));
 	}
 
-	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void invalidInputRenameLookTest() {
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename)).perform(click());
 
 		onRecyclerView().atPosition(0)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm)).perform(click());
+				.perform(click());
 
 		onView(withText(R.string.rename_look_dialog)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
@@ -180,6 +172,24 @@ public class RenameLookTest {
 
 		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
 				.check(matches(allOf(isDisplayed(), isEnabled())));
+	}
+
+	@Test
+	public void renameSingleLookTest() {
+		openActionBar();
+		onView(withText(R.string.delete)).perform(click());
+
+		onRecyclerView().atPosition(1).performCheckItem();
+
+		onActionMode().performConfirm();
+
+		onView(withText(R.string.yes)).perform(click());
+
+		openActionBar();
+		onView(withText(R.string.rename)).perform(click());
+
+		onView(withText(R.string.rename_look_dialog)).inRoot(isDialog())
+				.check(matches(isDisplayed()));
 	}
 
 	private void createProject() throws IOException {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameProjectTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameProjectTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -46,16 +46,16 @@ import org.junit.runner.RunWith;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.platform.app.InstrumentationRegistry;
 
+import static org.catrobat.catroid.uiespresso.ui.actionbar.utils.ActionModeWrapper.onActionMode;
 import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.openActionBar;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
 import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -65,6 +65,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
+@Category({Cat.AppUi.class, Level.Smoke.class})
 @RunWith(AndroidJUnit4.class)
 public class RenameProjectTest {
 
@@ -84,16 +85,13 @@ public class RenameProjectTest {
 		baseActivityTestRule.launchActivity(null);
 	}
 
-	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void renameProjectTest() {
-		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename)).perform(click());
 
 		onRecyclerView().atPosition(0)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm)).perform(click());
+				.perform(click());
 
 		onView(withText(R.string.rename_project)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
@@ -111,16 +109,13 @@ public class RenameProjectTest {
 		onView(withText(newProjectName)).check(matches(isDisplayed()));
 	}
 
-	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void cancelRenameProjectTest() {
-		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename)).perform(click());
 
 		onRecyclerView().atPosition(0)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm)).perform(click());
+				.perform(click());
 
 		onView(withText(R.string.rename_project)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
@@ -136,16 +131,13 @@ public class RenameProjectTest {
 		onView(withText(oldProjectName)).check(matches(isDisplayed()));
 	}
 
-	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void invalidInputRenameProjectTest() {
-		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename)).perform(click());
 
 		onRecyclerView().atPosition(0)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm)).perform(click());
+				.perform(click());
 
 		onView(withText(R.string.rename_project)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
@@ -177,6 +169,24 @@ public class RenameProjectTest {
 
 		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
 				.check(matches(allOf(isDisplayed(), isEnabled())));
+	}
+
+	@Test
+	public void renameSingleProjectTest() {
+		openActionBar();
+		onView(withText(R.string.delete)).perform(click());
+
+		onRecyclerView().atPosition(1).performCheckItem();
+
+		onActionMode().performConfirm();
+
+		onView(withText(R.string.yes)).perform(click());
+
+		openActionBar();
+		onView(withText(R.string.rename)).perform(click());
+
+		onView(withText(R.string.rename_project)).inRoot(isDialog())
+				.check(matches(isDisplayed()));
 	}
 
 	private void createProject(String projectName) {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSceneTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSceneTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -48,13 +48,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static junit.framework.Assert.assertEquals;
 
 import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.openActionBar;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.instanceOf;
 
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -75,14 +74,11 @@ public class RenameSceneTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void testRenameScene() {
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename))
 				.perform(click());
 
 		onRecyclerView().atPosition(0)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm))
 				.perform(click());
 
 		onView(withText(R.string.rename_scene_dialog)).inRoot(isDialog())

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSoundTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSoundTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -52,15 +52,15 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import static org.catrobat.catroid.common.Constants.SOUND_DIRECTORY_NAME;
+import static org.catrobat.catroid.uiespresso.ui.actionbar.utils.ActionModeWrapper.onActionMode;
 import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.openActionBar;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -91,13 +91,11 @@ public class RenameSoundTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void renameSoundTest() {
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename)).perform(click());
 
 		onRecyclerView().atPosition(0)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm)).perform(click());
+				.perform(click());
 
 		onView(withText(R.string.rename_sound_dialog)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
@@ -118,13 +116,11 @@ public class RenameSoundTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void cancelRenameSoundTest() {
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename)).perform(click());
 
 		onRecyclerView().atPosition(0)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm)).perform(click());
+				.perform(click());
 
 		onView(withText(R.string.rename_sound_dialog)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
@@ -143,13 +139,11 @@ public class RenameSoundTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void invalidInputRenameSoundTest() {
-		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+		openActionBar();
 		onView(withText(R.string.rename)).perform(click());
 
 		onRecyclerView().atPosition(0)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm)).perform(click());
+				.perform(click());
 
 		onView(withText(R.string.rename_sound_dialog)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
@@ -181,6 +175,24 @@ public class RenameSoundTest {
 
 		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
 				.check(matches(allOf(isDisplayed(), isEnabled())));
+	}
+
+	@Test
+	public void renameSingleSoundTest() {
+		openActionBar();
+		onView(withText(R.string.delete)).perform(click());
+
+		onRecyclerView().atPosition(1).performCheckItem();
+
+		onActionMode().performConfirm();
+
+		onView(withText(R.string.yes)).perform(click());
+
+		openActionBar();
+		onView(withText(R.string.rename)).perform(click());
+
+		onView(withText(R.string.rename_sound_dialog)).inRoot(isDialog())
+				.check(matches(isDisplayed()));
 	}
 
 	private void createProject() throws IOException {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/UiTestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/util/UiTestUtils.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -24,6 +24,7 @@ package org.catrobat.catroid.uiespresso.util;
 
 import android.app.Activity;
 import android.content.res.Resources;
+import android.util.Log;
 import android.view.View;
 
 import org.catrobat.catroid.ProjectManager;
@@ -37,6 +38,7 @@ import java.util.Collection;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.ViewInteraction;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 
 import static org.catrobat.catroid.uiespresso.util.matchers.SuperToastMatchers.isToast;
@@ -44,6 +46,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 
 import static androidx.test.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
 import static androidx.test.runner.lifecycle.Stage.RESUMED;
 
@@ -95,5 +98,15 @@ public final class UiTestUtils {
 
 	public static ViewInteraction onToast(Matcher<View> viewMatcher) {
 		return onView(viewMatcher).inRoot(isToast());
+	}
+
+	public static void openActionBar() {
+		try {
+			Thread.sleep(100);
+			openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext());
+			Thread.sleep(100);
+		} catch (InterruptedException e) {
+			Log.e(UiTestUtils.class.getName(), e.getMessage());
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/MultiViewSpriteAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/MultiViewSpriteAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -45,6 +45,8 @@ import java.util.Locale;
 
 import androidx.annotation.IntDef;
 
+import static android.view.View.GONE;
+
 public class MultiViewSpriteAdapter extends SpriteAdapter {
 
 	public static final String TAG = MultiViewSpriteAdapter.class.getSimpleName();
@@ -56,6 +58,7 @@ public class MultiViewSpriteAdapter extends SpriteAdapter {
 	private static final int SPRITE_SINGLE = 1;
 	private static final int SPRITE_GROUP = 2;
 	private static final int SPRITE_GROUP_ITEM = 3;
+	private View backgroundView;
 
 	public MultiViewSpriteAdapter(List<Sprite> items) {
 		super(items);
@@ -67,10 +70,10 @@ public class MultiViewSpriteAdapter extends SpriteAdapter {
 		LayoutInflater inflater = LayoutInflater.from(parent.getContext());
 		switch (viewType) {
 			case BACKGROUND:
-				View view = inflater.inflate(R.layout.vh_background_sprite, parent, false);
-				return new ExtendedVH(view);
+				backgroundView = inflater.inflate(R.layout.vh_background_sprite, parent, false);
+				return new ExtendedVH(backgroundView);
 			case SPRITE_SINGLE:
-				view = inflater.inflate(R.layout.vh_with_checkbox, parent, false);
+				View view = inflater.inflate(R.layout.vh_with_checkbox, parent, false);
 				return new ExtendedVH(view);
 			case SPRITE_GROUP:
 				view = inflater.inflate(R.layout.vh_sprite_group, parent, false);
@@ -95,13 +98,13 @@ public class MultiViewSpriteAdapter extends SpriteAdapter {
 					? context.getResources().getDrawable(R.drawable.ic_play)
 					: context.getResources().getDrawable(R.drawable.ic_play_down);
 			holder.image.setImageDrawable(drawable);
-			holder.checkBox.setVisibility(View.GONE);
+			holder.checkBox.setVisibility(GONE);
 			return;
 		}
 
 		if (holder.getItemViewType() == BACKGROUND) {
 			holder.itemView.setOnLongClickListener(null);
-			holder.checkBox.setVisibility(View.GONE);
+			holder.checkBox.setVisibility(GONE);
 		}
 
 		if (holder.getItemViewType() == SPRITE_GROUP_ITEM) {
@@ -128,7 +131,7 @@ public class MultiViewSpriteAdapter extends SpriteAdapter {
 					item.getSoundList().size()));
 			holder.details.setVisibility(View.VISIBLE);
 		} else {
-			holder.details.setVisibility(View.GONE);
+			holder.details.setVisibility(GONE);
 		}
 	}
 
@@ -220,5 +223,14 @@ public class MultiViewSpriteAdapter extends SpriteAdapter {
 		}
 
 		return items.size() - backgroundCount - groupSpriteCount;
+	}
+
+	public void setBackgroundVisible(int visible) {
+		backgroundView.setVisibility(visible);
+		if (visible == GONE) {
+			backgroundView.getLayoutParams().height = 0;
+		} else {
+			backgroundView.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
@@ -228,6 +228,10 @@ public class LookListFragment extends RecyclerViewFragment<LookData> {
 
 	@Override
 	public void onItemClick(LookData item) {
+		if (actionModeType == RENAME) {
+			super.onItemClick(item);
+			return;
+		}
 		if (actionModeType != NONE) {
 			return;
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/NfcTagListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/NfcTagListFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -189,5 +189,8 @@ public class NfcTagListFragment extends RecyclerViewFragment<NfcTagData> {
 
 	@Override
 	public void onItemClick(NfcTagData item) {
+		if (actionModeType == RENAME) {
+			super.onItemClick(item);
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ProjectListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ProjectListFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -362,6 +362,10 @@ public class ProjectListFragment extends RecyclerViewFragment<ProjectData> imple
 
 	@Override
 	public void onItemClick(ProjectData item) {
+		if (actionModeType == RENAME) {
+			super.onItemClick(item);
+			return;
+		}
 		if (actionModeType == NONE) {
 			setShowProgressBar(true);
 			new ProjectLoadTask(item.getDirectory(), getContext())
@@ -394,7 +398,7 @@ public class ProjectListFragment extends RecyclerViewFragment<ProjectData> imple
 								showDeleteAlert(new ArrayList<>(Collections.singletonList(item)));
 								break;
 							case 2:
-								showRenameDialog(new ArrayList<>(Collections.singletonList(item)));
+								showRenameDialog(item);
 								break;
 							case 3:
 								ProjectDetailsFragment fragment = new ProjectDetailsFragment();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/RecyclerViewFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/RecyclerViewFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -40,6 +40,7 @@ import org.catrobat.catroid.merge.NewProjectNameTextWatcher;
 import org.catrobat.catroid.ui.BottomBar;
 import org.catrobat.catroid.ui.controller.BackpackListManager;
 import org.catrobat.catroid.ui.recyclerview.adapter.ExtendedRVAdapter;
+import org.catrobat.catroid.ui.recyclerview.adapter.MultiViewSpriteAdapter;
 import org.catrobat.catroid.ui.recyclerview.adapter.RVAdapter;
 import org.catrobat.catroid.ui.recyclerview.adapter.draganddrop.TouchHelperCallback;
 import org.catrobat.catroid.ui.recyclerview.dialog.TextInputDialog;
@@ -107,6 +108,7 @@ public abstract class RecyclerViewFragment<T extends Nameable> extends Fragment 
 
 	@Override
 	public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+		mode.getMenuInflater().inflate(R.menu.context_menu, menu);
 		switch (actionModeType) {
 			case BACKPACK:
 				mode.setTitle(getString(R.string.am_backpack));
@@ -118,9 +120,9 @@ public abstract class RecyclerViewFragment<T extends Nameable> extends Fragment 
 				mode.setTitle(getString(R.string.am_delete));
 				break;
 			case RENAME:
-				adapter.selectionMode = adapter.SINGLE;
 				mode.setTitle(getString(R.string.am_rename));
-				break;
+				onRename(menu);
+				return true;
 			case MERGE:
 				adapter.selectionMode = adapter.PAIRS;
 				mode.setTitle(R.string.am_merge);
@@ -128,12 +130,26 @@ public abstract class RecyclerViewFragment<T extends Nameable> extends Fragment 
 			case NONE:
 				return false;
 		}
-
-		mode.getMenuInflater().inflate(R.menu.context_menu, menu);
-
 		adapter.showCheckBoxes = true;
 		adapter.notifyDataSetChanged();
 		return true;
+	}
+
+	private void onRename(Menu menu) {
+		menu.findItem(R.id.confirm).setVisible(false);
+		menu.findItem(R.id.overflow).setVisible(false);
+		menu.findItem(R.id.toggle_selection).setVisible(false);
+
+		if (this instanceof SpriteListFragment) {
+			((MultiViewSpriteAdapter) adapter).setBackgroundVisible(View.GONE);
+			if (((SpriteListFragment) this).isSingleVisibleSprite()) {
+				showRenameDialog(adapter.getItems().get(1));
+			}
+		} else if (adapter.getItemCount() == 1) {
+			showRenameDialog(adapter.getItems().get(0));
+		}
+
+		adapter.notifyDataSetChanged();
 	}
 
 	@Override
@@ -163,6 +179,9 @@ public abstract class RecyclerViewFragment<T extends Nameable> extends Fragment 
 		resetActionModeParameters();
 		adapter.clearSelection();
 		BottomBar.showBottomBar(getActivity());
+		if (this instanceof SpriteListFragment) {
+			((MultiViewSpriteAdapter) adapter).setBackgroundVisible(View.VISIBLE);
+		}
 	}
 
 	private void handleContextualAction() {
@@ -182,7 +201,6 @@ public abstract class RecyclerViewFragment<T extends Nameable> extends Fragment 
 				showDeleteAlert(adapter.getSelectedItems());
 				break;
 			case RENAME:
-				showRenameDialog(adapter.getSelectedItems());
 				break;
 			case MERGE:
 				showMergeDialog(adapter.getSelectedItems());
@@ -384,6 +402,13 @@ public abstract class RecyclerViewFragment<T extends Nameable> extends Fragment 
 	}
 
 	@Override
+	public void onItemClick(T item) {
+		if (actionModeType == RENAME) {
+			showRenameDialog(item);
+		}
+	}
+
+	@Override
 	public void onItemLongClick(T item, CheckableVH holder) {
 		touchHelper.startDrag(holder);
 	}
@@ -431,17 +456,23 @@ public abstract class RecyclerViewFragment<T extends Nameable> extends Fragment 
 
 	protected abstract void deleteItems(List<T> selectedItems);
 
-	protected void showRenameDialog(List<T> selectedItems) {
-		T item = selectedItems.get(0);
-
+	protected void showRenameDialog(T selectedItem) {
 		TextInputDialog.Builder builder = new TextInputDialog.Builder(getContext());
 		builder.setHint(getString(getRenameDialogHint()))
-				.setText(item.getName())
+				.setText(selectedItem.getName())
 				.setTextWatcher(new DuplicateInputTextWatcher(adapter.getItems()))
-				.setPositiveButton(getString(R.string.ok), (TextInputDialog.OnClickListener) (dialog, textInput) -> renameItem(item, textInput));
+				.setPositiveButton(getString(R.string.ok), (TextInputDialog.OnClickListener) (dialog, textInput) -> renameItem(selectedItem, textInput));
 
 		builder.setTitle(getRenameDialogTitle())
 				.setNegativeButton(R.string.cancel, null)
+				.setOnDismissListener(dialogInterface -> {
+					if (this instanceof SpriteListFragment) {
+						((MultiViewSpriteAdapter) adapter).setBackgroundVisible(View.VISIBLE);
+					}
+					if (actionMode != null) {
+						finishActionMode();
+					}
+				})
 				.show();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SceneListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SceneListFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -228,6 +228,10 @@ public class SceneListFragment extends RecyclerViewFragment<Scene> implements Pr
 
 	@Override
 	public void onItemClick(Scene item) {
+		if (actionModeType == RENAME) {
+			super.onItemClick(item);
+			return;
+		}
 		if (actionModeType == NONE) {
 			ProjectManager.getInstance().setCurrentlyEditedScene(item);
 			getFragmentManager().beginTransaction()

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SoundListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SoundListFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -172,6 +172,11 @@ public class SoundListFragment extends RecyclerViewFragment<SoundInfo> {
 
 	@Override
 	public void onItemClick(SoundInfo item) {
+		if (actionModeType == RENAME) {
+			super.onItemClick(item);
+			return;
+		}
+
 		if (actionModeType != NONE) {
 			return;
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SpriteListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SpriteListFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -287,16 +287,22 @@ public class SpriteListFragment extends RecyclerViewFragment<Sprite> {
 
 	@Override
 	public void onItemClick(Sprite item) {
+
 		if (item instanceof GroupSprite) {
 			GroupSprite groupSprite = (GroupSprite) item;
 			groupSprite.setCollapsed(!groupSprite.isCollapsed());
 			adapter.notifyDataSetChanged();
-		} else if (actionModeType == NONE) {
-			ProjectManager.getInstance().setCurrentSprite(item);
-			Intent intent = new Intent(getActivity(), SpriteActivity.class);
-			intent.putExtra(SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
-
-			startActivity(intent);
+		} else {
+			if (actionModeType == RENAME) {
+				super.onItemClick(item);
+				return;
+			}
+			if (actionModeType == NONE) {
+				ProjectManager.getInstance().setCurrentSprite(item);
+				Intent intent = new Intent(getActivity(), SpriteActivity.class);
+				intent.putExtra(SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+				startActivity(intent);
+			}
 		}
 	}
 
@@ -317,7 +323,7 @@ public class SpriteListFragment extends RecyclerViewFragment<Sprite> {
 									showDeleteAlert(new ArrayList<>(Collections.singletonList(item)));
 									break;
 								case 1:
-									showRenameDialog(new ArrayList<>(Collections.singletonList(item)));
+									showRenameDialog(item);
 									break;
 								default:
 									dialog.dismiss();
@@ -328,5 +334,9 @@ public class SpriteListFragment extends RecyclerViewFragment<Sprite> {
 		} else {
 			super.onItemLongClick(item, holder);
 		}
+	}
+
+	public boolean isSingleVisibleSprite() {
+		return adapter.getItems().size() == 2 && !(adapter.getItems().get(1) instanceof GroupSprite);
 	}
 }


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-885

- As lists or variables in the data segment of the FormulaEditor and items from the backpack cannot be renamed in the current version, those are not affected by this ticket 
- Modify existing testcases to check the new behavior and add testcases to check if the renaming of a single item works without asking for a selection
- added `sleep()` before/after opening the menu to reduce flakiness of existing tests

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
