### PR TITLE
Catroid-1194 prioritize recently used bricks in bricksearch

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/BrickSearchFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/BrickSearchFragment.kt
@@ -146,10 +146,18 @@ class BrickSearchFragment : ListFragment() {
         availableBricks.forEach { brick ->
             val regexQuery = (".*" + query.toLowerCase(Locale.ROOT).replace("\\s".toRegex(), ".*") + ".*").toRegex()
             val brickView = brick.getView(context)
-            if (regexQuery.containsMatchIn(findBrickString(brickView))) {
+            if (regexQuery.containsMatchIn(findBrickString(brickView)) && !searchResultContains(brick)) {
                 searchResults.add(brick)
             }
         }
+    }
+    private fun searchResultContains(brick: Brick): Boolean {
+        searchResults.forEach {
+            if (brick.javaClass == it.javaClass) {
+                return true
+            }
+        }
+        return false
     }
 
     private fun findBrickString(view: View): String {
@@ -172,7 +180,7 @@ class BrickSearchFragment : ListFragment() {
         }
         val backgroundSprite = ProjectManager.getInstance().currentlyEditedScene.backgroundSprite
         val sprite = ProjectManager.getInstance().currentSprite
-
+        availableBricks.addAll(categoryBricksFactory.getBricks(requireContext().getString(R.string.category_recently_used), backgroundSprite.equals(sprite), requireContext()))
         availableBricks.addAll(categoryBricksFactory.getBricks(requireContext().getString(R.string.category_event), backgroundSprite.equals(sprite), requireContext()))
         availableBricks.addAll(categoryBricksFactory.getBricks(requireContext().getString(R.string.category_control), backgroundSprite.equals(sprite), requireContext()))
         availableBricks.addAll(categoryBricksFactory.getBricks(requireContext().getString(R.string.category_motion), backgroundSprite.equals(sprite), requireContext()))


### PR DESCRIPTION
*Please enter a short description of your pull request and add a reference to the Jira ticket.*
https://jira.catrob.at/browse/CATROID-1194
When the user searches for a Brick, recently used bricks are shown on top of the search results
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
