### PR TITLE
CATROID-1062 Fix SystemOutTest

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/stage/SearchParameterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/stage/SearchParameterTest.java
@@ -23,8 +23,10 @@
 
 package org.catrobat.catroid.test.stage;
 
+import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
+import android.view.inputmethod.InputMethodManager;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
@@ -52,11 +54,14 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.matcher.ViewMatchers;
 
 import static org.catrobat.catroid.test.utils.TestUtils.deleteProjects;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
@@ -135,6 +140,26 @@ public class SearchParameterTest {
 		onView(withId(R.id.search_bar)).perform(typeText("look 1"));
 		onView(withId(R.id.find)).perform(click());
 		onView(withText("look 1")).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
+	}
+
+	@Test
+	public void closeKeyboardAfterSearching() {
+		openActionBarOverflowOrOptionsMenu(baseActivityTestRule.getActivity());
+		onView(withText(R.string.find)).perform(click());
+		assertTrue(isKeyboardVisible());
+		onView(withId(R.id.close)).perform(click());
+		assertFalse(isKeyboardVisible());
+	}
+
+	public boolean isKeyboardVisible() {
+		try {
+			final InputMethodManager manager = (InputMethodManager) ApplicationProvider.getApplicationContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+			final Method windowHeightMethod = InputMethodManager.class.getMethod("getInputMethodWindowVisibleHeight");
+			final int height = (int) windowHeightMethod.invoke(manager);
+			return height > 0;
+		} catch (Exception e) {
+			return false;
+		}
 	}
 
 	public void createProject(String projectName) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ScriptFinder.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ScriptFinder.java
@@ -38,7 +38,6 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
@@ -47,6 +46,7 @@ import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.utils.ToastUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -143,7 +143,7 @@ public class ScriptFinder extends LinearLayout {
 			updateUI();
 		} else {
 			searchPositionIndicator.setText("0/0");
-			Toast.makeText(getContext(), getContext().getString(R.string.no_results_found), Toast.LENGTH_SHORT).show();
+			ToastUtil.showError(getContext(), getContext().getString(R.string.no_results_found));
 		}
 	}
 
@@ -153,7 +153,7 @@ public class ScriptFinder extends LinearLayout {
 			updateUI();
 		} else {
 			searchPositionIndicator.setText("0/0");
-			Toast.makeText(getContext(), getContext().getString(R.string.no_results_found), Toast.LENGTH_SHORT).show();
+			ToastUtil.showError(getContext(), getContext().getString(R.string.no_results_found));
 		}
 	}
 
@@ -272,6 +272,7 @@ public class ScriptFinder extends LinearLayout {
 		searchEt.setText("");
 		searchQuery = "";
 		onCloseListener.onClose();
+		ViewUtils.hideKeyboard(this);
 	}
 
 	public boolean isClosed() {


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1062
- changed Toast.makeText() to ToastUtil.showError()
- additionally dismiss keyboard after searching in script view

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
