### PR TITLE
CATROID-1186 Fix Speak and wait bug

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/ActionFactory.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/ActionFactory.java
@@ -143,6 +143,7 @@ import org.catrobat.catroid.content.actions.SewUpAction;
 import org.catrobat.catroid.content.actions.ShowTextAction;
 import org.catrobat.catroid.content.actions.ShowTextColorSizeAlignmentAction;
 import org.catrobat.catroid.content.actions.SpeakAction;
+import org.catrobat.catroid.content.actions.SpeakAndWaitAction;
 import org.catrobat.catroid.content.actions.StampAction;
 import org.catrobat.catroid.content.actions.StartListeningAction;
 import org.catrobat.catroid.content.actions.StitchAction;
@@ -195,6 +196,7 @@ import org.catrobat.catroid.io.DeviceUserDataAccessor;
 import org.catrobat.catroid.io.DeviceVariableAccessor;
 import org.catrobat.catroid.physics.PhysicsLook;
 import org.catrobat.catroid.physics.PhysicsObject;
+import org.catrobat.catroid.stage.SpeechSynthesizer;
 import org.catrobat.catroid.userbrick.UserDefinedBrickInput;
 
 import java.io.File;
@@ -762,8 +764,16 @@ public class ActionFactory extends Actions {
 	public Action createSpeakAction(Sprite sprite, SequenceAction sequence, Formula text) {
 		SpeakAction action = action(SpeakAction.class);
 		Scope scope = new Scope(ProjectManager.getInstance().getCurrentProject(), sprite, sequence);
-		action.setScope(scope);
-		action.setText(text);
+		SpeechSynthesizer synthesizer = new SpeechSynthesizer(scope, text);
+		action.setSpeechSynthesizer(synthesizer);
+		return action;
+	}
+
+	public Action createSpeakAndWaitAction(Sprite sprite, SequenceAction sequence, Formula text) {
+		SpeakAndWaitAction action = action(SpeakAndWaitAction.class);
+		Scope scope = new Scope(ProjectManager.getInstance().getCurrentProject(), sprite, sequence);
+		SpeechSynthesizer synthesizer = new SpeechSynthesizer(scope, text);
+		action.setSpeechSynthesizer(synthesizer);
 		return action;
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SpeakAndWaitBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SpeakAndWaitBrick.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -23,21 +23,14 @@
 
 package org.catrobat.catroid.content.bricks;
 
-import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
-
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
-import org.catrobat.catroid.content.actions.SpeakAction;
 import org.catrobat.catroid.formulaeditor.Formula;
-
-import java.io.File;
 
 public class SpeakAndWaitBrick extends FormulaBrick {
 
 	private static final long serialVersionUID = 1L;
-
-	private File speechFile = null;
 
 	public SpeakAndWaitBrick() {
 		addAllowedBrickField(BrickField.SPEAK, R.id.brick_speak_and_wait_edit_text);
@@ -65,24 +58,7 @@ public class SpeakAndWaitBrick extends FormulaBrick {
 
 	@Override
 	public void addActionToSequence(Sprite sprite, ScriptSequenceAction sequence) {
-
-		Formula text = getFormulaWithBrickField(BrickField.SPEAK);
-		sequence.addAction(sprite.getActionFactory()
-				.createSpeakAction(sprite, sequence, text));
-
-		sequence.addAction(sprite.getActionFactory().createWaitForSoundAction(sprite, sequence,
-				new Formula(getDurationOfSpokenText(sprite, sequence,
-						text)), speechFile.getAbsolutePath()));
-	}
-
-	private float getDurationOfSpokenText(Sprite sprite, SequenceAction sequence, Formula text) {
-
-		SpeakAction action = (SpeakAction) sprite.getActionFactory()
-				.createSpeakAction(sprite, sequence, text);
-		action.setDetermineLength(true);
-
-		action.act(1.0f);
-		speechFile = action.getSpeechFile();
-		return action.getLengthOfText() / 1000;
+		sequence.addAction(sprite.getActionFactory().createSpeakAndWaitAction(
+				sprite, sequence, getFormulaWithBrickField(BrickField.SPEAK)));
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/stage/SpeechSynthesizer.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/SpeechSynthesizer.kt
@@ -1,0 +1,96 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.stage
+
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import android.util.Log
+import org.catrobat.catroid.common.Constants
+import org.catrobat.catroid.content.Scope
+import org.catrobat.catroid.formulaeditor.Formula
+import org.catrobat.catroid.formulaeditor.FormulaElement
+import org.catrobat.catroid.formulaeditor.InterpretationException
+import org.catrobat.catroid.utils.Utils
+import java.io.File
+import java.util.HashMap
+
+class SpeechSynthesizer(val scope: Scope?, val text: Formula?) {
+    private var interpretedText: Any? = null
+    private var hashText: String? = null
+    var speechFile: File? = null
+        private set
+
+    private var listener: UtteranceProgressListener? = null
+
+    fun synthesize() {
+        val listener = listener ?: return
+        interpretFormula()
+        hashText = Utils.md5Checksum(interpretedText.toString())
+        val fileName = hashText
+        val pathToSpeechFile = File(Constants.TEXT_TO_SPEECH_TMP_PATH)
+        pathToSpeechFile.mkdirs()
+        val speechFile = File(pathToSpeechFile, fileName + Constants.DEFAULT_SOUND_EXTENSION)
+        this.speechFile = speechFile
+
+        val speakParameter = HashMap<String, String?>()
+        speakParameter[TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID] = hashText
+        TextToSpeechHolder.instance.textToSpeech(
+            interpretedText.toString(),
+            speechFile,
+            listener,
+            speakParameter
+        )
+    }
+
+    private fun interpretFormula() {
+        interpretedText = try {
+            text?.interpretString(scope) ?: ""
+        } catch (interpretationException: InterpretationException) {
+            Log.d(
+                javaClass.simpleName,
+                "Formula interpretation for this specific Brick failed.",
+                interpretationException
+            )
+            ""
+        }
+        if (text?.root?.elementType != FormulaElement.ElementType.STRING && interpretedText is String) {
+            try {
+                val doubleValue = java.lang.Double.valueOf(interpretedText as String)
+                if (doubleValue.isNaN()) {
+                    interpretedText = ""
+                }
+            } catch (numberFormatException: NumberFormatException) {
+                Log.d(javaClass.simpleName, "Couldn't parse String", numberFormatException)
+            }
+        }
+    }
+
+    fun setUtteranceProgressListener(onError: () -> Unit, onDone: () -> Unit) {
+        listener = object : UtteranceProgressListener() {
+            override fun onStart(utteranceId: String) = Unit
+            override fun onError(utteranceId: String) = onError()
+            override fun onDone(utteranceId: String) = onDone()
+        }
+    }
+}

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SpeakActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SpeakActionTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -24,7 +24,6 @@ package org.catrobat.catroid.test.content.actions;
 
 import android.content.Context;
 
-import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 
 import org.catrobat.catroid.CatroidApplication;
@@ -33,11 +32,15 @@ import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.FlavoredConstants;
 import org.catrobat.catroid.content.ActionFactory;
 import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Scope;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.SpeakAction;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.SpeakBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.catrobat.catroid.formulaeditor.Functions;
+import org.catrobat.catroid.stage.SpeechSynthesizer;
 import org.catrobat.catroid.test.MockUtil;
 import org.catrobat.catroid.test.PowerMockUtil;
 import org.catrobat.catroid.test.utils.Reflection;
@@ -52,6 +55,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.io.File;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
@@ -60,9 +64,12 @@ public class SpeakActionTest {
 
 	private Sprite sprite;
 	private static final String SPEAK = "hello world!";
-	private Formula text;
-	private Formula text2;
+	private FormulaElement helloStringFormulaElement;
+	private FormulaElement worldStringFormulaElement;
+	private Formula textNumber;
+	private Formula textFunction;
 	private Formula textString;
+	private Scope scope;
 	private ActionFactory factory = new ActionFactory();
 	private TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -74,29 +81,16 @@ public class SpeakActionTest {
 		Mockito.when(contextMock.getCacheDir()).thenAnswer(invocation -> temporaryCacheFolder);
 
 		sprite = new Sprite("testSprite");
-		text = new Formula(666);
-		text2 = new Formula(888.88);
+		textNumber = new Formula(888.88);
+		helloStringFormulaElement = new FormulaElement(FormulaElement.ElementType.STRING, "hello ", null);
+		worldStringFormulaElement = new FormulaElement(FormulaElement.ElementType.STRING, "world!", null);
+		textFunction = new Formula(new FormulaElement(FormulaElement.ElementType.FUNCTION,
+			Functions.JOIN.name(), null, helloStringFormulaElement, worldStringFormulaElement));
 		textString = new Formula(SPEAK);
+		scope = new Scope(ProjectManager.getInstance().getCurrentProject(), sprite, new SequenceAction());
 
 		Project project = new Project(MockUtil.mockContextForProject(), "Project");
 		ProjectManager.getInstance().setCurrentProject(project);
-	}
-
-	@Test
-	public void testSpeak() throws Exception {
-		SpeakBrick speakBrick = new SpeakBrick(text);
-		Action action = factory.createSpeakAction(sprite, new SequenceAction(), text);
-		Formula textAfterExecution = (Formula) Reflection.getPrivateField(action, "text");
-
-		assertEquals(text, speakBrick.getFormulaWithBrickField(Brick.BrickField.SPEAK));
-		assertEquals(text, textAfterExecution);
-
-		speakBrick = new SpeakBrick(text2);
-		action = factory.createSpeakAction(sprite, new SequenceAction(), text);
-		textAfterExecution = (Formula) Reflection.getPrivateField(action, "text");
-
-		assertEquals(text2, speakBrick.getFormulaWithBrickField(Brick.BrickField.SPEAK));
-		assertEquals(text, textAfterExecution);
 	}
 
 	@Test
@@ -110,26 +104,54 @@ public class SpeakActionTest {
 	@Test
 	public void testBrickWithStringFormula() throws Exception {
 		SpeakBrick speakBrick = new SpeakBrick(textString);
-		Action action = factory.createSpeakAction(sprite, new SequenceAction(), textString);
-		Reflection.invokeMethod(action, "begin");
+		SpeakAction action = new SpeakAction();
+		SpeechSynthesizer synthesizer = new SpeechSynthesizer(scope, textString);
+
+		action.setSpeechSynthesizer(synthesizer);
+		action.initialize();
 
 		assertEquals(textString, speakBrick.getFormulaWithBrickField(Brick.BrickField.SPEAK));
-		assertEquals(SPEAK, String.valueOf(Reflection.getPrivateField(action, "interpretedText")));
+		assertEquals(SPEAK, String.valueOf(Reflection.getPrivateField(synthesizer, "interpretedText")));
+	}
+
+	@Test
+	public void testBrickWithFunctionFormula() throws Exception {
+		SpeakBrick speakBrick = new SpeakBrick(textFunction);
+		SpeakAction action = new SpeakAction();
+		SpeechSynthesizer synthesizer = new SpeechSynthesizer(scope, textString);
+
+		action.setSpeechSynthesizer(synthesizer);
+		action.initialize();
+
+		assertEquals(textFunction, speakBrick.getFormulaWithBrickField(Brick.BrickField.SPEAK));
+		assertEquals(SPEAK, String.valueOf(Reflection.getPrivateField(synthesizer, "interpretedText")));
 	}
 
 	@Test
 	public void testNullFormula() throws Exception {
-		Action action = factory.createSpeakAction(sprite, new SequenceAction(), null);
-		Reflection.invokeMethod(action, "begin");
+		SpeakAction action = new SpeakAction();
+		SpeechSynthesizer synthesizer = new SpeechSynthesizer(scope, null);
 
-		assertEquals("", String.valueOf(Reflection.getPrivateField(action, "interpretedText")));
+		action.setSpeechSynthesizer(synthesizer);
+		action.initialize();
+
+		assertEquals("", String.valueOf(Reflection.getPrivateField(synthesizer, "interpretedText")));
 	}
 
 	@Test
 	public void testNotANumberFormula() throws Exception {
-		Action action = factory.createSpeakAction(sprite, new SequenceAction(), new Formula(Double.NaN));
-		Reflection.invokeMethod(action, "begin");
+		SpeakAction action = new SpeakAction();
+		SpeechSynthesizer synthesizer = new SpeechSynthesizer(scope, new Formula(Double.NaN));
 
-		assertEquals("", String.valueOf(Reflection.getPrivateField(action, "interpretedText")));
+		action.setSpeechSynthesizer(synthesizer);
+		action.initialize();
+
+		assertEquals("", String.valueOf(Reflection.getPrivateField(synthesizer, "interpretedText")));
+	}
+
+	@Test
+	public void testSynthesizeInitialization() {
+		SpeakAction action = (SpeakAction) factory.createSpeakAction(sprite, new SequenceAction(), textNumber);
+		assertNotNull(action.getSpeechSynthesizer());
 	}
 }

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SpeakAndWaitActionTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SpeakAndWaitActionTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.actions
+
+import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction
+import junit.framework.Assert
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.content.ActionFactory
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Scope
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.content.actions.SpeakAndWaitAction
+import org.catrobat.catroid.content.bricks.Brick
+import org.catrobat.catroid.content.bricks.Brick.ResourcesSet
+import org.catrobat.catroid.content.bricks.SpeakAndWaitBrick
+import org.catrobat.catroid.formulaeditor.Formula
+import org.catrobat.catroid.stage.SpeechSynthesizer
+import org.catrobat.catroid.test.MockUtil
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.Mockito
+import org.mockito.Mockito.spy
+import java.lang.reflect.Method
+
+class SpeakAndWaitActionTest {
+    private lateinit var sprite: Sprite
+    private var textNumber: Formula? = null
+    private var scope: Scope? = null
+    private val factory = ActionFactory()
+    private val temporaryFolder = TemporaryFolder()
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        val contextMock = MockUtil.mockContextForProject()
+        temporaryFolder.create()
+        val temporaryCacheFolder = temporaryFolder.newFolder("SpeakTest")
+        Mockito.`when`(contextMock.cacheDir).thenAnswer { temporaryCacheFolder }
+        sprite = Sprite("testSprite")
+        textNumber = Formula(888.88)
+        scope = Scope(ProjectManager.getInstance().currentProject, sprite, SequenceAction())
+        val project = Project(MockUtil.mockContextForProject(), "Project")
+        ProjectManager.getInstance().currentProject = project
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testWaitOnSynthesis() {
+        val action = spy(SpeakAndWaitAction())
+        val synthesizer = Mockito.mock(SpeechSynthesizer::class.java)
+        action.speechSynthesizer = synthesizer
+
+        action.act(0.1f)
+        assert(!action.synthesizingFinished)
+        assertEquals(Float.MAX_VALUE, action.duration, 0.0f)
+
+        val onDone: Method = SpeakAndWaitAction::class.java.getDeclaredMethod("onDone")
+        onDone.isAccessible = true
+        onDone.invoke(action)
+
+        assert(action.synthesizingFinished)
+        action.act(0.1f)
+        assertEquals(0.0f, action.duration, 0.0f)
+    }
+
+    @Test
+    fun testRequirements() {
+        val speakAndWaitBrick = SpeakAndWaitBrick(Formula(""))
+        val resourcesSet = ResourcesSet()
+        speakAndWaitBrick.addRequiredResources(resourcesSet)
+        Assert.assertTrue(resourcesSet.contains(Brick.TEXT_TO_SPEECH))
+    }
+
+    @Test
+    fun testSynthesizeInitialization() {
+        val action = factory.createSpeakAndWaitAction(sprite, SequenceAction(), textNumber) as SpeakAndWaitAction
+        Assert.assertNotNull(action.speechSynthesizer)
+    }
+}


### PR DESCRIPTION
Seperated Speak Action and Speak and Wait Action as one is asynchronous and the other blocking.
Length of sound file must be discovered at runtime as formula expressions, e. g. variables, change
values during execution.

https://jira.catrob.at/browse/CATROID-1186

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
