### PR TITLE
CATROID-602: "Add sound" menu icons off center

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -62,6 +62,15 @@
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value />
       </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/catroid/src/main/java/org/catrobat/catroid/ui/CustomScrollAwareBehavior.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/CustomScrollAwareBehavior.java
@@ -1,0 +1,75 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.ui;
+
+import android.content.Context;
+import android.os.Handler;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.view.ViewCompat;
+
+public class CustomScrollAwareBehavior extends FloatingActionButton.Behavior{
+
+	private Handler handler = new Handler();
+	private FloatingActionButton fab;
+
+	public CustomScrollAwareBehavior(Context context, AttributeSet attrs) {
+		super();
+	}
+
+	@Override
+	public boolean onStartNestedScroll(CoordinatorLayout coordinatorLayout,
+			FloatingActionButton child, View directTargetChild, View target, int nestedScrollAxes) {
+		fab = child;
+		return nestedScrollAxes == ViewCompat.SCROLL_AXIS_VERTICAL ||
+				super.onStartNestedScroll(coordinatorLayout, child, directTargetChild, target,
+						nestedScrollAxes);
+	}
+
+
+
+	Runnable showRunnable = new Runnable() {
+		@Override
+		public void run() {
+			fab.show();
+		}
+	};
+
+
+	@Override
+	public void onNestedScroll(CoordinatorLayout coordinatorLayout, FloatingActionButton child,
+			View target, int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed) {
+		super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed,
+				dyUnconsumed);
+		if (dyConsumed > 0 && child.getVisibility() == View.VISIBLE) {
+			handler.removeCallbacks(showRunnable);
+			handler.postDelayed(showRunnable,2000);
+			child.hide();
+		}
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -26,6 +26,7 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.ActionMode;
@@ -77,6 +78,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 
@@ -180,6 +182,9 @@ public class SpriteActivity extends BaseActivity {
 		}
 		loadFragment(this, fragmentPosition);
 		addTabLayout(this, fragmentPosition);
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+			removeFloatingButtonWhenScrolling();
+		}
 	}
 
 	private String createActionBarTitle() {
@@ -827,7 +832,7 @@ public class SpriteActivity extends BaseActivity {
 				if (currentName.equals(generatedVariableName)) {
 					generatedVariableName =
 							uniqueVariableNameProvider.getUniqueName(getString(R.string.default_variable_name),
-							null);
+									null);
 					textInputEditText.setText(generatedVariableName);
 				}
 			}
