### PR TITLE
CATROID-1179 Fix Back Button not working in all Fragments

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/NavigateUpTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/NavigateUpTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment
+
+import android.content.Context
+import android.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.catrobat.catroid.R
+import org.catrobat.catroid.common.Constants
+import org.catrobat.catroid.common.Constants.CATROBAT_TERMS_OF_USE_ACCEPTED
+import org.catrobat.catroid.common.SharedPreferenceKeys.AGREED_TO_PRIVACY_POLICY_VERSION
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.test.utils.TestUtils
+import org.catrobat.catroid.ui.MainMenuActivity
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityTestRule
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.containsString
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NavigateUpTest {
+    private var privacyPreferenceSetting: Int = 0
+    private lateinit var applicationContext: Context
+    private val projectName = "Project"
+    private val navigateUpButtonContentDescription = "Navigate up"
+    private val sceneIndex = 0
+    private val spriteIndex = 1
+    private lateinit var project: Project
+    private lateinit var spriteName: String
+
+    @get:Rule
+    var baseActivityTestRule = BaseActivityTestRule(
+        MainMenuActivity::class.java,
+        false,
+        false
+    )
+
+    @Before
+    fun setUp() {
+        applicationContext = ApplicationProvider.getApplicationContext()
+        privacyPreferenceSetting = PreferenceManager
+            .getDefaultSharedPreferences(applicationContext)
+            .getInt(AGREED_TO_PRIVACY_POLICY_VERSION, 0)
+
+        PreferenceManager.getDefaultSharedPreferences(applicationContext)
+            .edit().putInt(
+                AGREED_TO_PRIVACY_POLICY_VERSION,
+                CATROBAT_TERMS_OF_USE_ACCEPTED
+            ).commit()
+
+        project = TestUtils.createProjectWithLanguageVersion(
+            Constants.CURRENT_CATROBAT_LANGUAGE_VERSION,
+            projectName
+        )
+        spriteName = project.sceneList[sceneIndex].spriteList[spriteIndex].name
+        baseActivityTestRule.launchActivity(null)
+    }
+
+    @After
+    fun tearDown() {
+        TestUtils.deleteProjects(projectName)
+        PreferenceManager.getDefaultSharedPreferences(applicationContext)
+            .edit()
+            .putInt(AGREED_TO_PRIVACY_POLICY_VERSION, privacyPreferenceSetting)
+            .commit()
+    }
+
+    @Test
+    fun testNavigateUp() {
+        clickOnText(applicationContext.getString(R.string.main_menu_programs))
+        clickOnText(projectName)
+        clickOnText(spriteName)
+
+        navigateUp()
+        checkIsTextDisplayed(spriteName)
+        navigateUp()
+        checkIsTextDisplayed(projectName)
+        navigateUp()
+        checkIsTextDisplayed(applicationContext.getString(R.string.main_menu_programs))
+    }
+
+    private fun checkIsTextDisplayed(text: String) =
+        onView(withText(text)).check(matches(isDisplayed()))
+
+    private fun clickOnText(text: String) =
+        onView(withText(text)).perform(click())
+
+    private fun navigateUp() =
+        onView(
+            allOf(withContentDescription(containsString(navigateUpButtonContentDescription)))
+        ).perform(click())
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.kt
@@ -105,7 +105,7 @@ abstract class BaseActivity : AppCompatActivity(), PermissionHandlingActivity {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.home -> onBackPressed()
+            android.R.id.home -> onBackPressed()
             else -> return super.onOptionsItemSelected(item)
         }
         return true


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1179

Fixed bug by correcting Button id from "R.id.home" to "android.R.id.home".

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
