### PR TITLE
Maintenance: Jenkins stores each Catroid build APK once

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,7 +139,7 @@ pipeline {
                                                 -Pdownload='https://share.catrob.at/pocketcode/download/817.catrobat'"""
 
                                     renameApks("${env.BRANCH_NAME}-${env.BUILD_NUMBER}")
-                                    archiveArtifacts '**/*.apk'
+                                    archiveArtifacts '**/catroid-standalone*.apk'
                                 }
                             }
                         }


### PR DESCRIPTION
Current output in jenkins jobs spuriously contained the debug apk twice. This fixes it.
