### PR TITLE
CATROID-971 Unused "empty" event bricks shall be discarded

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/BrickAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/BrickAdapter.java
@@ -31,6 +31,7 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.BaseAdapter;
 
+import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
@@ -104,6 +105,9 @@ public class BrickAdapter extends BaseAdapter implements
 
 	private void updateItemsFromCurrentScripts() {
 		items.clear();
+		if (ProjectManager.getInstance() != null && ProjectManager.getInstance().getCurrentSprite() != null) {
+			ProjectManager.getInstance().getCurrentSprite().removeAllEmptyScriptBricks();
+		}
 		for (Script script : scripts) {
 			script.setParents();
 			script.addToFlatList(items);


### PR DESCRIPTION
Deleted all "empty" event bricks that do not have associated bricks in their script.

https://jira.catrob.at/browse/CATROID-971

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
