### PR TITLE
CATROID-1178 Fix Memory Leaks of SpriteActivity in FormulaEditorFragment

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -130,11 +130,11 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	public static final String FORMULA_BRICK_BUNDLE_ARGUMENT = "formula_brick";
 	public static final String FORMULA_FIELD_BUNDLE_ARGUMENT = "formula_field";
 
-	private static FormulaEditorEditText formulaEditorEditText;
+	private FormulaEditorEditText formulaEditorEditText;
 	private TableLayout formulaEditorKeyboard;
-	private static LinearLayout formulaEditorBrick;
+	private LinearLayout formulaEditorBrick;
 
-	private static FormulaBrick formulaBrick;
+	private FormulaBrick formulaBrick;
 
 	private static Brick.FormulaField currentFormulaField;
 	private static Formula currentFormula;


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1178

Fixed the Memory Leaks by changing static variables to non-static in the FormulaEditorFragment. Android Studio already gave the hint that Android Context classes should not be used in a static field, since this is a memory leak.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
