### PR TITLE
CATROID-827 Help links to wiki in formula editor

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentHelpUrlTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentHelpUrlTest.java
@@ -1,0 +1,167 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.formulaeditor;
+
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.SetVariableBrick;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.testsuites.annotations.Cat;
+import org.catrobat.catroid.testsuites.annotations.Level;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.ui.recyclerview.fragment.CategoryListFragment;
+import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper;
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.catrobat.catroid.CatroidApplication.defaultSystemLanguage;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.DEVICE_LANGUAGE;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.LANGUAGE_TAGS;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.LANGUAGE_TAG_KEY;
+import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+import static org.junit.Assert.assertEquals;
+
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+@Category({Cat.AppUi.class, Level.Smoke.class})
+@RunWith(AndroidJUnit4.class)
+public class FormulaEditorFragmentHelpUrlTest {
+
+	@Rule
+	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
+			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+
+	static String language = getLanguage();
+	static String functionsHelpUrl = "https://wiki.catrobat"
+			+ ".org/bin/view/Documentation/FormulaEditor/Functions/" + language;
+	static String logicHelpUrl = "https://wiki.catrobat.org/bin/view/Documentation/FormulaEditor"
+			+ "/Logic/" + language;
+	static String sensorsHelpUrl = "https://wiki.catrobat"
+			+ ".org/bin/view/Documentation/FormulaEditor/Sensors/" + language;
+	static String objectHelpUrl = "https://wiki.catrobat.org/bin/view/Documentation/FormulaEditor"
+			+ "/Properties/" + language;
+
+	@Before
+	public void setUp() throws Exception {
+		createProject("FormulaEditorFragmentHelpUrlTest");
+		baseActivityTestRule.launchActivity();
+	}
+
+	@Test
+	public void testFunctionsHelpUrl() {
+		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
+				.perform(click());
+		String helpUrl = onFormulaEditor()
+				.performOpenCategory(FormulaEditorWrapper.Category.FUNCTIONS)
+				.getHelpUrl(CategoryListFragment.FUNCTION_TAG, baseActivityTestRule.getActivity());
+		assertEquals(functionsHelpUrl, helpUrl);
+	}
+
+	@Test
+	public void testLogicHelpUrl() {
+		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
+				.perform(click());
+		String helpUrl = onFormulaEditor()
+				.performOpenCategory(FormulaEditorWrapper.Category.LOGIC)
+				.getHelpUrl(CategoryListFragment.LOGIC_TAG, baseActivityTestRule.getActivity());
+		assertEquals(logicHelpUrl, helpUrl);
+	}
+
+	@Test
+	public void testSensorsHelpUrl() {
+		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
+				.perform(click());
+		String helpUrl = onFormulaEditor()
+				.performOpenCategory(FormulaEditorWrapper.Category.DEVICE)
+				.getHelpUrl(CategoryListFragment.SENSOR_TAG, baseActivityTestRule.getActivity());
+		assertEquals(sensorsHelpUrl, helpUrl);
+	}
+
+	@Test
+	public void testObjectHelpUrl() {
+		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
+				.perform(click());
+		String helpUrl = onFormulaEditor()
+				.performOpenCategory(FormulaEditorWrapper.Category.OBJECT)
+				.getHelpUrl(CategoryListFragment.OBJECT_TAG, baseActivityTestRule.getActivity());
+		assertEquals(objectHelpUrl, helpUrl);
+	}
+
+	public Project createProject(String projectName) {
+		Project project = new Project(ApplicationProvider.getApplicationContext(), projectName);
+		Sprite sprite = new Sprite("testSprite");
+		Script script = new StartScript();
+
+		SetVariableBrick setVariableBrick = new SetVariableBrick(new Formula(1), new UserVariable("var"));
+		UserVariable userVariable = new UserVariable("Global1");
+		project.addUserVariable(userVariable);
+		setVariableBrick.setUserVariable(userVariable);
+
+		script.addBrick(setVariableBrick);
+		sprite.addScript(script);
+		project.getDefaultScene().addSprite(sprite);
+
+		ProjectManager.getInstance().setCurrentProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+
+		return project;
+	}
+
+	public static String getLanguage() {
+		String language = "?language=";
+		SharedPreferences sharedPreferences = PreferenceManager
+				.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext());
+		String languageTag = sharedPreferences.getString(LANGUAGE_TAG_KEY, "");
+		Locale locale;
+
+		if (languageTag.equals(DEVICE_LANGUAGE)) {
+			locale = Locale.forLanguageTag(defaultSystemLanguage);
+		} else {
+			locale = Arrays.asList(LANGUAGE_TAGS).contains(languageTag)
+					? Locale.forLanguageTag(languageTag)
+					: Locale.forLanguageTag(defaultSystemLanguage);
+		}
+		return language + locale.getLanguage();
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/FormulaEditorCategoryListWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/FormulaEditorCategoryListWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -23,6 +23,8 @@
 
 package org.catrobat.catroid.uiespresso.formulaeditor.utils;
 
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.ui.recyclerview.fragment.CategoryListFragment;
 import org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper;
 import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.matchers.FormulaEditorCategoryListMatchers;
@@ -50,5 +52,10 @@ public final class FormulaEditorCategoryListWrapper extends RecyclerViewInteract
 	public void performSelect(int stringResourceId) {
 		UiTestUtils.getResourcesString(stringResourceId);
 		performSelect(UiTestUtils.getResourcesString(stringResourceId));
+	}
+
+	public String getHelpUrl(String tag, SpriteActivity activity) {
+		CategoryListFragment fragment = new CategoryListFragment();
+		return fragment.getHelpUrl(tag, activity);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -122,11 +122,16 @@ public final class Constants {
 	public static final String SHARE_PROJECT_URL = BASE_URL_HTTPS + "/project/";
 
 	public static final String CATROBAT_ABOUT_URL = "https://www.catrobat.org/";
+	public static final String CATROBAT_FORMULA_WIKI_URL = "https://wiki.catrobat.org/bin/view/Documentation/FormulaEditor";
 	public static final String ABOUT_POCKETCODE_LICENSE_URL = "https://catrob.at/licenses";
 	public static final String WEB_REQUEST_WIKI_URL = "https://catrob.at/webbricks";
 
 	public static final String CATROBAT_TERMS_OF_USE_URL = BASE_URL_HTTPS + "termsOfUse";
 	public static final String CATROBAT_HELP_URL = "https://catrob.at/help";
+	public static final String CATROBAT_FUNCTIONS_WIKI_URL = CATROBAT_FORMULA_WIKI_URL + "/Functions/";
+	public static final String CATROBAT_LOGIC_WIKI_URL = CATROBAT_FORMULA_WIKI_URL + "/Logic/";
+	public static final String CATROBAT_SENSORS_WIKI_URL = CATROBAT_FORMULA_WIKI_URL + "/Sensors/";
+	public static final String CATROBAT_OBJECT_WIKI_URL = CATROBAT_FORMULA_WIKI_URL + "/Properties/";
 	public static final String CATROBAT_TOKEN_LOGIN_URL = BASE_URL_HTTPS + "tokenlogin?username=";
 	public static final String CATROBAT_DELETE_ACCOUNT_URL = BASE_URL_HTTPS + "profile/edit";
 	public static final String CATROBAT_TERMS_OF_USE_TOKEN_FLAVOR_URL = "?flavorName=";

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -755,6 +755,7 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 				getActivity().getString(actionbarResId));
 		bundle.putString(CategoryListFragment.FRAGMENT_TAG_BUNDLE_ARGUMENT, tag);
 		fragment.setArguments(bundle);
+		fragment.onPrepareOptionsMenu(currentMenu);
 
 		getFragmentManager().beginTransaction()
 				.hide(getFragmentManager().findFragmentByTag(FORMULA_EDITOR_FRAGMENT_TAG))

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -23,11 +23,18 @@
 
 package org.catrobat.catroid.ui.recyclerview.fragment;
 
+import android.app.Activity;
+import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.res.TypedArray;
+import android.net.Uri;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -42,6 +49,7 @@ import org.catrobat.catroid.devices.mindstorms.ev3.sensors.EV3Sensor;
 import org.catrobat.catroid.devices.mindstorms.nxt.sensors.NXTSensor;
 import org.catrobat.catroid.formulaeditor.SensorHandler;
 import org.catrobat.catroid.formulaeditor.UserList;
+import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.ui.dialogs.LegoSensorPortConfigDialog;
 import org.catrobat.catroid.ui.dialogs.regexassistant.RegularExpressionAssistantDialog;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -54,8 +62,10 @@ import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
 import org.catrobat.catroid.utils.AddUserListDialog;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -65,6 +75,11 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.RecyclerView;
+
+import static org.catrobat.catroid.CatroidApplication.defaultSystemLanguage;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.DEVICE_LANGUAGE;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.LANGUAGE_TAGS;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.LANGUAGE_TAG_KEY;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -281,6 +296,8 @@ public class CategoryListFragment extends Fragment implements CategoryListRVAdap
 		if (appCompatActivity == null) {
 			return;
 		}
+		appCompatActivity.getMenuInflater().inflate(R.menu.menu_formulareditor_category, menu);
+
 		ActionBar supportActionBar = appCompatActivity.getSupportActionBar();
 		if (supportActionBar != null) {
 			supportActionBar.setDisplayHomeAsUpEnabled(true);
@@ -310,6 +327,71 @@ public class CategoryListFragment extends Fragment implements CategoryListRVAdap
 				}
 				break;
 		}
+	}
+
+	@Override
+	public boolean onOptionsItemSelected(MenuItem item) {
+		if (item.getItemId() == R.id.wiki_help) {
+			onOptionsMenuClick(getTag());
+		}
+		return true;
+	}
+
+	public void onOptionsMenuClick(String tag) {
+		String language = getLanguage(getActivity());
+		switch (tag) {
+			case FUNCTION_TAG:
+				startActivity(new Intent(Intent.ACTION_VIEW,
+						Uri.parse(Constants.CATROBAT_FUNCTIONS_WIKI_URL + language)));
+				break;
+			case LOGIC_TAG:
+				startActivity(new Intent(Intent.ACTION_VIEW,
+						Uri.parse(Constants.CATROBAT_LOGIC_WIKI_URL + language)));
+				break;
+			case OBJECT_TAG:
+				startActivity(new Intent(Intent.ACTION_VIEW,
+						Uri.parse(Constants.CATROBAT_OBJECT_WIKI_URL + language)));
+				break;
+			case SENSOR_TAG:
+				startActivity(new Intent(Intent.ACTION_VIEW,
+						Uri.parse(Constants.CATROBAT_SENSORS_WIKI_URL + language)));
+				break;
+		}
+	}
+
+	public String getHelpUrl(String tag, SpriteActivity activity) {
+		String language = getLanguage(activity);
+		switch (tag) {
+			case FUNCTION_TAG:
+				return Constants.CATROBAT_FUNCTIONS_WIKI_URL + language;
+			case LOGIC_TAG:
+				return Constants.CATROBAT_LOGIC_WIKI_URL + language;
+			case OBJECT_TAG:
+				return Constants.CATROBAT_OBJECT_WIKI_URL + language;
+			case SENSOR_TAG:
+				return Constants.CATROBAT_SENSORS_WIKI_URL + language;
+		}
+		return null;
+	}
+
+	private static SharedPreferences getSharedPreferences(Context context) {
+		return PreferenceManager.getDefaultSharedPreferences(context);
+	}
+
+	public String getLanguage(Activity activity) {
+		String language = "?language=";
+		SharedPreferences sharedPreferences = getSharedPreferences(activity.getApplicationContext());
+		String languageTag = sharedPreferences.getString(LANGUAGE_TAG_KEY, "");
+		Locale mLocale;
+		if (languageTag.equals(DEVICE_LANGUAGE)) {
+			mLocale = Locale.forLanguageTag(defaultSystemLanguage);
+		} else {
+			mLocale = Arrays.asList(LANGUAGE_TAGS).contains(languageTag)
+					? Locale.forLanguageTag(languageTag)
+					: Locale.forLanguageTag(defaultSystemLanguage);
+		}
+		language = language + mLocale.getLanguage();
+		return language;
 	}
 
 	private FormulaEditorFragment addResourceToActiveFormulaInFormulaEditor(CategoryListItem categoryListItem) {

--- a/catroid/src/main/res/drawable/ic_formula_editor_help.xml
+++ b/catroid/src/main/res/drawable/ic_formula_editor_help.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2021 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/toolbar_icons"
+        android:pathData="M11,18h2v-2h-2v2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM12,6c-2.21,0 -4,1.79 -4,4h2c0,-1.1 0.9,-2 2,-2s2,0.9 2,2c0,2 -3,1.75 -3,5h2c0,-2.25 3,-2.5 3,-5 0,-2.21 -1.79,-4 -4,-4z"/>
+</vector>

--- a/catroid/src/main/res/menu/menu_formulareditor_category.xml
+++ b/catroid/src/main/res/menu/menu_formulareditor_category.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2021 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:title="@string/main_menu_help"
+        android:id="@+id/wiki_help"
+        android:icon="@drawable/ic_formula_editor_help"
+        app:showAsAction="always" />
+</menu>


### PR DESCRIPTION
[CATROID-827](https://jira.catrob.at/browse/CATROID-827)
Added a button on the top bar of the Functions/Sensors/Logic/Properties submenus in the formula editor which opens the browser with the wiki page corresponding to the current submenu.


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
