### PR TITLE
CATROID-1019 Crash in org.catrobat.catroid.content.Scope

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SceneControllerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SceneControllerTest.java
@@ -31,6 +31,9 @@ import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.AddItemToUserListBrick;
+import org.catrobat.catroid.content.bricks.AssertUserListsBrick;
+import org.catrobat.catroid.content.bricks.HideTextBrick;
 import org.catrobat.catroid.content.bricks.PlaceAtBrick;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
@@ -240,6 +243,9 @@ public class SceneControllerTest {
 		StartScript script = new StartScript();
 		PlaceAtBrick placeAtBrick = new PlaceAtBrick(0, 0);
 		script.addBrick(placeAtBrick);
+		script.addBrick(new HideTextBrick());
+		script.addBrick(new AddItemToUserListBrick());
+		script.addBrick(new AssertUserListsBrick());
 		sprite.addScript(script);
 
 		XstreamSerializer.getInstance().saveProject(project);

--- a/catroid/src/main/java/org/catrobat/catroid/content/Scope.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Scope.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -26,7 +26,7 @@ package org.catrobat.catroid.content
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction
 
 data class Scope(
-    val project: Project,
+    val project: Project?,
     val sprite: Sprite,
     val sequence: SequenceAction?
 )

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/ColorAtXYDetection.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/ColorAtXYDetection.kt
@@ -108,14 +108,17 @@ class ColorAtXYDetection(
         val lookList: MutableList<Look> = getLooksOfRelevantSprites()
 
         val batch = SpriteBatch()
-        val projectionMatrix = createProjectionMatrix(scope.project)
-        val stagePixmap = createPicture(lookList, projectionMatrix, batch)
+        val projectionMatrix = scope.project?.let { createProjectionMatrix(it) }
+        val stagePixmap = projectionMatrix?.let { createPicture(lookList, it, batch) }
         try {
-            return rgbaColorToRGBHexString(Color(stagePixmap.getPixel(0, 0)))
+            if (stagePixmap != null) {
+                return rgbaColorToRGBHexString(Color(stagePixmap.getPixel(0, 0)))
+            }
         } finally {
             stagePixmap?.dispose()
             batch.dispose()
         }
+        return "#000000"
     }
 
     private fun getHexColorStringFromBitmapAtPosition(

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/ColorCollisionDetection.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/ColorCollisionDetection.kt
@@ -62,11 +62,13 @@ class ColorCollisionDetection(
         val lookList: MutableList<Look> = getLooksOfRelevantSprites()
         val batch = SpriteBatch()
         val spriteBatch = SpriteBatch()
-        val projectionMatrix = createProjectionMatrix(scope.project)
-        matcher.stagePixmap = createPicture(lookList, projectionMatrix, batch)
+        val projectionMatrix = scope.project?.let { createProjectionMatrix(it) }
+        matcher.stagePixmap = projectionMatrix?.let { createPicture(lookList, it, batch) }
         val wasLookVisible = look.isLookVisible
         look.isLookVisible = true
-        matcher.spritePixmap = createPicture(listOf(look), projectionMatrix, spriteBatch)
+        matcher.spritePixmap = projectionMatrix?.let {
+            createPicture(listOf(look), it, spriteBatch)
+        }
         look.isLookVisible = wasLookVisible
 
         try {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/ScriptController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/ScriptController.java
@@ -94,35 +94,42 @@ public class ScriptController {
 
 			if (brick instanceof UserVariableBrickInterface && ((UserVariableBrickInterface) brick).getUserVariable() != null) {
 				UserVariable previousUserVar = ((UserVariableBrickInterface) brick).getUserVariable();
-				Scope scope = new Scope(dstProject, dstSprite, null);
-				UserVariable updatedUserVar = UserDataWrapper
-						.getUserVariable(previousUserVar.getName(), scope);
-				((UserVariableBrickInterface) brick).setUserVariable(updatedUserVar);
+
+				if (previousUserVar != null) {
+					Scope scope = new Scope(dstProject, dstSprite, null);
+					UserVariable updatedUserVar = UserDataWrapper
+							.getUserVariable(previousUserVar.getName(), scope);
+					((UserVariableBrickInterface) brick).setUserVariable(updatedUserVar);
+				}
 			}
 
 			if (brick instanceof UserListBrick && ((UserListBrick) brick).getUserList() != null) {
 				UserList previousUserList = ((UserListBrick) brick).getUserList();
 
-				Scope scope = new Scope(dstProject, dstSprite, null);
-				UserList updatedUserList = UserDataWrapper
-						.getUserList(previousUserList.getName(), scope);
-				((UserListBrick) brick).setUserList(updatedUserList);
+				if (previousUserList != null) {
+					Scope scope = new Scope(dstProject, dstSprite, null);
+					UserList updatedUserList = UserDataWrapper
+							.getUserList(previousUserList.getName(), scope);
+					((UserListBrick) brick).setUserList(updatedUserList);
+				}
 			}
 
 			if (brick instanceof UserDataBrick) {
 				for (Map.Entry<Brick.BrickData, UserData> entry
 						: ((UserDataBrick) brick).getUserDataMap().entrySet()) {
 					UserData previousUserData = entry.getValue();
-					UserData updatedUserList;
-					Scope scope = new Scope(dstProject, dstSprite, null);
-					if (Brick.BrickData.isUserList(entry.getKey())) {
-						updatedUserList = UserDataWrapper
-								.getUserList(previousUserData.getName(), scope);
-					} else {
-						updatedUserList = UserDataWrapper
-								.getUserVariable(previousUserData.getName(), scope);
+					if (previousUserData != null) {
+						UserData updatedUserList;
+						Scope scope = new Scope(dstProject, dstSprite, null);
+						if (Brick.BrickData.isUserList(entry.getKey())) {
+							updatedUserList = UserDataWrapper
+									.getUserList(previousUserData.getName(), scope);
+						} else {
+							updatedUserList = UserDataWrapper
+									.getUserVariable(previousUserData.getName(), scope);
+						}
+						entry.setValue(updatedUserList);
 					}
-					entry.setValue(updatedUserList);
 				}
 			}
 		}


### PR DESCRIPTION
This bug happens when bricks with user defined data (variables, lists) get packed and a new scope is instantiated in the process. Fixed the bug by allowing a null pointer for the project in the scope. (This is necessary because when packing the script does not belong to any project). Added a userlist, a uservariable and a userdata brick type which are leading to this problem to the scenecontroller test.

https://jira.catrob.at/browse/CATROID-1019

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
