### PR TITLE
CATROID-1008 Bricks below empty event bricks (from Catblocks) shall not be set to disabled

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/EmptyEventBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/EmptyEventBrick.java
@@ -50,7 +50,6 @@ public class EmptyEventBrick extends ScriptBrickBaseType {
 	public EmptyEventBrick(@NonNull EmptyScript script) {
 		script.setScriptBrick(this);
 		this.script = script;
-		setCommentedOut(true);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/BrickAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/BrickAdapter.java
@@ -34,6 +34,7 @@ import android.widget.BaseAdapter;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.content.bricks.EmptyEventBrick;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
 import org.catrobat.catroid.content.bricks.ListSelectorBrick;
 import org.catrobat.catroid.content.bricks.ScriptBrick;
@@ -125,7 +126,7 @@ public class BrickAdapter extends BaseAdapter implements
 
 		Drawable background = brickViewContainer.getBackground();
 
-		if (item.isCommentedOut()) {
+		if (item.isCommentedOut() || item instanceof EmptyEventBrick) {
 			colorAsCommentedOut(background);
 		} else {
 			background.clearColorFilter();


### PR DESCRIPTION
Fixed the bug by not setting the empty event brick as disabled but just coloring it that way.

https://jira.catrob.at/browse/CATROID-1008

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
