### PR TITLE
Update RaspberryPiService.java

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/devices/raspberrypi/RaspberryPiService.java
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/raspberrypi/RaspberryPiService.java
@@ -172,8 +172,40 @@ public final class RaspberryPiService {
 	}
 
 	private void initGpioVersionMap() {
+		gpioVersionMap.put("900021", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("900032", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("900092", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("900093", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("9000c1", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("9020e0", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("920092", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("920093", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("900061", GpioVersionType.COMPUTE_MODULE);
+		gpioVersionMap.put("a01040", GpioVersionType.BIG_GPIO);
 		gpioVersionMap.put("a01041", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("a02082", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("a020a0", GpioVersionType.COMPUTE_MODULE);
+		gpioVersionMap.put("a020d3", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("a02042", GpioVersionType.BIG_GPIO);
 		gpioVersionMap.put("a21041", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("a22042", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("a22082", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("a220a0", GpioVersionType.COMPUTE_MODULE);
+		gpioVersionMap.put("a32082", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("a52082", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("a22083", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("a02100", GpioVersionType.COMPUTE_MODULE);
+		gpioVersionMap.put("a03111", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("b03111", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("b03112", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("b03114", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("c03111", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("c03112", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("c03114", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("d03114", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("c03130", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("0015", GpioVersionType.BIG_GPIO);
+		gpioVersionMap.put("0014", GpioVersionType.BIG_GPIO);
 		gpioVersionMap.put("0013", GpioVersionType.BIG_GPIO);
 		gpioVersionMap.put("0012", GpioVersionType.BIG_GPIO);
 		gpioVersionMap.put("0011", GpioVersionType.COMPUTE_MODULE);


### PR DESCRIPTION
The problem exists that many 40 GPIO pin Raspberry Pi do not have pin 27-40 available in the Raspberry Pi extension because the revision code is not in the list. I have added to the list of Raspberry Pi version codes and GPIO reference with all available Pi version codes, as per information on https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
Thanks

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
