### PR TITLE
CATROID-1086 Fix length of assert input fields

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/BrickLayout.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/BrickLayout.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -187,8 +187,10 @@ public class BrickLayout extends ViewGroup {
 			if (userBrick) {
 				newLine = lineLengthWithHorizontalSpacing > sizeWidth;
 			} else {
-				newLine = (layoutParams.newLine && totalLengthOfContent - combinedLengthOfPreviousLines > sizeWidth);
+				newLine = layoutParams.newLine && (totalLengthOfContent - combinedLengthOfPreviousLines) > sizeWidth;
 			}
+
+			newLine = newLine || layoutParams.forceNewLine;
 
 			boolean lastChildWasSpinner = false;
 			if (i > 0) {
@@ -197,11 +199,9 @@ public class BrickLayout extends ViewGroup {
 			newLine = newLine || child instanceof Spinner || lastChildWasSpinner;
 
 			if (newLine) {
-				int childWidthNotCountingField = (layoutParams.textField ? childWidth : 0);
-				int endingWidthOfLineMinusFields = (lineLength - (childWidthNotCountingField + horizontalSpacing + currentLine.totalTextFieldWidth));
-				float allowalbeWidth = (float) (sizeWidth - (endingWidthOfLineMinusFields))
-						/ currentLine.numberOfTextFields;
-				currentLine.allowableTextFieldWidth = (int) Math.floor(allowalbeWidth);
+				int endingWidthOfLineMinusFields = (lineLength - (childWidth + horizontalSpacing + currentLine.totalTextFieldWidth));
+				float allowableWidth = (float) (sizeWidth - (endingWidthOfLineMinusFields)) / currentLine.numberOfTextFields;
+				currentLine.allowableTextFieldWidth = (int) Math.floor(allowableWidth);
 
 				currentLine = getNextLine(currentLine);
 
@@ -222,22 +222,15 @@ public class BrickLayout extends ViewGroup {
 		}
 
 		int endingWidthOfLineMinusFields = (lineLength - currentLine.totalTextFieldWidth);
-		float allowalbeWidth = (float) (sizeWidth - endingWidthOfLineMinusFields) / currentLine.numberOfTextFields;
-		currentLine.allowableTextFieldWidth = (int) Math.floor(allowalbeWidth);
-
-		int minAllowableTextFieldWidth = Integer.MAX_VALUE;
-		for (LineData lineData : lines) {
-			if (lineData.allowableTextFieldWidth > 0 && lineData.allowableTextFieldWidth < minAllowableTextFieldWidth) {
-				minAllowableTextFieldWidth = lineData.allowableTextFieldWidth;
-			}
-		}
+		float allowableWidth = (float) (sizeWidth - endingWidthOfLineMinusFields) / currentLine.numberOfTextFields;
+		currentLine.allowableTextFieldWidth = (int) Math.floor(allowableWidth);
 
 		for (LineData lineData : lines) {
 			for (ElementData elementData : lineData.elements) {
 				if (elementData.view != null) {
 					LayoutParams layoutParams = (LayoutParams) elementData.view.getLayoutParams();
-					if (layoutParams.textField) {
-						((TextView) elementData.view).setMaxWidth(minAllowableTextFieldWidth);
+					if (layoutParams.textField && lineData.allowableTextFieldWidth > 0) {
+						((TextView) elementData.view).setMaxWidth(lineData.allowableTextFieldWidth);
 					}
 				}
 			}
@@ -588,6 +581,7 @@ public class BrickLayout extends ViewGroup {
 		private int horizontalSpacing = NO_SPACING;
 		private int verticalSpacing = NO_SPACING;
 		private boolean newLine = false;
+		private boolean forceNewLine = false;
 		private boolean textField = false;
 		private InputType inputType = InputType.NUMBER;
 
@@ -646,6 +640,7 @@ public class BrickLayout extends ViewGroup {
 				verticalSpacing = styledAttributes.getDimensionPixelSize(
 						R.styleable.BrickLayout_Layout_layout_verticalSpacing, NO_SPACING);
 				newLine = styledAttributes.getBoolean(R.styleable.BrickLayout_Layout_layout_newLine, false);
+				forceNewLine = styledAttributes.getBoolean(R.styleable.BrickLayout_Layout_layout_forceNewLine, false);
 				textField = styledAttributes.getBoolean(R.styleable.BrickLayout_Layout_layout_textField, false);
 				String inputTypeString = styledAttributes
 						.getString(R.styleable.BrickLayout_Layout_layout_inputType);

--- a/catroid/src/main/res/layout/brick_assert_equals.xml
+++ b/catroid/src/main/res/layout/brick_assert_equals.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2018 The Catrobat Team
+  ~ Copyright (C) 2010-2021 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -38,12 +38,10 @@
 
     <org.catrobat.catroid.ui.BrickLayout
         android:id="@+id/brick_assert_equals_layout"
-        style="@style/BrickContainer.Test.Medium"
         android:orientation="horizontal"
-        android:paddingBottom="0dp"
-        android:paddingTop="0dp"
         app:horizontalSpacing="@dimen/brick_flow_layout_horizontal_spacing"
-        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing">
+        app:verticalSpacing="@dimen/brick_flow_layout_vertical_spacing"
+        style="@style/BrickContainer.Test.Big">
 
         <include layout="@layout/icon_brick_category_look" />
 
@@ -56,14 +54,16 @@
             android:id="@+id/brick_assert_actual"
             style="@style/BrickEditText"
             app:layout_inputType="string"
-            android:layout_width="match_parent"
-            app:layout_textField="true">
+            app:layout_textField="true"
+            app:layout_forceNewLine="true"
+            android:singleLine="false"
+            android:maxLines="3">
         </TextView>
 
         <TextView
             style="@style/BrickText.SingleLine"
             android:text="@string/brick_is_equal_to"
-            app:layout_newLine="true">
+            app:layout_forceNewLine="true">
         </TextView>
 
         <TextView
@@ -71,12 +71,10 @@
             style="@style/BrickEditText"
             android:layout_width="match_parent"
             app:layout_inputType="number"
-            app:layout_textField="true">
-        </TextView>
-
-        <TextView
-            android:id="@+id/brick_seconds_label"
-            style="@style/BrickText.SingleLine">
+            app:layout_textField="true"
+            app:layout_forceNewLine="true"
+            android:singleLine="false"
+            android:maxLines="3">
         </TextView>
     </org.catrobat.catroid.ui.BrickLayout>
 

--- a/catroid/src/main/res/values/attrs.xml
+++ b/catroid/src/main/res/values/attrs.xml
@@ -93,6 +93,7 @@
         <attr name="layout_textField" format="boolean"/>
         <attr name="layout_inputType" format="string"/>
         <attr name="layout_newLine" format="boolean"/>
+        <attr name="layout_forceNewLine" format="boolean"/>
         <attr name="layout_customPadding" format="dimension"/>
         <attr name="layout_horizontalSpacing" format="dimension"/>
         <attr name="layout_verticalSpacing" format="dimension"/>


### PR DESCRIPTION
- fixes issue that Textfields in multiline bricks cannot have different lengths and thus are not maximized to the end of the line
- change assert bricks such that both Textfields are in a new line and can be expanded to up to three lines

https://jira.catrob.at/browse/CATROID-1086

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
