### PR TITLE
CATROID-1125 Add single-object to current scene

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/ImportObjectIntoProject.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/ImportObjectIntoProject.kt
@@ -1,0 +1,398 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.sprite
+
+import android.net.Uri
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import junit.framework.Assert.assertEquals
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.common.Constants
+import org.catrobat.catroid.common.Constants.MEDIA_LIBRARY_CACHE_DIR
+import org.catrobat.catroid.common.DefaultProjectHandler
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Script
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.content.StartScript
+import org.catrobat.catroid.content.bricks.PlaceAtBrick
+import org.catrobat.catroid.formulaeditor.UserList
+import org.catrobat.catroid.formulaeditor.UserVariable
+import org.catrobat.catroid.io.XstreamSerializer
+import org.catrobat.catroid.io.ZipArchiver
+import org.catrobat.catroid.test.utils.TestUtils
+import org.catrobat.catroid.ui.ProjectActivity
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
+import org.junit.After
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class ImportObjectIntoProject {
+    var project: Project? = null
+    var importedProject: Project? = null
+    var importName = "IMPORTED"
+    var defaultProjectName = "defaultProject"
+    var uri: Uri? = null
+    var spriteToBeImported: Sprite? = null
+    private lateinit var scriptForVisualPlacement: Script
+    val TAG: String = ImportObjectIntoProject::class.java.simpleName
+
+    @get:Rule
+    var baseActivityTestRule: FragmentActivityTestRule<ProjectActivity> = FragmentActivityTestRule(
+        ProjectActivity::class.java, ProjectActivity.EXTRA_FRAGMENT_POSITION, ProjectActivity.FRAGMENT_SPRITES
+    )
+
+    @Throws(Exception::class)
+    @Before
+    fun setUp() {
+        try {
+            MEDIA_LIBRARY_CACHE_DIR.mkdirs()
+        } catch (e: Exception) {
+            Log.e(TAG, Log.getStackTraceString(e))
+        }
+
+        TestUtils.deleteProjects(defaultProjectName, importName)
+
+        project = DefaultProjectHandler
+            .createAndSaveDefaultProject(
+                defaultProjectName,
+                ApplicationProvider.getApplicationContext(),
+                false
+            )
+
+        importedProject = DefaultProjectHandler
+            .createAndSaveDefaultProject(
+                importName,
+                ApplicationProvider.getApplicationContext(),
+                false
+            )
+
+        initProjectVars()
+
+        XstreamSerializer.getInstance().saveProject(importedProject)
+
+        val projectZip = File(
+            Constants.MEDIA_LIBRARY_CACHE_DIR,
+            importedProject?.name + Constants.CATROBAT_EXTENSION
+        )
+
+        ZipArchiver().zip(projectZip, importedProject?.directory?.listFiles())
+        uri = Uri.fromFile(projectZip)
+
+        ProjectManager.getInstance().currentProject = project
+        ProjectManager.getInstance().currentSprite = project!!.defaultScene.spriteList[1]
+        Intents.init()
+        baseActivityTestRule.launchActivity()
+    }
+
+    fun initProjectVars() {
+        spriteToBeImported = importedProject!!.defaultScene.spriteList[1]
+
+        spriteToBeImported!!.userVariables.add(UserVariable("localVariable1"))
+        spriteToBeImported!!.userVariables.add(UserVariable("localVariable2"))
+        spriteToBeImported!!.userLists.add(UserList("localList1"))
+        spriteToBeImported!!.userLists.add(UserList("localList2"))
+
+        importedProject!!.addUserVariable(UserVariable("globalVariable1", 1))
+        importedProject!!.addUserVariable(UserVariable("globalVariable2", 2))
+        importedProject!!.addUserList(UserList("globalListe1"))
+        importedProject!!.addUserList(UserList("globalListe2"))
+
+        scriptForVisualPlacement = StartScript().apply {
+            addBrick(PlaceAtBrick(100, 200))
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
+        baseActivityTestRule.finishActivity()
+        TestUtils.deleteProjects(defaultProjectName, importName)
+    }
+
+    @Test
+    fun importProjectWithoutConflictsTest() {
+        val anySpriteOfProject = project!!.defaultScene.spriteList[1]
+        anySpriteOfProject.userVariables.add(UserVariable("localVariable3"))
+        anySpriteOfProject.userVariables.add(UserVariable("localVariable4"))
+        anySpriteOfProject.userLists.add(UserList("localList3"))
+        anySpriteOfProject.userLists.add(UserList("localList4"))
+
+        project!!.addUserVariable(UserVariable("globalVariable3", 1))
+        project!!.addUserVariable(UserVariable("globalVariable4", 2))
+        project!!.addUserList(UserList("globalListe3"))
+        project!!.addUserList(UserList("globalListe4"))
+        XstreamSerializer.getInstance().saveProject(project)
+
+        val globalVariableList = project!!.userVariables
+        val globalListList = project!!.userLists
+
+        val importedLocalVariableList = spriteToBeImported!!.userVariables
+        val importedLocalListList = spriteToBeImported!!.userLists
+        val importedGlobalVariableList = importedProject!!.userVariables
+        val importedGlobalListList = importedProject!!.userLists
+        val importedLookList = spriteToBeImported!!.lookList
+        val importedSoundList = spriteToBeImported!!.soundList
+        val importedScriptList = spriteToBeImported!!.scriptList + scriptForVisualPlacement
+
+        baseActivityTestRule.activity.addObjectFromUri(uri)
+        Espresso.onView(withText(R.string.ok)).perform(click())
+        Espresso.onView(withId(R.id.confirm)).perform(click())
+
+        assertEquals(project!!.defaultScene.spriteList.last().userVariables, importedLocalVariableList)
+        assertEquals(project!!.defaultScene.spriteList.last().userLists, importedLocalListList)
+
+        globalVariableList.addAll(importedGlobalVariableList)
+        assertEquals(project!!.userVariables, globalVariableList)
+        globalListList.addAll(importedGlobalListList)
+        assertEquals(project!!.userLists, globalListList)
+
+        assertEquals(project!!.defaultScene.spriteList.last().lookList.size, importedLookList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().lookList[0].file.name, importedLookList[0].file.name)
+
+        assertEquals(project!!.defaultScene.spriteList.last().soundList.size, importedSoundList.size)
+
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList.size, importedScriptList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList[0].brickList.size, importedScriptList[0].brickList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList[1].brickList.size, importedScriptList[1].brickList.size)
+    }
+
+    @Test
+    fun importProjectWithoutConflictsTestEqualLocalVariable() {
+        val anySpriteOfProject = project!!.defaultScene.spriteList[1]
+        anySpriteOfProject.userVariables.add(UserVariable("localVariable1"))
+        anySpriteOfProject.userVariables.add(UserVariable("localVariable2"))
+        anySpriteOfProject.userLists.add(UserList("localList1"))
+        anySpriteOfProject.userLists.add(UserList("localList2"))
+
+        project!!.addUserVariable(UserVariable("globalVariable3", 1))
+        project!!.addUserVariable(UserVariable("globalVariable4", 2))
+        project!!.addUserList(UserList("globalListe3"))
+        project!!.addUserList(UserList("globalListe4"))
+        XstreamSerializer.getInstance().saveProject(project)
+
+        val globalVariableList = project!!.userVariables
+        val globalListList = project!!.userLists
+
+        val importedLocalVariableList = spriteToBeImported!!.userVariables
+        val importedLocalListList = spriteToBeImported!!.userLists
+        val importedGlobalVariableList = importedProject!!.userVariables
+        val importedGlobalListList = importedProject!!.userLists
+        val importedLookList = spriteToBeImported!!.lookList
+        val importedSoundList = spriteToBeImported!!.soundList
+        val importedScriptList = spriteToBeImported!!.scriptList + scriptForVisualPlacement
+
+        baseActivityTestRule.activity.addObjectFromUri(uri)
+        Espresso.onView(withText(R.string.ok)).perform(click())
+        Espresso.onView(withId(R.id.confirm)).perform(click())
+
+        assertEquals(project!!.defaultScene.spriteList.last().userVariables, importedLocalVariableList)
+        assertEquals(project!!.defaultScene.spriteList.last().userLists, importedLocalListList)
+
+        globalVariableList.addAll(importedGlobalVariableList)
+        assertEquals(project!!.userVariables, globalVariableList)
+        globalListList.addAll(importedGlobalListList)
+        assertEquals(project!!.userLists, globalListList)
+
+        assertEquals(project!!.defaultScene.spriteList.last().lookList.size, importedLookList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().lookList[0].file.name, importedLookList[0].file.name)
+
+        assertEquals(project!!.defaultScene.spriteList.last().soundList.size, importedSoundList.size)
+
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList.size, importedScriptList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList[0].brickList.size, importedScriptList[0].brickList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList[1].brickList.size, importedScriptList[1].brickList.size)
+    }
+
+    @Test
+    fun importProjectWithoutConflictsTestEqualGlobalVariable() {
+        val anySpriteOfProject = project!!.defaultScene.spriteList[1]
+        anySpriteOfProject.userVariables.add(UserVariable("localVariable3"))
+        anySpriteOfProject.userVariables.add(UserVariable("localVariable4"))
+        anySpriteOfProject.userLists.add(UserList("localList3"))
+        anySpriteOfProject.userLists.add(UserList("localList4"))
+
+        project!!.addUserVariable(UserVariable("globalVariable1", 1))
+        project!!.addUserVariable(UserVariable("globalVariable2", 2))
+        project!!.addUserList(UserList("globalListe1"))
+        project!!.addUserList(UserList("globalListe2"))
+        XstreamSerializer.getInstance().saveProject(project)
+
+        val globalVariableList = project!!.userVariables
+        val globalListList = project!!.userLists
+
+        val importedLocalVariableList = spriteToBeImported!!.userVariables
+        val importedLocalListList = spriteToBeImported!!.userLists
+        val importedGlobalVariableList = importedProject!!.userVariables
+        val importedGlobalListList = importedProject!!.userLists
+        val importedLookList = spriteToBeImported!!.lookList
+        val importedSoundList = spriteToBeImported!!.soundList
+        val importedScriptList = spriteToBeImported!!.scriptList + scriptForVisualPlacement
+
+        baseActivityTestRule.activity.addObjectFromUri(uri)
+        Espresso.onView(withText(R.string.ok)).perform(click())
+        Espresso.onView(withId(R.id.confirm)).perform(click())
+
+        assertEquals(project!!.defaultScene.spriteList.last().userVariables, importedLocalVariableList)
+        assertEquals(project!!.defaultScene.spriteList.last().userLists, importedLocalListList)
+
+        globalVariableList.addAll(importedGlobalVariableList)
+        assertEquals(project!!.userVariables, globalVariableList)
+        globalListList.addAll(importedGlobalListList)
+        assertEquals(project!!.userLists, globalListList)
+
+        assertEquals(project!!.defaultScene.spriteList.last().lookList.size, importedLookList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().lookList[0].file.name, importedLookList[0].file.name)
+
+        assertEquals(project!!.defaultScene.spriteList.last().soundList.size, importedSoundList.size)
+
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList.size, importedScriptList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList[0].brickList.size, importedScriptList[0].brickList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList[1].brickList.size, importedScriptList[1].brickList.size)
+    }
+
+    @Test
+    fun importProjectWithConflictsTestLocalVar() {
+        val anySpriteOfProject = project!!.defaultScene.spriteList[1]
+        anySpriteOfProject.userVariables.add(UserVariable("globalVariable1")) // Conflicting var
+        anySpriteOfProject.userVariables.add(UserVariable("localVariable4"))
+        anySpriteOfProject.userLists.add(UserList("localList3"))
+        anySpriteOfProject.userLists.add(UserList("globalListe1")) // Conflicting var
+
+        project!!.addUserVariable(UserVariable("globalVariable1", 1))
+        project!!.addUserVariable(UserVariable("globalVariable2", 2))
+        project!!.addUserList(UserList("globalListe1"))
+        project!!.addUserList(UserList("globalListe2"))
+        XstreamSerializer.getInstance().saveProject(project)
+
+        val importedLocalVariableList = spriteToBeImported!!.userVariables
+        val importedLocalListList = spriteToBeImported!!.userLists
+        val importedLookList = spriteToBeImported!!.lookList
+        val importedSoundList = spriteToBeImported!!.soundList
+        val importedScriptList = spriteToBeImported!!.scriptList + scriptForVisualPlacement
+
+        val originLastSprite = project!!.defaultScene.spriteList.last()
+        val originLocalVariableList = originLastSprite.userVariables
+        val originLocalListList = originLastSprite.userLists
+        val originGlobalVariableList = project!!.userVariables
+        val originGlobalListList = project!!.userLists
+        val originLookList = originLastSprite.lookList
+        val originSoundList = originLastSprite.soundList
+        val originScriptList = originLastSprite.scriptList
+
+        baseActivityTestRule.activity.addObjectFromUri(uri)
+        Espresso.onView(withText(R.string.ok)).perform(click())
+
+        assertNotEquals(project!!.defaultScene.spriteList.last().userVariables, importedLocalVariableList)
+        assertEquals(project!!.defaultScene.spriteList.last().userVariables, originLocalVariableList)
+        assertNotEquals(project!!.defaultScene.spriteList.last().userLists, importedLocalListList)
+        assertEquals(project!!.defaultScene.spriteList.last().userLists, originLocalListList)
+
+        assertEquals(project!!.userVariables, originGlobalVariableList)
+
+        assertEquals(project!!.userLists, originGlobalListList)
+
+        assertNotEquals(project!!.defaultScene.spriteList.last().lookList.size, importedLookList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().lookList.size, originLookList.size)
+
+        assertNotEquals(project!!.defaultScene.spriteList.last().lookList[0].file.name, importedLookList[0].file.name)
+        assertEquals(project!!.defaultScene.spriteList.last().lookList[0].file.name, originLookList[0].file.name)
+
+        assertNotEquals(project!!.defaultScene.spriteList.last().soundList.size, importedSoundList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().soundList.size, originSoundList.size)
+
+        assertNotEquals(project!!.defaultScene.spriteList.last().scriptList.size, importedScriptList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList.size, originScriptList.size)
+        assertNotEquals(project!!.defaultScene.spriteList.last().scriptList[0].brickList.size, importedScriptList[0].brickList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList[0].brickList.size, originScriptList[0].brickList.size)
+
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList[1].brickList.size, originScriptList[1].brickList.size)
+    }
+
+    @Test
+    fun importProjectWithConflictsTestGlobalVar() {
+        val anySpriteOfProject = project!!.defaultScene.spriteList[1]
+        anySpriteOfProject.userVariables.add(UserVariable("localVariable3"))
+        anySpriteOfProject.userVariables.add(UserVariable("localVariable4"))
+        anySpriteOfProject.userLists.add(UserList("localList3"))
+        anySpriteOfProject.userLists.add(UserList("localList2"))
+
+        project!!.addUserVariable(UserVariable("globalVariable1", 1))
+        project!!.addUserVariable(UserVariable("localVariable1", 2)) // Conflicting var
+        project!!.addUserList(UserList("localList1")) // Conflicting var
+        project!!.addUserList(UserList("globalListe2"))
+        XstreamSerializer.getInstance().saveProject(project)
+
+        val importedLocalVariableList = spriteToBeImported!!.userVariables
+        val importedLocalListList = spriteToBeImported!!.userLists
+        val importedLookList = spriteToBeImported!!.lookList
+        val importedSoundList = spriteToBeImported!!.soundList
+        val importedScriptList = spriteToBeImported!!.scriptList + scriptForVisualPlacement
+
+        val originLastSprite = project!!.defaultScene.spriteList.last()
+        val originLocalVariableList = originLastSprite.userVariables
+        val originLocalListList = originLastSprite.userLists
+        val originGlobalVariableList = project!!.userVariables
+        val originGlobalListList = project!!.userLists
+        val originLookList = originLastSprite.lookList
+        val originSoundList = originLastSprite.soundList
+        val originScriptList = originLastSprite.scriptList
+
+        baseActivityTestRule.activity.addObjectFromUri(uri)
+        Espresso.onView(withText(R.string.ok)).perform(click())
+
+        assertNotEquals(project!!.defaultScene.spriteList.last().userVariables, importedLocalVariableList)
+        assertEquals(project!!.defaultScene.spriteList.last().userVariables, originLocalVariableList)
+        assertNotEquals(project!!.defaultScene.spriteList.last().userLists, importedLocalListList)
+        assertEquals(project!!.defaultScene.spriteList.last().userLists, originLocalListList)
+
+        assertEquals(project!!.userVariables, originGlobalVariableList)
+
+        assertEquals(project!!.userLists, originGlobalListList)
+
+        assertNotEquals(project!!.defaultScene.spriteList.last().lookList.size, importedLookList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().lookList.size, originLookList.size)
+
+        assertNotEquals(project!!.defaultScene.spriteList.last().lookList[0].file.name, importedLookList[0].file.name)
+        assertEquals(project!!.defaultScene.spriteList.last().lookList[0].file.name, originLookList[0].file.name)
+
+        assertNotEquals(project!!.defaultScene.spriteList.last().soundList.size, importedSoundList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().soundList.size, originSoundList.size)
+
+        assertNotEquals(project!!.defaultScene.spriteList.last().scriptList.size, importedScriptList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList.size, originScriptList.size)
+        assertNotEquals(project!!.defaultScene.spriteList.last().scriptList[0].brickList.size, importedScriptList[0].brickList.size)
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList[0].brickList.size, originScriptList[0].brickList.size)
+
+        assertEquals(project!!.defaultScene.spriteList.last().scriptList[1].brickList.size, originScriptList[1].brickList.size)
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -335,6 +335,17 @@ public final class ProjectManager {
 		return conflicts;
 	}
 
