### PR TITLE
CATROID-1295 Fix all failing particle effect tests

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/ParticleEffectsTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/ParticleEffectsTest.kt
@@ -47,6 +47,7 @@ import org.catrobat.catroid.content.bricks.WaitBrick
 import org.catrobat.catroid.ui.SpriteActivity
 import org.catrobat.catroid.uiespresso.util.actions.CustomActions.wait
 import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
+import org.hamcrest.core.StringContains
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -98,8 +99,10 @@ class ParticleEffectsTest {
 
     @Test
     fun particleEffectAfterSceneRestartsTest() {
-        script.addBrick(WaitBrick(1000))
-        script.addBrick(FadeParticleEffectBrick(FADE_IN))
+        script.apply {
+            addBrick(WaitBrick(1000))
+            addBrick(FadeParticleEffectBrick(FADE_IN))
+        }
         onView(ViewMatchers.withId(R.id.button_play)).perform(click())
         onView(isRoot()).perform(wait(100))
         assertFalse(projectManager.currentSprite.look.hasParticleEffect)
@@ -110,12 +113,14 @@ class ParticleEffectsTest {
 
     @Test
     fun particleEffectAfterSceneContinuesTest() {
-        script.addBrick(WaitBrick(200))
-        script.addBrick(FadeParticleEffectBrick(FADE_IN))
-        script.addBrick(SceneStartBrick("scene2"))
+        script.apply {
+            addBrick(WaitBrick(200))
+            addBrick(FadeParticleEffectBrick(FADE_IN))
+            addBrick(SceneStartBrick(scene2.name))
+        }
         projectManager.currentlyEditedScene = scene2
         onView(ViewMatchers.withId(R.id.button_play)).perform(click())
-        onView(withText("Current scene (scene2)")).perform(click())
+        onView(withText(StringContains.containsString(scene2.name))).perform(click())
         onView(withText(R.string.play)).perform(click())
         onView(isRoot()).perform(wait(500))
         assertTrue(projectManager.currentSprite.look.hasParticleEffect)
@@ -133,7 +138,7 @@ class ParticleEffectsTest {
         scene2 = Scene("scene2", project)
         val sprite2 = Sprite("testSprite2")
         val script2 = StartScript()
-        script2.addBrick(SceneTransitionBrick("Scene (1)"))
+        script2.addBrick(SceneTransitionBrick(project.defaultScene.name))
         sprite2.addScript(script2)
         scene2.addSprite(sprite2)
 


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1295

Fix all failing particle effect tests. ParticleEffectsTest.particleEffectAfterSceneContinuesTest and
ParticleEffectsTest.particleEffectAfterSceneRestartsTest are failing regularly on jenkins.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
