### PR TITLE
CATROID-1092 Add ripples to Objects/Actors/Looks/Sounds

### DIFF
--- a/catroid/config/lint.xml
+++ b/catroid/config/lint.xml
@@ -51,4 +51,7 @@
         <ignore path="*/com.thoughtworks.xstream/xstream/*"/>
         <ignore path="*/ar.com.hjg/pngj/*"/>
     </issue>
+
+    <issue id="ContentDescription" severity="ignore" />
+
 </lint >

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ScratchProgramDetailsActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ScratchProgramDetailsActivity.java
@@ -142,6 +142,9 @@ public class ScratchProgramDetailsActivity extends BaseActivity implements
 		RecyclerView recyclerView = findViewById(R.id.recycler_view_remixes);
 		adapter = new ScratchProgramAdapter(new ArrayList<ScratchProgramData>());
 		adapter.setOnItemClickListener(this);
+		adapter.showRipples = false;
+		adapter.hideSettings = true;
+
 		recyclerView.setAdapter(adapter);
 
 		if (programData.getImage() != null && programData.getImage().getUrl() != null) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/NfcTagAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/NfcTagAdapter.java
@@ -23,6 +23,9 @@
 
 package org.catrobat.catroid.ui.recyclerview.adapter;
 
+import android.view.View;
+import android.widget.ImageView;
+
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.NfcTagData;
 import org.catrobat.catroid.ui.recyclerview.viewholder.ExtendedVH;
