### PR TITLE
CATROID-1198 Fix NoMatchingViewException in ProjectListActivityRecreateRegressionTest

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/regression/activitydestroy/ProjectListActivityRecreateRegressionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/regression/activitydestroy/ProjectListActivityRecreateRegressionTest.java
@@ -90,13 +90,14 @@ public class ProjectListActivityRecreateRegressionTest {
 		openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
 		onView(withText(R.string.rename)).perform(click());
 
-		onRecyclerView().atPosition(0)
-				.performCheckItem();
-
-		onView(withId(R.id.confirm)).perform(click());
+		onView(withClassName(is("com.google.android.material.textfield.TextInputEditText")))
+				.perform(typeText("TestProject0815"), closeSoftKeyboard());
 
 		onView(withText(R.string.rename_project)).inRoot(isDialog())
 				.check(matches(isDisplayed()));
+
+		onView(withText(R.string.ok))
+				.perform(click());
 
 		InstrumentationRegistry.getInstrumentation().runOnMainSync(new Runnable() {
 			@Override


### PR DESCRIPTION
JIRA TICKET : https://jira.catrob.at/browse/CATROID-1198

Fixed testActivityRecreateRenameProjectDialog() test which renames the project and checks for the name

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
