### PR TITLE
CATROID-1230 Fix testDeleteWebLook.catrobat

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/DeleteLookAction.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/DeleteLookAction.kt
@@ -60,6 +60,7 @@ class DeleteLookAction : SingleSpriteEventAction() {
     private fun setNewLookData(indexOfLookData: Int) {
         sprite?.apply {
             if (lookList.isNullOrEmpty()) {
+                look.lookData = null
                 return
             }
             look?.lookData ?: return


### PR DESCRIPTION
[CATROID-1230 - Fix testDeleteWebLook.catrobat](https://jira.catrob.at/browse/CATROID-1230)
Identified the error causing the deviation and fixed it

*Please enter a short description of your pull request and add a reference to the Jira ticket.*
The sprite's look in the CLT is now properly deleted

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
