### PR TITLE
CATROID-1231 Fix crash on Edit Formula for AssertBrick

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickContextMenuTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickContextMenuTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.bricks
+
+import org.catrobat.catroid.R
+import org.catrobat.catroid.content.bricks.AssertEqualsBrick
+import org.catrobat.catroid.content.bricks.AssertUserListsBrick
+import org.catrobat.catroid.content.bricks.Brick
+import org.catrobat.catroid.content.bricks.FadeParticleEffectBrick
+import org.catrobat.catroid.content.bricks.FlashBrick
+import org.catrobat.catroid.content.bricks.ForItemInUserListBrick
+import org.catrobat.catroid.content.bricks.ParticleEffectAdditivityBrick
+import org.catrobat.catroid.content.bricks.PenDownBrick
+import org.catrobat.catroid.content.bricks.ReadVariableFromDeviceBrick
+import org.catrobat.catroid.content.bricks.RepeatUntilBrick
+import org.catrobat.catroid.content.bricks.ScriptBrick
+import org.catrobat.catroid.content.bricks.SetInstrumentBrick
+import org.catrobat.catroid.content.bricks.SetVariableBrick
+import org.catrobat.catroid.content.bricks.SetVolumeToBrick
+import org.catrobat.catroid.content.bricks.SetXBrick
+import org.catrobat.catroid.content.bricks.UserDefinedBrick
+import org.catrobat.catroid.content.bricks.UserDefinedReceiverBrick
+import org.catrobat.catroid.content.bricks.WhenStartedBrick
+import org.catrobat.catroid.ui.recyclerview.fragment.ScriptFragment.getContextMenuItems
+import org.catrobat.catroid.userbrick.UserDefinedBrickInput
+import org.catrobat.catroid.userbrick.UserDefinedBrickLabel
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class BrickContextMenuTest(
+    private val brick: Brick,
+    private val expectedEditFormula: Boolean,
+    private val expectedHighlight: Boolean
+) {
+
+    private val contextMenuItems: MutableList<Int> = ArrayList()
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun parameters() = listOf(
+            arrayOf(AssertUserListsBrick(), false, false),
+            arrayOf(AssertEqualsBrick(), true, false),
+            arrayOf(UserDefinedReceiverBrick(), false, false),
+            arrayOf(UserDefinedBrick(), false, false),
+            arrayOf(UserDefinedBrick(listOf(UserDefinedBrickInput(""))), true, false),
+            arrayOf(UserDefinedBrick(listOf(UserDefinedBrickLabel(""))), false, false),
+            arrayOf(ForItemInUserListBrick(), false, true),
+            arrayOf(RepeatUntilBrick(), true, true),
+            arrayOf(WhenStartedBrick(), false, false),
+            arrayOf(SetXBrick(), true, false),
+            arrayOf(SetVariableBrick(), true, false),
+            arrayOf(PenDownBrick(), false, false),
+            arrayOf(SetVolumeToBrick(), true, false),
+            arrayOf(SetInstrumentBrick(), false, false),
+            arrayOf(FadeParticleEffectBrick(), false, false),
+            arrayOf(ParticleEffectAdditivityBrick(), false, false),
+            arrayOf(FlashBrick(), false, false),
+            arrayOf(ReadVariableFromDeviceBrick(), false, false)
+            )
+    }
+
+    @Before
+    fun setUp() {
+        contextMenuItems.addAll(getContextMenuItems(brick))
+    }
+
+    @After
+    fun tearDown() {
+        contextMenuItems.clear()
+    }
+
+    @Test
+    fun testEditFormula() {
+        assertEquals(contextMenuItems.contains(R.string.brick_context_dialog_formula_edit_brick), expectedEditFormula)
+    }
+
+    @Test
+    fun testHighlightBrickParts() {
+        assertEquals(contextMenuItems.contains(R.string.brick_context_dialog_highlight_brick_parts), expectedHighlight)
+    }
+
+    @Test
+    fun testExpectedDelete() {
+        val showsDelete: Boolean = when (brick) {
+            is UserDefinedReceiverBrick -> contextMenuItems.contains(R.string.brick_context_dialog_delete_definition)
+            is ScriptBrick -> contextMenuItems.contains(R.string.brick_context_dialog_delete_script)
+            else -> contextMenuItems.contains(R.string.brick_context_dialog_delete_brick)
+        }
+        assertTrue(showsDelete)
+    }
+
+    @Test
+    fun testExpectedCommentOut() {
+        val showsCommentOut: Boolean = when (brick) {
+            is UserDefinedReceiverBrick -> !contextMenuItems.contains(R.string.brick_context_dialog_comment_out_script)
+            is ScriptBrick -> contextMenuItems.contains(R.string.brick_context_dialog_comment_out_script)
+            else -> contextMenuItems.contains(R.string.brick_context_dialog_comment_out)
+        }
+        assertTrue(showsCommentOut)
+    }
+
+    @Test
+    fun testExpectedCommentIn() {
+        brick.isCommentedOut = true
+        contextMenuItems.addAll(getContextMenuItems(brick))
+        val showsCommentIn: Boolean = when (brick) {
+            is UserDefinedReceiverBrick -> !contextMenuItems.contains(R.string.brick_context_dialog_comment_in)
+            is ScriptBrick -> contextMenuItems.contains(R.string.brick_context_dialog_comment_in_script)
+            else -> contextMenuItems.contains(R.string.brick_context_dialog_comment_in)
+        }
+        assertTrue(showsCommentIn)
+    }
+
+    @Test
+    fun testExpectedCopy() {
+        val showsCopy: Boolean = when (brick) {
+            is UserDefinedReceiverBrick -> !contextMenuItems.contains(R.string.brick_context_dialog_copy_script)
+            is ScriptBrick -> contextMenuItems.contains(R.string.brick_context_dialog_copy_script)
+            else -> contextMenuItems.contains(R.string.brick_context_dialog_copy_brick)
+        }
+        assertTrue(showsCopy)
+    }
+
+    @Test
+    fun testExpectedHelp() {
+        assertTrue(contextMenuItems.contains(R.string.brick_context_dialog_help))
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/FormulaBrick.java
@@ -236,4 +236,8 @@ public abstract class FormulaBrick extends BrickBaseType implements View.OnClick
 
 		return null;
 	}
