### PR TITLE
CATROID-976 Build flag for user defined reporter functions

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -163,6 +163,7 @@ android {
         buildConfigField "boolean", "FEATURE_RASPI_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_SCRATCH_CONVERTER_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_WEBREQUEST_BRICK_ENABLED", "true"
+        buildConfigField "boolean", "FEATURE_USER_REPORTERS_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_MULTIPLAYER_VARIABLES_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_TESTBRICK_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_CATBLOCKS_ENABLED", "false"
@@ -253,6 +254,7 @@ android {
             buildConfigField "boolean", "FEATURE_MERGE_ENABLED", "false"
             buildConfigField "boolean", "FEATURE_POCKETMUSIC_ENABLED", "false"
             buildConfigField "boolean", "FEATURE_MULTIPLAYER_VARIABLES_ENABLED", "false"
+            buildConfigField "boolean", "FEATURE_USER_REPORTERS_ENABLED", "false"
             resValue "string", "SNACKBAR_HINTS_ENABLED", "true"
             signingConfig signingConfigs.debug
         }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/CategoryBricksFactory.java
@@ -415,7 +415,9 @@ public class CategoryBricksFactory {
 			userDefinedBricks = currentSprite.getUserDefinedBrickList();
 		}
 		userDefinedBricks = new ArrayList<>(userDefinedBricks);
-		userDefinedBricks.add(new ReportBrick());
+		if (BuildConfig.FEATURE_USER_REPORTERS_ENABLED) {
+			userDefinedBricks.add(new ReportBrick());
+		}
 		return userDefinedBricks;
 	}
 


### PR DESCRIPTION
Temporary build flag FEATURE_USER_REPORTERS_ENABLED to hide user defined reporter functions in release APKs.

https://jira.catrob.at/browse/CATROID-976

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
