### PR TITLE
CATROID-875 Rendering bug with "Go to touch position"

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/GoToTouchPositionAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/GoToTouchPositionAction.java
@@ -35,8 +35,9 @@ public class GoToTouchPositionAction extends TemporalAction {
 	@Override
 	protected void update(float percent) {
 		int touchIndex = TouchUtil.getLastTouchIndex();
-		sprite.look.setXInUserInterfaceDimensionUnit(TouchUtil.getX(touchIndex));
-		sprite.look.setYInUserInterfaceDimensionUnit(TouchUtil.getY(touchIndex));
+		float x = TouchUtil.getX(touchIndex);
+		float y = TouchUtil.getY(touchIndex);
+		sprite.look.setPositionInUserInterfaceDimensionUnit(x, y);
 	}
 
 	public void setSprite(Sprite sprite) {


### PR DESCRIPTION
Actual Behaviour: On touch, the sprite first used to go to the x PointF, update the screen, then proceed to the y PointF.

Expected: Sprite should update to the required Point in one go


- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