+	public static ArrayList<Object> checkForVariablesConflicts(List<Object> globalVariables, List<Object> localVariables) {
+
+		ArrayList<Object> conflicts = new ArrayList<>();
+		for (Object localVar : localVariables) {
+			if (globalVariables.contains(localVar)) {
+				conflicts.add(localVar);
+			}
+		}
+		return conflicts;
+	}
+
 	@VisibleForTesting
 	public static void updateCollisionFormulasTo993(Project project) {
 		for (Scene scene : project.getSceneList()) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -701,4 +701,14 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 	public Color getEmbroideryThreadColor() {
 		return this.embroideryThreadColor;
 	}
+
+	public void replaceSpriteWithSprite(Sprite sprite) {
+		this.scriptList = sprite.scriptList;
+		this.lookList = sprite.lookList;
+		this.soundList = sprite.soundList;
+		this.nfcTagList = sprite.nfcTagList;
+		this.userVariables = sprite.userVariables;
+		this.userLists = sprite.userLists;
+		this.userDefinedBrickList = sprite.userDefinedBrickList;
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -66,6 +66,7 @@ import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 
+import static org.catrobat.catroid.common.Constants.CATROBAT_EXTENSION;
 import static org.catrobat.catroid.common.Constants.DEFAULT_IMAGE_EXTENSION;
 import static org.catrobat.catroid.common.Constants.EV3;
 import static org.catrobat.catroid.common.Constants.JPEG_IMAGE_EXTENSION;
@@ -254,6 +255,7 @@ public class ProjectActivity extends BaseCastActivity {
 				break;
 			case SPRITE_OBJECT:
 				uri = Uri.fromFile(new File(data.getStringExtra(MEDIA_FILE_PATH)));
+				addObjectFromUri(uri);
 				break;
 			case SPRITE_FILE:
 				uri = data.getData();
@@ -281,10 +283,19 @@ public class ProjectActivity extends BaseCastActivity {
 	}
 
 	public void addSpriteFromUri(final Uri uri) {
-		addSpriteFromUri(uri, DEFAULT_IMAGE_EXTENSION);
+		addSpriteObjectFromUri(uri, DEFAULT_IMAGE_EXTENSION, false);
 	}
 
 	public void addSpriteFromUri(final Uri uri, final String imageExtension) {
+		addSpriteObjectFromUri(uri, imageExtension, false);
+	}
+
+	public void addObjectFromUri(final Uri uri) {
+		addSpriteObjectFromUri(uri, CATROBAT_EXTENSION, true);
+	}
+
+	public void addSpriteObjectFromUri(final Uri uri, final String imageExtension,
+			boolean isObject) {
 		final Scene currentScene = ProjectManager.getInstance().getCurrentlyEditedScene();
 
 		String resolvedName;
@@ -306,7 +317,8 @@ public class ProjectActivity extends BaseCastActivity {
 
 		lookDataName = new UniqueNameProvider().getUniqueNameInNameables(resolvedName, currentScene.getSpriteList());
 
-		new NewSpriteDialogFragment(lookDataName, lookFileName, getContentResolver(), uri, getCurrentFragment())
+		new NewSpriteDialogFragment(lookDataName, lookFileName, getContentResolver(), uri,
+				getCurrentFragment(), isObject)
 				.show(getSupportFragmentManager(), NewSpriteDialogFragment.Companion.getTAG());
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSpriteDialogFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/NewSpriteDialogFragment.kt
@@ -20,6 +20,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.catrobat.catroid.ui.recyclerview.dialog
 
 import android.app.Dialog
@@ -38,14 +39,21 @@ import androidx.appcompat.widget.SwitchCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.ProjectManager.checkForVariablesConflicts
 import org.catrobat.catroid.R
 import org.catrobat.catroid.common.BrickValues
 import org.catrobat.catroid.common.Constants
+import org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME
+import org.catrobat.catroid.common.Constants.MEDIA_LIBRARY_CACHE_DIR
+import org.catrobat.catroid.common.Constants.SOUND_DIRECTORY_NAME
 import org.catrobat.catroid.common.LookData
 import org.catrobat.catroid.common.SharedPreferenceKeys.NEW_SPRITE_VISUAL_PLACEMENT_KEY
+import org.catrobat.catroid.content.Project
 import org.catrobat.catroid.content.Scene
 import org.catrobat.catroid.content.Sprite
 import org.catrobat.catroid.io.StorageOperations
+import org.catrobat.catroid.io.XstreamSerializer
+import org.catrobat.catroid.io.ZipArchiver
 import org.catrobat.catroid.ui.SpriteActivity.EXTRA_X_TRANSFORM
 import org.catrobat.catroid.ui.SpriteActivity.EXTRA_Y_TRANSFORM
 import org.catrobat.catroid.ui.SpriteActivity.REQUEST_CODE_VISUAL_PLACEMENT
@@ -61,7 +69,8 @@ class NewSpriteDialogFragment(
     private val lookFileName: String,
     private val contentResolver: ContentResolver,
     private val uri: Uri,
-    private val currentFragment: Fragment
+    private val currentFragment: Fragment,
+    private val isObject: Boolean
 ) : DialogFragment() {
 
     private var visuallyPlaceSwitch: SwitchCompat? = null
@@ -87,7 +96,11 @@ class NewSpriteDialogFragment(
             ) { dialog: DialogInterface?, textInput: String? ->
                 sprite = Sprite(textInput)
                 currentScene.addSprite(sprite)
-                addLookDataToSprite(currentScene, textInput)
+                if (isObject) {
+                    addObjectDataToSprite(currentScene)
+                } else {
+                    addLookDataToSprite(currentScene, textInput)
+                }
 
                 if (currentFragment is SpriteListFragment) {
                     currentFragment.notifyDataSetChanged()
@@ -120,7 +133,7 @@ class NewSpriteDialogFragment(
         try {
             val imageDirectory = File(
                 currentScene?.directory,
-                Constants.IMAGE_DIRECTORY_NAME
+                IMAGE_DIRECTORY_NAME
             )
             val file = StorageOperations.copyUriToDir(
                 contentResolver, uri,
@@ -139,6 +152,111 @@ class NewSpriteDialogFragment(
         } catch (e: IOException) {
             Log.e(TAG, Log.getStackTraceString(e))
         }
+    }
+
+    private fun addObjectDataToSprite(currentScene: Scene?) {
+        try {
+            val resolvedFileName = StorageOperations.resolveFileName(contentResolver, uri)
+            val resolvedName = StorageOperations.getSanitizedFileName(resolvedFileName)
+
+            if (lookFileName == resolvedName + Constants.CATROBAT_EXTENSION) {
+                val project = getNewProject(resolvedName)
+                if (project == null) {
+                    undoImport(currentScene)
+                    return
+                }
+
+                val firstScene = project.defaultScene
+                val addedSprite: Sprite?
+                if (firstScene!!.spriteList.size >= 2) {
+                    addedSprite = firstScene.spriteList[1]
+                } else {
+                    undoImport(currentScene)
+                    return
+                }
+
+                val conflicts: ArrayList<Any> = checkForConflicts(project, addedSprite, currentScene)
+                if (conflicts.isNotEmpty()) {
+                    undoImport(currentScene)
+                    return
+                }
+
+                copyFilesToSoundAndSpriteDir(addedSprite, currentScene)
+                sprite.replaceSpriteWithSprite(addedSprite)
+                currentScene?.project?.userLists?.addAll(project.userLists)
+                currentScene?.project?.userVariables?.addAll(project.userVariables)
+            }
+            return
+        } catch (e: IOException) {
+            Log.e(TAG, Log.getStackTraceString(e))
+            undoImport(currentScene)
+            return
+        }
+    }
+
+    private fun copyFilesToSoundAndSpriteDir(addedSprite: Sprite?, currentScene: Scene?) {
+        val imageDirectory = File(
+            currentScene?.directory,
+            IMAGE_DIRECTORY_NAME
+        )
+        val soundsDirectory = File(
+            currentScene?.directory,
+            SOUND_DIRECTORY_NAME
+        )
+
+        addedSprite!!.lookList.forEach { currentListObject ->
+            StorageOperations.copyFileToDir(
+                currentListObject.file,
+                imageDirectory
+            )
+        }
+        addedSprite.soundList.forEach { currentListObject ->
+            StorageOperations.copyFileToDir(
+                currentListObject.file,
+                soundsDirectory
+            )
+        }
+    }
+
+    private fun checkForConflicts(newProject: Project, newSprite: Sprite, currentScene: Scene?): ArrayList<Any> {
+        val conflicts = ArrayList<Any>()
+
+        val returnedlists = checkForVariablesConflicts(
+            currentScene?.project?.userLists as List<Any>?,
+            newSprite.userLists as List<Any>?
+        )
+        val returnedVars = checkForVariablesConflicts(
+            currentScene?.project?.userVariables as List<Any>?,
+            newSprite.userVariables as List<Any>?
+        )
+
+        currentScene?.project?.sceneList?.forEach { scene ->
+            scene.spriteList?.forEach { sprite ->
+                returnedlists?.addAll(checkForVariablesConflicts(newProject.userLists as List<Any>?, sprite.userLists as List<Any>?))
+                returnedVars.addAll(checkForVariablesConflicts(newProject.userVariables as List<Any>?, sprite.userVariables as List<Any>?))
+            }
+        }
+
+        returnedlists?.let { conflicts.addAll(it) }
+        returnedVars?.let { conflicts.addAll(it) }
+        return conflicts
+    }
+
+    private fun undoImport(currentScene: Scene?) {
+        currentScene?.removeSprite(sprite)
+        isPlaceVisually = false
+    }
+
+    private fun getNewProject(resolvedName: String): Project? {
+        val cachedProjectDir =
+            File(MEDIA_LIBRARY_CACHE_DIR, resolvedName)
+        val cachedProject =
+            File(MEDIA_LIBRARY_CACHE_DIR, lookFileName)
+
+        ZipArchiver().unzip(cachedProject, cachedProjectDir)
+        val project = XstreamSerializer.getInstance()
+            .loadProject(cachedProjectDir, this.context)
+        return project
     }
 
     private fun setupToggleButtonListener(view: View) {


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1125
- implementation of the functionality
- possible conflicts: local and global variables with the same name
- conflict occurs: abort the import
- test cases for conflicting and nonconflicting imports

Ticket #1128 has also been solved in this merge already (https://jira.catrob.at/browse/CATROID-1128) 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
