### PR TITLE
CATROID-1034 Fix face/text detection bug

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -421,6 +421,11 @@ public class StageListener implements ApplicationListener {
 		scene = newScene;
 		ProjectManager.getInstance().setCurrentlyPlayingScene(scene);
 
+		CameraManager cameraManager = StageActivity.getActiveCameraManager();
+		if (cameraManager != null) {
+			cameraManager.resume();
+		}
+
 		SoundManager.getInstance().clear();
 		SpeechRecognitionHolder.Companion.getInstance().destroy();
 		stageBackupMap.remove(sceneName);


### PR DESCRIPTION
Ticket: https://jira.catrob.at/browse/CATROID-1034
### Problem:
Face/Text detection stops working when transitioned to any other scene.

### Cause and Fix:
Not sure, but observing the logs, the `CameraManager` seemed to be inactive/paused during the time `startScene()` method of class `StageListener` was called while changing scenes. Hence, added `cameraManager.resume()` in `startScene()` to resume it. Here are the logs before and after the commit -

Before | After
-------| ----- 
<img src="https://user-images.githubusercontent.com/10892504/115778613-900b8380-a3d4-11eb-8a0f-023f6cbecd19.png" width=600> | <img src="https://user-images.githubusercontent.com/10892504/115778718-b7fae700-a3d4-11eb-9e89-0c0caeb44f21.png" width=600>


- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behaviour
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
