### PR TITLE
DEVOPS-491 Include Kotlin classes in coverage report

### DIFF
--- a/catroid/gradle/setup_jacoco.gradle
+++ b/catroid/gradle/setup_jacoco.gradle
@@ -36,6 +36,7 @@ project.afterEvaluate {
 
     android.applicationVariants.all { variant ->
         def variantName = variant.name.capitalize()
+        def kotlinClassSubdirectory = variant.name
 
         def testTaskName = "test${variantName}UnitTest"
 
@@ -58,7 +59,9 @@ project.afterEvaluate {
                     'android/**/*.*'
             ]
             def javaClasses = fileTree(dir: variant.javaCompiler.destinationDir, excludes: excludes)
-            def kotlinClasses = fileTree(dir: "${buildDir}/tmp/kotlin-classes/${variantName}", excludes: excludes)
+            def kotlinClasses = fileTree(
+                    dir: "${buildDir}/tmp/kotlin-classes/${kotlinClassSubdirectory}",
+                    excludes: excludes)
             getClassDirectories().from(files([javaClasses, kotlinClasses]))
 
             getSourceDirectories().from(files([


### PR DESCRIPTION
https://jira.catrob.at/browse/DEVOPS-491

Fixes a small bug in gradle task. The subdirectory where the class-files
for Kotlin classes are dumped starts with a lower case letter
(camel case). In the gradle task however it was defined capitalized.
For that reason the class-files were not found and therefore not
included in the coverage report.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
