### PR TITLE
CATROID-1032: FATAL EXCEPTION when "aligned" is changed in "Show Variable" Data brick

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextColorSizeAlignmentBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextColorSizeAlignmentBrick.java
@@ -124,7 +124,7 @@ public class ShowTextColorSizeAlignmentBrick extends UserVariableBrickWithVisual
 		items.add(new AlignmentStyle(context.getString(R.string.brick_show_variable_aligned_centered), ALIGNMENT_STYLE_CENTERED));
 		items.add(new AlignmentStyle(context.getString(R.string.brick_show_variable_aligned_right), ALIGNMENT_STYLE_RIGHT));
 		BrickSpinner<AlignmentStyle> spinner =
-				new BrickSpinner<>(R.id.brick_show_variable_color_size_align_spinner, view, items);
+				new BrickSpinner<>(R.id.brick_show_variable_color_size_align_spinner, view, items, this);
 		spinner.setSelection(alignmentSelection);
 		spinner.setOnItemSelectedListener(new BrickSpinner.OnItemSelectedListener<AlignmentStyle>() {
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/brickspinner/BrickSpinner.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/brickspinner/BrickSpinner.java
@@ -53,6 +53,7 @@ public class BrickSpinner<T extends Nameable> implements AdapterView.OnItemSelec
 	private BrickSpinnerAdapter adapter;
 	private Integer spinnerid;
 	private T previousItem;
+	private Brick showTextColorSizeAlignmentBrick = null;
 
 	private OnItemSelectedListener<T> onItemSelectedListener;
 
@@ -63,6 +64,16 @@ public class BrickSpinner<T extends Nameable> implements AdapterView.OnItemSelec
 		spinner.setAdapter(adapter);
 		spinner.setSelection(0);
 		spinner.setOnItemSelectedListener(this);
+	}
+
+	public BrickSpinner(Integer spinnerId, @NonNull View parent, List<Nameable> items, Brick brick) {
+		spinnerid = spinnerId;
+		adapter = new BrickSpinnerAdapter(parent.getContext(), android.R.layout.simple_spinner_item, items);
+		spinner = parent.findViewById(spinnerId);
+		spinner.setAdapter(adapter);
+		spinner.setSelection(0);
+		spinner.setOnItemSelectedListener(this);
+		showTextColorSizeAlignmentBrick = brick;
 	}
 
 	public void setOnItemSelectedListener(OnItemSelectedListener<T> onItemSelectedListener) {
@@ -176,6 +187,8 @@ public class BrickSpinner<T extends Nameable> implements AdapterView.OnItemSelec
 			scriptFragment.showUndo(true);
 			if (onItemSelectedListener instanceof Brick) {
 				scriptFragment.setUndoBrickPosition((Brick) onItemSelectedListener);
+			} else if (showTextColorSizeAlignmentBrick != null) {
+				scriptFragment.setUndoBrickPosition(showTextColorSizeAlignmentBrick);
 			}
 		}
 	}


### PR DESCRIPTION
Ticket solve: [https://jira.catrob.at/browse/CATROID-1032](https://jira.catrob.at/browse/CATROID-1032)  

*Please enter a short description of your pull request and add a reference to the Jira ticket.*
* `scriptFragment.setUndoBrickPosition((Brick) onItemSelectedListener)` line in `BrickSpinner` file causing error because `onitemSelectedListener` wasn't implemented in `ShowTextColorSizeAlignmentBrick`.
* This was only happening with `ShowTextColorSizeAlignmentBrick`(Every other brick implemented onitemSelectedListener)
* I fixed it by passing the `ShowTextColorSizeAlignmentBrick` reference in `BrickSpinner` constructor

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
