### PR TITLE
CATROID-1007 Terms of use and service incorrectly shown too shortly in standalone APKs

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -78,6 +78,8 @@ public class MainMenuActivity extends BaseCastActivity implements
 
 	public static final String TAG = MainMenuActivity.class.getSimpleName();
 
+	private int oldPrivacyPolicy = 0;
+
 	public static Survey surveyCampaign;
 
 	@Override
@@ -89,10 +91,10 @@ public class MainMenuActivity extends BaseCastActivity implements
 		PreferenceManager.setDefaultValues(this, R.xml.preferences, true);
 		ScreenValueHandler.updateScreenWidthAndHeight(this);
 
-		loadContent();
-
-		int oldPrivacyPolicy = PreferenceManager.getDefaultSharedPreferences(this)
+		oldPrivacyPolicy = PreferenceManager.getDefaultSharedPreferences(this)
 				.getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0);
+
+		loadContent();
 
 		if (oldPrivacyPolicy != Constants.CATROBAT_TERMS_OF_USE_ACCEPTED) {
 			showTermsOfUseDialog();
@@ -142,6 +144,10 @@ public class MainMenuActivity extends BaseCastActivity implements
 				.edit()
 				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION, Constants.CATROBAT_TERMS_OF_USE_ACCEPTED)
 				.apply();
+
+		if (BuildConfig.FEATURE_APK_GENERATOR_ENABLED) {
+			prepareStandaloneProject();
+		}
 	}
 
 	public void handleDeclinedPrivacyPolicyButton() {
@@ -176,7 +182,9 @@ public class MainMenuActivity extends BaseCastActivity implements
 	private void loadContent() {
 		if (BuildConfig.FEATURE_APK_GENERATOR_ENABLED) {
 			setContentView(R.layout.activity_main_menu_splashscreen);
-			prepareStandaloneProject();
+			if (oldPrivacyPolicy == Constants.CATROBAT_TERMS_OF_USE_ACCEPTED) {
+				prepareStandaloneProject();
+			}
 			return;
 		}
 


### PR DESCRIPTION
In the standalone APKs, the dialog for our Terms of Use and Service is shortly shown, but then the app does not wait till the user taps on one of the buttons.

https://jira.catrob.at/browse/CATROID-1007

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