+
+	public boolean hasEditableFormulaField() {
+		return !brickFieldToTextViewIdMap.isEmpty();
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserDefinedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserDefinedBrick.java
@@ -292,6 +292,11 @@ public class UserDefinedBrick extends FormulaBrick {
 	}
 
 	@Override
+	public boolean hasEditableFormulaField() {
+		return containsInputs();
+	}
+
+	@Override
 	public void setClickListeners() {
 		for (BiMap.Entry<FormulaField, TextView> entry : formulaFieldToTextViewMap.entrySet()) {
 			TextView brickFieldView = entry.getValue();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -657,7 +657,8 @@ public class ScriptFragment extends ListFragment implements
 				.show();
 	}
 
-	private List<Integer> getContextMenuItems(Brick brick) {
+	@VisibleForTesting
+	public static List<Integer> getContextMenuItems(Brick brick) {
 		List<Integer> items = new ArrayList<>();
 
 		if (brick instanceof UserDefinedReceiverBrick) {
@@ -680,7 +681,7 @@ public class ScriptFragment extends ListFragment implements
 
 			items.add(R.string.brick_context_dialog_delete_script);
 
-			if (brick instanceof FormulaBrick) {
+			if (brick instanceof FormulaBrick && ((FormulaBrick) brick).hasEditableFormulaField()) {
 				items.add(R.string.brick_context_dialog_formula_edit_brick);
 			}
 			items.add(R.string.brick_context_dialog_move_script);
@@ -699,14 +700,8 @@ public class ScriptFragment extends ListFragment implements
 			if (brick instanceof VisualPlacementBrick && ((VisualPlacementBrick) brick).areAllBrickFieldsNumbers()) {
 				items.add(R.string.brick_option_place_visually);
 			}
-			if (brick instanceof FormulaBrick) {
-				if (brick instanceof UserDefinedBrick) {
-					if (((UserDefinedBrick) brick).containsInputs()) {
-						items.add(R.string.brick_context_dialog_formula_edit_brick);
-					}
-				} else {
-					items.add(R.string.brick_context_dialog_formula_edit_brick);
-				}
+			if (brick instanceof FormulaBrick && ((FormulaBrick) brick).hasEditableFormulaField()) {
+				items.add(R.string.brick_context_dialog_formula_edit_brick);
 			}
 			if (brick.equals(brick.getAllParts().get(0))) {
 				items.add(R.string.brick_context_dialog_move_brick);


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1231

- The "Edit Formula" item is now just visible for FormulaBricks that actually have a formula field
- Add a testcase to check if the items of the ContextMenu are correct for certain different bricks

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
