### PR TITLE
CATROID-1220 fix failing formula editor recreate activity test

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/regression/activitydestroy/FormulaEditorFragmentActivityRecreateRegressionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/regression/activitydestroy/FormulaEditorFragmentActivityRecreateRegressionTest.java
@@ -23,11 +23,11 @@
 
 package org.catrobat.catroid.uiespresso.ui.regression.activitydestroy;
 
+import android.content.Intent;
+
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.bricks.ChangeSizeByNBrick;
-import org.catrobat.catroid.rules.FlakyTestRule;
-import org.catrobat.catroid.runner.Flaky;
 import org.catrobat.catroid.testsuites.annotations.Cat;
 import org.catrobat.catroid.testsuites.annotations.Level;
 import org.catrobat.catroid.ui.SpriteActivity;
@@ -65,9 +65,6 @@ public class FormulaEditorFragmentActivityRecreateRegressionTest {
 			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION,
 			SpriteActivity.FRAGMENT_SCRIPTS);
 
-	@Rule
-	public FlakyTestRule flakyTestRule = new FlakyTestRule();
-
 	@Before
 	public void setUp() throws Exception {
 		Script script = BrickTestUtils.createProjectAndGetStartScript("FormulaEditorEditTextTest");
@@ -76,112 +73,81 @@ public class FormulaEditorFragmentActivityRecreateRegressionTest {
 		onBrickAtPosition(1)
 				.onFormulaTextField(R.id.brick_change_size_by_edit_text)
 				.perform(click());
+		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Quarantine.class})
-	@Flaky
 	@Test
 	public void testActivityRecreateFormulaEditorFragment() {
-		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().recreate());
-		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
-
-		onBrickAtPosition(0)
-				.checkShowsText(R.string.brick_when_started);
-		onBrickAtPosition(1)
-				.checkShowsText(R.string.brick_change_size_by);
-
-		onView(FORMULA_EDITOR_KEYBOARD_MATCHER)
-				.check(doesNotExist());
-		onView(FORMULA_EDITOR_TEXT_FIELD_MATCHER)
-				.check(doesNotExist());
-
-		onBrickAtPosition(1)
-				.onFormulaTextField(R.id.brick_change_size_by_edit_text)
-				.perform(click());
-
-		onView(FORMULA_EDITOR_KEYBOARD_MATCHER)
-				.check(matches(isDisplayed()));
-		onView(FORMULA_EDITOR_TEXT_FIELD_MATCHER)
-				.check(matches(isDisplayed()));
+		recreateActivity();
+		checkInitialListeners();
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Quarantine.class})
-	@Flaky
 	@Test
 	public void testActivityRecreateDataFragment() {
 		onFormulaEditor().performOpenDataFragment();
-
-		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().recreate());
 		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
-
-		onBrickAtPosition(0)
-				.checkShowsText(R.string.brick_when_started);
-		onBrickAtPosition(1)
-				.checkShowsText(R.string.brick_change_size_by);
-
-		onView(FORMULA_EDITOR_KEYBOARD_MATCHER)
-				.check(doesNotExist());
-		onView(FORMULA_EDITOR_TEXT_FIELD_MATCHER)
-				.check(doesNotExist());
-
-		onBrickAtPosition(1)
-				.onFormulaTextField(R.id.brick_change_size_by_edit_text)
-				.perform(click());
-
-		onView(FORMULA_EDITOR_KEYBOARD_MATCHER)
-				.check(matches(isDisplayed()));
-		onView(FORMULA_EDITOR_TEXT_FIELD_MATCHER)
-				.check(matches(isDisplayed()));
+		recreateActivity();
+		checkInitialListeners();
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Quarantine.class})
-	@Flaky
 	@Test
 	public void testActivityRecreateCategoryFragment() {
 		onFormulaEditor().performOpenFunctions();
-
-		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().recreate());
-
-		onBrickAtPosition(0)
-				.checkShowsText(R.string.brick_when_started);
-		onBrickAtPosition(1)
-				.checkShowsText(R.string.brick_change_size_by);
-
-		onView(FORMULA_EDITOR_KEYBOARD_MATCHER)
-				.check(doesNotExist());
-		onView(FORMULA_EDITOR_TEXT_FIELD_MATCHER)
-				.check(doesNotExist());
-
-		onBrickAtPosition(1)
-				.onFormulaTextField(R.id.brick_change_size_by_edit_text)
-				.perform(click());
-
-		onView(FORMULA_EDITOR_KEYBOARD_MATCHER)
-				.check(matches(isDisplayed()));
-		onView(FORMULA_EDITOR_TEXT_FIELD_MATCHER)
-				.check(matches(isDisplayed()));
+		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+		recreateActivity();
+		checkInitialListeners();
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Quarantine.class})
-	@Flaky
 	@Test
 	public void testActivityRecreateStringDialogFragment() {
 		onFormulaEditor().performClickOn(FormulaEditorWrapper.Control.TEXT);
+		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
 		onView(withId(R.id.input_edit_text))
 				.check(matches(isDisplayed()));
 		onView(withText(R.string.formula_editor_new_string_name)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
-
-		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().recreate());
+		recreateActivity();
+		checkInitialListeners();
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Quarantine.class})
-	@Flaky
 	@Test
 	public void testActivityRecreateComputeDialogFragment() {
 		onFormulaEditor().performCompute();
+		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
 		onView(withId(R.id.formula_editor_compute_dialog_textview)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
-		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().recreate());
+		recreateActivity();
+		checkInitialListeners();
+	}
+
+	private void recreateActivity() {
+		Intent intent = baseActivityTestRule.getActivity().getIntent();
+		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().finish());
+		InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> baseActivityTestRule.getActivity().startActivity(intent));
+		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+	}
+
+	private void checkInitialListeners() {
+		onBrickAtPosition(0)
+				.checkShowsText(R.string.brick_when_started);
+		onBrickAtPosition(1)
+				.checkShowsText(R.string.brick_change_size_by);
+		onView(FORMULA_EDITOR_KEYBOARD_MATCHER)
+				.check(doesNotExist());
+		onView(FORMULA_EDITOR_TEXT_FIELD_MATCHER)
+				.check(doesNotExist());
+		onBrickAtPosition(1).perform(click());
+		onView(withText(R.string.brick_context_dialog_formula_edit_brick)).perform(click());
+		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+		onView(FORMULA_EDITOR_KEYBOARD_MATCHER)
+				.check(matches(isDisplayed()));
+		onView(FORMULA_EDITOR_TEXT_FIELD_MATCHER)
+				.check(matches(isDisplayed()));
+		InstrumentationRegistry.getInstrumentation().waitForIdleSync();
 	}
 }


### PR DESCRIPTION
[CATROID-1220](https://jira.catrob.at/browse/CATROID-1220)

Fix failing test. In the test the activity's `recreate()` method was used, which didn't guarantee recreation in a test environment. 
This has been replaced with `finish()` -ing and `restart()` -ing with the original Intent. Additionally general refactoring of the test was performed 


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
