### PR TITLE
CATROID-921 Disable Hints dialog

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/DisableHintDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/DisableHintDialogTest.java
@@ -1,0 +1,192 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.dialog;
+
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.io.asynctask.ProjectSaveTask;
+import org.catrobat.catroid.testsuites.annotations.Cat;
+import org.catrobat.catroid.testsuites.annotations.Level;
+import org.catrobat.catroid.ui.MainMenuActivity;
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityTestRule;
+import org.catrobat.catroid.utils.SnackbarUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.matcher.PreferenceMatchers;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+import static org.catrobat.catroid.R.id.currentProjectLayout;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_VERSION;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.DISABLE_HINTS_DIALOG_SHOWN_PREFERENCE_KEY;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_HINTS;
+
+import static androidx.test.espresso.Espresso.onData;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+@RunWith(AndroidJUnit4.class)
+public class DisableHintDialogTest {
+
+	private boolean hintSetting;
+	private Set<String> hintList;
+	int bufferedPreferenceSetting;
+
+	@Rule
+	public BaseActivityTestRule<MainMenuActivity> baseActivityTestRule = new
+			BaseActivityTestRule<>(MainMenuActivity.class, false, false);
+
+	@Before
+	public void setUp() throws Exception {
+		createProject("firstProject");
+
+		SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext());
+		hintSetting = sharedPreferences.getBoolean(SettingsFragment.SETTINGS_SHOW_HINTS, false);
+		hintList = new HashSet<>(sharedPreferences.getStringSet(SnackbarUtil.SHOWN_HINT_LIST, new HashSet<String>()));
+		bufferedPreferenceSetting = sharedPreferences.getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0);
+
+		getDefaultSharedPreferences()
+				.edit()
+				.putBoolean(SETTINGS_SHOW_HINTS, true)
+				.putStringSet(SnackbarUtil.SHOWN_HINT_LIST, new HashSet<String>())
+				.putBoolean(DISABLE_HINTS_DIALOG_SHOWN_PREFERENCE_KEY, false)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION, Constants.CATROBAT_TERMS_OF_USE_ACCEPTED)
+				.apply();
+
+		baseActivityTestRule.launchActivity(null);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		baseActivityTestRule.deleteAllProjects();
+
+		PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())
+				.edit()
+				.putBoolean(SETTINGS_SHOW_HINTS, hintSetting)
+				.putStringSet(SnackbarUtil.SHOWN_HINT_LIST, hintList)
+				.putBoolean(DISABLE_HINTS_DIALOG_SHOWN_PREFERENCE_KEY, true)
+				.putInt(AGREED_TO_PRIVACY_POLICY_VERSION, bufferedPreferenceSetting)
+				.apply();
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void disableHintDialogTest() {
+		onView(withId(currentProjectLayout)).perform(click());
+
+		onView(withText(R.string.dialog_disable_hints_title))
+				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.dialog_disable_hints_text))
+				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.dialog_disable_hints_button_hide)).perform(click());
+
+		pressBack();
+
+		openActionBarOverflowOrOptionsMenu(baseActivityTestRule.getActivity());
+		onView(withText(R.string.settings)).perform(click());
+		checkPreferenceHide(R.string.preference_title_enable_hints, SETTINGS_SHOW_HINTS);
+
+		pressBack();
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void enableHintDialogTest() {
+		onView(withId(currentProjectLayout)).perform(click());
+
+		onView(withText(R.string.dialog_disable_hints_title))
+				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.dialog_disable_hints_text))
+				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.dialog_disable_hints_button_show)).perform(click());
+
+		pressBack();
+
+		openActionBarOverflowOrOptionsMenu(baseActivityTestRule.getActivity());
+		onView(withText(R.string.settings)).perform(click());
+		checkPreferenceShow(R.string.preference_title_enable_hints, SETTINGS_SHOW_HINTS);
+
+		pressBack();
+	}
+
+	private void createProject(String projectName) {
+		Project project = UiTestUtils.createEmptyProject(projectName);
+		ProjectSaveTask.task(project, ApplicationProvider.getApplicationContext());
+	}
+
+	private SharedPreferences getDefaultSharedPreferences() {
+		return PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext());
+	}
+
+	private void checkPreferenceHide(int displayedTitleResourceString, String sharedPreferenceTag) {
+		SharedPreferences sharedPreferences = PreferenceManager
+				.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext());
+
+		assertFalse(sharedPreferences.getBoolean(sharedPreferenceTag, false));
+
+		onData(PreferenceMatchers.withTitle(displayedTitleResourceString))
+				.perform(click());
+
+		assertTrue(sharedPreferences.getBoolean(sharedPreferenceTag, true));
+	}
+
+	private void checkPreferenceShow(int displayedTitleResourceString, String sharedPreferenceTag) {
+		SharedPreferences sharedPreferences = PreferenceManager
+				.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext());
+
+		assertTrue(sharedPreferences.getBoolean(sharedPreferenceTag, true));
+
+		onData(PreferenceMatchers.withTitle(displayedTitleResourceString))
+				.perform(click());
+
+		assertFalse(sharedPreferences.getBoolean(sharedPreferenceTag, false));
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/hints/Android9SnackbarRegressionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/hints/Android9SnackbarRegressionTest.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static org.catrobat.catroid.common.SharedPreferenceKeys.DISABLE_HINTS_DIALOG_SHOWN_PREFERENCE_KEY;
 import static org.hamcrest.core.AllOf.allOf;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -79,6 +80,7 @@ public class Android9SnackbarRegressionTest {
 		sharedPreferences.edit()
 				.putBoolean(SettingsFragment.SETTINGS_SHOW_HINTS, true)
 				.putStringSet(SnackbarUtil.SHOWN_HINT_LIST, new HashSet<String>())
+				.putBoolean(DISABLE_HINTS_DIALOG_SHOWN_PREFERENCE_KEY, true)
 				.commit();
 
 		createProject();

--- a/catroid/src/main/java/org/catrobat/catroid/common/SharedPreferenceKeys.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/SharedPreferenceKeys.java
@@ -50,6 +50,9 @@ public final class SharedPreferenceKeys {
 
 	public static final String SORT_PROJECTS_PREFERENCE_KEY = "sortProjectsList";
 
+	public static final String DISABLE_HINTS_DIALOG_SHOWN_PREFERENCE_KEY =
+			"disableHintsDialogShown";
+
 	public static final String SCRATCH_CONVERTER_CLIENT_ID_PREFERENCE_KEY = "scratchconverter.clientID";
 	public static final String SCRATCH_CONVERTER_DOWNLOAD_STATE_PREFERENCE_KEY = "scratchconverter"
 			+ ".downloadStatePref";

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SpriteListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SpriteListFragment.java
@@ -114,6 +114,7 @@ public class SpriteListFragment extends RecyclerViewFragment<Sprite> {
 	public void onResume() {
 		initializeAdapter();
 		super.onResume();
+		SnackbarUtil.showHintSnackbar(getActivity(), R.string.hint_objects);
 		Project currentProject = ProjectManager.getInstance().getCurrentProject();
 		String title;
 
@@ -178,7 +179,6 @@ public class SpriteListFragment extends RecyclerViewFragment<Sprite> {
 
 	@Override
 	protected void initializeAdapter() {
-		SnackbarUtil.showHintSnackbar(getActivity(), R.string.hint_objects);
 		sharedPreferenceDetailsKey = SHOW_DETAILS_SPRITES_PREFERENCE_KEY;
 		List<Sprite> items = ProjectManager.getInstance().getCurrentlyEditedScene().getSpriteList();
 		adapter = new MultiViewSpriteAdapter(items);

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -2096,6 +2096,15 @@ needs read and write access to it. You can always change permissions through you
         To add a new actor or object, tap the \"+\" symbol.</string>
     <!--  -->
 
+    <!-- Dialog Disable hints -->
+    <string name="dialog_disable_hints_title">Show hints?</string>
+    <string name="dialog_disable_hints_text">Hints provide you with helpful information
+        while making your first project.\n\nVisibility of hints can be changed in the
+        settings.</string>
+    <string name="dialog_disable_hints_button_hide">HIDE</string>
+    <string name="dialog_disable_hints_button_show">SHOW</string>
+    <!--  -->
+
     <!-- Crash report dialog -->
     <string name="plus" translatable="false">+</string>
     <!--  -->


### PR DESCRIPTION
Implement a dialog that asks the user if they want to enable or disable hints. The dialog is shown only once, right before the first hint would be shown and will not be shown again if the user changes the hint settings afterwards.
https://jira.catrob.at/browse/CATROID-921

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
