### PR TITLE
CATROID-1276: [Maintenance] No dependency on 817.catrobat for apk generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,6 @@ pipeline {
                             }
                         }
 
-                    stages {
                         stage('Standalone') {
                             steps {
                                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1276

Maintenance: No dependency on 817.catrobat for apk generation