### PR TITLE
CATROID-1051 Fix crash when deleting sprite of clone

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/DeleteSpriteCloneTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/DeleteSpriteCloneTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uiespresso.stage
+
+import androidx.test.InstrumentationRegistry
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Script
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.content.StartScript
+import org.catrobat.catroid.content.bricks.CloneBrick
+import org.catrobat.catroid.test.utils.TestUtils
+import org.catrobat.catroid.testsuites.annotations.Cat.AppUi
+import org.catrobat.catroid.testsuites.annotations.Level.Smoke
+import org.catrobat.catroid.ui.ProjectActivity
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper
+import org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityTestRule
+import org.hamcrest.Matchers.allOf
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import java.io.IOException
+
+@Category(AppUi::class, Smoke::class)
+class DeleteSpriteCloneTest {
+    private var sprite1: Sprite? = null
+    private var sprite2: Sprite? = null
+    private var project: Project? = null
+
+    @Rule
+    @JvmField
+    var baseActivityTestRule = BaseActivityTestRule(
+        ProjectActivity::class.java, true, false
+    )
+
+    @Before
+    @kotlin.jvm.Throws(Exception::class)
+    fun setUp() {
+        createProject()
+        baseActivityTestRule.launchActivity(null)
+    }
+
+    @After
+    @kotlin.jvm.Throws(IOException::class)
+    fun tearDown() {
+        TestUtils.deleteProjects(javaClass.simpleName)
+    }
+
+    @Test
+    fun testDeleteSpriteOfClone() {
+        Espresso.onView(withText(sprite1!!.name))
+            .perform(click())
+        BrickDataInteractionWrapper.onBrickAtPosition(1)
+            .onSpinner(R.id.brick_clone_spinner)
+            .performSelectNameable(sprite2!!.name)
+        Espresso.pressBack()
+        Espresso.openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().targetContext)
+        Espresso.onView(withText(R.string.delete))
+            .perform(click())
+        RecyclerViewInteractionWrapper.onRecyclerView().atPosition(2)
+            .performCheckItem()
+        Espresso.onView(withId(R.id.confirm))
+            .perform(click())
+        Espresso.onView(allOf(withId(android.R.id.button1), withText(R.string.delete)))
+            .perform(click())
+
+        Espresso.onView(withId(R.id.button_play))
+            .perform(click())
+    }
+
+    private fun createProject() {
+        val projectName = javaClass.simpleName
+        project = Project(ApplicationProvider.getApplicationContext(), projectName)
+        sprite1 = Sprite("Sprite (1)")
+        val startScirpt: Script = StartScript()
+        startScirpt.addBrick(CloneBrick())
+        sprite1!!.addScript(startScirpt)
+        sprite2 = Sprite("Sprite (2)")
+        val scene1 = project!!.defaultScene
+        scene1.addSprite(sprite1)
+        scene1.addSprite(sprite2)
+        ProjectManager.getInstance().currentProject = project
+        ProjectManager.getInstance().startScene = scene1
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Scene.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -28,6 +28,7 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.Nameable;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.BroadcastMessageBrick;
+import org.catrobat.catroid.content.bricks.CloneBrick;
 import org.catrobat.catroid.formulaeditor.UserData;
 import org.catrobat.catroid.io.XStreamFieldKeyOrder;
 import org.catrobat.catroid.physics.PhysicsWorld;
@@ -149,6 +150,25 @@ public class Scene implements Nameable, Serializable {
 			Sprite sprite = iterator.next();
 			if (sprite.isClone) {
 				iterator.remove();
+			}
+		}
+	}
+
+	public void removeSpriteFromCloneBricks(Sprite spriteToDelete) {
+		for (Sprite currentSprite : spriteList) {
+			if (!currentSprite.equals(spriteToDelete)) {
+				for (Script currentScript : currentSprite.getScriptList()) {
+					List<Brick> flatList = new ArrayList();
+					currentScript.addToFlatList(flatList);
+					for (Brick currentBrick : flatList) {
+						if (currentBrick instanceof CloneBrick) {
+							CloneBrick cloneBrick = (CloneBrick) currentBrick;
+							if (cloneBrick.getSelectedItem().equals(spriteToDelete)) {
+								cloneBrick.resetSpinner();
+							}
+						}
+					}
+				}
 			}
 		}
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/CloneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/CloneBrick.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -43,6 +43,7 @@ public class CloneBrick extends BrickBaseType implements BrickSpinner.OnItemSele
 	private static final long serialVersionUID = 1L;
 
 	private Sprite objectToClone;
+	private transient BrickSpinner<Sprite> spinner;
 
 	public CloneBrick() {
 	}
@@ -62,7 +63,7 @@ public class CloneBrick extends BrickBaseType implements BrickSpinner.OnItemSele
 		items.remove(ProjectManager.getInstance().getCurrentlyEditedScene().getBackgroundSprite());
 		items.remove(ProjectManager.getInstance().getCurrentSprite());
 
-		BrickSpinner<Sprite> spinner = new BrickSpinner<>(R.id.brick_clone_spinner, view, items);
+		spinner = new BrickSpinner<>(R.id.brick_clone_spinner, view, items);
 		spinner.setOnItemSelectedListener(this);
 		spinner.setSelection(objectToClone);
 
@@ -91,5 +92,14 @@ public class CloneBrick extends BrickBaseType implements BrickSpinner.OnItemSele
 	public void addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
 		Sprite s = (objectToClone != null) ? objectToClone : sprite;
 		sequence.addAction(sprite.getActionFactory().createCloneAction(s));
+	}
+
+	public Sprite getSelectedItem() {
+		return objectToClone;
+	}
+
+	public void resetSpinner() {
+		spinner.setSelection(0);
+		objectToClone = null;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SpriteController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SpriteController.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -165,6 +165,10 @@ public class SpriteController {
 			} catch (IOException e) {
 				Log.e(TAG, Log.getStackTraceString(e));
 			}
+		}
+		Scene currentScene = ProjectManager.getInstance().getCurrentlyEditedScene();
+		if (currentScene != null) {
+			currentScene.removeSpriteFromCloneBricks(spriteToDelete);
 		}
 	}
 


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1051

If the sprite that was used for the clone brick was deleted a clone of the current sprite will be created instead (which was also the default implementation if the sprite to clone was null)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
