### PR TITLE
CATROID-1112 Topbar disappears in script search

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/stage/SearchParameterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/stage/SearchParameterTest.java
@@ -49,6 +49,7 @@ import org.catrobat.catroid.content.bricks.TapAtBrick;
 import org.catrobat.catroid.rules.FlakyTestRule;
 import org.catrobat.catroid.runner.Flaky;
 import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper;
 import org.catrobat.catroid.uiespresso.util.actions.CustomActions;
 import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
 import org.junit.After;
@@ -68,10 +69,12 @@ import static org.junit.Assert.assertTrue;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -147,6 +150,20 @@ public class SearchParameterTest {
 		onView(withId(R.id.search_bar)).perform(typeText("look 1"));
 		onView(withId(R.id.find)).perform(click());
 		onView(withText("look 1")).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
+	}
+
+	@Test
+	public void tobBarVisibleAfterSelectingBrickFieldTest() {
+		String searchParam = "0";
+		openActionBarOverflowOrOptionsMenu(baseActivityTestRule.getActivity());
+		onView(withText(R.string.find)).perform(click());
+		onView(withId(R.id.search_bar)).perform(clearText());
+		onView(withId(R.id.search_bar)).perform(typeText(searchParam));
+		onView(withId(R.id.find)).perform(click());
+		BrickDataInteractionWrapper.onBrickAtPosition(1).onFormulaTextField(R.id.brick_set_x_edit_text).perform(click());
+		pressBack();
+		pressBack();
+		onView(withId(R.id.toolbar)).check(matches(isDisplayed()));
 	}
 
 	@Test

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -141,6 +141,8 @@ public class ScriptFragment extends ListFragment implements
 	private Brick brickToFocus;
 	private Script scriptToFocus;
 
+	private SpriteActivity activity;
+
 	public static ScriptFragment newInstance(Brick brickToFocus) {
 		ScriptFragment scriptFragment = new ScriptFragment();
 		Bundle bundle = new Bundle();
@@ -270,8 +272,9 @@ public class ScriptFragment extends ListFragment implements
 		View view = View.inflate(getActivity(), R.layout.fragment_script, null);
 		listView = view.findViewById(android.R.id.list);
 
-		scriptFinder = view.findViewById(R.id.findview);
+		activity = (SpriteActivity) getActivity();
 
+		scriptFinder = view.findViewById(R.id.findview);
 		scriptFinder.setOnResultFoundListener((sceneIndex, spriteIndex, brickIndex, totalResults,
 				textView
 				) -> {
@@ -293,12 +296,10 @@ public class ScriptFragment extends ListFragment implements
 			hideKeyboard();
 		});
 
-		SpriteActivity activity = (SpriteActivity) getActivity();
-
 		scriptFinder.setOnCloseListener(() -> {
 			listView.cancelHighlighting();
 			finishActionMode();
-			if (activity instanceof SpriteActivity && !activity.isFinishing()) {
+			if (activity != null && !activity.isFinishing()) {
 				activity.setCurrentSceneAndSprite(ProjectManager.getInstance().getCurrentlyEditedScene(),
 						ProjectManager.getInstance().getCurrentSprite());
 				activity.getSupportActionBar().setTitle(activity.createActionBarTitle());
@@ -334,6 +335,14 @@ public class ScriptFragment extends ListFragment implements
 		InputMethodManager imm =
 				(InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
 		imm.hideSoftInputFromWindow(getView().getWindowToken(), 0);
+	}
+
+	@Override
+	public void onDestroyView() {
+		super.onDestroyView();
+		if (scriptFinder.isOpen() && activity != null) {
+			activity.findViewById(R.id.toolbar).setVisibility(View.VISIBLE);
+		}
 	}
 
 	@Override

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -2111,6 +2111,7 @@ needs read and write access to it. You can always change permissions through you
 
     <string name="find">Find</string>
     <string name="no_results_found">No results found</string>
+    <string name="query_field_is_empty">Query field is empty</string>
 
     <string name="cut">Cut</string>
     <string name="paste">Paste</string>


### PR DESCRIPTION
Ticket: https://jira.catrob.at/browse/CATROID-1112

## Topbar disappears in script search

### Additional changes:
1. Disable search when the query is empty
2. Changed variable naming scheme in ScriptFinder to make them easier to understand.


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
