### PR TITLE
CATROID-1005 FATAL EXCEPTION: androidx.test.espresso.NoMatchingViewException

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/stage/SearchParameterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/stage/SearchParameterTest.java
@@ -70,9 +70,8 @@ import static org.junit.Assert.assertTrue;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.Espresso.pressBack;
-import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
@@ -123,8 +122,7 @@ public class SearchParameterTest {
 		openActionBarOverflowOrOptionsMenu(baseActivityTestRule.getActivity());
 		onView(withText(R.string.find)).perform(click());
 		for (String argument : arguments) {
-			onView(withId(R.id.search_bar)).perform(clearText());
-			onView(withId(R.id.search_bar)).perform(typeText(argument));
+			onView(withId(R.id.search_bar)).perform(replaceText(argument));
 			onView(withId(R.id.find)).perform(click());
 			onView(withText(argument)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 		}
@@ -136,20 +134,19 @@ public class SearchParameterTest {
 				baseActivityTestRule.getActivity().getString(R.string.brick_glide) + baseActivityTestRule.getActivity().getString(R.string.brick_glide_to_x);
 		openActionBarOverflowOrOptionsMenu(baseActivityTestRule.getActivity());
 		onView(withText(R.string.find)).perform(click());
-		onView(withId(R.id.search_bar)).perform(clearText());
-		onView(withId(R.id.search_bar)).perform(typeText(searchParam));
+		onView(withId(R.id.search_bar)).perform(replaceText(searchParam));
 		onView(withId(R.id.find)).perform(click());
 		onView(withText(searchParam)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 	}
 
 	@Test
 	public void testSearchSpinner() {
+		final String searchTerm = "look 1";
 		openActionBarOverflowOrOptionsMenu(baseActivityTestRule.getActivity());
 		onView(withText(R.string.find)).perform(click());
-		onView(withId(R.id.search_bar)).perform(clearText());
-		onView(withId(R.id.search_bar)).perform(typeText("look 1"));
+		onView(withId(R.id.search_bar)).perform(replaceText(searchTerm));
 		onView(withId(R.id.find)).perform(click());
-		onView(withText("look 1")).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
+		onView(withText(searchTerm)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
 	}
 
 	@Test
@@ -157,8 +154,7 @@ public class SearchParameterTest {
 		String searchParam = "0";
 		openActionBarOverflowOrOptionsMenu(baseActivityTestRule.getActivity());
 		onView(withText(R.string.find)).perform(click());
-		onView(withId(R.id.search_bar)).perform(clearText());
-		onView(withId(R.id.search_bar)).perform(typeText(searchParam));
+		onView(withId(R.id.search_bar)).perform(replaceText(searchParam));
 		onView(withId(R.id.find)).perform(click());
 		BrickDataInteractionWrapper.onBrickAtPosition(1).onFormulaTextField(R.id.brick_set_x_edit_text).perform(click());
 		pressBack();

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/ui/BrickSearchTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/ui/BrickSearchTest.kt
@@ -33,14 +33,15 @@ import android.view.inputmethod.InputMethodManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.pressKey
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.platform.app.InstrumentationRegistry
 import org.catrobat.catroid.ProjectManager
 import org.catrobat.catroid.R
 import org.catrobat.catroid.content.Project
@@ -86,13 +87,24 @@ class BrickSearchTest {
     @Flaky
     fun testSearchBrickParams() {
         val arguments = arrayOf("When scene starts", "move", "BROADCAST")
-        val bricks = arrayOf(WhenStartedBrick::class.java, MoveNStepsBrick::class.java, BroadcastBrick::class.java)
+        val bricks = arrayOf(
+            WhenStartedBrick::class.java,
+            MoveNStepsBrick::class.java,
+            BroadcastBrick::class.java
+        )
+        ensureKeyboardIsClosed()
         Espresso.onView(withId(R.id.button_add)).perform(click())
         Espresso.onView(withId(R.id.search)).perform(click())
         for (index in arguments.indices) {
-            Espresso.onView(withId(R.id.search_src_text)).perform(clearText(), ViewActions.typeText(arguments[index])).perform(pressKey(KeyEvent.KEYCODE_ENTER))
-            Espresso.onView(ViewMatchers.isRoot()).perform(CustomActions.wait(2000))
-            Espresso.onData(Matchers.allOf(Matchers.`is`(Matchers.instanceOf(bricks[index] as Class<*>?))))
+            Espresso.onView(withId(R.id.search_src_text)).perform(click())
+            val viewMatcher = Espresso.onView(withId(R.id.search_src_text)).perform(
+                replaceText(arguments[index])
+            )
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            viewMatcher.perform(pressKey(KeyEvent.KEYCODE_ENTER))
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            Espresso.onData(Matchers.allOf(Matchers.`is`(Matchers.instanceOf
+            (bricks[index] as Class<*>?))))
                 .inAdapterView(BrickPrototypeListMatchers.isBrickPrototypeView())
                 .atPosition(0)
                 .check(matches(isDisplayed()))
@@ -102,13 +114,30 @@ class BrickSearchTest {
     @Test
     @Flaky
     fun testSearchIfBrick() {
+        ensureKeyboardIsClosed()
         Espresso.onView(withId(R.id.button_add)).perform(click())
         Espresso.onView(withId(R.id.search)).perform(click())
-        Espresso.onView(withId(R.id.search_src_text)).perform(clearText(), ViewActions.typeText("if")).perform(pressKey(KeyEvent.KEYCODE_ENTER))
-        val searchAutoComplete = Espresso.onView(Matchers.allOf(withId(R.id.search_src_text), ViewMatchers.withText("if"),
-                childAtPosition(Matchers.allOf(withId(R.id.search_plate), childAtPosition(withId(R.id.search_edit_frame), 1)), 0), isDisplayed()))
+        Espresso.onView(withId(R.id.search_src_text)).perform(
+            replaceText("if")
+        ).perform(pressKey(KeyEvent.KEYCODE_ENTER))
+        val searchAutoComplete = Espresso.onView(
+            Matchers.allOf(
+                withId(R.id.search_src_text),
+                ViewMatchers.withText("if"), childAtPosition(
+                    Matchers.allOf(
+                        withId(R.id.search_plate),
+                        childAtPosition(withId(R.id.search_edit_frame), 1)
+                    ), 0
+                ), isDisplayed()
+            )
+        )
         searchAutoComplete.perform(ViewActions.pressImeActionButton())
-        val linearLayout = Espresso.onData(Matchers.anything()).inAdapterView(Matchers.allOf(withId(android.R.id.list), childAtPosition(withId(R.id.fragment_brick_search), 0))).atPosition(0)
+        val linearLayout = Espresso.onData(Matchers.anything()).inAdapterView(
+            Matchers.allOf(
+                withId(android.R.id.list),
+                childAtPosition(withId(R.id.fragment_brick_search), 0)
+            )
+        ).atPosition(0)
         linearLayout.perform(click())
         Assert.assertFalse(isKeyboardVisible())
     }
@@ -116,11 +145,14 @@ class BrickSearchTest {
     @Test
     @Flaky
     fun testCloseKeyboardAfterSearching() {
+        ensureKeyboardIsClosed()
         Espresso.onView(withId(R.id.button_add)).perform(click())
         Espresso.onView(withId(R.id.search)).perform(click())
         Espresso.onView(ViewMatchers.isRoot()).perform(CustomActions.wait(2000))
         Assert.assertTrue(isKeyboardVisible())
-        Espresso.onView(withId(R.id.search_src_text)).perform(clearText(), ViewActions.typeText("if")).perform(pressKey(KeyEvent.KEYCODE_ENTER))
+        Espresso.onView(withId(R.id.search_src_text)).perform(
+            replaceText("if")
+        ).perform(pressKey(KeyEvent.KEYCODE_ENTER))
         Espresso.onView(ViewMatchers.isRoot()).perform(CustomActions.wait(2000))
         Assert.assertFalse(isKeyboardVisible())
     }
@@ -128,9 +160,15 @@ class BrickSearchTest {
     @Test
     @Flaky
     fun testCategorySearch() {
+        ensureKeyboardIsClosed()
         Espresso.onView(withId(R.id.button_add)).perform(click())
         Espresso.onView(withId(R.id.search)).perform(click())
-        Espresso.onView(withId(R.id.search_src_text)).perform(clearText(), ViewActions.typeText("When")).perform(pressKey(KeyEvent.KEYCODE_ENTER))
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        Espresso.onView(withId(R.id.search_src_text)).perform(
+            replaceText("When")
+        ).perform(pressKey(KeyEvent.KEYCODE_ENTER))
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync() // previous action takes
+        // long to execute
         Espresso.onView(
             Matchers.allOf(
                 ViewMatchers.withText("When scene starts"),
@@ -145,20 +183,29 @@ class BrickSearchTest {
         ).check(matches(isDisplayed()))
         Espresso.onView(
             Matchers.allOf(
-                ViewMatchers.withContentDescription("Navigate up"),
+                ViewMatchers.withContentDescription(Matchers.containsString("Navigate up")),
                 childAtPosition(
-                    Matchers.allOf(withId(R.id.toolbar), childAtPosition(withId(R.id.activity_sprite), 0)), 1
+                    Matchers.allOf(
+                        withId(R.id.toolbar),
+                        childAtPosition(withId(R.id.activity_sprite), 0)
+                    ), 1
                 ),
                 isDisplayed()
             )
         ).perform(click())
         Espresso.onData(Matchers.anything())
             .inAdapterView(
-                Matchers.allOf(withId(R.id.brick_category_list), childAtPosition(withId(R.id.fragment_container), 1))
+                Matchers.allOf(
+                    withId(R.id.brick_category_list),
+                    childAtPosition(withId(R.id.fragment_container), 1)
+                )
             ).atPosition(5).perform(click())
         Espresso.onView(withId(R.id.search)).perform(click())
-        Espresso.onView(withId(R.id.search_src_text)).perform(clearText(), ViewActions.typeText("When")).perform(pressKey(KeyEvent.KEYCODE_ENTER))
-        Espresso.onView(ViewMatchers.isRoot()).perform(CustomActions.wait(2000))
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        Espresso.onView(withId(R.id.search_src_text))
+            .perform(replaceText("When"))
+            .perform(pressKey(KeyEvent.KEYCODE_ENTER))
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         Espresso.onView(
             Matchers.allOf(
                 ViewMatchers.withText("When scene starts")
@@ -172,10 +219,22 @@ class BrickSearchTest {
         )
     }
 
+    fun ensureKeyboardIsClosed() {
+        if (isKeyboardVisible()) {
+            hideKeyboard()
+        }
+    }
+
+    fun hideKeyboard() {
+        Espresso.onView(ViewMatchers.isRoot()).perform(ViewActions.closeSoftKeyboard())
+    }
+
     fun isKeyboardVisible(): Boolean {
         return try {
-            val manager = ApplicationProvider.getApplicationContext<Context>().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            val windowHeightMethod = InputMethodManager::class.java.getMethod("getInputMethodWindowVisibleHeight")
+            val manager = ApplicationProvider.getApplicationContext<Context>()
+                .getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            val windowHeightMethod =
+                InputMethodManager::class.java.getMethod("getInputMethodWindowVisibleHeight")
             val height = windowHeightMethod.invoke(manager) as Int
             height > 0
         } catch (e: Exception) {
@@ -216,7 +275,8 @@ class BrickSearchTest {
 
             public override fun matchesSafely(view: View): Boolean {
                 val parent = view.parent
-                return parent is ViewGroup && parentMatcher.matches(parent) && view == parent.getChildAt(position)
+                return parent is ViewGroup && parentMatcher.matches(parent) &&
+                    view == parent.getChildAt(position)
             }
         }
     }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/SetVariableBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/SetVariableBrickTest.java
@@ -48,10 +48,9 @@ import static org.hamcrest.Matchers.allOf;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
-import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
-import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -137,7 +136,7 @@ public class SetVariableBrickTest {
 		onView(withId(R.id.button_add))
 				.perform(click());
 		onView(withId(R.id.input_edit_text))
-				.perform(clearText(), typeText(userVariableName), closeSoftKeyboard());
+				.perform(replaceText(userVariableName), closeSoftKeyboard());
 		onView(withText(R.string.ok))
 				.perform(click());
 		onView(allOf(withChild(withText(userVariableName)), withChild(withText("0"))))

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickVariableSpinnerDataInteractionWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/utils/BrickVariableSpinnerDataInteractionWrapper.java
@@ -37,11 +37,10 @@ import static org.hamcrest.core.AllOf.allOf;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.pressBack;
-import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -88,7 +87,7 @@ public class BrickVariableSpinnerDataInteractionWrapper extends BrickSpinnerData
 
 	private static void enterTextOnDialogue(int editTextId, String textToEnter) {
 		onView(withId(editTextId))
-				.perform(clearText(), typeText(textToEnter), closeSoftKeyboard());
+				.perform(replaceText(textToEnter), closeSoftKeyboard());
 		onView(withId(android.R.id.button1))
 				.perform(click());
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/FormulaEditorDataListWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/FormulaEditorDataListWrapper.java
@@ -30,10 +30,9 @@ import static org.catrobat.catroid.uiespresso.util.matchers.FormulaEditorDataLis
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
-import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
-import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -75,7 +74,7 @@ public final class FormulaEditorDataListWrapper extends ViewInteractionWrapper {
 		onView(withId(R.id.button_add))
 				.perform(click());
 		onView(withId(R.id.input_edit_text))
-				.perform(clearText(), typeText(itemName), closeSoftKeyboard());
+				.perform(replaceText(itemName), closeSoftKeyboard());
 
 		switch (scope) {
 			case GLOBAL:
@@ -131,7 +130,7 @@ public final class FormulaEditorDataListWrapper extends ViewInteractionWrapper {
 				.perform(click());
 
 		onView(withId(R.id.input_edit_text))
-				.perform(clearText(), typeText(itemName), closeSoftKeyboard());
+				.perform(replaceText(itemName), closeSoftKeyboard());
 
 		onView(withId(android.R.id.button2))
 				.perform(click());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/FormulaEditorWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/FormulaEditorWrapper.java
@@ -34,16 +34,19 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import androidx.test.espresso.ViewInteraction;
+
 import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorCategoryListWrapper.onCategoryList;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 public final class FormulaEditorWrapper extends ViewInteractionWrapper {
@@ -92,9 +95,10 @@ public final class FormulaEditorWrapper extends ViewInteractionWrapper {
 		onView(Control.TEXT)
 				.perform(click());
 		onView(withId(R.id.input_edit_text))
-				.perform(clearText(), typeText(stringToBeEntered));
+				.perform(replaceText(stringToBeEntered));
 		onView(withText(R.string.ok))
 				.perform(click());
+		performCloseFormulaStringWarning();
 		return new FormulaEditorWrapper();
 	}
 
@@ -102,9 +106,10 @@ public final class FormulaEditorWrapper extends ViewInteractionWrapper {
 		onView(Control.TEXT)
 				.perform(click());
 		onView(withId(R.id.input_edit_text))
-				.perform(clearText(), typeText(UiTestUtils.getResourcesString(stringResourceId)));
+				.perform(replaceText(UiTestUtils.getResourcesString(stringResourceId)));
 		onView(withText(R.string.ok))
 				.perform(click());
+		performCloseFormulaStringWarning();
 		return new FormulaEditorWrapper();
 	}
 
@@ -124,6 +129,20 @@ public final class FormulaEditorWrapper extends ViewInteractionWrapper {
 		onView(category)
 				.perform(click());
 		return onCategoryList();
+	}
+
+	public void performCloseFormulaStringWarning() {
+		try {
+			onView(allOf(withText(R.string.warning),
+					withParent(allOf(withId(R.id.title_template),
+					withParent(withId(R.id.topPanel)))), isDisplayed()));
+			onView(allOf(withText(R.string.warning_formula_recognized),
+					withParent(withParent(withId(R.id.scrollView))), isDisplayed()));
+			ViewInteraction button = onView(
+					allOf(withText(R.string.ok),
+					withParent(withParent(withId(R.id.buttonPanel))), isDisplayed()));
+			button.perform(click());
+		} catch (Exception ignored) { }
 	}
 
 	public void performOpenDataFragment() {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/UserDataItemRVInteractionWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/UserDataItemRVInteractionWrapper.java
@@ -28,7 +28,6 @@ import org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewItemInter
 import org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewItemMatcher;
 
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.replaceText;
@@ -63,7 +62,7 @@ public abstract class UserDataItemRVInteractionWrapper<T extends UserDataItemRVI
 		onView(withText(R.string.rename))
 				.perform(click());
 		onView(withId(R.id.input_edit_text))
-				.perform(clearText(), replaceText(newName), closeSoftKeyboard());
+				.perform(replaceText(newName), closeSoftKeyboard());
 		onView(withText(R.string.ok))
 				.perform(click());
 	}


### PR DESCRIPTION
[CATROID-1005](https://jira.catrob.at/browse/CATROID-1005)

Problem was: in many cases the entered string was truncated due to
too fast automated typing. Modify type string method to use replaceText
instead of doing them sequentially, since that way they might collide
with each other.
Another problem was: an alert message popped up that the string might
be a formula. This now gets dismissed if it pops up.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
