### PR TITLE
CATROID-933 Naming Convention Problem

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameLookTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameLookTest.java
@@ -183,7 +183,7 @@ public class RenameLookTest {
 
 		onActionMode().performConfirm();
 
-		onView(withText(R.string.yes)).perform(click());
+		onView(withText(R.string.delete)).perform(click());
 
 		openActionBar();
 		onView(withText(R.string.rename)).perform(click());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameProjectTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameProjectTest.java
@@ -180,7 +180,7 @@ public class RenameProjectTest {
 
 		onActionMode().performConfirm();
 
-		onView(withText(R.string.yes)).perform(click());
+		onView(withText(R.string.delete)).perform(click());
 
 		openActionBar();
 		onView(withText(R.string.rename)).perform(click());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSoundTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSoundTest.java
@@ -186,7 +186,7 @@ public class RenameSoundTest {
 
 		onActionMode().performConfirm();
 
-		onView(withText(R.string.yes)).perform(click());
+		onView(withText(R.string.delete)).perform(click());
 
 		openActionBar();
 		onView(withText(R.string.rename)).perform(click());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSpriteTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSpriteTest.java
@@ -179,7 +179,7 @@ public class RenameSpriteTest {
 
 		onActionMode().performConfirm();
 
-		onView(withText(R.string.yes)).perform(click());
+		onView(withText(R.string.delete)).perform(click());
 
 		openActionBar();
 		onView(withText(R.string.rename)).perform(click());


### PR DESCRIPTION
[CATROID-933](https://jira.catrob.at/browse/CATROID-933) Fixed simple naming problem in a few renaming tests. The delete confirmation dialog was being affirmed with the wrong string resource (`R.string.ok` instead of `R.string.delete`) 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
