### PR TITLE
CATROID-1063 Fix UserDefinedBricks lost when converting to GroupItemSprite

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SpriteControllerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SpriteControllerTest.java
@@ -31,6 +31,7 @@ import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.PlaceAtBrick;
+import org.catrobat.catroid.content.bricks.UserDefinedBrick;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.io.ResourceImporter;
@@ -90,8 +91,10 @@ public class SpriteControllerTest {
 
 		String spriteVarName = "spriteVar";
 		String spriteListName = "spriteList";
+		UserDefinedBrick userDefinedBrick = new UserDefinedBrick();
 		assertTrue(sprite.addUserVariable(new UserVariable(spriteVarName)));
 		assertTrue(sprite.addUserList(new UserList(spriteListName)));
+		sprite.addUserDefinedBrick(userDefinedBrick);
 
 		Sprite copy = controller.copy(sprite, project, scene);
 
@@ -112,8 +115,47 @@ public class SpriteControllerTest {
 		assertNotSame(sprite.getUserList(spriteListName),
 				copy.getUserList(spriteListName));
 
+		assertNotNull(sprite.getUserDefinedBrickWithSameUserData(userDefinedBrick));
+		assertNotNull(copy.getUserDefinedBrickWithSameUserData(userDefinedBrick));
+		assertNotSame(sprite.getUserDefinedBrickWithSameUserData(userDefinedBrick),
+				copy.getUserDefinedBrickWithSameUserData(userDefinedBrick));
+
 		assertFileExists(copy.getLookList().get(0).getFile());
 		assertFileExists(copy.getSoundList().get(0).getFile());
+	}
+
+	@Test
+	public void testConvertSpriteToGroupItemSprite() {
+		SpriteController controller = new SpriteController();
+
+		String spriteVarName = "spriteVar";
+		String spriteListName = "spriteList";
+		UserDefinedBrick userDefinedBrick = new UserDefinedBrick();
+		assertTrue(sprite.addUserVariable(new UserVariable(spriteVarName)));
+		assertTrue(sprite.addUserList(new UserList(spriteListName)));
+		sprite.addUserDefinedBrick(userDefinedBrick);
+
+		sprite.setConvertToGroupItemSprite(true);
+		Sprite groupItemSprite = controller.convert(sprite);
+
+		assertEquals(2, scene.getSpriteList().size());
+
+		assertEquals(sprite.getLookList().size(), groupItemSprite.getLookList().size());
+		assertEquals(sprite.getSoundList().size(), groupItemSprite.getSoundList().size());
+		assertEquals(sprite.getNumberOfScripts(), groupItemSprite.getNumberOfScripts());
+		assertEquals(sprite.getNumberOfBricks(), groupItemSprite.getNumberOfBricks());
+
+		assertNotNull(sprite.getUserVariable(spriteVarName));
+		assertNotNull(groupItemSprite.getUserVariable(spriteVarName));
+
+		assertNotNull(sprite.getUserList(spriteListName));
+		assertNotNull(groupItemSprite.getUserList(spriteListName));
+
+		assertNotNull(sprite.getUserDefinedBrickWithSameUserData(userDefinedBrick));
+		assertNotNull(groupItemSprite.getUserDefinedBrickWithSameUserData(userDefinedBrick));
+
+		assertFileExists(groupItemSprite.getLookList().get(0).getFile());
+		assertFileExists(groupItemSprite.getSoundList().get(0).getFile());
 	}
 
 	@Test

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -420,6 +420,7 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 
 		convertedSprite.userVariables = userVariables;
 		convertedSprite.userLists = userLists;
+		convertedSprite.userDefinedBrickList = userDefinedBrickList;
 
 		return convertedSprite;
 	}


### PR DESCRIPTION
The issue in the ticket does not come from copying itself, but from moving the Sprite into a Group. Thereby the Sprite is converted to a GroupItemSprite and all the variables, looks, etc. copied. However it was forgotten to also copy the list of UserDefinedBricks there, leading to the issue that the UserDefinedBricks get lost when the corresponding Sprite is moved into a Group.
- Added further testcase for the conversion of Sprites to GroupItemSprites to existing test

https://jira.catrob.at/browse/CATROID-1063

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
