### PR TITLE
CATROID-1018 NullPointerException when calling brickDialogManager

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageLifeCycleController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageLifeCycleController.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -233,7 +233,9 @@ public final class StageLifeCycleController {
 
 	static void stageDestroy(StageActivity stageActivity) {
 		if (checkPermission(stageActivity, getProjectsRuntimePermissionList())) {
-			stageActivity.brickDialogManager.dismissAllDialogs();
+			if (stageActivity.brickDialogManager != null) {
+				stageActivity.brickDialogManager.dismissAllDialogs();
+			}
 			stageActivity.jumpingSumoDisconnect();
 			BluetoothDeviceService service = ServiceProvider.getService(CatroidService.BLUETOOTH_DEVICE_SERVICE);
 			if (service != null) {
@@ -250,10 +252,12 @@ public final class StageLifeCycleController {
 			}
 			StageActivity.stageListener.finish();
 			stageActivity.manageLoadAndFinish();
-			if (stageActivity.stageResourceHolder.droneInitializer != null) {
+			if (stageActivity.stageResourceHolder != null
+					&& stageActivity.stageResourceHolder.droneInitializer != null) {
 				stageActivity.stageResourceHolder.droneInitializer.onDestroy();
 			}
-			if (stageActivity.stageResourceHolder.droneController != null) {
+			if (stageActivity.stageResourceHolder != null
+					&& stageActivity.stageResourceHolder.droneController != null) {
 				stageActivity.stageResourceHolder.droneController.onDestroy();
 			}
 		}


### PR DESCRIPTION
The stageActivity.brickDialogManager can be null and this causes a NullPointerException. 
Fixed it by adding a null check and also added null checks to other members that could be null.
https://jira.catrob.at/browse/CATROID-1018

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
