### PR TITLE
CATROID-1267 Names of objects in backpacks get changed

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/util/UniqueNameProvider.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/util/UniqueNameProvider.java
@@ -36,6 +36,10 @@ public class UniqueNameProvider implements UniqueNameProviderInterface {
 	public String getUniqueName(String name, List<String> scope) {
 		this.scope = scope;
 
+		if (isUnique(name)) {
+			return name;
+		}
+
 		Pattern pattern = Pattern.compile("\\((\\d+)\\)");
 		Matcher matcher = pattern.matcher(name);
 


### PR DESCRIPTION
When packing and unpacking the object name was previously
chosen with getUniqueNameInNameables of UniqueNameProvider.

This method always appends (1) at the end of the name
even if there is no name-duplicate.

For backpack-operations a new method is used:
getUniqueNameInNameablesIfNecessary

If there is a duplicate name the old method gets called,
otherwise the original name is taken.

affected objects:
- Scene
- Sprite
- Sound
- Look
- Script

Ticket: [CATROID-1267](https://jira.catrob.at/browse/CATROID-1267)

This bug is already fixed in [CATROID-1277](https://jira.catrob.at/browse/CATROID-1277)! 


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
