### PR TITLE
CATROID-847 Fix floating + and play buttons in script view

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/ScriptFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/ScriptFragmentTest.java
@@ -39,6 +39,9 @@ import org.catrobat.catroid.uiespresso.util.UiTestUtils;
 import org.catrobat.catroid.uiespresso.util.matchers.BrickCategoryListMatchers;
 import org.catrobat.catroid.uiespresso.util.matchers.BrickPrototypeListMatchers;
 import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+
+import androidx.test.espresso.matcher.ViewMatchers;
+import kotlinx.coroutines.ExperimentalCoroutinesApi;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,6 +69,7 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
@@ -256,5 +260,14 @@ public class ScriptFragmentTest {
 
 		ProjectManager.getInstance().setCurrentProject(project);
 		ProjectManager.getInstance().setCurrentSprite(sprite);
+	}
+
+	@Test
+	public void hideFabOnScroll_hideFab_whenLastItemReached() throws InterruptedException {
+		onView(withId(R.id.button_add)).check(matches(not(withEffectiveVisibility(ViewMatchers.Visibility.GONE))));
+		onView(withId(R.id.button_play)).check(matches(not(withEffectiveVisibility(ViewMatchers.Visibility.GONE))));
+		Thread.sleep(2000);
+		onView(withId(R.id.button_add)).check(matches(not(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))));
+		onView(withId(R.id.button_play)).check(matches(not(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))));
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -938,12 +938,14 @@ public class ScriptFragment extends ListFragment implements
 		fab = rootView.findViewById(R.id.bottom_bar);
 		listView.setOnScrollListener(new BrickListView.OnScrollListener() {
 			@Override
-			public void onScrollStateChanged(AbsListView view, int scrollState) { }
+			public void onScrollStateChanged(AbsListView view, int scrollState) {
+			}
+
 			@Override
 			public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
-				if(firstVisibleItem + visibleItemCount == totalItemCount && fab.getVisibility() == View.VISIBLE){
+				if (firstVisibleItem + visibleItemCount == totalItemCount && fab.getVisibility() == View.VISIBLE) {
 					view.removeCallbacks(showRunnable);
-					view.postDelayed(showRunnable,2000);
+					view.postDelayed(showRunnable, 2000);
 					fab.setVisibility(View.GONE);
 				}
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -249,7 +249,7 @@ public class ScriptFragment extends ListFragment implements
 		listView = view.findViewById(android.R.id.list);
 		setHasOptionsMenu(true);
 		SnackbarUtil.showHintSnackbar(getActivity(), R.string.hint_scripts);
-		hideFab();
+		hideFabOnScroll();
 		return view;
 	}
 
@@ -929,7 +929,7 @@ public class ScriptFragment extends ListFragment implements
 		brickToFocus = null;
 	}
 
-	private void hideFab() {
+	private void hideFabOnScroll() {
 		LayoutInflater inflater2 =
 				(LayoutInflater) getActivity().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.ui.recyclerview.fragment;
 
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -34,6 +35,8 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AbsListView;
+import android.widget.RelativeLayout;
 
 import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.ProjectManager;
@@ -126,6 +129,7 @@ public class ScriptFragment extends ListFragment implements
 	private String currentSceneName;
 	private String currentSpriteName;
 	private int undoBrickPosition;
+	private RelativeLayout fab;
 
 	private ScriptController scriptController = new ScriptController();
 	private BrickController brickController = new BrickController();
@@ -245,6 +249,7 @@ public class ScriptFragment extends ListFragment implements
 		listView = view.findViewById(android.R.id.list);
 		setHasOptionsMenu(true);
 		SnackbarUtil.showHintSnackbar(getActivity(), R.string.hint_scripts);
+		hideFab();
 		return view;
 	}
 
@@ -922,5 +927,26 @@ public class ScriptFragment extends ListFragment implements
 		}
 		scriptToFocus = null;
 		brickToFocus = null;
+	}
+
+	private void hideFab() {
+		LayoutInflater inflater2 =
+				(LayoutInflater) getActivity().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+
+		View rootView = inflater2.inflate(R.layout.activity_sprite,
+				getActivity().findViewById(R.id.activity_sprite));
+		fab = rootView.findViewById(R.id.bottom_bar);
+		listView.setOnScrollListener(new BrickListView.OnScrollListener() {
+			@Override
+			public void onScrollStateChanged(AbsListView view, int scrollState) { }
+			@Override
+			public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
+				if(firstVisibleItem + visibleItemCount == totalItemCount && fab.getVisibility() == View.VISIBLE){
+					fab.setVisibility(View.GONE);
+				} else if(firstVisibleItem + visibleItemCount < totalItemCount && fab.getVisibility() == View.GONE){
+					fab.setVisibility(View.VISIBLE);
+				}
+			}
+		});
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -942,11 +942,18 @@ public class ScriptFragment extends ListFragment implements
 			@Override
 			public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
 				if(firstVisibleItem + visibleItemCount == totalItemCount && fab.getVisibility() == View.VISIBLE){
+					view.removeCallbacks(showRunnable);
+					view.postDelayed(showRunnable,2000);
 					fab.setVisibility(View.GONE);
-				} else if(firstVisibleItem + visibleItemCount < totalItemCount && fab.getVisibility() == View.GONE){
-					fab.setVisibility(View.VISIBLE);
 				}
 			}
 		});
 	}
+
+	Runnable showRunnable = new Runnable() {
+		@Override
+		public void run() {
+			fab.setVisibility(View.VISIBLE);
+		}
+	};
 }

--- a/catroid/src/main/res/layout/activity_sprite.xml
+++ b/catroid/src/main/res/layout/activity_sprite.xml
@@ -32,6 +32,7 @@
     <include layout="@layout/toolbar" />
 
     <RelativeLayout
+        android:animateLayoutChanges="true"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-847

Scrolling to the last item in the hides Fab<br><br>
Added a scrollchangelistner in scriptFragment to hide the fab when last item is visible.
The Fab would be visible after the 2000 millisecond.<br>
This will work on scriptFragment only as it was only required in the fragment.<br>

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
