### PR TITLE
CATROID-1171 Fix Memory Leak in SensorHandler at sensorManager

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/SensorHandlerTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/SensorHandlerTest.kt
@@ -60,6 +60,7 @@ class SensorHandlerTest {
 
     @Test
     fun testSensorManagerNotInitialized() {
+        SensorHandler.destroy()
         SensorHandler.registerListener(null)
         SensorHandler.unregisterListener(null)
         SensorHandler.startSensorListener(ApplicationProvider.getApplicationContext())
@@ -68,6 +69,7 @@ class SensorHandlerTest {
 
     @Test
     fun testSensorHandlerWithLookSensorValue() {
+        SensorHandler.startSensorListener(ApplicationProvider.getApplicationContext())
         compareToSensor(0, Sensors.OBJECT_BRIGHTNESS)
     }
 
@@ -129,7 +131,7 @@ class SensorHandlerTest {
 
     @After
     fun tearDown() {
-        SensorHandler.stopSensorListeners()
+        SensorHandler.destroy()
     }
 
     private fun compareToSensor(value: Int, sensor: Sensors) {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/SensorHandler.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/SensorHandler.java
@@ -747,4 +747,12 @@ public final class SensorHandler implements SensorEventListener, SensorCustomEve
 				break;
 		}
 	}
+
+	public static void destroy() {
+		if (instance == null) {
+			return;
+		}
+		stopSensorListeners();
+		instance = null;
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageLifeCycleController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageLifeCycleController.java
@@ -233,7 +233,7 @@ public final class StageLifeCycleController {
 				stageActivity.cameraManager.destroy();
 				stageActivity.cameraManager = null;
 			}
-			SensorHandler.stopSensorListeners();
+			SensorHandler.destroy();
 			if (ProjectManager.getInstance().getCurrentProject().isCastProject()) {
 				CastManager.getInstance().onStageDestroyed();
 			}


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1171

Fixed Memory Leak by destroying SensorHandler when StageActivity is destroyed.
To compile with Leak Canary see: https://jira.catrob.at/browse/CATROID-1171?focusedCommentId=25921&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-25921

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
