### PR TITLE
CATROID-958 Textblock detection x and y sensors return the wrong value

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/utils/TextBlockUtil.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/TextBlockUtil.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -102,13 +102,13 @@ public final class TextBlockUtil {
 				float aspectRatio = (float) imageWidth / imageHeight;
 
 				if (ProjectManager.getInstance().isCurrentProjectLandscapeMode()) {
-					float relativeY = textBlockBounds.exactCenterX() / imageWidth;
-					relativeY = invertAxis ? relativeY : 1 - relativeY;
+					float relativeX = textBlockBounds.exactCenterX() / imageWidth;
+					relativeX = invertAxis ? 1 - relativeX : relativeX;
 					return coordinatesFromRelativePosition(
+							relativeX,
+							SCREEN_WIDTH,
 							1 - textBlockBounds.exactCenterY() / imageHeight,
-							SCREEN_WIDTH / aspectRatio,
-							relativeY,
-							(float) SCREEN_WIDTH
+							(float) SCREEN_WIDTH / aspectRatio
 					);
 				} else {
 					float relativeX = textBlockBounds.exactCenterX() / imageHeight;


### PR DESCRIPTION
Changed the value of the sensor variable X to Y and Y to -X.

https://jira.catrob.at/browse/CATROID-958

I tested the work on the Honor 9i android device.
 
Signed-off-by: ritiksp2411 <ritik.rjt@gmail.com>

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
