### PR TITLE
CATROID-1294 Remove toMetricUnitRepresentation

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorMovementPropertiesTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorMovementPropertiesTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2021 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -72,7 +72,7 @@ public class FormulaEditorMovementPropertiesTest {
 		onFormulaEditor()
 				.performCompute();
 		onView(withId(R.id.formula_editor_compute_dialog_textview))
-				.check(matches(withText("0")));
+				.check(matches(withText(R.string.formula_editor_false)));
 		pressBack();
 		pressBack();
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserDefinedBrickInputTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserDefinedBrickInputTest.kt
@@ -155,8 +155,8 @@ class DataListFragmentUserDefinedBrickInputTest(
                 trueString
             ),
             arrayOf("Int 1", Formula(1), "1"),
-            arrayOf("Int 1000", Formula(1_000), "1k"),
-            arrayOf("Int 1000000", Formula(1_000_000), "1M"),
+            arrayOf("Int 1300", Formula(1_300), "1300"),
+            arrayOf("Int 1000300", Formula(1_000_300), "1000300"),
             arrayOf("Double 1.1", Formula(1.1), "1.1"),
             arrayOf("String hello", Formula("hello"), "hello")
         )

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserListsTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserListsTest.kt
@@ -120,15 +120,15 @@ class DataListFragmentUserListsTest(
             arrayOf("listOf(false)", listOf(false), listOf(falseString)),
             arrayOf("listOf(true)", listOf(true), listOf(trueString)),
             arrayOf("listOf(1)", listOf(1), listOf("1")),
-            arrayOf("listOf(1k)", listOf(1_000), listOf("1k")),
-            arrayOf("listOf(1M)", listOf(1_000_000), listOf("1M")),
+            arrayOf("listOf(1300)", listOf(1_300), listOf("1300")),
+            arrayOf("listOf(1000300)", listOf(1_000_300), listOf("1000300")),
             arrayOf("listOf(1.1)", listOf(1.1), listOf("1.1")),
             arrayOf("listOf(NaN)", listOf(Double.NaN), listOf("NaN")),
             arrayOf("listOf(hello)", listOf("hello"), listOf("hello")),
             arrayOf(
-                "listOf(false, true, 1, 1k, 1M, 1.1, NaN, hello)",
-                listOf(false, true, 1, 1_000, 1_000_000, 1.1, Double.NaN, "hello"),
-                listOf(falseString, trueString, "1", "1k", "1M", "1.1", "NaN", "hello")
+                "listOf(false, true, 1, 1300, 1000300, 1.1, NaN, hello)",
+                listOf(false, true, 1, 1_300, 1_000_300, 1.1, Double.NaN, "hello"),
+                listOf(falseString, trueString, "1", "1300", "1000300", "1.1", "NaN", "hello")
             )
         )
     }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserVariablesTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserVariablesTest.kt
@@ -113,8 +113,8 @@ class DataListFragmentUserVariablesTest(
             arrayOf("Boolean false", false, falseString),
             arrayOf("Boolean true", true, trueString),
             arrayOf("Int 1", 1, "1"),
-            arrayOf("Int 1k", 1_000, "1k"),
-            arrayOf("Int 1M", 1_000_000, "1M"),
+            arrayOf("Int 1300", 1_300, "1300"),
+            arrayOf("Int 1000300", 1_000_300, "1000300"),
             arrayOf("Double 1.1", 1.1, "1.1"),
             arrayOf("Double NaN", Double.NaN, "NaN"),
             arrayOf("String hello", "hello", "hello")

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/UserDefinedBrickInputRVAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/UserDefinedBrickInputRVAdapter.java
@@ -33,7 +33,6 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.ui.recyclerview.viewholder.CheckableVH;
 import org.catrobat.catroid.ui.recyclerview.viewholder.VariableVH;
 import org.catrobat.catroid.userbrick.UserDefinedBrickInput;
-import org.catrobat.catroid.utils.ShowTextUtils;
 import org.catrobat.catroid.utils.ShowTextUtils.AndroidStringProvider;
 
 import java.util.List;
@@ -65,7 +64,6 @@ public class UserDefinedBrickInputRVAdapter extends RVAdapter<UserDefinedBrickIn
 				CatroidApplication.getAppContext()
 		);
 		String result = item.getValue().getUserFriendlyString(stringProvider, null);
-		result = ShowTextUtils.convertStringToMetricRepresentation(result);
 		variableVH.value.setText(result);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
@@ -57,9 +57,9 @@ import org.catrobat.catroid.ui.recyclerview.dialog.TextInputDialog
 import org.catrobat.catroid.ui.recyclerview.dialog.textwatcher.DuplicateInputTextWatcher
 import org.catrobat.catroid.ui.recyclerview.viewholder.CheckableVH
 import org.catrobat.catroid.userbrick.UserDefinedBrickInput
+import org.catrobat.catroid.utils.ShowTextUtils
 import org.catrobat.catroid.utils.ToastUtil
 import org.catrobat.catroid.utils.UserDataUtil.renameUserData
-import java.util.ArrayList
 import java.util.Collections
 
 class DataListFragment : Fragment(),
@@ -459,7 +459,7 @@ class DataListFragment : Fragment(),
         val builder = TextInputDialog.Builder(requireContext())
 
         builder.setHint(getString(R.string.data_value))
-            .setText(item.value.toString())
+            .setText(ShowTextUtils.convertObjectToString(item.value))
             .setPositiveButton(getString(R.string.save)) { _: DialogInterface?, textInput: String? ->
                 editItem(item, textInput)
             }

--- a/catroid/src/main/java/org/catrobat/catroid/utils/ShowTextUtils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/ShowTextUtils.java
@@ -138,7 +138,7 @@ public final class ShowTextUtils {
 			return new AndroidStringProvider(CatroidApplication.getAppContext())
 					.getTrueOrFalse((Boolean) object);
 		} else {
-			return convertStringToMetricRepresentation(trimTrailingCharacters(object.toString()));
+			return trimTrailingCharacters(object.toString());
 		}
 	}
 


### PR DESCRIPTION
Remove toMetricUnitRepresentation in DataListFragment
**Also added TrimTrailingCharacters to remove unnecessary ".0" in the Edit-Value Dialog in the DataListFragment**

https://jira.catrob.at/browse/CATROID-1294

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
