### PR TITLE
CATROID-891 remove catblocks options when adding bricks

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/BrickCategoryFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/BrickCategoryFragment.java
@@ -145,6 +145,8 @@ public class BrickCategoryFragment extends ListFragment {
 		menu.findItem(R.id.copy).setVisible(false);
 		menu.findItem(R.id.backpack).setVisible(false);
 		menu.findItem(R.id.comment_in_out).setVisible(false);
+		menu.findItem(R.id.catblocks).setVisible(false);
+		menu.findItem(R.id.catblocks_reorder_scripts).setVisible(false);
 	}
 
 	private void setUpActionBar() {


### PR DESCRIPTION
Remove "Toggle 2D" and "Reorder scripts" options when adding bricks.
https://jira.catrob.at/browse/CATROID-891

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
