### PR TITLE
CATROID-850 Insert flatten(*list*) for backwards compatibility

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -133,6 +133,8 @@ android {
 
         buildConfigField "boolean", "USE_ANDROID_LOCALES_FOR_SCREENSHOTS", "false"
 
+        buildConfigField "boolean", "FEATURE_LIST_AS_BASIC_DATATYPE", "false"
+
         buildConfigField "boolean", "FEATURE_AI_SENSORS_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_APK_GENERATOR_ENABLED", "false"
         buildConfigField "boolean", "FEATURE_ARDUINO_ENABLED", "true"

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/FlattenListTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/FlattenListTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.formulaeditor
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Script
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.content.StartScript
+import org.catrobat.catroid.content.bricks.Brick
+import org.catrobat.catroid.content.bricks.FormulaBrick
+import org.catrobat.catroid.content.bricks.NoteBrick
+import org.catrobat.catroid.formulaeditor.Formula
+import org.catrobat.catroid.formulaeditor.FormulaElement
+import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType.FUNCTION
+import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType.NUMBER
+import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType.OPERATOR
+import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType.USER_LIST
+import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType.USER_VARIABLE
+import org.catrobat.catroid.formulaeditor.Functions.CONTAINS
+import org.catrobat.catroid.formulaeditor.Functions.FLATTEN
+import org.catrobat.catroid.formulaeditor.Functions.INDEX_OF_ITEM
+import org.catrobat.catroid.formulaeditor.Functions.LENGTH
+import org.catrobat.catroid.formulaeditor.Functions.LIST_ITEM
+import org.catrobat.catroid.formulaeditor.Functions.NUMBER_OF_ITEMS
+import org.catrobat.catroid.formulaeditor.Functions.SQRT
+import org.catrobat.catroid.formulaeditor.Operators.PLUS
+import org.catrobat.catroid.test.utils.TestUtils.deleteProjects
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.io.IOException
+
+@RunWith(Parameterized::class)
+class FlattenListTest(
+    private val name: String,
+    private val parentFormulaElement: FormulaElement,
+    private val leftChildrenFormulaElementList: List<FormulaElement>?,
+    private val rightChildrenFormulaElementList: List<FormulaElement>?,
+    private val expectedValue: String?
+) {
+    private var projectManager: ProjectManager? = null
+    private lateinit var project: Project
+    private lateinit var brick: Brick
+    private lateinit var context: Context
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        projectManager = ProjectManager.getInstance()
+        createProject()
+    }
+
+    @After
+    @Throws(Exception::class)
+    fun tearDown() {
+        projectManager?.currentProject = null
+        deleteProjects(PROJECT_NAME)
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun testFlattenAllLists() {
+        ProjectManager.flattenAllLists(project)
+        val newFormula = (brick as FormulaBrick).formulas[0].getTrimmedFormulaString(context)
+        assertEquals(expectedValue, newFormula)
+    }
+
+    fun createProject() {
+        val sprite = Sprite(SPRITE_NAME)
+        val script: Script = StartScript()
+        brick = NoteBrick(buildFormula())
+        script.addBrick(brick)
+        sprite.addScript(script)
+        project = Project(context, PROJECT_NAME)
+        project.defaultScene.addSprite(sprite)
+        ProjectManager.getInstance().currentProject = project
+        ProjectManager.getInstance().currentSprite = sprite
+    }
+
+    private fun buildFormula(): Formula {
+        linkFormulaElements(leftChildrenFormulaElementList)
+        linkFormulaElements(rightChildrenFormulaElementList)
+        if (leftChildrenFormulaElementList != null && leftChildrenFormulaElementList.isNotEmpty()) {
+            parentFormulaElement.setLeftChild(leftChildrenFormulaElementList[0])
+        }
+        if (rightChildrenFormulaElementList != null && rightChildrenFormulaElementList.isNotEmpty()) {
+            parentFormulaElement.setRightChild(rightChildrenFormulaElementList[0])
+        }
+        return Formula(parentFormulaElement)
+    }
+
+    private fun linkFormulaElements(
+        formulaElementList: List<FormulaElement>?
+    ) {
+        var previousElement: FormulaElement? = null
+        if (formulaElementList != null) {
+            for (formulaElement in formulaElementList) {
+                previousElement?.setLeftChild(formulaElement)
+                previousElement = formulaElement
+            }
+        }
+    }
+
+    companion object {
+        private const val PROJECT_NAME = "project"
+        private const val SPRITE_NAME = "sprite"
+        private const val USER_VARIABLE_NAME = "variable"
+        private const val USER_LIST_NAME = "list"
+        private const val SECOND_USER_LIST_NAME = "secondList"
+        private val context = ApplicationProvider.getApplicationContext<Context>()
+        private val functionFlatten = context.getString(R.string.formula_editor_function_flatten)
+        private val functionNumberOfItems =
+            context.getString(R.string.formula_editor_function_number_of_items)
+        private val functionListItem = context.getString(R.string.formula_editor_function_list_item)
+        private val functionContains = context.getString(R.string.formula_editor_function_contains)
+        private val functionIndexOfItem =
+            context.getString(R.string.formula_editor_function_index_of_item)
+        private val functionLength = context.getString(R.string.formula_editor_function_length)
+        private val functionSqrt = context.getString(R.string.formula_editor_function_sqrt)
+        private val operatorPlus = context.getString(R.string.formula_editor_operator_plus)
+
+        private val numberTwo = FormulaElement(NUMBER, "2", null)
+        private val userVariable = FormulaElement(USER_VARIABLE, USER_VARIABLE_NAME, null)
+        private val userList = FormulaElement(USER_LIST, USER_LIST_NAME, null)
+        private val secondUserList = FormulaElement(USER_LIST, SECOND_USER_LIST_NAME, null)
+        private val numberOfItems = FormulaElement(FUNCTION, NUMBER_OF_ITEMS.name, null)
+        private val listItem = FormulaElement(FUNCTION, LIST_ITEM.name, null)
+        private val containsItem = FormulaElement(FUNCTION, CONTAINS.name, null)
+        private val indexOfItem = FormulaElement(FUNCTION, INDEX_OF_ITEM.name, null)
+        private val flattenList = FormulaElement(FUNCTION, FLATTEN.name, null)
+        private val length = FormulaElement(FUNCTION, LENGTH.name, null)
+        private val squareRoot = FormulaElement(FUNCTION, SQRT.name, null)
+        private val operatorAdd = FormulaElement(OPERATOR, PLUS.name, null)
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun parameters() = listOf(
+            arrayOf(
+                "no flatten in number of items function", numberOfItems, listOf(userList), null,
+                "$functionNumberOfItems( *$USER_LIST_NAME* ) "
+            ),
+            arrayOf(
+                "no flatten in item function", listItem, listOf(numberTwo), listOf(userList),
+                "$functionListItem( 2 , *$USER_LIST_NAME* ) "
+            ),
+            arrayOf(
+                "no flatten in contains function", containsItem, listOf(userList),
+                listOf(numberTwo), "$functionContains( *$USER_LIST_NAME* , 2 ) "
+            ),
+            arrayOf(
+                "no flatten in item's index function", indexOfItem, listOf(numberTwo),
+                listOf(userList), "$functionIndexOfItem( 2 , *$USER_LIST_NAME* ) "
+            ),
+            arrayOf(
+                "no flatten in flatten function", flattenList, listOf(userList), null,
+                "$functionFlatten( *$USER_LIST_NAME* ) "
+            ),
+            arrayOf(
+                "user variable", userVariable, null, null, "\"$USER_VARIABLE_NAME\" "
+            ),
+            arrayOf(
+                "user variable nested once", squareRoot, listOf(userVariable), null,
+                "$functionSqrt( \"$USER_VARIABLE_NAME\" ) "
+            ),
+            arrayOf(
+                "user list simple", userList, null, null, "$functionFlatten( *$USER_LIST_NAME* ) "
+            ),
+            arrayOf(
+                "user list nested once", length, listOf(userList), null,
+                "$functionLength( $functionFlatten( *$USER_LIST_NAME* ) ) "
+            ),
+            arrayOf(
+                "user list nested twice", squareRoot, listOf(length, userList), null,
+                "$functionSqrt( $functionLength( $functionFlatten( *$USER_LIST_NAME* ) ) ) "
+            ),
+            arrayOf(
+                "multiple user lists", operatorAdd, listOf(userList), listOf(secondUserList),
+                "$functionFlatten( *$USER_LIST_NAME* ) $operatorPlus " +
+                    "$functionFlatten( *$SECOND_USER_LIST_NAME* ) "
+            ),
+            arrayOf(
+                "multiple nested user lists", operatorAdd, listOf(length, userList),
+                listOf(squareRoot, secondUserList),
+                "$functionLength( $functionFlatten( *$USER_LIST_NAME* ) ) $operatorPlus " +
+                    "$functionSqrt( $functionFlatten( *$SECOND_USER_LIST_NAME* ) ) "
+            )
+        )
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -167,9 +167,13 @@ public final class ProjectManager {
 		if (project.getCatrobatLanguageVersion() <= 0.9999995) {
 			updateBackgroundIndexTo9999995(project);
 		}
+		if (project.getCatrobatLanguageVersion() < 999.9 && !BuildConfig.FEATURE_LIST_AS_BASIC_DATATYPE) {
+			ProjectManager.flattenAllLists(project);
+		}
 		if (project.getCatrobatLanguageVersion() <= 1.03) {
 			ProjectManager.updateDirectionProperty(project);
 		}
+
 		project.setCatrobatLanguageVersion(CURRENT_CATROBAT_LANGUAGE_VERSION);
 
 		localizeBackgroundSprites(project, context.getString(R.string.background));
@@ -348,6 +352,25 @@ public final class ProjectManager {
 			}
 		}
 		return conflicts;
+	}
+
+	public static void flattenAllLists(Project project) {
+		for (Scene scene : project.getSceneList()) {
+			for (Sprite sprite : scene.getSpriteList()) {
+				for (Script script : sprite.getScriptList()) {
+					List<Brick> flatList = new ArrayList();
+					script.addToFlatList(flatList);
+					for (Brick brick : flatList) {
+						if (brick instanceof FormulaBrick) {
+							FormulaBrick formulaBrick = (FormulaBrick) brick;
+							for (Formula formula : formulaBrick.getFormulas()) {
+								formula.flattenAllLists();
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 
 	@VisibleForTesting

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -93,6 +93,12 @@ public class Formula implements Serializable {
 	public void updateCollisionFormulas(String oldName, String newName, Context context) {
 		internFormula.updateCollisionFormula(oldName, newName, context);
 		formulaTree.updateElementByName(oldName, newName, ElementType.COLLISION_FORMULA);
+	}
+
+	public void flattenAllLists() {
+		formulaTree.insertFlattenForAllUserLists(formulaTree, null);
+		formulaTree = formulaTree.getRoot();
+		internFormula.setInternTokenFormulaList(formulaTree.getInternTokenList());
 	}
 
 	public void updateCollisionFormulasToVersion() {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Functions.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Functions.java
@@ -41,7 +41,7 @@ public enum Functions {
 	private static final String TAG = Functions.class.getSimpleName();
 	public static final EnumSet<Functions> TEXT = EnumSet.of(LENGTH, LETTER, JOIN, JOIN3, REGEX);
 	public static final EnumSet<Functions> LIST = EnumSet.of(LIST_ITEM, CONTAINS, INDEX_OF_ITEM,
-			NUMBER_OF_ITEMS);
+			NUMBER_OF_ITEMS, FLATTEN);
 
 	public static boolean isFunction(String value) {
 		return EnumUtils.isValidEnum(Functions.class, value);

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
@@ -1173,4 +1173,8 @@ public class InternFormula {
 		return !(cursorTokenPosition == null
 				|| (cursorTokenPosition == CursorTokenPosition.LEFT && getFirstLeftInternToken(externCursorPosition - 1) == null));
 	}
+
+	public void setInternTokenFormulaList(List<InternToken> list) {
+		internTokenFormulaList = list;
+	}
 }

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1817,6 +1817,8 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_index_of_item_parameter">(1,*list name*)</string>
     <string name="formula_editor_function_number_of_items">number of items</string>
     <string name="formula_editor_function_number_of_items_parameter">(*list name*)</string>
+    <string name="formula_editor_function_flatten">flatten</string>
+    <string name="formula_editor_function_flatten_parameter">(*list name*)</string>
     <string name="formula_editor_function_collision">touches actor or object</string>
     <string name="formula_editor_function_collides_with_edge">touches edge</string>
     <string name="formula_editor_function_touched">touches finger</string>
@@ -2089,8 +2091,6 @@ needs read and write access to it. You can always change permissions through you
     <string name="camera_error_text_detection">
         There was a problem with text detection. Some components may still be downloading in the
         background. Please make sure you are connected to the internet and check back later.</string>
-    <string name="formula_editor_function_flatten">flatten</string>
-    <string name="formula_editor_function_flatten_parameter">(*list name*)</string>
     <string name="warning_formula_recognized">You entered a text that looks like a formula. If you want to use functions,
         sensors, variables and other formula elements, please select them instead using the
         buttons in the formula editor.</string>

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/project/LoadProjectsTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/project/LoadProjectsTest.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.test.content.project;
 
 import android.content.Context;
 
+import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -79,7 +80,7 @@ public class LoadProjectsTest {
 		doReturn(projectMock).when(xstreamSerializerMock).loadProject(Mockito.any(), Mockito.any());
 	}
 
-	@Test (expected = CompatibilityProjectException.class)
+	@Test(expected = CompatibilityProjectException.class)
 	public void testInvalidLanguageVersion() throws Exception {
 		when(projectMock.getCatrobatLanguageVersion()).thenReturn(INVALID_LANGUAGE_VERSION);
 
@@ -91,7 +92,7 @@ public class LoadProjectsTest {
 		}
 	}
 
-	@Test (expected = OutdatedVersionProjectException.class)
+	@Test(expected = OutdatedVersionProjectException.class)
 	public void testTooBigLanguageVersion() throws Exception {
 		when(projectMock.getCatrobatLanguageVersion()).thenReturn(TOO_BIG_LANGUAGE_VERSION);
 
@@ -136,6 +137,9 @@ public class LoadProjectsTest {
 		ProjectManager.updateBackgroundIndexTo9999995(projectMock);
 
 		PowerMockito.verifyStatic(ProjectManager.class, times(1));
+		ProjectManager.flattenAllLists(projectMock);
+
+		PowerMockito.verifyStatic(ProjectManager.class, times(1));
 		ProjectManager.updateDirectionProperty(projectMock);
 	}
 
@@ -170,5 +174,12 @@ public class LoadProjectsTest {
 
 		PowerMockito.verifyStatic(ProjectManager.class, times(0));
 		ProjectManager.updateDirectionProperty(projectMock);
+
+		if (!BuildConfig.FEATURE_LIST_AS_BASIC_DATATYPE) {
+			PowerMockito.verifyStatic(ProjectManager.class, times(1));
+		} else {
+			PowerMockito.verifyStatic(ProjectManager.class, times(0));
+		}
+		ProjectManager.flattenAllLists(projectMock);
 	}
 }


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-850

Insert flatten(*list*) around all userlists when opening old projects where "flatten" was not yet available.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
