### PR TITLE
CATROID-888 Fix deleting a scene after renaming

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SceneControllerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SceneControllerTest.java
@@ -69,6 +69,7 @@ public class SceneControllerTest {
 	private Project project;
 	private Scene scene;
 	private BackpackListManager backpackListManager;
+	private String newName = "new Scene Name";
 
 	@Before
 	public void setUp() throws IOException {
@@ -86,7 +87,6 @@ public class SceneControllerTest {
 	@Test
 	public void testRenameScene() {
 		String previousName = scene.getName();
-		String newName = "new Scene Name";
 
 		SceneController controller = new SceneController();
 		controller.rename(scene, newName);
@@ -135,8 +135,22 @@ public class SceneControllerTest {
 
 		controller.delete(scene);
 
-		assertEquals(1, project.getSceneList().size());
+		assertEquals(0, project.getSceneList().size());
+
 		assertFileDoesNotExist(deletedSceneDirectory);
+	}
+
+	@Test
+	public void testDeleteAfterRenameScene() throws IOException {
+		SceneController controller = new SceneController();
+		Scene sceneToRename = new Scene("Scene To Rename", project);
+		project.addScene(sceneToRename);
+		XstreamSerializer.getInstance().saveProject(project);
+		File renamedSceneDirectory = sceneToRename.getDirectory();
+		controller.rename(sceneToRename, newName);
+		controller.delete(sceneToRename);
+		assertEquals(1, project.getSceneList().size());
+		assertFileDoesNotExist(renamedSceneDirectory);
 	}
 
 	@Test

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SceneController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SceneController.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -84,10 +84,14 @@ public class SceneController {
 	}
 
 	public boolean rename(Scene sceneToRename, String name) {
+		boolean renamed = true;
 		String previousName = sceneToRename.getName();
 		String encodedName = FileMetaDataExtractor.encodeSpecialCharsForFileSystem(name);
 		File newDir = new File(sceneToRename.getProject().getDirectory(), encodedName);
-		boolean renamed = sceneToRename.getDirectory().renameTo(newDir);
+		File oldDir = sceneToRename.getDirectory();
+		if (oldDir.exists()) {
+			renamed = oldDir.renameTo(newDir);
+		}
 
 		if (renamed) {
 			sceneToRename.setName(name);
@@ -131,6 +135,7 @@ public class SceneController {
 	}
 
 	public void delete(Scene sceneToDelete) throws IOException {
+		ProjectManager.getInstance().getCurrentProject().removeScene(sceneToDelete);
 		StorageOperations.deleteDir(sceneToDelete.getDirectory());
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SceneListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SceneListFragment.java
@@ -197,6 +197,9 @@ public class SceneListFragment extends RecyclerViewFragment<Scene> implements Pr
 		scene.addSprite(backgroundSprite);
 
 		adapter.add(scene);
+		if (!currentProject.hasScene()) {
+			currentProject.addScene(scene);
+		}
 		setShowProgressBar(false);
 	}
 


### PR DESCRIPTION
- deleting a scene previously only deleted the corresponding directory -> also delete the instance within ProjectManager
- adapt already existing testcase to check for deleting a scene after a renaming
- adding a new scene and immediately renaming it without opening it once before, sometimes leads to the warning that the scene cannot be renamed -> also fixed by this PR

https://jira.catrob.at/browse/CATROID-888

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
