### PR TITLE
CATROID-1058 Fix Edit look does not work correctly with clones

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/EditLookAction.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/EditLookAction.kt
@@ -23,7 +23,6 @@
 
 package org.catrobat.catroid.content.actions
 
-import android.app.Activity
 import android.content.ComponentName
 import android.content.Intent
 import android.os.Bundle
@@ -53,6 +52,7 @@ class EditLookAction : PocketPaintAction() {
         if (scope?.sprite?.look?.lookData?.file?.exists() != true) {
             return null
         }
+        setLookData()
         val lookAbsolutePath = scope?.sprite?.look?.lookData?.file?.absolutePath ?: return null
         return StageActivity.activeStageActivity.get()?.let { stageActivity ->
             val intent = Intent("android.intent.action.MAIN").setComponent(ComponentName(
@@ -68,9 +68,6 @@ class EditLookAction : PocketPaintAction() {
 
     override fun onIntentResult(resultCode: Int, data: Intent?) {
         val stageActivity = StageActivity.activeStageActivity.get()
-        if (resultCode == Activity.RESULT_OK && stageActivity != null) {
-            setLookData()
-        }
         LookRequester.anyAsked = false
         responseReceived = true
         stageActivity?.onResume()
@@ -79,19 +76,17 @@ class EditLookAction : PocketPaintAction() {
     @VisibleForTesting
     fun setLookData() {
         val sprite = scope?.sprite ?: return
-        val lookData = sprite?.look?.lookData ?: return
+        val lookData = sprite.look?.lookData ?: return
         val lookDataName = lookData.name ?: return
         val lookDataOldFile = sprite.look?.lookData?.file ?: return
-
         try {
             val lookDataNewFile = StorageOperations.duplicateFile(lookDataOldFile)
-            val lookData = LookData(lookDataName, lookDataNewFile)
+            val newLookData = LookData(lookDataName, lookDataNewFile)
             val lookDataIndex = sprite.lookList.indexOf(sprite.look.lookData)
             sprite.look.lookListIndexBeforeLookRequest = lookDataIndex
             sprite.lookList.removeAt(lookDataIndex)
-            sprite.lookList.add(lookDataIndex, lookData)
-            lookDataOldFile.delete()
-            lookData.collisionInformation.calculate()
+            sprite.lookList.add(lookDataIndex, newLookData)
+            newLookData.collisionInformation.calculate()
         } catch (e: IOException) {
             Log.e(TAG, Log.getStackTraceString(e))
         }

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/EditLookActionTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/EditLookActionTest.kt
@@ -25,7 +25,7 @@ package org.catrobat.catroid.test.content.actions
 
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction
 import com.badlogic.gdx.utils.GdxNativesLoader
-import junit.framework.Assert
+import junit.framework.Assert.assertEquals
 import org.catrobat.catroid.ProjectManager
 import org.catrobat.catroid.common.LookData
 import org.catrobat.catroid.content.Project
@@ -38,8 +38,10 @@ import org.catrobat.catroid.test.MockUtil
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 import org.powermock.api.mockito.PowerMockito
 import org.powermock.core.classloader.annotations.PrepareForTest
 import org.powermock.modules.junit4.PowerMockRunner
@@ -64,9 +66,9 @@ class EditLookActionTest {
         PowerMockito.mockStatic(XstreamSerializer::class.java)
         PowerMockito.mockStatic(GdxNativesLoader::class.java)
         PowerMockito.mockStatic(StorageOperations::class.java)
-        Mockito.`when`(StorageOperations.duplicateFile(lookDataFile)).thenReturn(lookDataFileEdited)
-        Mockito.`when`(XstreamSerializer.getInstance()).thenReturn(xstreamSerializerMock)
-        Mockito.`when`(xstreamSerializerMock.saveProject(projectMock)).thenReturn(true)
+        `when`(StorageOperations.duplicateFile(lookDataFile)).thenReturn(lookDataFileEdited)
+        `when`(XstreamSerializer.getInstance()).thenReturn(xstreamSerializerMock)
+        `when`(xstreamSerializerMock.saveProject(projectMock)).thenReturn(true)
     }
 
     @Test
@@ -74,10 +76,12 @@ class EditLookActionTest {
         with(Sprite()) {
             val setNewLookAction = actionFactory.createSetNextLookAction(this, testSequence)
             val editLookAction = actionFactory.createEditLookAction(
-                this, testSequence, setNewLookAction as SetNextLookAction) as EditLookAction
+                this, testSequence, setNewLookAction as SetNextLookAction
+            ) as EditLookAction
             editLookAction.setLookData()
             setNewLookAction.act(1f)
-            Assert.assertEquals(0, this.lookList.size)
+            assertEquals(0, this.lookList.size)
+            verify(lookDataFile, times(0)).delete()
         }
     }
 
@@ -88,9 +92,11 @@ class EditLookActionTest {
             this.look.lookData = lookData
             val setNewLookAction = actionFactory.createSetNextLookAction(this, testSequence)
             val editLookAction = actionFactory.createEditLookAction(
-                this, testSequence, setNewLookAction as SetNextLookAction) as EditLookAction
+                this, testSequence, setNewLookAction as SetNextLookAction
+            ) as EditLookAction
             editLookAction.setLookData()
-            Assert.assertEquals(lookDataFileEdited, this.lookList[0].file)
+            assertEquals(lookDataFileEdited, this.lookList[0].file)
+            verify(lookDataFile, times(0)).delete()
         }
     }
 }


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1058

Before this PR when Edit Look was used a new look file for editing was created and the old look file was deleted. This caused problems when clones still needed the old look file. Now Edit Look does not delete the old file anymore. If the old file is not in use by anyone, it is cleaned up later by the LookFileGarbageCollector when the project is loaded.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
