### PR TITLE
CATROID-581 Refactor handling of screen sizes in StageActivity

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/camera/FaceTextPoseDetector.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/camera/FaceTextPoseDetector.kt
@@ -439,6 +439,7 @@ object FaceTextPoseDetector : ImageAnalysis.Analyzer {
         imageWidth: Int,
         imageHeight: Int
     ): Point {
+        // TODO: check - use resolution here?
         val frontCamera = StageActivity.getActiveCameraManager().isCameraFacingFront
         val aspectRatio = imageWidth.toFloat() / imageHeight
 

--- a/catroid/src/main/java/org/catrobat/catroid/camera/PreviewView.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/camera/PreviewView.kt
@@ -50,6 +50,7 @@ class PreviewView(context: Context) : FrameLayout(context) {
         )
     }
 
+    // TODO: check - use resolution here?
     private fun scaleView(imageWidth: Int, imageHeight: Int) {
         val imageAspectRatio = imageHeight.toFloat() / imageWidth
         val screenAspectRatio = this.width.toFloat() / this.height

--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -95,6 +95,7 @@ public class Project implements Serializable {
 		if (ScreenValues.SCREEN_HEIGHT == 0 || ScreenValues.SCREEN_WIDTH == 0) {
 			ScreenValueHandler.updateScreenWidthAndHeight(context);
 		}
+		//TODO: check - use resolution here?
 		if (landscapeMode && ScreenValues.SCREEN_WIDTH < ScreenValues.SCREEN_HEIGHT) {
 			int tmp = ScreenValues.SCREEN_HEIGHT;
 			ScreenValues.SCREEN_HEIGHT = ScreenValues.SCREEN_WIDTH;

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -78,6 +78,7 @@ import org.catrobat.catroid.physics.shapebuilder.PhysicsShapeBuilder;
 import org.catrobat.catroid.pocketmusic.mididriver.MidiSoundManager;
 import org.catrobat.catroid.ui.dialogs.StageDialog;
 import org.catrobat.catroid.ui.recyclerview.controller.SpriteController;
+import org.catrobat.catroid.utils.Resolution;
 import org.catrobat.catroid.utils.TouchUtil;
 import org.catrobat.catroid.utils.VibrationUtil;
 import org.catrobat.catroid.web.WebConnectionHolder;
@@ -149,10 +150,7 @@ public class StageListener implements ApplicationListener {
 
 	private StageDialog stageDialog;
 
-	int maxViewPortX = 0;
-	int maxViewPortY = 0;
-	int maxViewPortHeight = 0;
-	int maxViewPortWidth = 0;
+	Resolution maxViewPort = new Resolution(0, 0);
 
 	public boolean axesOn = false;
 	private static final Color AXIS_COLOR = new Color(0xff000cff);
@@ -201,7 +199,8 @@ public class StageListener implements ApplicationListener {
 		embroideryPatternManager = new DSTPatternManager();
 		initActors(sprites);
 
-		passepartout = new Passepartout(SCREEN_WIDTH, SCREEN_HEIGHT, maxViewPortWidth, maxViewPortHeight, virtualWidth, virtualHeight);
+		passepartout = new Passepartout(SCREEN_WIDTH, SCREEN_HEIGHT, maxViewPort.getWidth(),
+				maxViewPort.getHeight(), virtualWidth, virtualHeight);
 		stage.addActor(passepartout);
 
 		axes = new Texture(Gdx.files.internal("stage/red_pixel.bmp"));
@@ -729,19 +728,20 @@ public class StageListener implements ApplicationListener {
 				shapeRenderer.identity();
 				break;
 			case MAXIMIZE:
+				//TODO: maybe also do some resizing here...?
 				float yScale = 1.0f;
 				float xScale = 1.0f;
-				if (screenshotWidth != maxViewPortWidth && maxViewPortWidth > 0) {
-					xScale = screenshotWidth / (float) maxViewPortWidth;
+				if (screenshotWidth != maxViewPort.getWidth() && maxViewPort.getWidth() > 0) {
+					xScale = screenshotWidth / (float) maxViewPort.getWidth();
 				}
-				if (screenshotHeight != maxViewPortHeight && maxViewPortHeight > 0) {
-					yScale = screenshotHeight / (float) maxViewPortHeight;
+				if (screenshotHeight != maxViewPort.getHeight() && maxViewPort.getHeight() > 0) {
+					yScale = screenshotHeight / (float) maxViewPort.getHeight();
 				}
 
-				screenshotWidth = maxViewPortWidth;
-				screenshotHeight = maxViewPortHeight;
-				screenshotX = maxViewPortX;
-				screenshotY = maxViewPortY;
+				screenshotWidth = maxViewPort.getWidth();
+				screenshotHeight = maxViewPort.getHeight();
+				screenshotX = maxViewPort.getOffsetX();
+				screenshotY = maxViewPort.getOffsetY();
 
 				viewPort = new ExtendViewport(virtualWidth, virtualHeight, camera);
 				shapeRenderer.scale(xScale, yScale, 1.0f);

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/StageDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/StageDialog.java
@@ -86,7 +86,7 @@ public class StageDialog extends Dialog implements View.OnClickListener {
 		((Button) findViewById(R.id.stage_dialog_button_restart)).setOnClickListener(this);
 		((Button) findViewById(R.id.stage_dialog_button_toggle_axes)).setOnClickListener(this);
 		((Button) findViewById(R.id.stage_dialog_button_screenshot)).setOnClickListener(this);
-		if (stageActivity.getResizePossible()) {
+		if (stageActivity.isResizePossible()) {
 			((ImageButton) findViewById(R.id.stage_dialog_button_maximize)).setOnClickListener(this);
 		} else {
 			((ImageButton) findViewById(R.id.stage_dialog_button_maximize)).setVisibility(View.GONE);

--- a/catroid/src/main/java/org/catrobat/catroid/utils/Resolution.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/Resolution.kt
@@ -1,0 +1,71 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.utils
+
+class Resolution @JvmOverloads constructor(
+    val width: Int,
+    val height: Int,
+    val offsetX: Int = 0,
+    val offsetY: Int = 0
+) {
+
+    val aspectRatio: Float = width / height.toFloat()
+    private val isInPortraitMode: Boolean = width < height
+    private val isInLandscapeMode: Boolean = !isInPortraitMode
+
+    fun flipToFit(target: Resolution): Resolution = when {
+        doesOrientationMatch(target) -> Resolution(width, height)
+        else -> Resolution(height, width)
+    }
+
+    private fun doesOrientationMatch(target: Resolution): Boolean {
+        return target.height > target.width && isInPortraitMode ||
+            target.height < target.width && isInLandscapeMode
+    }
+
+    fun resizeToFit(target: Resolution): Resolution {
+        val ratioHeight = target.height.toFloat() / height
+        val ratioWidth = target.width.toFloat() / width
+
+        return when {
+            aspectRatio < target.aspectRatio -> {
+                val scaleFactor = ratioHeight / ratioWidth
+                val newWidth = (target.width * scaleFactor).toInt()
+                val horizontalOffset = ((target.width - newWidth) / 2.0).toInt()
+                Resolution(newWidth, target.height, horizontalOffset, 0)
+            }
+            aspectRatio > target.aspectRatio -> {
+                val scaleFactor = ratioWidth / ratioHeight
+                val newHeight = (target.height * scaleFactor).toInt()
+                val verticalOffset = ((target.height - newHeight) / 2.0).toInt()
+                Resolution(target.width, newHeight, 0, verticalOffset)
+            }
+            else -> Resolution(target.width, target.height, 0, 0)
+        }
+    }
+
+    fun sameRatioOrMeasurements(target: Resolution): Boolean =
+        width == target.width && height == target.height ||
+            aspectRatio.compareTo(target.aspectRatio) == 0
+}

--- a/catroid/src/main/java/org/catrobat/catroid/utils/TextBlockUtil.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/TextBlockUtil.kt
@@ -58,6 +58,7 @@ object TextBlockUtil {
 
     fun getTextBlockLanguage(index: Int): String = textBlockLanguages.getOrNull(index - 1) ?: "0"
 
+    // TODO: check - use resolution here?
     fun getCenterCoordinates(index: Int): Point {
         val textBlockBounds = textBlocks?.getOrNull(index - 1)?.boundingBox ?: return Point(0, 0)
         val isCameraFacingFront = StageActivity.getActiveCameraManager()?.isCameraFacingFront ?: return Point(0, 0)

--- a/catroid/src/main/java/org/catrobat/catroid/visualplacement/VisualPlacementActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/visualplacement/VisualPlacementActivity.java
@@ -55,6 +55,7 @@ import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.ui.BaseCastActivity;
 import org.catrobat.catroid.utils.ProjectManagerExtensionsKt;
+import org.catrobat.catroid.utils.Resolution;
 import org.catrobat.catroid.utils.ToastUtil;
 
 import java.util.Locale;
@@ -188,36 +189,22 @@ public class VisualPlacementActivity extends BaseCastActivity implements View.On
 
 		frameLayout = findViewById(R.id.frame_container);
 
-		int screenWidth = ScreenValues.SCREEN_WIDTH;
-		int screenHeight = ScreenValues.SCREEN_HEIGHT;
-		int virtualScreenWidth = currentProject.getXmlHeader().virtualScreenWidth;
-		int virtualScreenHeight = currentProject.getXmlHeader().virtualScreenHeight;
-
-		float aspectRatio = (float) virtualScreenWidth / (float) virtualScreenHeight;
-		float screenAspectRatio = ScreenValues.getAspectRatio();
-
-		float scale;
-		float ratioHeight = (float) screenHeight / (float) virtualScreenHeight;
-		float ratioWidth = (float) screenWidth / (float) virtualScreenWidth;
+		Resolution projectResolution = new Resolution(
+				currentProject.getXmlHeader().virtualScreenWidth,
+				currentProject.getXmlHeader().virtualScreenHeight);
 
 		switch (currentProject.getScreenMode()) {
 			case MAXIMIZE:
-				if (aspectRatio < screenAspectRatio) {
-					scale = ratioHeight / ratioWidth;
-					layoutWidth = (int) (screenWidth * scale);
-					layoutHeight = screenHeight;
-				} else if (aspectRatio > screenAspectRatio) {
-					scale = ratioWidth / ratioHeight;
-					layoutHeight = (int) (screenHeight * scale);
-					layoutWidth = screenWidth;
-				} else {
-					layoutHeight = screenHeight;
-					layoutWidth = screenWidth;
-				}
+				Resolution screenResolution = new Resolution(ScreenValues.SCREEN_WIDTH,
+						ScreenValues.SCREEN_HEIGHT);
+				Resolution resizedResolution = projectResolution.resizeToFit(screenResolution);
+
+				layoutWidth = resizedResolution.getWidth();
+				layoutHeight = resizedResolution.getHeight();
 				break;
 			case STRETCH:
-				layoutHeight = screenHeight;
-				layoutWidth = screenWidth;
+				layoutWidth = ScreenValues.SCREEN_WIDTH;
+				layoutHeight = ScreenValues.SCREEN_HEIGHT;
 				break;
 		}
 
@@ -228,10 +215,10 @@ public class VisualPlacementActivity extends BaseCastActivity implements View.On
 		layoutParams.height = layoutHeight;
 		frameLayout.setLayoutParams(layoutParams);
 
-		layoutHeightRatio = (float) layoutHeight / (float) virtualScreenHeight;
-		layoutWidthRatio = (float) layoutWidth / (float) virtualScreenWidth;
-		reversedRatioHeight = (float) virtualScreenHeight / (float) layoutHeight;
-		reversedRatioWidth = (float) virtualScreenWidth / (float) layoutWidth;
+		layoutHeightRatio = (float) layoutHeight / (float) projectResolution.getHeight();
+		layoutWidthRatio = (float) layoutWidth / (float) projectResolution.getWidth();
+		reversedRatioHeight = (float) projectResolution.getHeight() / (float) layoutHeight;
+		reversedRatioWidth = (float) projectResolution.getWidth() / (float) layoutWidth;
 
 		bitmapOptions = new BitmapFactory.Options();
 		bitmapOptions.inPreferredConfig = Bitmap.Config.ARGB_8888;

--- a/catroid/src/test/java/org/catrobat/catroid/test/utiltests/ResolutionTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/utiltests/ResolutionTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.utiltests
+
+import org.catrobat.catroid.utils.Resolution
+import org.hamcrest.Matchers.`is`
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+class ResolutionTest {
+
+    @Test
+    fun testResizeToFitBiggerAspectRatio() {
+        val screen = Resolution(1280, 720)
+        val scaledResolution = Resolution(640, 480).resizeToFit(screen)
+
+        assertThat(scaledResolution.width, `is`(960))
+        assertThat(scaledResolution.height, `is`(720))
+        assertThat(scaledResolution.offsetX, `is`(160))
+        assertThat(scaledResolution.offsetY, `is`(0))
+    }
+
+    @Test
+    fun testResizeToFitSmallerAspectRatio() {
+        val screen = Resolution(640, 480)
+        val scaledResolution = Resolution(1280, 720).resizeToFit(screen)
+
+        assertThat(scaledResolution.width, `is`(640))
+        assertThat(scaledResolution.height, `is`(360))
+        assertThat(scaledResolution.offsetX, `is`(0))
+        assertThat(scaledResolution.offsetY, `is`(60))
+    }
+
+    @Test
+    fun testResizeToFitSameAspectRatio() {
+        val screen = Resolution(640, 480)
+        val scaledResolution = Resolution(1280, 960).resizeToFit(screen)
+
+        assertThat(scaledResolution.width, `is`(640))
+        assertThat(scaledResolution.height, `is`(480))
+        assertThat(scaledResolution.offsetX, `is`(0))
+        assertThat(scaledResolution.offsetY, `is`(0))
+    }
+
+    @Test
+    fun testFlipFromLandscapeToPortrait() {
+        val portraitResolution = Resolution(960, 1280)
+        val flippedResolution = Resolution(640, 480).flipToFit(portraitResolution)
+
+        assertThat(flippedResolution.width, `is`(480))
+        assertThat(flippedResolution.height, `is`(640))
+        assertThat(flippedResolution.offsetX, `is`(0))
+        assertThat(flippedResolution.offsetY, `is`(0))
+    }
+
+    @Test
+    fun testFlipFromPortraitToLandscape() {
+        val landscapeResolution = Resolution(1280, 960)
+        val flippedResolution = Resolution(480, 640).flipToFit(landscapeResolution)
+
+        assertThat(flippedResolution.width, `is`(640))
+        assertThat(flippedResolution.height, `is`(480))
+        assertThat(flippedResolution.offsetX, `is`(0))
+        assertThat(flippedResolution.offsetY, `is`(0))
+    }
+
+    @Test
+    fun testNoFlipInLandscape() {
+        val landscapeResolution = Resolution(1280, 960)
+        val flippedResolution = Resolution(640, 480).flipToFit(landscapeResolution)
+
+        assertThat(flippedResolution.width, `is`(640))
+        assertThat(flippedResolution.height, `is`(480))
+        assertThat(flippedResolution.offsetX, `is`(0))
+        assertThat(flippedResolution.offsetY, `is`(0))
+    }
+
+    @Test
+    fun testNoFlipInPortrait() {
+        val portraitResolution = Resolution(960, 1280)
+        val flippedResolution = Resolution(480, 640).flipToFit(portraitResolution)
+
+        assertThat(flippedResolution.width, `is`(480))
+        assertThat(flippedResolution.height, `is`(640))
+        assertThat(flippedResolution.offsetX, `is`(0))
+        assertThat(flippedResolution.offsetY, `is`(0))
+    }
+
+    @Test
+    fun testFlippedTwice() {
+        val landscape = Resolution(640, 480)
+        val portrait = Resolution(960, 1280)
+
+        val doubleFlipped = landscape
+            .flipToFit(portrait)
+            .flipToFit(landscape)
+
+        assertThat(doubleFlipped.width, `is`(landscape.width))
+        assertThat(doubleFlipped.height, `is`(landscape.height))
+        assertThat(doubleFlipped.offsetX, `is`(landscape.offsetX))
+        assertThat(doubleFlipped.offsetY, `is`(landscape.offsetY))
+    }
+
+    @Test
+    fun testThatAspectRatioRemainsUnchangedAfterResize() {
+        val screen = Resolution(640, 480)
+        val scaledResolution = Resolution(1280, 720).resizeToFit(screen)
+
+        assertThat(scaledResolution.aspectRatio, `is`(1280.0f / 720.0f))
+    }
+
+    @Test
+    fun testSameSize() {
+        val resolution1 = Resolution(1280, 720)
+        val resolution2 = Resolution(1280, 720)
+
+        assertThat(resolution1.sameRatioOrMeasurements(resolution2), `is`(true))
+    }
+
+    @Test
+    fun testSameAspectRatio() {
+        val resolution1 = Resolution(1280, 720)
+        val resolution2 = Resolution(640, 360)
+
+        assertThat(resolution1.sameRatioOrMeasurements(resolution2), `is`(true))
+    }
+
+    @Test
+    fun testDifferentResolutions() {
+        val resolution1 = Resolution(1280, 720)
+        val resolution2 = Resolution(1024, 768)
+
+        assertThat(resolution1.sameRatioOrMeasurements(resolution2), `is`(false))
+    }
+
+    // TODO: maybe add tests which are closer to real usages? any suggestions?
+}


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-581

In the StageActivity there exist a few methods which are responsible
for resizing the project's resolution in order the fit the mobile
device's screen.
This code was extracted into a new class (-> Resolution) and tests
were created. Same or similar calculations in other places throughout
the code base were refactored to use this new class in order to
consolidate the responsibility for resizing in one single place.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
