### PR TITLE
CATROID-890 Division with decimal number crashes project

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaElement.java
@@ -44,6 +44,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -725,22 +726,22 @@ public class FormulaElement implements Serializable {
 				if (atLeastOneIsNaN) {
 					return Double.NaN;
 				}
-				return left.add(right).doubleValue();
+				return left.add(right, MathContext.DECIMAL128).doubleValue();
 			case MINUS:
 				if (atLeastOneIsNaN) {
 					return Double.NaN;
 				}
-				return left.subtract(right).doubleValue();
+				return left.subtract(right, MathContext.DECIMAL128).doubleValue();
 			case MULT:
 				if (atLeastOneIsNaN) {
 					return Double.NaN;
 				}
-				return left.multiply(right).doubleValue();
+				return left.multiply(right, MathContext.DECIMAL128).doubleValue();
 			case DIVIDE:
 				if (atLeastOneIsNaN || right.equals(BigDecimal.valueOf(0d))) {
 					return Double.NaN;
 				}
-				return left.divide(right).doubleValue();
+				return left.divide(right, MathContext.DECIMAL128).doubleValue();
 			case POW:
 				if (atLeastOneIsNaN) {
 					return Double.NaN;

--- a/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/FormulaElementTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/FormulaElementTest.java
@@ -180,5 +180,12 @@ public class FormulaElementTest {
 				new FormulaElement(ElementType.NUMBER, "5", null));
 
 		assertEquals(0.22, formulaElementDivision.interpretRecursive(null));
+
+		FormulaElement formulaElementDivisionInfiniteDecimals = new FormulaElement(ElementType.OPERATOR,
+				Operators.DIVIDE.name(), null,
+				new FormulaElement(ElementType.NUMBER, "1", null),
+				new FormulaElement(ElementType.NUMBER, "2.34", null));
+
+		assertEquals(0.42735042735042733, formulaElementDivisionInfiniteDecimals.interpretRecursive(null));
 	}
 }


### PR DESCRIPTION
This bug occured due to an exception caused by BigDecimal after the operation resulted in an
infinitely long sequence of decimals. Fixed this by adding a precision of 128.

https://jira.catrob.at/browse/CATROID-890

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
