### PR TITLE
CATROID-1282 Project crashes on edit object

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/InternFormulaTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/formulaeditor/InternFormulaTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2020 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -37,11 +37,12 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 
-import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 
 @RunWith(AndroidJUnit4.class)
 public class InternFormulaTest {
@@ -60,11 +61,11 @@ public class InternFormulaTest {
 		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
 
 		InternFormula internFormula = new InternFormula(internTokens);
-		internFormula.generateExternFormulaStringAndInternExternMapping(ApplicationProvider.getApplicationContext());
+		internFormula.generateExternFormulaStringAndInternExternMapping(getApplicationContext());
 
 		internFormula.setCursorAndSelection(internFormula.getExternFormulaString().length(), true);
-		internFormula.handleKeyInput(R.id.formula_editor_keyboard_4, ApplicationProvider.getApplicationContext(), null);
-		internFormula.handleKeyInput(R.id.formula_editor_keyboard_2, ApplicationProvider.getApplicationContext(), null);
+		internFormula.handleKeyInput(R.id.formula_editor_keyboard_4, getApplicationContext(), null);
+		internFormula.handleKeyInput(R.id.formula_editor_keyboard_2, getApplicationContext(), null);
 		assertNull(internFormula.getSelection());
 
 		internFormula.setCursorAndSelection(internFormula.getExternFormulaString().length(), true);
@@ -86,18 +87,18 @@ public class InternFormulaTest {
 		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
 
 		InternFormula internFormula = new InternFormula(internTokens);
-		internFormula.generateExternFormulaStringAndInternExternMapping(ApplicationProvider.getApplicationContext());
+		internFormula.generateExternFormulaStringAndInternExternMapping(getApplicationContext());
 
 		internFormula.setCursorAndSelection(internFormula.getExternFormulaString().length(), true);
 		assertInternFormulaSelectionIndices(0, 9, internFormula);
 
-		internFormula.handleKeyInput(R.string.formula_editor_function_rand, ApplicationProvider.getApplicationContext(), null);
+		internFormula.handleKeyInput(R.string.formula_editor_function_rand, getApplicationContext(), null);
 		assertInternFormulaSelectionIndices(2, 8, internFormula);
 
 		internFormula.setCursorAndSelection(internFormula.getExternFormulaString().length(), true);
 		assertInternFormulaSelectionIndices(0, 11, internFormula);
 
-		internFormula.handleKeyInput(R.string.formula_editor_function_sqrt, ApplicationProvider.getApplicationContext(), null);
+		internFormula.handleKeyInput(R.string.formula_editor_function_sqrt, getApplicationContext(), null);
 		assertInternFormulaSelectionIndices(2, 8, internFormula);
 
 		internFormula.setCursorAndSelection(internFormula.getExternFormulaString().length(), true);
@@ -112,7 +113,7 @@ public class InternFormulaTest {
 		internTokens.add(new InternToken(InternTokenType.BRACKET_CLOSE));
 
 		InternFormula internFormula = new InternFormula(internTokens);
-		internFormula.generateExternFormulaStringAndInternExternMapping(ApplicationProvider.getApplicationContext());
+		internFormula.generateExternFormulaStringAndInternExternMapping(getApplicationContext());
 		String externFormulaString = internFormula.getExternFormulaString();
 
 		internFormula.setCursorAndSelection(externFormulaString.length(), true);
@@ -128,7 +129,7 @@ public class InternFormulaTest {
 		internTokens.add(new InternToken(InternTokenType.NUMBER, "42.42"));
 
 		InternFormula internFormula = new InternFormula(internTokens);
-		internFormula.generateExternFormulaStringAndInternExternMapping(ApplicationProvider.getApplicationContext());
+		internFormula.generateExternFormulaStringAndInternExternMapping(getApplicationContext());
 
 		internFormula.setCursorAndSelection(1, true);
 		String externFormulaString = internFormula.getExternFormulaString();
@@ -139,8 +140,8 @@ public class InternFormulaTest {
 		internFormula.internFormulaTokenSelection = new InternFormulaTokenSelection(
 				TokenSelectionType.USER_SELECTION, tokenSelectionStartIndex, tokenSelectionEndIndex);
 
-		internFormula.handleKeyInput(R.id.formula_editor_keyboard_0, ApplicationProvider.getApplicationContext(), null);
-		internFormula.generateExternFormulaStringAndInternExternMapping(ApplicationProvider.getApplicationContext());
+		internFormula.handleKeyInput(R.id.formula_editor_keyboard_0, getApplicationContext(), null);
+		internFormula.generateExternFormulaStringAndInternExternMapping(getApplicationContext());
 		assertEquals(externFormulaString, internFormula.getExternFormulaString());
 	}
 
@@ -151,7 +152,7 @@ public class InternFormulaTest {
 		internTokens.add(new InternToken(InternTokenType.OPERATOR, Operators.PLUS.name()));
 		internTokens.add(new InternToken(InternTokenType.NUMBER, "42.42"));
 		InternFormula internFormula = new InternFormula(internTokens);
-		internFormula.generateExternFormulaStringAndInternExternMapping(ApplicationProvider.getApplicationContext());
+		internFormula.generateExternFormulaStringAndInternExternMapping(getApplicationContext());
 		internFormula.setCursorAndSelection(1, false);
 
 		ExternInternRepresentationMapping externInternRepresentationMapping = new ExternInternRepresentationMapping();
@@ -167,7 +168,7 @@ public class InternFormulaTest {
 	public void testSetExternCursorPositionRightToEmptyFormula() {
 		ArrayList<InternToken> internTokens = new ArrayList<>();
 		InternFormula internFormula = new InternFormula(internTokens);
-		internFormula.generateExternFormulaStringAndInternExternMapping(ApplicationProvider.getApplicationContext());
+		internFormula.generateExternFormulaStringAndInternExternMapping(getApplicationContext());
 		internFormula.setCursorAndSelection(1, false);
 
 		int externCursorPositionBeforeMethodCall = internFormula.getExternCursorPosition();
@@ -182,7 +183,7 @@ public class InternFormulaTest {
 		internTokens.add(new InternToken(InternTokenType.OPERATOR, Operators.PLUS.name()));
 		internTokens.add(new InternToken(InternTokenType.NUMBER, "42.42"));
 		InternFormula internFormula = new InternFormula(internTokens);
-		internFormula.generateExternFormulaStringAndInternExternMapping(ApplicationProvider.getApplicationContext());
+		internFormula.generateExternFormulaStringAndInternExternMapping(getApplicationContext());
 		internFormula.setCursorAndSelection(1, false);
 
 		internFormula.setExternCursorPositionRightTo(3);
@@ -204,6 +205,14 @@ public class InternFormulaTest {
 		internFormula.cursorPositionInternToken = null;
 		internFormula.selectCursorPositionInternToken(InternFormula.TokenSelectionType.USER_SELECTION);
 		assertNull(internFormula.internFormulaTokenSelection);
+	}
+
+	@Test
+	public void testTokenTrailingWhiteSpace() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.NUMBER, "0 "));
+		InternFormula internFormula = new InternFormula(internTokens);
+		internFormula.trimExternFormulaString(getApplicationContext());
 	}
 
 	private void assertInternFormulaSelectionIndices(int expectedStartIndex, int expectedEndIndex, InternFormula internFormula) {

--- a/catroid/src/main/java/org/catrobat/catroid/utils/FormatNumberUtil.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/FormatNumberUtil.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -32,8 +32,7 @@ public final class FormatNumberUtil {
 	}
 
 	public static String cutTrailingZeros(String number) {
-
-		BigDecimal decimal = new BigDecimal(number);
+		BigDecimal decimal = new BigDecimal(number.trim());
 		decimal = decimal.stripTrailingZeros();
 
 		// compare with Zero because of faulty implementation of stripTrailingZeros in the library


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1282

Crash happens because of trailing whitespaces ("0 ") in the conversion to a BigDecimal number, which throws a NumberFormatException.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
