### PR TITLE
Fix jenkins testsuite failing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,10 +206,6 @@ pipeline {
                         }
 
                         stage('Quarantined Tests') {
-                            when {
-                                expression { isJobStartedByTimer() }
-                            }
-
                             steps {
                                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                     sh '''./gradlew -PenableCoverage -PlogcatFile=quarantined_logcat.txt -Pemulator=android28 \

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/FormulaEditorComputeDialogComputationResultTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/FormulaEditorComputeDialogComputationResultTest.kt
@@ -138,6 +138,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @SuppressWarnings("LargeClass")
+@Category(AppUi::class, Smoke::class)
 @RunWith(Parameterized::class)
 class FormulaEditorComputeDialogComputationResultTest(
     private val name: String,
@@ -166,7 +167,6 @@ class FormulaEditorComputeDialogComputationResultTest(
         TestUtils.deleteProjects(projectName)
     }
 
-    @Category(AppUi::class, Smoke::class)
     @Test
     fun testComputeDialogValue() {
         openComputeDialog()


### PR DESCRIPTION
Jenkins testsuite fails with error "Category annotations on Parameterized classes are not supported on individual methods."
Fixed through annotating the categories for the whole instead for the (one and only) test in this file.
No change in behaviour, but now complies to rules

+ additionally changed the quarantined testsuite to always be triggert