### PR TITLE
Maintenance: Rename sprite(s) to actor(s)s or object(s)

### DIFF
--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -552,8 +552,8 @@
         <item quantity="other">Deleted %d scenes.</item>
     </plurals>
     <plurals name="deleted_sprites">
-        <item quantity="one">Deleted %d sprite.</item>
-        <item quantity="other">Deleted %d sprites.</item>
+        <item quantity="one">Deleted %d actor or object.</item>
+        <item quantity="other">Deleted %d actors or objects.</item>
     </plurals>
     <plurals name="deleted_looks">
         <item quantity="one">Deleted %d look.</item>


### PR DESCRIPTION
There was still one instance where "sprite" incorrectly hadn't been renamed to actor or object, which is hereby corrected.