### PR TITLE
CATROID-1177 Memory Leak of StageActivity in Gdx.app and Gdx.graphics

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ProjectManager.java
@@ -721,6 +721,7 @@ public final class ProjectManager {
 	}
 
 	public void resetProjectManager() {
+		startScene = null;
 		currentlyEditedScene = null;
 		currentlyPlayingScene = null;
 		currentSprite = null;

--- a/catroid/src/main/java/org/catrobat/catroid/stage/SpeechRecognitionHolder.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/SpeechRecognitionHolder.kt
@@ -45,10 +45,10 @@ import java.util.Locale
 
 class SpeechRecognitionHolder : SpeechRecognitionHolderInterface {
 
-    private lateinit var speechRecognizer: SpeechRecognizer
+    private var speechRecognizer: SpeechRecognizer? = null
     override var callback: OnSpeechRecognitionResultCallback? = null
     private lateinit var speechIntent: Intent
-    private lateinit var listener: RecognitionListener
+    private var listener: RecognitionListener? = null
 
     companion object {
         private val TAG = SpeechRecognitionHolder::class.java.simpleName
@@ -100,7 +100,7 @@ class SpeechRecognitionHolder : SpeechRecognitionHolderInterface {
                 Log.e(TAG, "SpeechRecognizer onError: $error")
                 when (error) {
                     SpeechRecognizer.ERROR_NO_MATCH -> {
-                        speechRecognizer.cancel()
+                        speechRecognizer?.cancel()
                         startListening()
                     }
                     SpeechRecognizer.ERROR_NETWORK -> {
@@ -138,15 +138,17 @@ class SpeechRecognitionHolder : SpeechRecognitionHolderInterface {
         //  Note 8 with ANDROID 9, Xiaomi MI A2 Android 10
         SensorHandler.stopSensorListeners()
         GlobalScope.launch(Dispatchers.Main.immediate) {
-            speechRecognizer.setRecognitionListener(listener)
-            speechRecognizer.startListening(speechIntent)
+            speechRecognizer?.setRecognitionListener(listener)
+            speechRecognizer?.startListening(speechIntent)
         }
     }
 
     override fun destroy() {
         GlobalScope.launch(Dispatchers.Main.immediate) {
-            speechRecognizer.cancel()
-            speechRecognizer.destroy()
+            speechRecognizer?.cancel()
+            speechRecognizer?.destroy()
+            speechRecognizer = null
+            listener = null
         }
     }
 

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageLifeCycleController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageLifeCycleController.java
@@ -30,6 +30,7 @@ import android.util.Log;
 import android.view.SurfaceView;
 import android.view.WindowManager;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;
 import com.badlogic.gdx.backends.android.surfaceview.GLSurfaceView20;
 
@@ -259,7 +260,19 @@ public final class StageLifeCycleController {
 			StageActivity.stageListener.finish();
 			stageActivity.manageLoadAndFinish();
 			StageActivity.stageListener = null;
+			StageActivity.messageHandler = null;
 		}
 		ProjectManager.getInstance().setCurrentlyPlayingScene(ProjectManager.getInstance().getCurrentlyEditedScene());
+		ProjectManager.getInstance().resetProjectManager();
+		cleanupGdxMembers();
+	}
+
+	public static void cleanupGdxMembers() {
+		Gdx.app = null;
+		Gdx.input = null;
+		Gdx.audio = null;
+		Gdx.files = null;
+		Gdx.graphics = null;
+		Gdx.net = null;
 	}
 }


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1177

Fixed Memory Leak in StageActivity, ProjectManager and SpeechRecognitionHolder.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