@@ -41,5 +44,9 @@ public class NfcTagAdapter extends ExtendedRVAdapter<NfcTagData> {
 
 		holder.title.setText(item.getName());
 		holder.image.setImageResource(R.drawable.ic_program_menu_nfc);
+		ImageView ripples = holder.itemView.findViewById(R.id.ic_ripples);
+		if (ripples != null) {
+			ripples.setVisibility(View.GONE);
+		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/ProjectAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/ProjectAdapter.java
@@ -26,6 +26,7 @@ package org.catrobat.catroid.ui.recyclerview.adapter;
 import android.content.Context;
 import android.text.format.DateUtils;
 import android.view.View;
+import android.widget.ImageView;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.ProjectData;
@@ -57,6 +58,11 @@ public class ProjectAdapter extends ExtendedRVAdapter<ProjectData> {
 				loader.getScreenshotSceneName(item.getDirectory()),
 				false,
 				holder.image);
+
+		ImageView ripples = holder.itemView.findViewById(R.id.ic_ripples);
+		if (ripples != null) {
+			ripples.setVisibility(View.GONE);
+		}
 
 		if (showDetails) {
 			Date lastModified = new Date(item.getLastUsed());

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/RVAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/RVAdapter.java
@@ -26,6 +26,8 @@ package org.catrobat.catroid.ui.recyclerview.adapter;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.ImageView;
 
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.ui.recyclerview.adapter.draganddrop.TouchHelperAdapterInterface;
@@ -55,6 +57,8 @@ public abstract class RVAdapter<T> extends RecyclerView.Adapter<CheckableVH> imp
 
 	protected List<T> items;
 	public boolean showCheckBoxes = false;
+	public boolean showRipples = true;
+	public boolean hideSettings = false;
 
 	@SelectionType
 	public int selectionMode = MULTIPLE;
@@ -99,6 +103,16 @@ public abstract class RVAdapter<T> extends RecyclerView.Adapter<CheckableVH> imp
 
 		holder.checkBox.setVisibility(showCheckBoxes ? View.VISIBLE : View.GONE);
 		holder.checkBox.setChecked(selectionManager.isPositionSelected(position));
+
+		ImageView ripples = holder.itemView.findViewById(R.id.ic_ripples);
+		if (ripples != null && showRipples) {
+			ripples.setVisibility(View.VISIBLE);
+		}
+
+		ImageButton settings = holder.itemView.findViewById(R.id.settingsButton);
+		if (settings != null && hideSettings) {
+			settings.setVisibility(View.GONE);
+		}
 	}
 
 	protected void onCheckBoxClick(int position) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/backpack/BackpackRecyclerViewFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/backpack/BackpackRecyclerViewFragment.java
@@ -169,6 +169,8 @@ public abstract class BackpackRecyclerViewFragment<T> extends Fragment implement
 
 		adapter.setSelectionListener(this);
 		adapter.setOnItemClickListener(this);
+		adapter.showRipples = false;
+		adapter.notifyDataSetChanged();
 
 		ItemTouchHelper.Callback callback = new TouchHelperCallback(adapter);
 		touchHelper = new ItemTouchHelper(callback);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/scratchconverter/ScratchSearchResultsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/scratchconverter/ScratchSearchResultsFragment.java
@@ -232,11 +232,11 @@ public class ScratchSearchResultsFragment extends Fragment implements
 		adapter = new ScratchProgramAdapter(new ArrayList<ScratchProgramData>());
 		adapter.showDetails = PreferenceManager.getDefaultSharedPreferences(
 				getActivity()).getBoolean(SHOW_DETAILS_SCRATCH_PROJECTS_PREFERENCE_KEY, false);
-
 		recyclerView.setAdapter(adapter);
 
 		adapter.setSelectionListener(this);
 		adapter.setOnItemClickListener(this);
+		adapter.showRipples = false;
 
 		searchView.setOnQueryTextListener(onQueryListener);
 	}

--- a/catroid/src/main/res/drawable/ic_ripples.xml
+++ b/catroid/src/main/res/drawable/ic_ripples.xml
@@ -1,0 +1,132 @@
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2021 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector  xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="25.636dp"
+    android:viewportWidth="31.458"
+    android:viewportHeight="25.636">
+            <group>
+            <clip-path android:pathData="M1.229,0h29v5h-29z"/>
+            <group>
+              <path
+                  android:fillAlpha="0.01"
+                  android:pathData="M0,0h31v7.5h-31z"
+                  android:strokeAlpha="0.5"
+                  android:fillColor="#fff">
+              </path>
+              <path
+                  android:pathData="M0,0h31.458v1h-31.458z"
+                  android:strokeAlpha="0.5"
+                  android:fillColor="#04222C">
+                 </path>
+                 <path
+                     android:pathData="M0,0h1.5v7.636h-1.5z"
+                     android:strokeAlpha="0.5"
+                     android:fillColor="#04222c">
+                  </path>
+                <path
+                    android:pathData="M31.5,0h-1.5v7.636h1.5z"
+                    android:strokeAlpha="0.5"
+                    android:fillColor="#04222c">
+                  </path>
+             </group>
+            </group>
+            <group>
+            <clip-path android:pathData="M1.229,6h29v5h-29z"/>
+                <group>
+              <path
+                  android:fillAlpha="0.01"
+                  android:pathData="M0,6h31v7.5h-31z"
+                  android:strokeAlpha="0.5"
+                  android:fillColor="#fff">
+              </path>
+              <path
+                  android:pathData="M0,6h31.458v1h-31.458z"
+                  android:strokeAlpha="0.5"
+                  android:fillColor="#04222c">
+                 </path>
+                 <path
+                     android:pathData="M0,6h1.5v7.636h-1.5z"
+                     android:strokeAlpha="0.5"
+                     android:fillColor="#04222c">
+                  </path>
+                <path
+                    android:pathData="M31.5,6h-1.5v7.636h1.5z"
+                    android:strokeAlpha="0.5"
+                    android:fillColor="#04222c">
+                  </path>
+             </group>
+            </group>
+            <group>
+            <clip-path android:pathData="M1.229,12h29v5h-29z"/>
+                <group>
+              <path
+                  android:fillAlpha="0.01"
+                  android:pathData="M0,12h31v7.5h-31z"
+                  android:strokeAlpha="0.5"
+                  android:fillColor="#fff">
+              </path>
+              <path
+                  android:pathData="M0,12h31.458v1h-31.458z"
+                  android:strokeAlpha="0.5"
+                  android:fillColor="#04222c">
+                 </path>
+                 <path
+                     android:pathData="M0,12h1.5v7.636h-1.5z"
+                     android:strokeAlpha="0.5"
+                     android:fillColor="#04222c">
+                  </path>
+                <path
+                    android:pathData="M31.5,12h-1.5v7.636h1.5z"
+                    android:strokeAlpha="0.5"
+                    android:fillColor="#04222c">
+                  </path>
+             </group>
+            </group>
+            <group>
+             <clip-path android:pathData="M1.229,18h29v5h-29z" />
+             <group>
+               <path
+                   android:fillAlpha="0.01"
+                   android:pathData="M0,18h31v7.5h-31z"
+                   android:strokeAlpha="0.5"
+                   android:fillColor="#fff"/>
+                <path
+                    android:pathData="M0,18h31.458v1h-31.458z"
+                    android:strokeAlpha="0.5"
+                    android:fillColor="#04222c">
+                 </path>
+                 <path
+                     android:pathData="M0,18h1.5v7.636h-1.5z"
+                     android:strokeAlpha="0.5"
+                     android:fillColor="#04222c">
+                  </path>
+                <path
+                    android:pathData="M31.5,18h-1.5v7.636h1.5z"
+                    android:strokeAlpha="0.5"
+                    android:fillColor="#04222c">
+                  </path>
+            </group>
+            </group>
+</vector>

--- a/catroid/src/main/res/layout/vh_sprite_group_item.xml
+++ b/catroid/src/main/res/layout/vh_sprite_group_item.xml
@@ -48,6 +48,13 @@
         android:orientation="horizontal">
 
         <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_ripples"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="@dimen/img_margin"/>
+
+        <ImageView
             android:id="@+id/image_view"
             android:layout_width="72dp"
             android:layout_height="65dp"

--- a/catroid/src/main/res/layout/vh_with_checkbox.xml
+++ b/catroid/src/main/res/layout/vh_with_checkbox.xml
@@ -29,7 +29,7 @@
     android:layout_height="wrap_content"
     android:minHeight="@dimen/view_holder_height"
     android:paddingStart="@dimen/view_holder_padding"
-    android:paddingEnd="@dimen/view_holder_padding"
+    android:paddingEnd="@dimen/view_holder_padding_small"
     android:layout_marginTop="?attr/element_spacing"
     android:layout_marginBottom="?attr/element_spacing"
     tools:ignore="Overdraw"
@@ -48,6 +48,15 @@
         android:layout_height="match_parent"
         android:gravity="center_vertical"
         android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/ic_ripples"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_ripples"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="@dimen/img_margin"
+            android:visibility="gone"/>
 
         <ImageView
             android:id="@+id/image_view"
@@ -87,7 +96,8 @@
             android:layout_weight="0"
             android:gravity="center_vertical"
             android:backgroundTint="@color/accent"
-            android:background="@drawable/ic_more_vert" />
+            android:background="@drawable/ic_more_vert"
+            android:visibility="visible" />
 
     </LinearLayout>
 </LinearLayout>

--- a/catroid/src/main/res/values/dimens.xml
+++ b/catroid/src/main/res/values/dimens.xml
@@ -75,6 +75,7 @@
     <dimen name="sprite_group_vh_height">50dp</dimen>
     <dimen name="user_data_vh_height">50dp</dimen>
     <dimen name="view_holder_padding">16dp</dimen>
+    <dimen name="view_holder_padding_small">10dp</dimen>
     <dimen name="sprite_group_item_vh_padding">40dp</dimen>
     <dimen name="checkbox_margin">16dp</dimen>
 


### PR DESCRIPTION
Added visual "ripples" on the left to Objects, Actors, Looks and Sounds to indicate to the user that these blocks can be dragged up and down. Moved the icon and text a bit to the right to make place for the ripples.



### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
