### PR TITLE
PAINTROID-248 Make "BUILD_WITH_CATROID" flag work again on Jenkins

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -50,6 +50,7 @@ ext {
     gdxVersion = "1.9.10"
     mockitoVersion = "2.8.47"
     espressoVersion = "3.1.0"
+    paintroidVersion = '2.7.3'
     playServicesVersion = "17.0.0"
     cameraXVersion = "1.0.0-beta07"
 }
@@ -331,7 +332,13 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     // Paintroid local aar lib files
-    implementation fileTree(dir: 'src/main/libs', include: ['*.aar'])
+    if(rootProject.hasProperty('paintroidLocal')) {
+        paintroidVersion = paintroidVersion + "-LOCAL"
+        catroidImplementation "org.catrobat.paintroid:paintroid:$paintroidVersion"
+        implementation "org.catrobat.paintroid:colorpicker:$paintroidVersion"
+    } else {
+        implementation fileTree(dir: 'src/main/libs', include: ['*.aar'])
+    }
     implementation 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
 
     // Kotlin


### PR DESCRIPTION
I am not sure if I 100% understood the more future proof way. So this way when Paintroid is built with the Catroid Flag ("paintroidLocal") on Jenkins, the artifacts get stored by MavenLocal and then will be used to build the Catroid project. If the flag is not set (basically the usual build), Catroid will use its local paintroid libs. 

Here is a PR where I added a Toast in the MainActivity to verify that the building would work with Catroid.
https://github.com/Catrobat/Paintroid/pull/909

https://jira.catrob.at/browse/PAINTROID-248

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
