### PR TITLE
CATROID 958 Textblock detection x and y sensors return the wrong value

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/utils/TextBlockUtil.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/TextBlockUtil.java
@@ -102,10 +102,10 @@ public final class TextBlockUtil {
 				float aspectRatio = (float) imageWidth / imageHeight;
 
 				if (ProjectManager.getInstance().isCurrentProjectLandscapeMode()) {
-					float relativeY = textBlockBounds.exactCenterX() / imageWidth;
+					float relativeY = -1 * textBlockBounds.exactCenterX() / imageWidth;
 					relativeY = invertAxis ? relativeY : 1 - relativeY;
 					return coordinatesFromRelativePosition(
-							1 - textBlockBounds.exactCenterY() / imageHeight,
+							textBlockBounds.exactCenterY() / imageHeight,
 							SCREEN_WIDTH / aspectRatio,
 							relativeY,
 							(float) SCREEN_WIDTH


### PR DESCRIPTION
Changed the value of the sensor variable X to Y and Y to -X.

https://jira.catrob.at/browse/CATROID-958

Signed-off-by: ritiksp2411 <ritik.rjt@gmail.com>

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
