### PR TITLE
CATROID-882 Large unused empty area in formula editor

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -455,9 +455,40 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		ImageButton toggleButton = getActivity().findViewById(R.id.formula_editor_keyboard_functional_button_toggle);
 
 		boolean isVisible = row1.getVisibility() == View.VISIBLE;
-		row1.setVisibility(isVisible ? View.INVISIBLE : View.VISIBLE);
-		row2.setVisibility(isVisible ? View.INVISIBLE : View.VISIBLE);
+		row1.setVisibility(isVisible ? View.GONE : View.VISIBLE);
+		row2.setVisibility(isVisible ? View.GONE : View.VISIBLE);
 		toggleButton.setImageDrawable(ContextCompat.getDrawable(getContext(), isVisible ? R.drawable.ic_keyboard_toggle_caret_up : R.drawable.ic_keyboard_toggle_caret_down));
+		toggleFormulaEditorSpace(isVisible);
+	}
+
+	private void toggleFormulaEditorSpace(boolean isVisible) {
+		View keyboard = getActivity().findViewById(R.id.formula_editor_keyboardview);
+		View brickAndFormula = getActivity().findViewById(R.id.formula_editor_brick_and_formula);
+
+		LinearLayout.LayoutParams keyboardLayoutParams = new LinearLayout.LayoutParams(
+				LinearLayout.LayoutParams.MATCH_PARENT,
+				LinearLayout.LayoutParams.MATCH_PARENT,
+				1
+		);
+
+		LinearLayout.LayoutParams formulaLayoutParams = new LinearLayout.LayoutParams(
+				LinearLayout.LayoutParams.MATCH_PARENT,
+				LinearLayout.LayoutParams.MATCH_PARENT,
+				1
+		);
+
+		if (isVisible) {
+			View row1 = getActivity().findViewById(R.id.tableRow11);
+			View row2 = getActivity().findViewById(R.id.tableRow12);
+			int rowsHeight = row1.getHeight() + row2.getHeight();
+			keyboardLayoutParams.topMargin = rowsHeight;
+			formulaLayoutParams.bottomMargin = -rowsHeight;
+		} else {
+			keyboardLayoutParams.topMargin = 0;
+			formulaLayoutParams.bottomMargin = 0;
+		}
+		brickAndFormula.setLayoutParams(formulaLayoutParams);
+		keyboard.setLayoutParams(keyboardLayoutParams);
 	}
 
 	@VisibleForTesting

--- a/catroid/src/main/res/layout/fragment_formula_editor.xml
+++ b/catroid/src/main/res/layout/fragment_formula_editor.xml
@@ -28,6 +28,7 @@
     android:theme="@android:style/Theme.Light" >
 
     <LinearLayout
+        android:id="@+id/formula_editor_brick_and_formula"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_weight="1"
@@ -59,7 +60,7 @@
                 android:hint="@string/formula_nothing_selected"
                 android:inputType="textMultiLine"
                 android:lineSpacingExtra="5dp"
-                android:maxLines="5"
+                android:maxLines="20"
                 android:scrollbarStyle="insideInset"
                 android:scrollbars="vertical"
                 android:textColor="@color/solid_black"


### PR DESCRIPTION
Maximum lines of formula field is now 20

When toggling the functional-rows in the formula editor
the space between the layout of the formula editor and
the layout above is set accordingly.

Ticket: [CATROID-882](https://jira.catrob.at/browse/CATROID-882)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
