### PR TITLE
CATROID-189 Visual placement interface in the object creation workflow

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/NewSpriteVisuallyPlaceDialogTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/NewSpriteVisuallyPlaceDialogTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uiespresso.ui.dialog
+
+import android.app.Activity
+import android.app.Instrumentation.ActivityResult
+import android.content.Intent
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.scrollTo
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.WaitForConditionAction.Companion.waitFor
+import org.catrobat.catroid.common.Constants
+import org.catrobat.catroid.common.FlavoredConstants
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.io.StorageOperations
+import org.catrobat.catroid.io.XstreamSerializer
+import org.catrobat.catroid.testsuites.annotations.Cat.AppUi
+import org.catrobat.catroid.testsuites.annotations.Level.Smoke
+import org.catrobat.catroid.ui.ProjectActivity
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition
+import org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView
+import org.catrobat.catroid.uiespresso.util.UiTestUtils
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers
+import org.hamcrest.core.AllOf
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import java.io.File
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class NewSpriteVisuallyPlaceDialogTest {
+    @get:Rule
+    var baseActivityTestRule = FragmentActivityTestRule(
+        ProjectActivity::class.java, ProjectActivity.EXTRA_FRAGMENT_POSITION,
+        ProjectActivity.FRAGMENT_SPRITES
+    )
+    private val ProjectName = "newProject"
+    private lateinit var expectedIntent: Matcher<Intent>
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        createProject(ProjectName)
+        baseActivityTestRule.launchActivity()
+        Intents.init()
+
+        expectedIntent = AllOf.allOf(
+            IntentMatchers.hasComponent(Constants.POCKET_PAINT_INTENT_ACTIVITY_NAME),
+            IntentMatchers.hasAction("android.intent.action.MAIN"),
+            IntentMatchers.hasCategories(Matchers.hasItem(Matchers.equalTo("android.intent.category.LAUNCHER")))
+        )
+        val result = ActivityResult(Activity.RESULT_OK, null)
+        Intents.intending(expectedIntent).respondWith(result)
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
+        baseActivityTestRule.finishActivity()
+        try {
+            StorageOperations.deleteDir(File(FlavoredConstants.DEFAULT_ROOT_DIRECTORY, ProjectName))
+        } catch (e: IOException) {
+            Log.e(javaClass.simpleName, Log.getStackTraceString(e))
+        }
+    }
+
+    @Category(AppUi::class, Smoke::class)
+    @Test
+    fun newSpriteVisuallyPlaced() {
+        val newSpriteName =
+            UiTestUtils.getResourcesString(R.string.default_sprite_name).toString() + " (1)"
+        onView(withId(R.id.button_add))
+            .perform(click())
+        onView(withId(R.id.dialog_new_look_paintroid))
+            .perform(click())
+        intended(expectedIntent)
+        onView(withId(R.id.place_visually_sprite_switch))
+            .perform(waitFor(isDisplayed(), 1000))
+        onView(withId(R.id.place_visually_sprite_switch))
+            .check(matches(isNotChecked())).perform(scrollTo(), click())
+
+        onView(withText(R.string.place_visually_text))
+            .check(matches(isDisplayed()))
+
+        onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+            .perform(click())
+        onView(withId(R.id.confirm)).perform(click())
+        onRecyclerView().performOnItemWithText(newSpriteName, click())
+
+        onBrickAtPosition(0).checkShowsText("When scene starts")
+        onBrickAtPosition(1).checkShowsText("Place at")
+        onBrickAtPosition(1).onChildView(withId(R.id.brick_place_at_edit_text_x))
+            .check(matches(withText("100 ")))
+        onBrickAtPosition(1).onFormulaTextField(R.id.brick_place_at_edit_text_y)
+            .check(matches(withText("200 ")))
+    }
+
+    private fun createProject(projectName: String) {
+        val project = Project(ApplicationProvider.getApplicationContext(), projectName)
+        ProjectManager.getInstance().currentProject = project
+        ProjectManager.getInstance().currentlyEditedScene = project.defaultScene
+        XstreamSerializer.getInstance().saveProject(project)
+    }
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/ReplaceExistingProjectDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/ReplaceExistingProjectDialogTest.java
@@ -40,12 +40,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.hamcrest.Matchers.not;
-import static org.mockito.ArgumentMatchers.any;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.replaceText;
@@ -65,12 +65,21 @@ public class ReplaceExistingProjectDialogTest {
 
 	String[] projectNames = {"Project1", "Project2", "Project3"};
 
+	private static final String URL = "https://share.catrob.at/pocketcode/download/71489.catrobat?fname=Pet%20Simulator";
+
+	private ProjectDownloader.ProjectDownloadQueue queueMock = null;
+
 	@Before
 	public void setUp() throws Exception {
 		createProjects();
 		baseActivityTestRule.launchActivity(null);
+
+		queueMock = Mockito.mock(ProjectDownloader.ProjectDownloadQueue.class);
+
 		ReplaceExistingProjectDialogFragment dialog =
-				ReplaceExistingProjectDialogFragment.newInstance(projectNames[0], any(ProjectDownloader.class));
+				ReplaceExistingProjectDialogFragment.newInstance(projectNames[0],
+						new ProjectDownloader(queueMock, URL, null));
+
 		dialog.show(baseActivityTestRule.getActivity().getSupportFragmentManager(),
 				ReplaceExistingProjectDialogFragment.TAG);
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -37,11 +37,10 @@ import android.view.View;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.cast.CastManager;
-import org.catrobat.catroid.common.LookData;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
-import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.content.bricks.VisualPlacementBrick;
 import org.catrobat.catroid.io.StorageOperations;
 import org.catrobat.catroid.io.asynctask.ProjectSaveTask;
 import org.catrobat.catroid.stage.StageActivity;
@@ -49,6 +48,7 @@ import org.catrobat.catroid.stage.TestResult;
 import org.catrobat.catroid.ui.dialogs.LegoSensorConfigInfoDialog;
 import org.catrobat.catroid.ui.fragment.ProjectOptionsFragment;
 import org.catrobat.catroid.ui.recyclerview.controller.SceneController;
+import org.catrobat.catroid.ui.recyclerview.dialog.NewSpriteDialogFragment;
 import org.catrobat.catroid.ui.recyclerview.dialog.TextInputDialog;
 import org.catrobat.catroid.ui.recyclerview.dialog.textwatcher.DuplicateInputTextWatcher;
 import org.catrobat.catroid.ui.recyclerview.fragment.RecyclerViewFragment;
@@ -59,7 +59,7 @@ import org.catrobat.catroid.utils.ToastUtil;
 import org.catrobat.catroid.utils.Utils;
 
 import java.io.File;
-import java.io.IOException;
+import java.util.UUID;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
@@ -68,8 +68,6 @@ import androidx.fragment.app.FragmentTransaction;
 
 import static org.catrobat.catroid.common.Constants.DEFAULT_IMAGE_EXTENSION;
 import static org.catrobat.catroid.common.Constants.EV3;
-import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME;
-import static org.catrobat.catroid.common.Constants.MEDIA_LIBRARY_CACHE_DIR;
 import static org.catrobat.catroid.common.Constants.NXT;
 import static org.catrobat.catroid.common.Constants.TMP_IMAGE_FILE_NAME;
 import static org.catrobat.catroid.common.FlavoredConstants.LIBRARY_LOOKS_URL;
@@ -78,6 +76,8 @@ import static org.catrobat.catroid.ui.WebViewActivity.MEDIA_FILE_PATH;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_EV3_SHOW_SENSOR_INFO_BOX_DISABLED;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.isCastSharedPreferenceEnabled;
+import static org.catrobat.catroid.visualplacement.VisualPlacementActivity.X_COORDINATE_BUNDLE_ARGUMENT;
+import static org.catrobat.catroid.visualplacement.VisualPlacementActivity.Y_COORDINATE_BUNDLE_ARGUMENT;
 
 public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask.ProjectSaveListener {
 
@@ -93,6 +93,11 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 
 	public static final String EXTRA_FRAGMENT_POSITION = "fragmentPosition";
 
+	public static final int REQUEST_CODE_VISUAL_PLACEMENT_NEW_SPRITE = 2121;
+	public static final String EXTRA_X_TRANSFORM_NEW_SPRITE = "X";
+	public static final String EXTRA_Y_TRANSFORM_NEW_SPRITE = "Y";
+	public static UUID PLACE_AT_BRICK_ID;
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -100,7 +105,6 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 		if (isFinishing()) {
 			return;
 		}
-
 		setContentView(R.layout.activity_recycler);
 		setSupportActionBar(findViewById(R.id.toolbar));
 		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -229,6 +233,8 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
 		super.onActivityResult(requestCode, resultCode, data);
 
+		Log.d(TAG, "onActivityResult: " + requestCode);
+
 		if (resultCode == TestResult.STAGE_ACTIVITY_TEST_SUCCESS
 				|| resultCode == TestResult.STAGE_ACTIVITY_TEST_FAIL) {
 			String message = data.getStringExtra(TEST_RESULT_MESSAGE);
@@ -268,15 +274,17 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 				uri = new ImportFromCameraLauncher(this).getCacheCameraUri();
 				addSpriteFromUri(uri);
 				break;
+			case REQUEST_CODE_VISUAL_PLACEMENT_NEW_SPRITE:
+				Bundle extras = data.getExtras();
+				if (extras == null) {
+					return;
+				}
+				int xCoordinate = extras.getInt(X_COORDINATE_BUNDLE_ARGUMENT);
+				int yCoordinate = extras.getInt(Y_COORDINATE_BUNDLE_ARGUMENT);
+				Brick brick = (Brick) ProjectManager.getInstance().getCurrentSprite().findBrickInSprite(PLACE_AT_BRICK_ID);
+				((VisualPlacementBrick) brick).setCoordinates(xCoordinate, yCoordinate);
+				break;
 		}
-	}
-
-	public void imgFormatNotSupportedDialog() {
-
-		AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this).setMessage(getString(R.string.Image_format_not_supported)).setPositiveButton(getString(R.string.ok), (dialog1, which) -> dialog1.cancel());
-
-		AlertDialog alertDialog = alertDialogBuilder.create();
-		alertDialog.show();
 	}
 
 	public void addSpriteFromUri(final Uri uri) {
@@ -301,43 +309,8 @@ public class ProjectActivity extends BaseCastActivity implements ProjectSaveTask
 
 		lookDataName = new UniqueNameProvider().getUniqueNameInNameables(resolvedName, currentScene.getSpriteList());
 
-		TextInputDialog.Builder builder = new TextInputDialog.Builder(this);
-		builder.setHint(getString(R.string.sprite_name_label))
-				.setText(lookDataName)
-				.setTextWatcher(new DuplicateInputTextWatcher<>(currentScene.getSpriteList()))
-				.setPositiveButton(getString(R.string.ok), (TextInputDialog.OnClickListener) (dialog, textInput) -> {
-					Sprite sprite = new Sprite(textInput);
-					currentScene.addSprite(sprite);
-					try {
-						File imageDirectory = new File(currentScene.getDirectory(), IMAGE_DIRECTORY_NAME);
-						File file = StorageOperations.copyUriToDir(getContentResolver(), uri, imageDirectory, lookFileName);
-						LookData lookData = new LookData(textInput, file);
-						if (lookData.getImageMimeType() == null) {
-							imgFormatNotSupportedDialog();
-							currentScene.removeSprite(sprite);
-						} else {
-							sprite.getLookList().add(lookData);
-							lookData.getCollisionInformation().calculate();
-						}
-					} catch (IOException e) {
-						Log.e(TAG, Log.getStackTraceString(e));
-					}
-					if (getCurrentFragment() instanceof SpriteListFragment) {
-						((SpriteListFragment) getCurrentFragment()).notifyDataSetChanged();
-					}
-				});
-
-		builder.setTitle(R.string.new_sprite_dialog_title)
-				.setNegativeButton(R.string.cancel, (dialog, which) -> {
-					try {
-						if (MEDIA_LIBRARY_CACHE_DIR.exists()) {
-							StorageOperations.deleteDir(MEDIA_LIBRARY_CACHE_DIR);
-						}
-					} catch (IOException e) {
-						Log.e(TAG, Log.getStackTraceString(e));
-					}
-				})
-				.show();
+		new NewSpriteDialogFragment(lookDataName, lookFileName, getContentResolver(), uri, getCurrentFragment())
+				.show(getSupportFragmentManager(), NewSpriteDialogFragment.TAG);
 	}
 
 	public void handleAddButton(View view) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSpriteDialogFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSpriteDialogFragment.kt
@@ -1,0 +1,191 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.ui.recyclerview.dialog
+
+import android.app.Dialog
+import android.content.ContentResolver
+import android.content.DialogInterface
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.CompoundButton
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.SwitchCompat
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.common.BrickValues
+import org.catrobat.catroid.common.Constants
+import org.catrobat.catroid.common.LookData
+import org.catrobat.catroid.content.Scene
+import org.catrobat.catroid.content.Script
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.content.StartScript
+import org.catrobat.catroid.content.bricks.PlaceAtBrick
+import org.catrobat.catroid.io.StorageOperations
+import org.catrobat.catroid.ui.ProjectActivity
+import org.catrobat.catroid.ui.ProjectActivity.EXTRA_X_TRANSFORM_NEW_SPRITE
+import org.catrobat.catroid.ui.ProjectActivity.EXTRA_Y_TRANSFORM_NEW_SPRITE
+import org.catrobat.catroid.ui.ProjectActivity.REQUEST_CODE_VISUAL_PLACEMENT_NEW_SPRITE
+import org.catrobat.catroid.ui.recyclerview.dialog.textwatcher.DuplicateInputTextWatcher
+import org.catrobat.catroid.ui.recyclerview.fragment.SpriteListFragment
+import org.catrobat.catroid.visualplacement.VisualPlacementActivity
+import java.io.File
+import java.io.IOException
+
+class NewSpriteDialogFragment(
+    private val lookDataName: String,
+    private val lookFileName: String,
+    private val contentResolver: ContentResolver,
+    private val uri: Uri,
+    private val currentFragment: Fragment
+) : DialogFragment() {
+
+    private var visuallyPlaceSwitch: SwitchCompat? = null
+    private var placeVisuallyTextView: TextView? = null
+    private var isPlaceVisually = false
+    private lateinit var sprite: Sprite
+
+    companion object {
+        lateinit var TAG: String
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+
+        val view = View.inflate(activity, R.layout.dialog_new_sprite, null)
+        val currentScene = ProjectManager.getInstance().currentlyEditedScene
+
+        val builder = context?.let { TextInputDialog.Builder(it) }
+        builder?.setHint(getString(R.string.sprite_name_label))
+            ?.setText(lookDataName)
+            ?.setTextWatcher(DuplicateInputTextWatcher(currentScene.spriteList))
+            ?.setPositiveButton(
+                getString(R.string.ok)
+            ) { dialog: DialogInterface?, textInput: String? ->
+                sprite = Sprite(textInput)
+                currentScene.addSprite(sprite)
+                addLookDataToSprite(currentScene, textInput)
+
+                if (currentFragment is SpriteListFragment) {
+                    currentFragment.notifyDataSetChanged()
+                }
+                if (isPlaceVisually) {
+                    initializeVisualPlacement()
+                }
+            }
+
+        setupToggleButtonListener(view)
+
+        builder?.setTitle(R.string.new_sprite_dialog_title)
+            ?.setNegativeButton(R.string.cancel) { dialog: DialogInterface?, which: Int ->
+                try {
+                    if (Constants.MEDIA_LIBRARY_CACHE_DIR.exists()) {
+                        StorageOperations.deleteDir(Constants.MEDIA_LIBRARY_CACHE_DIR)
+                    }
+                } catch (e: IOException) {
+                    Log.e(TAG, Log.getStackTraceString(e))
+                }
+            }
+
+        return builder
+            ?.setView(view)
+            ?.setNegativeButton(R.string.cancel, null)
+            ?.create() as AlertDialog
+    }
+
+    private fun addLookDataToSprite(currentScene: Scene?, textInput: String?) {
+        try {
+            val imageDirectory = File(
+                currentScene?.directory,
+                Constants.IMAGE_DIRECTORY_NAME
+            )
+            val file = StorageOperations.copyUriToDir(
+                contentResolver, uri,
+                imageDirectory,
+                lookFileName
+            )
+            val lookData = LookData(textInput, file)
+            if (lookData.imageMimeType == null) {
+                imgFormatNotSupportedDialog()
+                currentScene?.removeSprite(sprite)
+            } else {
+                sprite.lookList?.add(lookData)
+                lookData.collisionInformation.calculate()
+            }
+        } catch (e: IOException) {
+            Log.e(TAG, Log.getStackTraceString(e))
+        }
+    }
+
+    private fun setupToggleButtonListener(view: View) {
+        visuallyPlaceSwitch = view.findViewById(R.id.place_visually_sprite_switch)
+        placeVisuallyTextView = view.findViewById(R.id.place_visually_textView)
+
+        visuallyPlaceSwitch?.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
+            if (isChecked) {
+                placeVisuallyTextView?.visibility = View.VISIBLE
+                isPlaceVisually = true
+            } else {
+                placeVisuallyTextView?.visibility = View.GONE
+            }
+        }
+    }
+
+    private fun initializeVisualPlacement() {
+        val placeAtBrick = PlaceAtBrick(
+            BrickValues.X_POSITION,
+            BrickValues.Y_POSITION
+        )
+        val startScript: Script = StartScript()
+        sprite.addScript(startScript)
+        startScript.addBrick(placeAtBrick)
+
+        ProjectManager.getInstance().currentSprite = sprite
+        ProjectActivity.PLACE_AT_BRICK_ID = placeAtBrick.brickID
+
+        startVisualPlacementActivity()
+    }
+
+    private fun startVisualPlacementActivity() {
+        val intent = Intent(requireContext(), VisualPlacementActivity()::class.java)
+        intent.putExtra(EXTRA_X_TRANSFORM_NEW_SPRITE, BrickValues.X_POSITION)
+        intent.putExtra(EXTRA_Y_TRANSFORM_NEW_SPRITE, BrickValues.Y_POSITION)
+        activity?.startActivityForResult(intent, REQUEST_CODE_VISUAL_PLACEMENT_NEW_SPRITE)
+    }
+
+    private fun imgFormatNotSupportedDialog() {
+        val alertDialogBuilder = context?.let {
+            AlertDialog.Builder(it)
+                .setMessage(getString(R.string.Image_format_not_supported))
+                .setPositiveButton(getString(R.string.ok)) { dialog: DialogInterface, which: Int ->
+                    dialog.cancel()
+                }
+        }
+        val alertDialog = alertDialogBuilder?.create()
+        alertDialog?.show()
+    }
+}

