### PR TITLE
CATROID-1165 Fix org.catrobat.catroid.content.LegoEV3Setting in code.xml

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -42,7 +42,7 @@ import static org.catrobat.catroid.common.FlavoredConstants.DEFAULT_ROOT_DIRECTO
 
 public final class Constants {
 
-	public static final double CURRENT_CATROBAT_LANGUAGE_VERSION = 1.08;
+	public static final double CURRENT_CATROBAT_LANGUAGE_VERSION = 1.09;
 	public static final String REMOTE_DISPLAY_APP_ID = "CEBB9229";
 	public static final int CAST_CONNECTION_TIMEOUT = 5000; //in milliseconds
 	public static final int CAST_NOT_SEEING_DEVICE_TIMEOUT = 3000; //in milliseconds

--- a/catroid/src/main/java/org/catrobat/catroid/io/XstreamSerializer.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/XstreamSerializer.java
@@ -41,6 +41,7 @@ import org.catrobat.catroid.content.BroadcastScript;
 import org.catrobat.catroid.content.EmptyScript;
 import org.catrobat.catroid.content.GroupItemSprite;
 import org.catrobat.catroid.content.GroupSprite;
+import org.catrobat.catroid.content.LegoEV3Setting;
 import org.catrobat.catroid.content.LegoNXTSetting;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.RaspiInterruptScript;
@@ -626,6 +627,9 @@ public final class XstreamSerializer {
 
 		xstream.alias("setting", LegoNXTSetting.class);
 		xstream.alias("nxtPort", LegoNXTSetting.NXTPort.class);
+
+		xstream.alias("setting", LegoEV3Setting.class);
+		xstream.alias("ev3Port", LegoEV3Setting.EV3Port.class);
 
 		xstream.alias("brick", FadeParticleEffectBrick.class);
 		xstream.alias("brick", ParticleEffectAdditivityBrick.class);

--- a/catroid/src/test/java/org/catrobat/catroid/test/xmlformat/SettingsXmlSerializerTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/xmlformat/SettingsXmlSerializerTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.xmlformat
+
+import org.catrobat.catroid.content.Setting
+import org.catrobat.catroid.io.XstreamSerializer
+import org.hamcrest.Matchers
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.powermock.api.mockito.PowerMockito
+import java.io.Serializable
+import java.util.ArrayList
+
+@RunWith(Parameterized::class)
+class SettingsXmlSerializerTest(
+    private val name: String,
+    private val componentClass: Class<Serializable>
+) {
+    @Test
+    @kotlin.jvm.Throws(IllegalAccessException::class, InstantiationException::class)
+    fun testSettingAlias() {
+        if (isComponentNoSetting(componentClass)) {
+            return
+        }
+        val xml = mockAndSerialize(componentClass)
+        Assert.assertThat(
+            xml,
+            Matchers.startsWith("<setting type=\"${componentClass.simpleName}\"/>")
+        )
+    }
+
+    @Test
+    @kotlin.jvm.Throws(InstantiationException::class, IllegalAccessException::class)
+    fun testMissingAliasInComponent() {
+        val xml = mockAndSerialize(componentClass)
+        Assert.assertThat(xml, Matchers.not(Matchers.containsString("org.catrobat.catroid")))
+    }
+
+    private fun mockAndSerialize(componentClass: Class<Serializable>): String {
+        val component = PowerMockito.mock<Serializable>(componentClass)
+        return XstreamSerializer.getInstance().xstream.toXML(component)
+    }
+
+    private fun isComponentNoSetting(componentClass: Class<Serializable>): Boolean {
+        val settingsClasses = ClassDiscoverer.getAllSubClassesOf(Setting::class.java) ?: return true
+        return !settingsClasses.contains<Serializable>(componentClass)
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun parameters(): Iterable<Array<Any>> {
+            val parameters: MutableList<Array<Any>> = ArrayList()
+
+            ClassDiscoverer.getAllSubClassesOf(Setting::class.java)?.forEach { settingClassesElement ->
+                parameters.add(arrayOf(settingClassesElement.name, settingClassesElement))
+                val portClasses = settingClassesElement.declaredClasses
+                portClasses.forEach { portClass ->
+                    parameters.add(arrayOf(portClass.name, portClass))
+                }
+            }
+            return parameters
+        }
+    }
+}


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1165

Fixed the issue by adding xstream aliases for EV3.class and EV3Port.class . Also added a test that prevents forgetting to add the aliases of newly added Settings and Ports.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
