### PR TITLE
CATROID-924 app crashes on pressing the undo button after you switch tabs

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -237,7 +237,7 @@ public class SpriteActivity extends BaseActivity {
 			setUndoMenuItemVisibility(false);
 			showUndoMenuItem(isUndoMenuItemVisible);
 			Fragment fragment = getCurrentFragment();
-			if (fragment instanceof LookListFragment && !((LookListFragment) fragment).undo()) {
+			if (fragment instanceof LookListFragment && !((LookListFragment) fragment).undo() && currentLookData != null) {
 				((LookListFragment) fragment).deleteItem(currentLookData);
 				currentLookData.dispose();
 				currentLookData = null;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.java
@@ -159,6 +159,11 @@ public class LookListFragment extends RecyclerViewFragment<LookData> {
 	public void onDestroy() {
 		super.onDestroy();
 		disposeItem();
+		Activity activity = getActivity();
+		if (activity instanceof SpriteActivity) {
+			((SpriteActivity) activity).setUndoMenuItemVisibility(false);
+			((SpriteActivity) activity).showUndoMenuItem(false);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
fixes: https://jira.catrob.at/browse/CATROID-924

The app crashes on pressing the undo button when you switch back to the looks tab (from the scripts or sounds tab) after editing a look! The app should either perform the undo operation or hide the undo button!

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
