### PR TITLE
CATROID-925 Fix flaky tests

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ChangeVariableTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ChangeVariableTest.java
@@ -27,7 +27,6 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.bricks.ChangeVariableBrick;
 import org.catrobat.catroid.ui.SpriteActivity;
-import org.catrobat.catroid.uiespresso.content.brick.utils.BrickCoordinatesProvider;
 import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
 import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
 import org.junit.Before;
@@ -121,7 +120,6 @@ public class ChangeVariableTest {
 
 		performNewVariableFromFormulaEditor(1, userVariableName2);
 
-		onBrickAtPosition(1).performDragNDrop(BrickCoordinatesProvider.DOWN_ONE_POSITION);
 		onBrickAtPosition(1).onVariableSpinner(R.id.change_variable_spinner)
 				.checkShowsVariableNamesInAdapter(Arrays.asList(userVariableName, userVariableName2));
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/DeleteLookBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/DeleteLookBrickTest.java
@@ -79,21 +79,18 @@ public class DeleteLookBrickTest {
 		ProjectManager.getInstance().setCurrentSprite(sprite);
 		ProjectManager.getInstance().setCurrentlyEditedScene(project.getDefaultScene());
 
+		Intents.init();
 		baseActivityTestRule.launchActivity();
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void testPaintLookWithoutDelete() {
-		Intents.init();
-
 		onView(withId(R.id.button_play)).perform(click());
 		onView(withId(R.id.pocketpaint_drawing_surface_view)).perform(click());
 		pressBack();
 
 		assertEquals(1, sprite.getLookList().size());
-
-		Intents.release();
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
@@ -101,19 +98,16 @@ public class DeleteLookBrickTest {
 	public void testPaintAndDeleteLook() {
 		script.addBrick(new DeleteLookBrick());
 
-		Intents.init();
-
 		onView(withId(R.id.button_play)).perform(click());
 		onView(withId(R.id.pocketpaint_drawing_surface_view)).perform(click());
 		pressBack();
 
 		assertEquals(0, sprite.getLookList().size());
-
-		Intents.release();
 	}
 
 	@After
 	public void tearDown() throws IOException {
+		Intents.release();
 		baseActivityTestRule.finishActivity();
 		TestUtils.deleteProjects(projectName);
 	}


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-925
ChangeVariableTest works without DragNDrop, which is not needed for the test
DeleteLookBrickTests made other test fail if it fails itself, because then Intent.release would not be called and every other test using Intent.init would get an exception.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
