### PR TITLE
CATROID-1056 Fix wrong variable references after undo

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUndoTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUndoTest.java
@@ -49,9 +49,9 @@ import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInter
 import static org.catrobat.catroid.uiespresso.content.brick.utils.ColorPickerInteractionWrapper.onColorPickerPresetButton;
 import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorDataListWrapper.onDataList;
 import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.Espresso.onView;
@@ -72,6 +72,7 @@ public class FormulaEditorUndoTest {
 	private static final String NEW_VARIABLE_NAME = "NewVariable";
 	private static final int VARIABLE_VALUE = 5;
 	private static final String NEW_VARIABLE_VALUE = "10";
+	UserVariable userVariable;
 
 	@Rule
 	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
@@ -87,7 +88,7 @@ public class FormulaEditorUndoTest {
 		brickPosition = 1;
 		Script script = BrickTestUtils.createProjectAndGetStartScript(FormulaEditorUndoTest.class.getName());
 		script.addBrick(new PlaceAtBrick());
-		UserVariable userVariable = new UserVariable(VARIABLE_NAME, VARIABLE_VALUE);
+		userVariable = new UserVariable(VARIABLE_NAME, VARIABLE_VALUE);
 		ProjectManager.getInstance().getCurrentProject().addUserVariable(userVariable);
 		script.addBrick(new SetVariableBrick(new Formula(0), userVariable));
 		baseActivityTestRule.launchActivity();
@@ -280,7 +281,8 @@ public class FormulaEditorUndoTest {
 
 		assertNotNull(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME));
 
-		assertTrue(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME).getValue().equals(VARIABLE_VALUE));
+		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME), userVariable);
+		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME).getValue(), VARIABLE_VALUE);
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
@@ -309,16 +311,19 @@ public class FormulaEditorUndoTest {
 
 		assertNull(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME));
 		assertNotNull(ProjectManager.getInstance().getCurrentProject().getUserVariable(NEW_VARIABLE_NAME));
-		assertTrue(ProjectManager.getInstance().getCurrentProject().getUserVariable(NEW_VARIABLE_NAME).getValue().equals(VARIABLE_VALUE));
+		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(NEW_VARIABLE_NAME), userVariable);
+		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(NEW_VARIABLE_NAME).getValue(), VARIABLE_VALUE);
 
 		onView(withId(R.id.menu_undo))
 				.perform(click());
+		userVariable.setName(VARIABLE_NAME);
 		onView(withId(R.id.menu_undo))
 				.check(doesNotExist());
 
 		assertNull(ProjectManager.getInstance().getCurrentProject().getUserVariable(NEW_VARIABLE_NAME));
 		assertNotNull(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME));
-		assertTrue(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME).getValue().equals(VARIABLE_VALUE));
+		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME), userVariable);
+		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME).getValue(), VARIABLE_VALUE);
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
@@ -345,14 +350,16 @@ public class FormulaEditorUndoTest {
 		onView(withId(R.id.menu_undo))
 				.check(matches(isDisplayed()));
 
-		assertTrue(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME).getValue().equals(NEW_VARIABLE_VALUE));
+		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME), userVariable);
+		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME).getValue(), NEW_VARIABLE_VALUE);
 
 		onView(withId(R.id.menu_undo))
 				.perform(click());
 		onView(withId(R.id.menu_undo))
 				.check(doesNotExist());
 
