### PR TITLE
CATROID-1191 Fix failing FormulaEditorFragmentActivityRecreateRegressionTest with "androidx.test.espresso.NoActivityResumedException:"

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/regression/activitydestroy/FormulaEditorFragmentActivityRecreateRegressionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/regression/activitydestroy/FormulaEditorFragmentActivityRecreateRegressionTest.java
@@ -23,6 +23,8 @@
 
 package org.catrobat.catroid.uiespresso.ui.regression.activitydestroy;
 
+import android.content.Intent;
+
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.bricks.ChangeSizeByNBrick;
@@ -41,7 +43,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.platform.app.InstrumentationRegistry;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
 import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.FORMULA_EDITOR_KEYBOARD_MATCHER;
@@ -82,8 +83,9 @@ public class FormulaEditorFragmentActivityRecreateRegressionTest {
 	@Flaky
 	@Test
 	public void testActivityRecreateFormulaEditorFragment() {
-		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().recreate());
-		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+		Intent intent = baseActivityTestRule.getActivity().getIntent();
+		baseActivityTestRule.getActivity().finish();
+		baseActivityTestRule.launchActivity(intent);
 
 		onBrickAtPosition(0)
 				.checkShowsText(R.string.brick_when_started);
@@ -111,8 +113,9 @@ public class FormulaEditorFragmentActivityRecreateRegressionTest {
 	public void testActivityRecreateDataFragment() {
 		onFormulaEditor().performOpenDataFragment();
 
-		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().recreate());
-		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+		Intent intent = baseActivityTestRule.getActivity().getIntent();
+		baseActivityTestRule.getActivity().finish();
+		baseActivityTestRule.launchActivity(intent);
 
 		onBrickAtPosition(0)
 				.checkShowsText(R.string.brick_when_started);
@@ -140,7 +143,9 @@ public class FormulaEditorFragmentActivityRecreateRegressionTest {
 	public void testActivityRecreateCategoryFragment() {
 		onFormulaEditor().performOpenFunctions();
 
-		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().recreate());
+		Intent intent = baseActivityTestRule.getActivity().getIntent();
+		baseActivityTestRule.getActivity().finish();
+		baseActivityTestRule.launchActivity(intent);
 
 		onBrickAtPosition(0)
 				.checkShowsText(R.string.brick_when_started);
@@ -172,7 +177,9 @@ public class FormulaEditorFragmentActivityRecreateRegressionTest {
 		onView(withText(R.string.formula_editor_new_string_name)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
 
-		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().recreate());
+		Intent intent = baseActivityTestRule.getActivity().getIntent();
+		baseActivityTestRule.getActivity().finish();
+		baseActivityTestRule.launchActivity(intent);
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Quarantine.class})
@@ -182,6 +189,8 @@ public class FormulaEditorFragmentActivityRecreateRegressionTest {
 		onFormulaEditor().performCompute();
 		onView(withId(R.id.formula_editor_compute_dialog_textview)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
-		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().recreate());
+		Intent intent = baseActivityTestRule.getActivity().getIntent();
+		baseActivityTestRule.getActivity().finish();
+		baseActivityTestRule.launchActivity(intent);
 	}
 }


### PR DESCRIPTION
Fixed by manually restarting the intent.

https://jira.catrob.at/browse/CATROID-1191

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