--- a/catroid/src/main/res/layout/dialog_new_sprite.xml
+++ b/catroid/src/main/res/layout/dialog_new_sprite.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2021 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="@dimen/dialog_content_area_padding_top"
+    android:paddingStart="@dimen/dialog_content_area_padding_input"
+    android:paddingEnd="@dimen/dialog_content_area_padding_input">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:hintEnabled="true">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:selectAllOnFocus="true" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+         <androidx.appcompat.widget.SwitchCompat
+             android:id="@+id/place_visually_sprite_switch"
+             android:layout_width="match_parent"
+             android:layout_height="wrap_content"
+             android:paddingTop="@dimen/material_design_spacing_large"
+             android:paddingBottom="@dimen/material_design_spacing_large"
+             android:text="@string/new_sprite_dialog_place_visually" />
+
+        <TextView
+            android:id="@+id/place_visually_textView"
+            android:text="@string/place_visually_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone" />
+
+    </LinearLayout>
+</ScrollView>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -2108,6 +2108,8 @@ needs read and write access to it. You can always change permissions through you
     <string name="serif_font" translatable="false">serif</string>
     <string name="edit">Edit</string>
     <string name="data_value">Value</string>
+    <string name="new_sprite_dialog_place_visually">Place Visually</string>
+    <string name="place_visually_text">You will be asked to place the new actor or object on the stage</string>
 
     <!-- Information -->
     <string name="no_variable_selected">No variable selected</string>


### PR DESCRIPTION
Ticket: https://jira.catrob.at/browse/CATROID-189
Added switch for placing newly created sprite visually 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
