### PR TITLE
CATROID-1264 Music composer(PocketMusic) crash

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/pocketmusic/note/PianoViewTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/pocketmusic/note/PianoViewTest.java
@@ -1,0 +1,125 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2021 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.pocketmusic.note;
+
+import android.content.Context;
+import android.graphics.drawable.ColorDrawable;
+import android.widget.TextView;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.pocketmusic.note.NoteName;
+import org.catrobat.catroid.pocketmusic.ui.PianoView;
+import org.catrobat.catroid.pocketmusic.ui.TrackRowView;
+import org.catrobat.catroid.pocketmusic.ui.TrackView;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import androidx.core.content.ContextCompat;
+import androidx.test.core.app.ApplicationProvider;
+
+import static junit.framework.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class PianoViewTest {
+	private PianoView pianoView;
+	private List<TextView> blackKeys;
+	private List<TextView> whiteKeys;
+
+	private int activeColor;
+	private int disabledwhiteKeyColor;
+	private int disabledblackKeyColor;
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{"Set One Key", Arrays.asList(0), Arrays.asList(), Arrays.asList(0)},
+				{"Set All Keys", Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), Arrays.asList(), Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)},
+				{"Set And Reset All Keys", Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), Arrays.asList()},
+				{"Set various Keys", Arrays.asList(1, 5, 10), Arrays.asList(5), Arrays.asList(1, 10)},
+				{"Set Invalid Key", Arrays.asList(-1, 13), Arrays.asList(-5, 14), Arrays.asList()}
+		});
+	}
+
+	@Parameterized.Parameter
+	public String name;
+
+	@Parameterized.Parameter(1)
+	public List<Integer> activeKeys;
+
+	@Parameterized.Parameter(2)
+	public List<Integer> disabledKeys;
+
+	@Parameterized.Parameter(3)
+	public List<Integer> expectedActiveKeys;
+
+	@Before
+	public void setUp() {
+		Context context = ApplicationProvider.getApplicationContext();
+		pianoView = new PianoView(context);
+		blackKeys = pianoView.getBlackPianoKeys();
+		whiteKeys = pianoView.getWhitePianoKeys();
+		activeColor = ContextCompat.getColor(context, R.color.orange);
+		disabledwhiteKeyColor = ContextCompat.getColor(context, R.color.solid_white);
+		disabledblackKeyColor = ContextCompat.getColor(context, R.color.solid_black);
+	}
+
+	@Test
+	public void testSetButtonColor() {
+		for (int activeKey : activeKeys) {
+			NoteName tempNote = NoteName.getNoteNameFromMidiValue(TrackRowView.getMidiValueForRow(activeKey));
+			pianoView.setKeyColor(tempNote, true);
+		}
+
+		for (int disabledKey : disabledKeys) {
+			NoteName tempNote = NoteName.getNoteNameFromMidiValue(TrackRowView.getMidiValueForRow(disabledKey));
+			pianoView.setKeyColor(tempNote, false);
+		}
+
+		for (int i = 0; i < blackKeys.size() + whiteKeys.size(); ++i) {
+			int index = Arrays.binarySearch(TrackView.BLACK_KEY_INDICES, i);
+			if (index < 0) {
+				index = Arrays.binarySearch(TrackView.WHITE_KEY_INDICES, i);
+				if (index < 0) {
+					continue;
+				}
+				boolean keyExpectedActive = Arrays.binarySearch(expectedActiveKeys.toArray(), i) >= 0;
+				assertEquals(keyExpectedActive ? activeColor : disabledwhiteKeyColor, getKeyColor(whiteKeys.get(index)));
+			} else {
+				boolean keyExpectedActive = Arrays.binarySearch(expectedActiveKeys.toArray(), i) >= 0;
+				assertEquals(keyExpectedActive ? activeColor : disabledblackKeyColor, getKeyColor(blackKeys.get(index)));
+			}
+		}
+	}
+
+	private int getKeyColor(TextView key) {
+		ColorDrawable cd = (ColorDrawable) key.getBackground();
+		return cd.getColor();
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/pocketmusic/PocketMusicActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/pocketmusic/PocketMusicActivity.java
@@ -69,8 +69,7 @@ public class PocketMusicActivity extends BaseActivity {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		midiFolder = new File(ProjectManager.getInstance().getCurrentlyEditedScene().getDirectory(),
-				SOUND_DIRECTORY_NAME);
+		midiFolder = new File(getApplicationContext().getFilesDir().getPath(), SOUND_DIRECTORY_NAME);
 
 		midiDriver = new MidiNotePlayer();
 

--- a/catroid/src/main/java/org/catrobat/catroid/pocketmusic/mididriver/MidiRunnable.java
+++ b/catroid/src/main/java/org/catrobat/catroid/pocketmusic/mididriver/MidiRunnable.java
@@ -81,7 +81,7 @@ public class MidiRunnable implements Runnable {
 		status |= channel;
 		midiNotePlayer.sendMidi(status, noteName.getMidi(), 127);
 		if (pianoView != null && pianoRow != null) {
-			pianoView.setButtonColor(pianoRow, MidiSignals.NOTE_ON.equals(signal));
+			pianoView.setKeyColor(pianoRow, MidiSignals.NOTE_ON.equals(signal));
 		}
 		if (signal.equals(MidiSignals.NOTE_ON) && !manualNoteOff) {
 			handler.postDelayed(new MidiRunnable(MidiSignals.NOTE_OFF, noteName, duration, handler, midiNotePlayer,

--- a/catroid/src/main/java/org/catrobat/catroid/pocketmusic/ui/PianoView.java
+++ b/catroid/src/main/java/org/catrobat/catroid/pocketmusic/ui/PianoView.java
@@ -32,8 +32,10 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.pocketmusic.note.NoteName;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
 
 public class PianoView extends ViewGroup {
@@ -190,30 +192,32 @@ public class PianoView extends ViewGroup {
 		}
 	}
 
-	public void setButtonColor(NoteName note, boolean active) {
+	public void setKeyColor(NoteName note, boolean active) {
 		int i = 0;
-		for (int counter = TrackView.HIGHEST_MIDI / TrackView.ROW_COUNT; counter <= TrackRowView.getMidiValueForRow(TrackView.ROW_COUNT);
-				counter += TrackView.HIGHEST_MIDI / TrackView.ROW_COUNT) {
-			NoteName tempNote = NoteName.getNoteNameFromMidiValue(counter);
+		for (; i <= TrackView.ROW_COUNT; i++) {
+			NoteName tempNote = NoteName.getNoteNameFromMidiValue(TrackRowView.getMidiValueForRow(i));
 			if (note.equals(tempNote)) {
 				break;
 			}
-			if (note.isSigned() == tempNote.isSigned()) {
-				i++;
-			}
 		}
-
 		View noteView;
-		if (note.isSigned()) {
-			noteView = blackPianoKeys.get(i);
+		Boolean isBlackKey = false;
+		int index = Arrays.binarySearch(TrackView.BLACK_KEY_INDICES, i);
+		if (index < 0) {
+			index = Arrays.binarySearch(TrackView.WHITE_KEY_INDICES, i);
+			if (index < 0) {
+				return;
+			}
+			noteView = whitePianoKeys.get(index);
 		} else {
-			noteView = whitePianoKeys.get(i);
+			noteView = blackPianoKeys.get(index);
+			isBlackKey = true;
 		}
 		if (active) {
 			noteView.setBackgroundColor(ContextCompat.getColor(getContext(), R.color.orange));
 		} else {
-			noteView.setBackgroundColor(ContextCompat.getColor(getContext(), note.isSigned() ? R.color.solid_black : R
-					.color.solid_white));
+			noteView.setBackgroundColor(ContextCompat.getColor(getContext(),
+					isBlackKey ? R.color.solid_black : R.color.solid_white));
 		}
 	}
 
@@ -223,6 +227,16 @@ public class PianoView extends ViewGroup {
 
 	private int round(float floatValue) {
 		return (int) (floatValue + 0.5f);
+	}
+
+	@VisibleForTesting
+	public List<TextView> getWhitePianoKeys() {
+		return whitePianoKeys;
+	}
+
+	@VisibleForTesting
+	public List<TextView> getBlackPianoKeys() {
+		return blackPianoKeys;
 	}
 
 	enum ButtonHeight {


### PR DESCRIPTION
[CATROID-1264 Music composer(PocketMusic) crash](https://jira.catrob.at/browse/CATROID-1264)
- rewrite function setKeyColor in PianoView 
- write unit tests to test the implementation.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
