### PR TITLE
CATROID-916 Toggle 2D cause App crash if script is empty

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -699,10 +699,9 @@ public class ScriptFragment extends ListFragment implements
 		}
 
 		int scriptIndex = -1;
-
 		int firstVisible = listView.getFirstVisiblePosition();
 
-		if (firstVisible >= 0) {
+		if (listView.getCount() > 0 && firstVisible >= 0) {
 			Object firstBrick = listView.getItemAtPosition(firstVisible);
 			if (firstBrick instanceof Brick) {
 				Script scriptOfBrick = ((Brick) firstBrick).getScript();


### PR DESCRIPTION
When there were not scripts in the script list the app crashed. this should be fixed now.
https://jira.catrob.at/browse/CATROID-916

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
