### PR TITLE
CATROID-189 Visual placement interface in the object creation workflow

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/intents/looks/gallery/SpriteFromGalleryIntentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/intents/looks/gallery/SpriteFromGalleryIntentTest.java
@@ -29,6 +29,7 @@ import android.app.Instrumentation;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Environment;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.catrobat.catroid.ProjectManager;
@@ -60,6 +61,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 
 import static org.catrobat.catroid.common.FlavoredConstants.DEFAULT_ROOT_DIRECTORY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.NEW_SPRITE_VISUAL_PLACEMENT_KEY;
 import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView;
 import static org.catrobat.catroid.uiespresso.util.matchers.BundleMatchers.bundleHasExtraIntent;
 import static org.catrobat.catroid.uiespresso.util.matchers.BundleMatchers.bundleHasMatchingString;
@@ -134,6 +136,9 @@ public class SpriteFromGalleryIntentTest {
 	@After
 	public void tearDown() throws IOException {
 		Intents.release();
+		PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext()).edit()
+				.remove(NEW_SPRITE_VISUAL_PLACEMENT_KEY)
+				.apply();
 		baseActivityTestRule.finishActivity();
 		StorageOperations.deleteDir(tmpPath);
 		try {
@@ -146,6 +151,10 @@ public class SpriteFromGalleryIntentTest {
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
 	public void testSpriteFromGalleryIntentTest() {
+		PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext()).edit()
+				.putBoolean(NEW_SPRITE_VISUAL_PLACEMENT_KEY, false)
+				.commit();
+
 		onView(withId(R.id.button_add))
 				.perform(click());
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/intents/looks/paintroid/PocketPaintNewSpriteIntentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/intents/looks/paintroid/PocketPaintNewSpriteIntentTest.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.uiespresso.intents.looks.paintroid;
 
 import android.app.Activity;
 import android.app.Instrumentation;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.catrobat.catroid.ProjectManager;
@@ -56,6 +57,7 @@ import androidx.test.espresso.intent.Intents;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.catrobat.catroid.common.FlavoredConstants.DEFAULT_ROOT_DIRECTORY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.NEW_SPRITE_VISUAL_PLACEMENT_KEY;
 import static org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -64,6 +66,7 @@ import static org.junit.Assert.assertEquals;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.Intents.intending;
@@ -105,6 +108,10 @@ public class PocketPaintNewSpriteIntentTest {
 	@After
 	public void tearDown() {
 		Intents.release();
+		PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext()).edit()
+				.remove(NEW_SPRITE_VISUAL_PLACEMENT_KEY)
+				.apply();
+
 		baseActivityTestRule.finishActivity();
 		try {
 			StorageOperations.deleteDir(new File(DEFAULT_ROOT_DIRECTORY, projectName));
@@ -118,6 +125,10 @@ public class PocketPaintNewSpriteIntentTest {
 	public void testAddNewSprite() {
 		String newSpriteName = UiTestUtils.getResourcesString(R.string.default_sprite_name) + " (1)";
 
+		PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext()).edit()
+				.putBoolean(NEW_SPRITE_VISUAL_PLACEMENT_KEY, false)
+				.commit();
+
 		onView(withId(R.id.button_add))
 				.perform(click());
 
@@ -128,6 +139,8 @@ public class PocketPaintNewSpriteIntentTest {
 
 		onView(withText(newSpriteName))
 				.check(matches(isDisplayed()));
+
+		closeSoftKeyboard();
 
 		onView(Matchers.allOf(withId(android.R.id.button1), withText(R.string.ok)))
 				.perform(click());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/NewSpriteVisuallyPlaceDialogTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/NewSpriteVisuallyPlaceDialogTest.kt
@@ -1,0 +1,179 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uiespresso.ui.dialog
+
+import android.app.Activity
+import android.app.Instrumentation.ActivityResult
+import android.content.Intent
+import android.preference.PreferenceManager.getDefaultSharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.Espresso.closeSoftKeyboard
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.WaitForConditionAction.Companion.waitFor
+import org.catrobat.catroid.common.Constants
+import org.catrobat.catroid.common.SharedPreferenceKeys.NEW_SPRITE_VISUAL_PLACEMENT_KEY
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.io.XstreamSerializer
+import org.catrobat.catroid.test.utils.TestUtils
+import org.catrobat.catroid.testsuites.annotations.Cat.AppUi
+import org.catrobat.catroid.testsuites.annotations.Level.Smoke
+import org.catrobat.catroid.ui.ProjectActivity
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition
+import org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView
+import org.catrobat.catroid.uiespresso.util.UiTestUtils
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers
+import org.hamcrest.core.AllOf
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NewSpriteVisuallyPlaceDialogTest {
+    @get:Rule
+    var baseActivityTestRule = FragmentActivityTestRule(
+        ProjectActivity::class.java, ProjectActivity.EXTRA_FRAGMENT_POSITION,
+        ProjectActivity.FRAGMENT_SPRITES
+    )
+    private val projectName = "newProject"
+    private lateinit var expectedIntent: Matcher<Intent>
+    val newSpriteName = UiTestUtils.getResourcesString(R.string.default_sprite_name).toString() + " (1)"
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        createProject(projectName)
+        getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())?.edit()
+            ?.putBoolean(NEW_SPRITE_VISUAL_PLACEMENT_KEY, true)
+            ?.apply()
+        baseActivityTestRule.launchActivity()
+        Intents.init()
+
+        expectedIntent = AllOf.allOf(
+            IntentMatchers.hasComponent(Constants.POCKET_PAINT_INTENT_ACTIVITY_NAME),
+            IntentMatchers.hasAction("android.intent.action.MAIN"),
+            IntentMatchers.hasCategories(Matchers.hasItem(Matchers.equalTo("android.intent.category.LAUNCHER")))
+        )
+
+        val result = ActivityResult(Activity.RESULT_OK, null)
+        Intents.intending(expectedIntent).respondWith(result)
+
+        baseActivityTestRule.launchActivity(null)
+
+        onView(withId(R.id.button_add))
+            .perform(click())
+        onView(withId(R.id.dialog_new_look_paintroid))
+            .perform(click())
+        intended(expectedIntent)
+        closeSoftKeyboard()
+        onView(withId(R.id.place_visually_sprite_switch))
+            .perform(waitFor(isDisplayed(), 1000))
+        onView(withId(R.id.place_visually_sprite_switch))
+            .check(matches(isChecked()))
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
+        getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())?.edit()
+            ?.remove(NEW_SPRITE_VISUAL_PLACEMENT_KEY)
+            ?.apply()
+        TestUtils.deleteProjects(projectName)
+    }
+
+    @Category(AppUi::class, Smoke::class)
+    @Test
+    fun newSpriteVisuallyPlaced() {
+        onView(withText(R.string.place_visually_text))
+            .check(matches(isDisplayed()))
+
+        onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+            .perform(click())
+        onView(withId(R.id.confirm)).perform(click())
+        onRecyclerView().performOnItemWithText(newSpriteName, click())
+
+        onBrickAtPosition(0).checkShowsText(R.string.brick_when_started)
+        onBrickAtPosition(1).checkShowsText(R.string.brick_place_at)
+        onBrickAtPosition(1).onChildView(withId(R.id.brick_place_at_edit_text_x))
+            .check(matches(withText("100 ")))
+        onBrickAtPosition(1).onFormulaTextField(R.id.brick_place_at_edit_text_y)
+            .check(matches(withText("200 ")))
+    }
+
+    @Category(AppUi::class, Smoke::class)
+    @Test
+    fun newSpriteCancelVisuallyPlacing() {
+        onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+            .perform(click())
+        pressBack()
+        onRecyclerView().performOnItemWithText(newSpriteName, click())
+        onView(withText(R.string.fragment_script_text_description))
+            .check(matches(isDisplayed()))
+    }
+
+    @Category(AppUi::class, Smoke::class)
+    @Test
+    fun newSpriteCheckVisualPlacementSettingRetained() {
+        onView(withId(R.id.place_visually_sprite_switch))
+            .perform(click())
+        onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+            .perform(click())
+
+        onView(withId(R.id.button_add))
+            .perform(click())
+        onView(withId(R.id.dialog_new_look_paintroid))
+            .perform(click())
+        intended(expectedIntent, Intents.times(2))
+        closeSoftKeyboard()
+        onView(withId(R.id.place_visually_sprite_switch))
+            .perform(waitFor(isDisplayed(), 1000))
+        onView(withId(R.id.place_visually_sprite_switch))
+            .check(matches(isNotChecked()))
+    }
+
+    private fun createProject(projectName: String) {
+        val project = Project(ApplicationProvider.getApplicationContext(), projectName)
+        ProjectManager.getInstance().currentProject = project
+        ProjectManager.getInstance().currentlyEditedScene = project.defaultScene
+        XstreamSerializer.getInstance().saveProject(project)
+    }
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/SpriteListFragmentExplanationTextNoObjectsProjectTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/SpriteListFragmentExplanationTextNoObjectsProjectTest.java
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.uiespresso.ui.fragment;
 
 import android.app.Activity;
+import android.preference.PreferenceManager;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
@@ -39,11 +40,13 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import static org.catrobat.catroid.common.SharedPreferenceKeys.NEW_SPRITE_VISUAL_PLACEMENT_KEY;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.IsNot.not;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -73,6 +76,11 @@ public class SpriteListFragmentExplanationTextNoObjectsProjectTest {
 	public void testAddSprite() {
 		onView(withId(R.id.empty_view))
 				.check(matches(isDisplayed()));
+
+		PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext()).edit()
+				.putBoolean(NEW_SPRITE_VISUAL_PLACEMENT_KEY, false)
+				.commit();
+
 		onView(withText(R.string.fragment_sprite_text_description))
 				.check(matches(isDisplayed()));
 
@@ -84,6 +92,8 @@ public class SpriteListFragmentExplanationTextNoObjectsProjectTest {
 			}
 		});
 
+		closeSoftKeyboard();
+
 		onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
 				.perform(click());
 
@@ -91,6 +101,10 @@ public class SpriteListFragmentExplanationTextNoObjectsProjectTest {
 				.check(matches(not(isDisplayed())));
 		onView(withText(R.string.fragment_sprite_text_description))
 				.check(matches(not(isDisplayed())));
+
+		PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext()).edit()
+				.remove(NEW_SPRITE_VISUAL_PLACEMENT_KEY)
+				.apply();
 	}
 
 	private void createNoObjectsProject() {

--- a/catroid/src/main/java/org/catrobat/catroid/common/SharedPreferenceKeys.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/SharedPreferenceKeys.java
@@ -59,4 +59,5 @@ public final class SharedPreferenceKeys {
 	public static final String SHOW_SURVEY_KEY = "showSurvey";
 	public static final String SURVEY_URL1_HASH_KEY = "surveyUrl1Hash";
 	public static final String SURVEY_URL2_HASH_KEY = "surveyUrl2Hash";
+	public static final String NEW_SPRITE_VISUAL_PLACEMENT_KEY = "newSpriteVisualPlacement";
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSpriteDialogFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSpriteDialogFragment.kt
@@ -1,0 +1,191 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.ui.recyclerview.dialog
+
+import android.app.Dialog
+import android.content.ContentResolver
+import android.content.DialogInterface
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.preference.PreferenceManager
+import android.util.Log
+import android.view.View
+import android.widget.CompoundButton
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.SwitchCompat
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.common.BrickValues
+import org.catrobat.catroid.common.Constants
+import org.catrobat.catroid.common.LookData
+import org.catrobat.catroid.common.SharedPreferenceKeys.NEW_SPRITE_VISUAL_PLACEMENT_KEY
+import org.catrobat.catroid.content.Scene
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.io.StorageOperations
+import org.catrobat.catroid.ui.SpriteActivity.EXTRA_X_TRANSFORM
+import org.catrobat.catroid.ui.SpriteActivity.EXTRA_Y_TRANSFORM
+import org.catrobat.catroid.ui.SpriteActivity.REQUEST_CODE_VISUAL_PLACEMENT
+import org.catrobat.catroid.ui.recyclerview.dialog.textwatcher.DuplicateInputTextWatcher
+import org.catrobat.catroid.ui.recyclerview.fragment.SpriteListFragment
+import org.catrobat.catroid.utils.Utils
+import org.catrobat.catroid.visualplacement.VisualPlacementActivity
+import java.io.File
+import java.io.IOException
+
+class NewSpriteDialogFragment(
+    private val lookDataName: String,
+    private val lookFileName: String,
+    private val contentResolver: ContentResolver,
+    private val uri: Uri,
+    private val currentFragment: Fragment
+) : DialogFragment() {
+
+    private var visuallyPlaceSwitch: SwitchCompat? = null
+    private var placeVisuallyTextView: TextView? = null
+    private var isPlaceVisually = true
+    private lateinit var sprite: Sprite
+
+    companion object {
+        val TAG: String = NewSpriteDialogFragment::class.java.simpleName
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+
+        val view = View.inflate(activity, R.layout.dialog_new_sprite, null)
+        val currentScene = ProjectManager.getInstance().currentlyEditedScene
+
+        val builder = context?.let { TextInputDialog.Builder(it) }
+        builder?.setHint(getString(R.string.sprite_name_label))
+            ?.setText(lookDataName)
+            ?.setTextWatcher(DuplicateInputTextWatcher(currentScene.spriteList))
+            ?.setPositiveButton(
+                getString(R.string.ok)
+            ) { dialog: DialogInterface?, textInput: String? ->
+                sprite = Sprite(textInput)
+                currentScene.addSprite(sprite)
+                addLookDataToSprite(currentScene, textInput)
+
+                if (currentFragment is SpriteListFragment) {
+                    currentFragment.notifyDataSetChanged()
+                }
+                if (isPlaceVisually) {
+                    startVisualPlacementActivity()
+                }
+            }
+
+        setupToggleButtonListener(view)
+
+        builder?.setTitle(R.string.new_sprite_dialog_title)
+            ?.setNegativeButton(R.string.cancel) { dialog: DialogInterface?, which: Int ->
+                try {
+                    if (Constants.MEDIA_LIBRARY_CACHE_DIR.exists()) {
+                        StorageOperations.deleteDir(Constants.MEDIA_LIBRARY_CACHE_DIR)
+                    }
+                } catch (e: IOException) {
+                    Log.e(TAG, Log.getStackTraceString(e))
+                }
+            }
+
+        return builder
+            ?.setView(view)
+            ?.setNegativeButton(R.string.cancel, null)
+            ?.create() as AlertDialog
+    }
+
+    private fun addLookDataToSprite(currentScene: Scene?, textInput: String?) {
+        try {
+            val imageDirectory = File(
+                currentScene?.directory,
+                Constants.IMAGE_DIRECTORY_NAME
+            )
+            val file = StorageOperations.copyUriToDir(
+                contentResolver, uri,
+                imageDirectory,
+                lookFileName
+            )
+            Utils.removeExifData(imageDirectory, lookFileName)
+            val lookData = LookData(textInput, file)
+            if (lookData.imageMimeType == null) {
+                imgFormatNotSupportedDialog()
+                currentScene?.removeSprite(sprite)
+            } else {
+                sprite.lookList?.add(lookData)
+                lookData.collisionInformation.calculate()
+            }
+        } catch (e: IOException) {
+            Log.e(TAG, Log.getStackTraceString(e))
+        }
+    }
+
+    private fun setupToggleButtonListener(view: View) {
+        visuallyPlaceSwitch = view.findViewById(R.id.place_visually_sprite_switch)
+        placeVisuallyTextView = view.findViewById(R.id.place_visually_textView)
+
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .getBoolean(NEW_SPRITE_VISUAL_PLACEMENT_KEY, true).apply {
+                visuallyPlaceSwitch?.isChecked = this
+                visualTextViewVisibility(this)
+            }
+
+        visuallyPlaceSwitch?.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
+            visualTextViewVisibility(isChecked)
+            PreferenceManager.getDefaultSharedPreferences(activity)
+                .edit()
+                .putBoolean(NEW_SPRITE_VISUAL_PLACEMENT_KEY, isPlaceVisually)
+                .apply()
+        }
+    }
+
+    private fun visualTextViewVisibility(isVisible: Boolean) {
+        isPlaceVisually = isVisible
+        placeVisuallyTextView?.visibility = if (isVisible) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
+    }
+
+    private fun startVisualPlacementActivity() {
+        ProjectManager.getInstance().currentSprite = sprite
+        val intent = Intent(requireContext(), VisualPlacementActivity()::class.java)
+        intent.putExtra(EXTRA_X_TRANSFORM, BrickValues.X_POSITION)
+        intent.putExtra(EXTRA_Y_TRANSFORM, BrickValues.Y_POSITION)
+        activity?.startActivityForResult(intent, REQUEST_CODE_VISUAL_PLACEMENT)
+    }
+
+    private fun imgFormatNotSupportedDialog() {
+        val alertDialogBuilder = context?.let {
+            AlertDialog.Builder(it)
+                .setMessage(getString(R.string.Image_format_not_supported))
+                .setPositiveButton(getString(R.string.ok)) { dialog: DialogInterface, which: Int ->
+                    dialog.cancel()
+                }
+        }
+        val alertDialog = alertDialogBuilder?.create()
+        alertDialog?.show()
+    }
+}

--- a/catroid/src/main/res/layout/dialog_new_sprite.xml
+++ b/catroid/src/main/res/layout/dialog_new_sprite.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2021 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingTop="@dimen/dialog_content_area_padding_top"
+        android:paddingStart="@dimen/dialog_content_area_padding_input"
+        android:paddingEnd="@dimen/dialog_content_area_padding_input">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:hintEnabled="true">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_edit_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:selectAllOnFocus="true" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+         <androidx.appcompat.widget.SwitchCompat
+             android:id="@+id/place_visually_sprite_switch"
+             android:layout_width="match_parent"
+             android:layout_height="wrap_content"
+             android:paddingTop="@dimen/material_design_spacing_large"
+             android:paddingBottom="@dimen/material_design_spacing_large"
+             android:text="@string/new_sprite_dialog_place_visually" />
+
+        <TextView
+            android:id="@+id/place_visually_textView"
+            android:text="@string/place_visually_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+</ScrollView>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -2077,6 +2077,9 @@ needs read and write access to it. You can always change permissions through you
     <string name="edit">Edit</string>
     <string name="data_value">Value</string>
     <string name="category_recently_used">Recently used</string>
+    <string name="new_sprite_dialog_place_visually">Place visually</string>
+    <string name="place_visually_text">You will be asked to place the new actor or object on the
+        stage.</string>
 
     <!-- Information -->
     <string name="no_variable_selected">No variable selected</string>


### PR DESCRIPTION
Ticket: https://jira.catrob.at/browse/CATROID-189
Added switch for placing newly created sprite visually

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
