### PR TITLE
CATROID-1180 Memory Leak of SpriteActivity in ProjectManager.currentlyEditedScene

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -688,4 +688,10 @@ public final class ProjectManager {
 			saveDownloadedProjects();
 		}
 	}
+
+	public void resetProjectManager() {
+		currentlyEditedScene = null;
+		currentlyPlayingScene = null;
+		currentSprite = null;
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.java
@@ -196,6 +196,8 @@ public class ProjectActivity extends BaseCastActivity {
 			getSupportFragmentManager().popBackStack();
 			BottomBar.showBottomBar(this);
 			return;
+		} else {
+			ProjectManager.getInstance().resetProjectManager();
 		}
 
 		boolean multiSceneProject = ProjectManager.getInstance().getCurrentProject().getSceneList().size() > 1;


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1180

reset Project references in ProjectManager when project gets closed. 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
