### PR TITLE
CATROID-977 Fix crash with old "Set background to number __" brick (and its "and wait" variant)

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -41,6 +41,8 @@ import org.catrobat.catroid.content.backwardcompatibility.BrickTreeBuilder;
 import org.catrobat.catroid.content.bricks.ArduinoSendPWMValueBrick;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
+import org.catrobat.catroid.content.bricks.SetBackgroundByIndexAndWaitBrick;
+import org.catrobat.catroid.content.bricks.SetBackgroundByIndexBrick;
 import org.catrobat.catroid.content.bricks.SetPenColorBrick;
 import org.catrobat.catroid.exceptions.CompatibilityProjectException;
 import org.catrobat.catroid.exceptions.LoadingProjectException;
@@ -151,6 +153,9 @@ public final class ProjectManager {
 		}
 		if (project.getCatrobatLanguageVersion() <= 0.99992) {
 			removePermissionsFile(project);
+		}
+		if (project.getCatrobatLanguageVersion() <= 0.9999995) {
+			updateBackgroundIndexTo9999995(project);
 		}
 		project.setCatrobatLanguageVersion(CURRENT_CATROBAT_LANGUAGE_VERSION);
 
@@ -373,6 +378,27 @@ public final class ProjectManager {
 							spriteToCollideWith = spriteNames[1];
 						}
 						bounceOffScript.setSpriteToBounceOffName(spriteToCollideWith);
+					}
+				}
+			}
+		}
+	}
+
+	@VisibleForTesting
+	public static void updateBackgroundIndexTo9999995(Project project) {
+		for (Scene scene : project.getSceneList()) {
+			for (Sprite sprite : scene.getSpriteList()) {
+				for (Script script : sprite.getScriptList()) {
+					for (Brick brick : script.getBrickList()) {
+						if (brick instanceof SetBackgroundByIndexBrick) {
+							FormulaBrick formulaBrick = (FormulaBrick) brick;
+							formulaBrick.replaceFormulaBrickField(Brick.BrickField.LOOK_INDEX,
+									Brick.BrickField.BACKGROUND_INDEX);
+						} else if (brick instanceof SetBackgroundByIndexAndWaitBrick) {
+							FormulaBrick formulaBrick = (FormulaBrick) brick;
+							formulaBrick.replaceFormulaBrickField(Brick.BrickField.LOOK_INDEX,
+									Brick.BrickField.BACKGROUND_WAIT_INDEX);
+						}
 					}
 				}
 			}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/project/LoadProjectsTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/project/LoadProjectsTest.java
@@ -131,6 +131,9 @@ public class LoadProjectsTest {
 
 		PowerMockito.verifyStatic(ProjectManager.class, times(1));
 		ProjectManager.removePermissionsFile(projectMock);
+
+		PowerMockito.verifyStatic(ProjectManager.class, times(1));
+		ProjectManager.updateBackgroundIndexTo9999995(projectMock);
 	}
 
 	@Test


### PR DESCRIPTION
Added a conversion in the load project function.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
