### PR TITLE
CATROID-1021 fix crash because of NullPointer in LookData

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/CloneBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/CloneBrick.java
@@ -90,7 +90,7 @@ public class CloneBrick extends BrickBaseType implements BrickSpinner.OnItemSele
 
 	@Override
 	public void addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
-		Sprite s = (objectToClone != null) ? objectToClone : sprite;
+		Sprite s = ((objectToClone != null) && (ProjectManager.getInstance().getCurrentlyPlayingScene().getSprite(objectToClone.getName()) != null)) ? objectToClone : sprite;
 		sequence.addAction(sprite.getActionFactory().createCloneAction(s));
 	}
 


### PR DESCRIPTION
*Please enter a short description of your pull request and add a reference to the Jira ticket.*
The app crashed because of a NullPointerException when a look was cloned, which was deleted before. This does not happen anymore and it clones its own look instead, which is the default behavior. 
Can be reproduced by: 
- Create Project
- Add one actor and copy it (e.g. Raccon)
- insert Clone brick into one actor and choose the other second actor from the spinner
- delete second actor(do **not** go into the first actor)
- navigate back to landing page
- get back into the project
- run project

https://jira.catrob.at/browse/CATROID-1021
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Stick to the project’s gitflow workflow
- [X] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
