### PR TITLE
CATROID-886 Preserve broadcast messages after copying via backpack

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/LookControllerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/LookControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -48,6 +48,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import static junit.framework.Assert.assertEquals;
 
 import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME;
+import static org.catrobat.catroid.test.utils.TestUtils.clearBackPack;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileDoesNotExist;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileDoesNotExistInDirectory;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileExists;
@@ -65,14 +66,14 @@ public class LookControllerTest {
 	@Before
 	public void setUp() throws IOException {
 		backpackListManager = BackpackListManager.getInstance();
-		clearBackPack();
+		clearBackPack(backpackListManager);
 		createProject();
 	}
 
 	@After
 	public void tearDown() throws IOException {
 		deleteProject();
-		clearBackPack();
+		clearBackPack(backpackListManager);
 	}
 
 	@Test
@@ -140,13 +141,6 @@ public class LookControllerTest {
 
 		assertFileDoesNotExist(copy.getFile());
 		assertFileExists(lookData.getFile());
-	}
-
-	private void clearBackPack() throws IOException {
-		if (backpackListManager.backpackImageDirectory.exists()) {
-			StorageOperations.deleteDir(backpackListManager.backpackImageDirectory);
-		}
-		backpackListManager.backpackImageDirectory.mkdirs();
 	}
 
 	private void createProject() throws IOException {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SceneControllerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SceneControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -56,6 +56,7 @@ import static junit.framework.Assert.assertTrue;
 
 import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME;
 import static org.catrobat.catroid.common.Constants.SOUND_DIRECTORY_NAME;
+import static org.catrobat.catroid.test.utils.TestUtils.clearBackPack;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileDoesNotExist;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileExists;
 
@@ -69,14 +70,14 @@ public class SceneControllerTest {
 	@Before
 	public void setUp() throws IOException {
 		backpackListManager = BackpackListManager.getInstance();
-		clearBackPack();
+		clearBackPack(backpackListManager);
 		createProject();
 	}
 
 	@After
 	public void tearDown() throws IOException {
 		deleteProject();
-		clearBackPack();
+		clearBackPack(backpackListManager);
 	}
 
 	@Test
@@ -221,13 +222,6 @@ public class SceneControllerTest {
 
 	private void assertSoundFileExistsInScene(String fileName, Scene scene) {
 		assertFileExists(new File(new File(scene.getDirectory(), Constants.SOUND_DIRECTORY_NAME), fileName));
-	}
-
-	private void clearBackPack() throws IOException {
-		if (backpackListManager.backpackSceneDirectory.exists()) {
-			StorageOperations.deleteDir(backpackListManager.backpackSceneDirectory);
-		}
-		backpackListManager.backpackSceneDirectory.mkdirs();
 	}
 
 	private void createProject() throws IOException {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SoundControllerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SoundControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -48,6 +48,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import static junit.framework.Assert.assertEquals;
 
 import static org.catrobat.catroid.common.Constants.SOUND_DIRECTORY_NAME;
+import static org.catrobat.catroid.test.utils.TestUtils.clearBackPack;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileDoesNotExist;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileDoesNotExistInDirectory;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileExists;
@@ -65,14 +66,14 @@ public class SoundControllerTest {
 	@Before
 	public void setUp() throws IOException {
 		backpackListManager = BackpackListManager.getInstance();
-		clearBackPack();
+		clearBackPack(backpackListManager);
 		createProject();
 	}
 
 	@After
 	public void tearDown() throws IOException {
 		deleteProject();
-		clearBackPack();
+		clearBackPack(backpackListManager);
 	}
 
 	@Test
@@ -147,13 +148,6 @@ public class SoundControllerTest {
 
 		assertFileDoesNotExist(copy.getFile());
 		assertFileExists(soundInfo.getFile());
-	}
-
-	private void clearBackPack() throws IOException {
-		if (backpackListManager.backpackSoundDirectory.exists()) {
-			StorageOperations.deleteDir(backpackListManager.backpackSoundDirectory);
-		}
-		backpackListManager.backpackSoundDirectory.mkdirs();
 	}
 
 	private void createProject() throws IOException {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SpriteControllerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SpriteControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -57,6 +57,7 @@ import static junit.framework.Assert.assertTrue;
 
 import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME;
 import static org.catrobat.catroid.common.Constants.SOUND_DIRECTORY_NAME;
+import static org.catrobat.catroid.test.utils.TestUtils.clearBackPack;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileDoesNotExist;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileDoesNotExistInDirectory;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileExists;
@@ -73,14 +74,14 @@ public class SpriteControllerTest {
 	@Before
 	public void setUp() throws IOException {
 		backpackListManager = BackpackListManager.getInstance();
-		clearBackPack();
+		clearBackPack(backpackListManager);
 		createProject();
 	}
 
 	@After
 	public void tearDown() throws IOException {
 		deleteProject();
-		clearBackPack();
+		clearBackPack(backpackListManager);
 	}
 
 	@Test
@@ -218,17 +219,6 @@ public class SpriteControllerTest {
 
 		assertFileDoesNotExist(sprite.getLookList().get(0).getFile());
 		assertFileDoesNotExist(sprite.getSoundList().get(0).getFile());
-	}
-
-	private void clearBackPack() throws IOException {
-		if (backpackListManager.backpackImageDirectory.exists()) {
-			StorageOperations.deleteDir(backpackListManager.backpackImageDirectory);
-		}
-		if (backpackListManager.backpackSoundDirectory.exists()) {
-			StorageOperations.deleteDir(backpackListManager.backpackSoundDirectory);
-		}
-		backpackListManager.backpackImageDirectory.mkdirs();
-		backpackListManager.backpackSoundDirectory.mkdirs();
 	}
 
 	private void createProject() throws IOException {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/messagecontainer/BackpackBroadcastMessageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/messagecontainer/BackpackBroadcastMessageTest.java
@@ -1,0 +1,116 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.messagecontainer;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scene;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.BroadcastBrick;
+import org.catrobat.catroid.content.bricks.BroadcastMessageBrick;
+import org.catrobat.catroid.test.utils.TestUtils;
+import org.catrobat.catroid.ui.controller.BackpackListManager;
+import org.catrobat.catroid.ui.recyclerview.controller.ScriptController;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Set;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.catrobat.catroid.test.utils.TestUtils.clearBackPack;
+
+@RunWith(AndroidJUnit4.class)
+public class BackpackBroadcastMessageTest {
+
+	private final String firstMessage = "firstMessage";
+	private final String secondMessage = "secondMessage";
+	private final String thirdMessage = "thirdMessage";
+	private Script backpackedStartScript;
+	private Scene secondScene;
+	private BackpackListManager backpackListManager;
+
+	@Before
+	public void setUp() throws Exception {
+		backpackListManager = BackpackListManager.getInstance();
+		clearBackPack(backpackListManager);
+		createProject(BackpackBroadcastMessageTest.class.getSimpleName());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		TestUtils.deleteProjects(BackpackBroadcastMessageTest.class.getSimpleName());
+		clearBackPack(backpackListManager);
+	}
+
+	@Test
+	public void testUnpackBroadcastMessagesIntoNewScene() throws CloneNotSupportedException {
+		ScriptController scriptController = new ScriptController();
+		scriptController.pack("Backpack", backpackedStartScript.getBrickList());
+		scriptController.unpack(backpackedStartScript, ProjectManager.getInstance().getCurrentSprite());
+
+		Set<String> usedMessages = secondScene.getBroadcastMessagesInUse();
+		Assert.assertTrue(usedMessages.contains(firstMessage));
+		Assert.assertTrue(usedMessages.contains(secondMessage));
+		Assert.assertTrue(usedMessages.contains(thirdMessage));
+		Assert.assertEquals(3, usedMessages.size());
+	}
+
+	private void createProject(String projectName) {
+		Project project = new Project(ApplicationProvider.getApplicationContext(), projectName);
+
+		String secondSceneName = "Scene 2";
+		secondScene = new Scene(secondSceneName, project);
+		project.addScene(secondScene);
+
+		Sprite spriteOfFirstScene = new Sprite("firstSceneSprite");
+		Sprite spriteOfSecondScene = new Sprite("secondSceneSprite");
+
+		backpackedStartScript = new StartScript();
+		BroadcastMessageBrick firstBroadcastBrick = new BroadcastBrick(firstMessage);
+		firstBroadcastBrick.setBroadcastMessage(firstMessage);
+		BroadcastMessageBrick secondBroadcastBrick = new BroadcastBrick(secondMessage);
+		secondBroadcastBrick.setBroadcastMessage(secondMessage);
+		backpackedStartScript.addBrick(firstBroadcastBrick);
+		backpackedStartScript.addBrick(secondBroadcastBrick);
+		spriteOfFirstScene.addScript(backpackedStartScript);
+		project.getDefaultScene().addSprite(spriteOfFirstScene);
+
+		Script secondStartScript = new StartScript();
+		BroadcastMessageBrick thirdBroadcastBrick = new BroadcastBrick(thirdMessage);
+		thirdBroadcastBrick.setBroadcastMessage(thirdMessage);
+		secondStartScript.addBrick(thirdBroadcastBrick);
+		spriteOfSecondScene.addScript(secondStartScript);
+		secondScene.addSprite(spriteOfSecondScene);
+
+		ProjectManager.getInstance().setCurrentProject(project);
+		ProjectManager.getInstance().setCurrentSprite(spriteOfSecondScene);
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/TestUtils.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/TestUtils.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -39,6 +39,7 @@ import org.catrobat.catroid.content.bricks.HideBrick;
 import org.catrobat.catroid.io.ResourceImporter;
 import org.catrobat.catroid.io.StorageOperations;
 import org.catrobat.catroid.io.XstreamSerializer;
+import org.catrobat.catroid.ui.controller.BackpackListManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -104,5 +105,20 @@ public final class TestUtils {
 				.createSoundFileFromResourcesInDirectory(InstrumentationRegistry.getInstrumentation().getContext().getResources(),
 						source, new File(project.getDefaultScene().getDirectory(),
 								SOUND_DIRECTORY_NAME), soundName);
+	}
+
+	public static boolean clearBackPack(BackpackListManager backpackListManager) throws IOException {
+		if (backpackListManager.backpackImageDirectory.exists()) {
+			StorageOperations.deleteDir(backpackListManager.backpackImageDirectory);
+		}
+		if (backpackListManager.backpackSoundDirectory.exists()) {
+			StorageOperations.deleteDir(backpackListManager.backpackSoundDirectory);
+		}
+		if (backpackListManager.backpackSceneDirectory.exists()) {
+			StorageOperations.deleteDir(backpackListManager.backpackSceneDirectory);
+		}
+		return backpackListManager.backpackSceneDirectory.mkdirs()
+				&& backpackListManager.backpackImageDirectory.mkdirs()
+				&& backpackListManager.backpackSoundDirectory.mkdirs();
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/ScriptController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/ScriptController.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -32,6 +32,7 @@ import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.content.bricks.BroadcastMessageBrick;
 import org.catrobat.catroid.content.bricks.PlaySoundAndWaitBrick;
 import org.catrobat.catroid.content.bricks.PlaySoundBrick;
 import org.catrobat.catroid.content.bricks.ScriptBrick;
@@ -177,6 +178,7 @@ public class ScriptController {
 
 	public void unpack(Script scriptToUnpack, Sprite dstSprite) throws CloneNotSupportedException {
 		Script script = scriptToUnpack.clone();
+		copyBroadcastMessages(script.getScriptBrick());
 
 		for (Brick brick : script.getBrickList()) {
 			if (ProjectManager.getInstance().getCurrentProject().isCastProject()
@@ -184,9 +186,18 @@ public class ScriptController {
 				Log.e(TAG, "CANNOT insert bricks into ChromeCast project");
 				return;
 			}
+			copyBroadcastMessages(brick);
 		}
 
 		dstSprite.getScriptList().add(script);
+	}
+
+	private boolean copyBroadcastMessages(Brick brick) {
+		if (brick instanceof BroadcastMessageBrick) {
+			String broadcastMessage = ((BroadcastMessageBrick) brick).getBroadcastMessage();
+			return ProjectManager.getInstance().getCurrentProject().getBroadcastMessageContainer().addBroadcastMessage(broadcastMessage);
+		}
+		return false;
 	}
 
 	void unpackForSprite(Script scriptToUnpack, Project dstProject, Scene dstScene, Sprite dstSprite)


### PR DESCRIPTION
- Add testcase for unpacking a script that contains broadcast messages into a different scene
- outsource `clearBackPack()` test method to avoid code duplication

https://jira.catrob.at/browse/CATROID-886

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
