### PR TITLE
CATROID-1213 "Pen down" brick not working correctly

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PenDownActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PenDownActionTest.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.test.content.actions;
 
 import android.graphics.PointF;
 
+import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.actions.SequenceAction;
 import com.badlogic.gdx.utils.Queue;
@@ -35,6 +36,7 @@ import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.io.XstreamSerializer;
+import org.catrobat.catroid.stage.CameraPositioner;
 import org.catrobat.catroid.test.utils.TestUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -42,6 +44,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -60,11 +63,14 @@ public class PenDownActionTest {
 	private Formula xMovement = new Formula(X_MOVEMENT);
 	private Formula yMovement = new Formula(Y_MOVEMENT);
 	private Sprite sprite;
+	private OrthographicCamera camera = Mockito.spy(new OrthographicCamera());
+	private CameraPositioner cameraPositioner = new CameraPositioner(camera, 960.0f, 540.0f);
 	private String projectName = "testProject";
 
 	@Before
 	public void setUp() throws Exception {
 		sprite = new Sprite("testSprite");
+		Mockito.doNothing().when(camera).update();
 		createTestProject();
 	}
 
@@ -107,6 +113,27 @@ public class PenDownActionTest {
 		assertEquals(0f, positions.first().removeFirst().x);
 		assertEquals(X_MOVEMENT, positions.first().first().x);
 		assertEquals(Y_MOVEMENT, positions.first().removeFirst().y);
+	}
+
+	@Test
+	public void testAfterBecomeFocusPoint() {
+		assertEquals(0f, sprite.look.getXInUserInterfaceDimensionUnit());
+		assertEquals(0f, sprite.look.getYInUserInterfaceDimensionUnit());
+
+		cameraPositioner.setHorizontalFlex(0f);
+		cameraPositioner.setVerticalFlex(0f);
+		cameraPositioner.setSpriteToFocusOn(sprite);
+
+		sprite.getActionFactory().createPenDownAction(sprite).act(1.0f);
+		sprite.getActionFactory().createPlaceAtAction(sprite, new SequenceAction(), xMovement,
+				yMovement).act(1.0f);
+		cameraPositioner.updateCameraPositionForFocusedSprite();
+
+		Queue<Queue<PointF>> positions = sprite.penConfiguration.getPositions();
+		assertEquals(0f, positions.first().removeFirst().x);
+		assertEquals(X_MOVEMENT, positions.first().first().x);
+		assertEquals(Y_MOVEMENT, positions.first().removeFirst().y);
+		cameraPositioner.reset();
 	}
 
 	@Test

--- a/catroid/src/main/java/org/catrobat/catroid/content/PenConfiguration.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/PenConfiguration.java
@@ -25,6 +25,7 @@ package org.catrobat.catroid.content;
 
 import android.graphics.PointF;
 
+import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.utils.Queue;
@@ -44,14 +45,14 @@ public class PenConfiguration {
 	public PenConfiguration() {
 	}
 
-	public void drawLinesForSprite(Float screenRatio) {
+	public void drawLinesForSprite(Float screenRatio, Camera camera) {
 
 		ShapeRenderer renderer = StageActivity.stageListener.shapeRenderer;
 		renderer.setColor(new Color(penColor.r, penColor.g, penColor.b, penColor.a));
 		renderer.begin(ShapeRenderer.ShapeType.Filled);
 
 		while (currentQueueHasJobToHandle()) {
-			drawLine(screenRatio, renderer);
+			drawLine(screenRatio, renderer, camera);
 			updateQueues();
 		}
 
@@ -62,11 +63,14 @@ public class PenConfiguration {
 		return !positions.isEmpty() && (positions.first().size > 1 || queuesToFinish > 0);
 	}
 
-	private void drawLine(Float screenRatio, ShapeRenderer renderer) {
+	private void drawLine(Float screenRatio, ShapeRenderer renderer, Camera camera) {
 
 		PointF currentPosition = positions.first().removeFirst();
 		PointF nextPosition = positions.first().first();
-
+		currentPosition.x += camera.position.x;
+		currentPosition.y += camera.position.y;
+		nextPosition.x += camera.position.x;
+		nextPosition.y += camera.position.y;
 		if (currentPosition.x != nextPosition.x || currentPosition.y != nextPosition.y) {
 			Float penSize = (float) this.penSize * screenRatio;
 			renderer.circle(currentPosition.x, currentPosition.y, penSize / 2);
@@ -74,6 +78,8 @@ public class PenConfiguration {
 					penSize);
 			renderer.circle(nextPosition.x, nextPosition.y, penSize / 2);
 		}
+		nextPosition.x -= camera.position.x;
+		nextPosition.y -= camera.position.y;
 	}
 
 	private void updateQueues() {

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/GoToRandomPositionAction.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/GoToRandomPositionAction.java
@@ -41,8 +41,7 @@ public class GoToRandomPositionAction extends TemporalAction {
 		randomYPosition = (float) Math.random()
 				* (ScreenValues.SCREEN_HEIGHT + 1) - (ScreenValues.SCREEN_HEIGHT / 2);
 
-		sprite.look.setXInUserInterfaceDimensionUnit(randomXPosition);
-		sprite.look.setYInUserInterfaceDimensionUnit(randomYPosition);
+		sprite.look.setPositionInUserInterfaceDimensionUnit(randomXPosition, randomYPosition);
 	}
 
 	public void setSprite(Sprite sprite) {

--- a/catroid/src/main/java/org/catrobat/catroid/stage/PenActor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/PenActor.java
@@ -63,7 +63,7 @@ public class PenActor extends Actor {
 		buffer.begin();
 		for (Sprite sprite : StageActivity.stageListener.getSpritesFromStage()) {
 			PenConfiguration pen = sprite.penConfiguration;
-			pen.drawLinesForSprite(screenRatio);
+			pen.drawLinesForSprite(screenRatio, getStage().getViewport().getCamera());
 		}
 		buffer.end();
 


### PR DESCRIPTION
The Bug happened because in the PenConfiguration, the change of the Camera wasn`t taken into consideration.
I also found a small Bug where in the GoToRandomPosition Brick in Combination with PenDown it would always first change the x and then the y coordinate, which resulted in a wrong drawing of the Pen.

https://jira.catrob.at/browse/CATROID-1213

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