-		assertTrue(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME).getValue().equals(VARIABLE_VALUE));
+		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME), userVariable);
+		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME).getValue(), VARIABLE_VALUE);
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -42,7 +42,7 @@ import static org.catrobat.catroid.common.FlavoredConstants.DEFAULT_ROOT_DIRECTO
 
 public final class Constants {
 
-	public static final double CURRENT_CATROBAT_LANGUAGE_VERSION = 1.02;
+	public static final double CURRENT_CATROBAT_LANGUAGE_VERSION = 1.03;
 	public static final String REMOTE_DISPLAY_APP_ID = "CEBB9229";
 	public static final int CAST_CONNECTION_TIMEOUT = 5000; //in milliseconds
 	public static final int CAST_NOT_SEEING_DEVICE_TIMEOUT = 3000; //in milliseconds

--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -225,8 +225,24 @@ public class Project implements Serializable {
 		return userVariablesCopy;
 	}
 
-	public void setUserVariables(List<UserVariable> newUserVariables) {
-		userVariables = newUserVariables;
+	public <T> void restoreUserDataValues(List<T> currentUserDataList, List<T> userDataListToRestore) {
+		for (T userData : currentUserDataList) {
+			for (T userDataToRestore : userDataListToRestore) {
+				if (userData.getClass() == UserVariable.class) {
+					UserVariable userVariable = (UserVariable) userData;
+					UserVariable newUserVariable = (UserVariable) userDataToRestore;
+					if (userVariable.getName().equals(newUserVariable.getName())) {
+						userVariable.setValue(newUserVariable.getValue());
+					}
+				} else {
+					UserList userList = (UserList) userData;
+					UserList newUserList = (UserList) userDataToRestore;
+					if (userList.getName().equals(newUserList.getName())) {
+						userList.setValue(newUserList.getValue());
+					}
+				}
+			}
+		}
 	}
 
 	public UserVariable getUserVariable(String name) {
@@ -256,10 +272,6 @@ public class Project implements Serializable {
 			userLists = new ArrayList<>();
 		}
 		return userLists;
-	}
-
-	public void setUserLists(List<UserList> newUserLists) {
-		userLists = newUserLists;
 	}
 
 	public List<UserList> getUserListsCopy() {
@@ -295,10 +307,6 @@ public class Project implements Serializable {
 			}
 		}
 		return false;
-	}
-
-	public void setMultiplayerVariables(List<UserVariable> newMultiplayerVariables) {
-		multiplayerVariables = newMultiplayerVariables;
 	}
 
 	public List<UserVariable> getMultiplayerVariablesCopy() {

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -228,8 +228,24 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 		return false;
 	}
 
-	public void setUserVariables(List<UserVariable> newUserVariables) {
-		userVariables = newUserVariables;
+	public <T> void restoreUserDataValues(List<T> currentUserDataList, List<T> userDataListToRestore) {
+		for (T userData : currentUserDataList) {
+			for (T userDataToRestore : userDataListToRestore) {
+				if (userData.getClass() == UserVariable.class) {
+					UserVariable userVariable = (UserVariable) userData;
+					UserVariable newUserVariable = (UserVariable) userDataToRestore;
+					if (userVariable.getName().equals(newUserVariable.getName())) {
+						userVariable.setValue(newUserVariable.getValue());
+					}
+				} else {
+					UserList userList = (UserList) userData;
+					UserList newUserList = (UserList) userDataToRestore;
+					if (userList.getName().equals(newUserList.getName())) {
+						userList.setValue(newUserList.getValue());
+					}
+				}
+			}
+		}
 	}
 
 	public List<UserVariable> getUserVariablesCopy() {
@@ -260,10 +276,6 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 
 	public boolean addUserVariable(UserVariable userVariable) {
 		return userVariables.add(userVariable);
-	}
-
-	public void setUserLists(List<UserList> newUserLists) {
-		userLists = newUserLists;
 	}
 
 	public List<UserList> getUserListsCopy() {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -857,7 +857,9 @@ public class ScriptFragment extends ListFragment implements
 	@Override
 	public void onLoadFinished(boolean success) {
 		ProjectManager.getInstance().setCurrentSceneAndSprite(currentSceneName, currentSpriteName);
-		loadVariables();
+		if (checkVariables()) {
+			loadVariables();
+		}
 		refreshFragmentAfterUndo();
 	}
 
@@ -890,11 +892,11 @@ public class ScriptFragment extends ListFragment implements
 		Sprite currentSprite = projectManager.getCurrentSprite();
 		Project project = projectManager.getCurrentProject();
 
-		project.setUserVariables(savedUserVariables);
-		project.setMultiplayerVariables(savedMultiplayerVariables);
-		project.setUserLists(savedUserLists);
-		currentSprite.setUserVariables(savedLocalUserVariables);
-		currentSprite.setUserLists(savedLocalLists);
+		project.restoreUserDataValues(project.getUserVariables(), savedUserVariables);
+		project.restoreUserDataValues(project.getMultiplayerVariables(), savedMultiplayerVariables);
+		project.restoreUserDataValues(project.getUserLists(), savedUserLists);
+		currentSprite.restoreUserDataValues(currentSprite.getUserVariables(), savedLocalUserVariables);
+		currentSprite.restoreUserDataValues(currentSprite.getUserLists(), savedLocalLists);
 	}
 
 	private void refreshFragmentAfterUndo() {


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1056

When loading the old values of the variables after an undo a deep copy of all the uservariables was restored. This leads to the problem that there are now two instances of the same uservariable (one in the uservariable list of the project and one that is actually stored within the bricks). In order to fix this after performing an undo the uservariables are not copied in a deep manner but just the values are restored (so that the references do not change).

Additionally changed the test `FormulaEditorUndoTest` to also check if the uservariable references stay the same after an undo.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
