### PR TITLE
CATROID-996 Fix null pointer exceptions on local unit tests

### DIFF
--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ChangeColorByNActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ChangeColorByNActionTest.java
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class ChangeColorByNActionTest {
 
@@ -49,6 +51,7 @@ public class ChangeColorByNActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 
 		sprite.getActionFactory().createSetColorAction(sprite,

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ChangeSizeByNActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ChangeSizeByNActionTest.java
@@ -37,6 +37,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class ChangeSizeByNActionTest {
 
@@ -52,6 +54,7 @@ public class ChangeSizeByNActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ChangeTransparencyByNActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ChangeTransparencyByNActionTest.java
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class ChangeTransparencyByNActionTest {
 
@@ -50,6 +52,7 @@ public class ChangeTransparencyByNActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ChangeVolumeByNActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ChangeVolumeByNActionTest.java
@@ -34,6 +34,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class ChangeVolumeByNActionTest {
 
@@ -46,6 +48,7 @@ public class ChangeVolumeByNActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 		SoundManager.getInstance().setVolume(INITIALIZED_VALUE);
 	}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ChangeYByNActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ChangeYByNActionTest.java
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class ChangeYByNActionTest {
 	@Rule
@@ -47,6 +49,7 @@ public class ChangeYByNActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ForVariableFromToActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ForVariableFromToActionTest.java
@@ -38,6 +38,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class ForVariableFromToActionTest {
 	Sprite sprite;
@@ -48,6 +50,7 @@ public class ForVariableFromToActionTest {
 
 	@Before
 	public void setUp() {
+		initializeStaticSingletonMethods();
 		executedLoops = new UserVariable("executedLoops", 0.0);
 		controlVariable = new UserVariable("controlVariable", 0.0);
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ForeverActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ForeverActionTest.java
@@ -33,6 +33,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class ForeverActionTest {
 
@@ -40,6 +42,7 @@ public class ForeverActionTest {
 
 	@Test
 	public void testLoopDelay() {
+		initializeStaticSingletonMethods();
 		int deltaY = -10;
 
 		Sprite sprite = new Sprite("testSprite");

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/GlideToActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/GlideToActionTest.java
@@ -37,6 +37,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class GlideToActionTest {
 
@@ -56,6 +58,7 @@ public class GlideToActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/MoveNStepsActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/MoveNStepsActionTest.java
@@ -35,6 +35,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class MoveNStepsActionTest {
 	private final float delta = 0.0001f;
@@ -47,6 +49,7 @@ public class MoveNStepsActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("Test");
 		factory = sprite.getActionFactory();
 	}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/PlaceAtBrickTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/PlaceAtBrickTest.java
@@ -35,6 +35,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class PlaceAtBrickTest {
 
@@ -51,6 +53,7 @@ public class PlaceAtBrickTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/PointInDirectionActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/PointInDirectionActionTest.java
@@ -33,6 +33,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class PointInDirectionActionTest {
 
@@ -41,6 +43,7 @@ public class PointInDirectionActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/RepeatActionTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/RepeatActionTest.kt
@@ -27,6 +27,7 @@ import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction
 import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction
 import org.catrobat.catroid.content.Sprite
 import org.catrobat.catroid.formulaeditor.Formula
+import org.catrobat.catroid.test.StaticSingletonInitializer.Companion.initializeStaticSingletonMethods
 import org.catrobat.catroid.test.utils.Reflection
 import org.junit.Assert
 import org.junit.Before
@@ -65,6 +66,7 @@ class RepeatActionTest(
 
     @Before
     fun setUp() {
+        initializeStaticSingletonMethods()
         sprite = Sprite("testSprite")
         innerLoopAction = Mockito.mock(MockAction()::class.java, Mockito.CALLS_REAL_METHODS)
         repeatAction = sprite.actionFactory.createRepeatAction(

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetColorActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetColorActionTest.java
@@ -37,6 +37,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class SetColorActionTest {
 
@@ -50,6 +52,7 @@ public class SetColorActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetSizeToActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetSizeToActionTest.java
@@ -37,6 +37,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class SetSizeToActionTest {
 
@@ -50,6 +52,7 @@ public class SetSizeToActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetTransparencyActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetTransparencyActionTest.java
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class SetTransparencyActionTest {
 
@@ -49,6 +51,7 @@ public class SetTransparencyActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetVolumeToActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetVolumeToActionTest.java
@@ -34,6 +34,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class SetVolumeToActionTest {
 
@@ -44,6 +46,7 @@ public class SetVolumeToActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetXActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetXActionTest.java
@@ -37,6 +37,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class SetXActionTest {
 
@@ -50,6 +52,7 @@ public class SetXActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetYActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetYActionTest.java
@@ -37,6 +37,8 @@ import org.junit.runners.JUnit4;
 
 import static junit.framework.Assert.assertEquals;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(JUnit4.class)
 public class SetYActionTest {
 
@@ -50,6 +52,7 @@ public class SetYActionTest {
 
 	@Before
 	public void setUp() throws Exception {
+		initializeStaticSingletonMethods();
 		sprite = new Sprite("testSprite");
 	}
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/WriteVariableToFileActionTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/WriteVariableToFileActionTest.kt
@@ -27,6 +27,7 @@ import org.catrobat.catroid.content.Sprite
 import org.catrobat.catroid.content.actions.WriteVariableToFileAction
 import org.catrobat.catroid.formulaeditor.Formula
 import org.catrobat.catroid.formulaeditor.UserVariable
+import org.catrobat.catroid.test.StaticSingletonInitializer.Companion.initializeStaticSingletonMethods
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -81,6 +82,7 @@ class WriteVariableToFileActionTest(
 
     @Before
     fun setUp() {
+        initializeStaticSingletonMethods()
         sprite = Sprite("testSprite")
         sequence = SequenceAction()
         file = Mockito.mock(File::class.java)

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CloneBrickWithFormulaTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CloneBrickWithFormulaTest.java
@@ -78,6 +78,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -154,6 +155,7 @@ public class CloneBrickWithFormulaTest {
 
 	@Before
 	public void setUp() throws CloneNotSupportedException {
+		initializeStaticSingletonMethods();
 		FormulaBrick cloneBrick = (FormulaBrick) brick.clone();
 		brickFormula = brick.getFormulaWithBrickField(brickField);
 		cloneBrickFormula = cloneBrick.getFormulaWithBrickField(brickField);

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickBroadcastMessageTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickBroadcastMessageTest.java
@@ -44,6 +44,8 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Set;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(Parameterized.class)
 public class CompositeBrickBroadcastMessageTest {
 
@@ -69,6 +71,7 @@ public class CompositeBrickBroadcastMessageTest {
 
 	@Before
 	public void setUp() throws IllegalAccessException, InstantiationException {
+		initializeStaticSingletonMethods();
 		Project project = new Project();
 		scene = new Scene();
 		Sprite sprite = new Sprite();

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 
 import static junit.framework.Assert.assertNull;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -83,6 +84,7 @@ public class CompositeBrickTest {
 
 	@Before
 	public void setUp() throws IllegalAccessException, InstantiationException {
+		initializeStaticSingletonMethods();
 		compositeBrick = compositeBrickClass.newInstance();
 		List<Brick> compositeBrickParts = compositeBrick.getAllParts();
 		compositeEndBrick = compositeBrickParts.get(compositeBrickParts.size() - 1);

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickVariableUpdateTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickVariableUpdateTest.java
@@ -50,6 +50,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
@@ -87,6 +88,7 @@ public class CompositeBrickVariableUpdateTest {
 
 	@Before
 	public void setUp() throws IllegalAccessException, InstantiationException {
+		initializeStaticSingletonMethods();
 		Project project = new Project();
 		userVariable = new UserVariable();
 		userList = new UserList();

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickWithSecondaryListBroadcastMessageTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickWithSecondaryListBroadcastMessageTest.java
@@ -43,6 +43,8 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Set;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
+
 @RunWith(Parameterized.class)
 public class CompositeBrickWithSecondaryListBroadcastMessageTest {
 
@@ -68,6 +70,7 @@ public class CompositeBrickWithSecondaryListBroadcastMessageTest {
 
 	@Before
 	public void setUp() throws IllegalAccessException, InstantiationException {
+		initializeStaticSingletonMethods();
 		Project project = new Project();
 		scene = new Scene();
 		Sprite sprite = new Sprite();

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickWithSecondaryListTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickWithSecondaryListTest.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -83,6 +84,7 @@ public class CompositeBrickWithSecondaryListTest {
 
 	@Before
 	public void setUp() throws IllegalAccessException, InstantiationException {
+		initializeStaticSingletonMethods();
 		compositeBrick = compositeBrickClass.newInstance();
 		List<Brick> compositeBrickParts = compositeBrick.getAllParts();
 		compositeMiddleBrick = compositeBrickParts.get(1);

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickWithSecondaryListUpdateTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickWithSecondaryListUpdateTest.java
@@ -49,6 +49,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 
+import static org.catrobat.catroid.test.StaticSingletonInitializer.initializeStaticSingletonMethods;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
@@ -84,6 +85,7 @@ public class CompositeBrickWithSecondaryListUpdateTest {
 
 	@Before
 	public void setUp() throws IllegalAccessException, InstantiationException {
+		initializeStaticSingletonMethods();
 		Project project = new Project();
 		userVariable = new UserVariable();
 		userList = new UserList();


### PR DESCRIPTION
Locally null pointer exceptions occur when executing single tests.
When executing multiple tests at once many tests do not fail even if they should.
This behaviour occured because of the wrong usage of the Junit class instead of the PowerMockRunner class.

https://jira.catrob.at/browse/CATROID-996

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
