### PR TITLE
CATROID-1188 Mindstorms flavor: NXT and EV3 brick categories are initially not visible

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/MainMenuActivity.java
@@ -90,6 +90,9 @@ public class MainMenuActivity extends BaseCastActivity implements
 		SettingsFragment.setToChosenLanguage(this);
 
 		PreferenceManager.setDefaultValues(this, R.xml.preferences, true);
+		PreferenceManager.setDefaultValues(this, R.xml.nxt_preferences, true);
+		PreferenceManager.setDefaultValues(this, R.xml.ev3_preferences, true);
+
 		ScreenValueHandler.updateScreenWidthAndHeight(this);
 
 		oldPrivacyPolicy = PreferenceManager.getDefaultSharedPreferences(this)

--- a/catroid/src/mindstorms/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/mindstorms/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -51,6 +51,7 @@ public final class FlavoredConstants {
 	// Media Library:
 	public static final String LIBRARY_BASE_URL = BASE_URL_HTTPS + "download-media/";
 	public static final String LIBRARY_LOOKS_URL = BASE_URL_HTTPS + "media-library/looks";
+	public static final String LIBRARY_OBJECT_URL = BASE_URL_HTTPS + "media-library/objects";
 	public static final String LIBRARY_BACKGROUNDS_URL_PORTRAIT = BASE_URL_HTTPS + "media-library/backgrounds-portrait";
 	public static final String LIBRARY_BACKGROUNDS_URL_LANDSCAPE = BASE_URL_HTTPS + "media-library/backgrounds-landscape";
 	public static final String LIBRARY_SOUNDS_URL = BASE_URL_HTTPS + "media-library/sounds";


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1188

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
