### PR TITLE
CATROID-1177 Memory Leak of StageActivity in Gdx.app and Gdx.graphics

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageLifeCycleController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageLifeCycleController.java
@@ -30,6 +30,7 @@ import android.util.Log;
 import android.view.SurfaceView;
 import android.view.WindowManager;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;
 import com.badlogic.gdx.backends.android.surfaceview.GLSurfaceView20;
 
@@ -240,6 +241,16 @@ public final class StageLifeCycleController {
 			StageActivity.stageListener.finish();
 			stageActivity.manageLoadAndFinish();
 		}
+		cleanupGdxMembers();
 		ProjectManager.getInstance().setCurrentlyPlayingScene(ProjectManager.getInstance().getCurrentlyEditedScene());
+	}
+
+	private static void cleanupGdxMembers() {
+		Gdx.app = null;
+		Gdx.input = null;
+		Gdx.audio = null;
+		Gdx.files = null;
+		Gdx.graphics = null;
+		Gdx.net = null;
 	}
 }


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1177

Fixed Memory Leak by clearing the members of Gdx when StageActivity is destroyed.
To compile with Leak Canary see: https://jira.catrob.at/browse/CATROID-1171?focusedCommentId=25921&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-25921

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