@@ -910,5 +915,18 @@ public class SpriteActivity extends BaseActivity {
 
 	public void setCurrentSprite(Sprite sprite) {
 		currentSprite = sprite;
+	}
+
+	@RequiresApi(api = Build.VERSION_CODES.M)
+	private void removeFloatingButtonWhenScrolling() {
+		findViewById(R.id.activity_sprite_sv).setOnScrollChangeListener(new View.OnScrollChangeListener() {
+			@Override
+			public void onScrollChange(View v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
+				Log.e(TAG,
+						"onScrollChange: " + scrollX + scrollY +" old "+ oldScrollX + oldScrollY);
+				findViewById(R.id.bottom_bar).setVisibility(scrollX < oldScrollX ?
+						View.VISIBLE : View.GONE);
+			}
+		});
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dragndrop/BrickListView.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dragndrop/BrickListView.java
@@ -43,6 +43,7 @@ import java.util.List;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import androidx.recyclerview.widget.RecyclerView;
 
 import static android.animation.ValueAnimator.REVERSE;
 import static android.view.MotionEvent.ACTION_CANCEL;
@@ -53,7 +54,7 @@ import static android.view.MotionEvent.ACTION_POINTER_INDEX_SHIFT;
 import static android.view.MotionEvent.ACTION_POINTER_UP;
 import static android.view.MotionEvent.ACTION_UP;
 
-public class BrickListView extends ListView {
+public class BrickListView extends RecyclerView {
 
 	private static final int SMOOTH_SCROLL_BY = 15;
 	private static final int ANIMATION_DURATION = 250;
@@ -122,6 +123,7 @@ public class BrickListView extends ListView {
 		brickPositionsToHighlight.addAll(positions);
 		invalidate();
 	}
+
 
 	public void startMoving(Brick brickToMove) {
 		cancelMove();
@@ -334,7 +336,7 @@ public class BrickListView extends ListView {
 	}
 
 	@Override
-	public void setAdapter(ListAdapter adapter) {
+	public void setAdapter(Adapter adapter) {
 		if (!(adapter instanceof BrickAdapterInterface)) {
 			throw new IllegalArgumentException("Adapter has to implement the BrickListView.AdapterInterface.");
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -22,9 +22,12 @@
  */
 package org.catrobat.catroid.ui.recyclerview.fragment;
 
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.Parcelable;
 import android.util.Log;
 import android.view.ActionMode;
@@ -34,6 +37,9 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AbsListView;
+import android.widget.ListView;
+import android.widget.RelativeLayout;
 
 import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.ProjectManager;
@@ -81,6 +87,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import androidx.annotation.IntDef;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -121,6 +128,7 @@ public class ScriptFragment extends ListFragment implements
 	private BrickListView listView;
 	private String currentSceneName;
 	private String currentSpriteName;
+	private RelativeLayout fab;
 	private int undoBrickPosition;
 
 	private ScriptController scriptController = new ScriptController();
@@ -229,14 +237,18 @@ public class ScriptFragment extends ListFragment implements
 		adapter.setCheckBoxMode(BrickAdapter.NONE);
 	}
 
+	@RequiresApi(api = Build.VERSION_CODES.M)
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		View view = View.inflate(getActivity(), R.layout.fragment_script, null);
 		listView = view.findViewById(android.R.id.list);
+		hideFab();
 		setHasOptionsMenu(true);
 		SnackbarUtil.showHintSnackbar(getActivity(), R.string.hint_scripts);
 		return view;
 	}
+
+
 
 	@Override
 	public void onActivityCreated(Bundle savedInstanceState) {
@@ -861,5 +873,34 @@ public class ScriptFragment extends ListFragment implements
 		}
 		scriptToFocus = null;
 		brickToFocus = null;
+	}
+
+	Runnable showRunnable = new Runnable() {
+		@Override
+		public void run() {
+			fab.setVisibility(View.VISIBLE);
+		}
+	};
+
+	private void hideFab() {
+		LayoutInflater inflater2 =
+				(LayoutInflater) getActivity().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+
+		View vi = inflater2.inflate(R.layout.activity_sprite,
+				(ViewGroup) getActivity().findViewById(R.id.activity_sprite));
+		fab = vi.findViewById(R.id.bottom_bar);
+		Handler handler = new Handler();
+		listView.setOnScrollListener(new BrickListView.OnScrollListener() {
+			@Override
+			public void onScrollStateChanged(AbsListView view, int scrollState) { }
+			@Override
+			public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
+				if(firstVisibleItem + visibleItemCount == totalItemCount && fab.getVisibility() == View.VISIBLE){
+					handler.removeCallbacks(showRunnable);
+					handler.postDelayed(showRunnable,2000);
+					fab.setVisibility(View.GONE);
+				}
+			}
+		});
 	}
 }

--- a/catroid/src/main/res/layout/activity_sprite.xml
+++ b/catroid/src/main/res/layout/activity_sprite.xml
@@ -22,27 +22,34 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:animateLayoutChanges="true"
     android:id="@+id/activity_sprite">
 
     <include layout="@layout/toolbar" />
 
-    <RelativeLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/activity_sprite_sv"
+            android:layout_width="match_parent"
+            android:fillViewport="true"
+            android:layout_height="match_parent">
 
         <FrameLayout
             android:id="@+id/fragment_container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="wrap_content" />
+        </androidx.core.widget.NestedScrollView>
 
         <include
             android:id="@+id/bottom_bar"
             layout="@layout/list_action_buttons" />
-    </RelativeLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </LinearLayout>

--- a/catroid/src/main/res/layout/activity_sprite.xml
+++ b/catroid/src/main/res/layout/activity_sprite.xml
@@ -27,6 +27,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:animateLayoutChanges="true"
     android:id="@+id/activity_sprite">
 
     <include layout="@layout/toolbar" />

--- a/catroid/src/main/res/layout/dialog_new_sound.xml
+++ b/catroid/src/main/res/layout/dialog_new_sound.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Catroid: An on-device visual programming system for Android devices
   ~ Copyright (C) 2010-2018 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
@@ -24,22 +23,24 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="@dimen/dialog_content_area_padding_top"
-    android:paddingStart="@dimen/dialog_content_area_padding"
+    android:paddingBottom="@dimen/dialog_content_area_padding_top"
     android:paddingEnd="@dimen/dialog_content_area_padding"
-    android:paddingBottom="@dimen/dialog_content_area_padding_top">
+    android:paddingStart="@dimen/dialog_content_area_padding"
+    android:paddingTop="@dimen/dialog_content_area_padding_top">
 
     <TableLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:stretchColumns="*">
+        android:measureWithLargestChild="true">
 
         <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_weight="1">
 
             <TextView
                 android:id="@+id/dialog_new_sound_recorder"
+                android:layout_weight="1"
                 android:background="@drawable/new_object_dialog_selector"
                 android:drawableTop="@drawable/pc_toolbar_icon"
                 android:gravity="center"
@@ -48,6 +49,7 @@
 
             <TextView
                 android:id="@+id/dialog_new_sound_media_library"
+                android:layout_weight="1"
                 android:background="@drawable/new_object_dialog_selector"
                 android:drawableTop="@drawable/ic_media_library"
                 android:gravity="center"
@@ -56,11 +58,14 @@
         </TableRow>
 
         <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:measureWithLargestChild="true">
 
             <TextView
                 android:id="@+id/dialog_new_sound_gallery"
+                android:layout_weight="1"
                 android:background="@drawable/new_object_dialog_selector"
                 android:drawableTop="@drawable/ic_gallery"
                 android:gravity="center"
@@ -69,6 +74,7 @@
 
             <TextView
                 android:id="@+id/dialog_new_sound_pocketmusic"
+                android:layout_weight="1"
                 android:background="@drawable/new_object_dialog_selector"
                 android:drawableTop="@drawable/ic_pocketmusic"
                 android:gravity="center"


### PR DESCRIPTION
*Please enter a short description of your pull request and add a reference to the Jira ticket.*
this will fix the issue that is caused while opening the app new sound for a single item
CATROID-602
https://jira.catrob.at/browse/CATROID-602

changes were only in xml file i.e. in dialog_new_sound
I made some textview wrap_content and added weights to them and also android:measureWithLargestChild="true" to layout

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
