### PR TITLE
CATROID-1272 Copying Userdefined Bricks

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/backpack/BackpackUserDefinedBricksTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/backpack/BackpackUserDefinedBricksTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2022 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.content.backpack
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Script
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.content.StartScript
+import org.catrobat.catroid.content.UserDefinedScript
+import org.catrobat.catroid.content.bricks.Brick
+import org.catrobat.catroid.content.bricks.SetXBrick
+import org.catrobat.catroid.content.bricks.UserDefinedBrick
+import org.catrobat.catroid.content.bricks.UserDefinedReceiverBrick
+import org.catrobat.catroid.test.utils.TestUtils
+import org.catrobat.catroid.ui.controller.BackpackListManager
+import org.catrobat.catroid.ui.recyclerview.controller.ScriptController
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.java.KoinJavaComponent.inject
+
+@RunWith(AndroidJUnit4::class)
+class BackpackUserDefinedBricksTest {
+    private val backpackGroupName: String = "group without definition"
+    private lateinit var firstSprite: Sprite
+    private lateinit var secondSprite: Sprite
+    private lateinit var userDefinedBrick: UserDefinedBrick
+    private lateinit var userDefinedScript: UserDefinedScript
+    private lateinit var startScript: Script
+    private var backpackListManager: BackpackListManager? = null
+    private val projectManager: ProjectManager by inject(ProjectManager::class.java)
+
+    @Before
+    fun setUp() {
+        backpackListManager = BackpackListManager.getInstance()
+        TestUtils.clearBackPack(backpackListManager)
+        createProject(BackpackUserDefinedBricksTest::class.java.simpleName)
+    }
+
+    @After
+    fun tearDown() {
+        TestUtils.deleteProjects(BackpackUserDefinedBricksTest::class.java.simpleName)
+        TestUtils.clearBackPack(backpackListManager)
+    }
+
+    @Test
+    fun testCopyingOfUserDefinedBrickWithoutDefinition() {
+        val scriptController = ScriptController()
+        val bricksToPack: ArrayList<Brick> = ArrayList()
+        startScript.addToFlatList(bricksToPack)
+        scriptController.pack(backpackGroupName, bricksToPack)
+        val scripts = BackpackListManager.getInstance().backpackedScripts[backpackGroupName]
+        scripts?.forEach {
+            scriptController.unpack(it, secondSprite)
+        }
+
+        Assert.assertNotNull(secondSprite.getUserDefinedScript(userDefinedBrick.userDefinedBrickID))
+    }
+
+    @Test
+    fun testCopyingOfUserDefinedBrickWithDefinition() {
+        val scriptController = ScriptController()
+        val bricksToPack: ArrayList<Brick> = ArrayList()
+        startScript.addToFlatList(bricksToPack)
+        userDefinedScript.addToFlatList(bricksToPack)
+        scriptController.pack(backpackGroupName, bricksToPack)
+        val scripts = BackpackListManager.getInstance().backpackedScripts[backpackGroupName]
+        scripts?.forEach {
+            scriptController.unpack(it, secondSprite)
+        }
+
+        Assert.assertNotNull(secondSprite.getUserDefinedScript(userDefinedBrick.userDefinedBrickID))
+        Assert.assertEquals(2, secondSprite.scriptList.size)
+    }
+
+    private fun createProject(projectName: String) {
+        val project = Project(ApplicationProvider.getApplicationContext(), projectName)
+        firstSprite = Sprite("firstSprite")
+        secondSprite = Sprite("secondSprite")
+
+        startScript = StartScript()
+        userDefinedBrick = UserDefinedBrick()
+        userDefinedScript = UserDefinedScript(userDefinedBrick.userDefinedBrickID)
+        userDefinedScript.scriptBrick = UserDefinedReceiverBrick(userDefinedBrick)
+        userDefinedScript.addBrick(SetXBrick())
+        firstSprite.addScript(userDefinedScript)
+        firstSprite.addUserDefinedBrick(userDefinedBrick)
+
+        startScript.addBrick(userDefinedBrick)
+        firstSprite.addScript(startScript)
+        project.defaultScene.addSprite(firstSprite)
+        project.defaultScene.addSprite(secondSprite)
+
+        projectManager.currentProject = project
+        projectManager.currentSprite = firstSprite
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -742,6 +742,15 @@ public class Sprite implements Cloneable, Nameable, Serializable {
 		this.userDefinedBrickList.addAll(sprite.userDefinedBrickList);
 	}
 
+	public UserDefinedScript getUserDefinedScript(UUID userDefinedBrickId) {
+		for (Script script : scriptList) {
+			if (script instanceof UserDefinedScript && ((UserDefinedScript) script).getUserDefinedBrickID().equals(userDefinedBrickId)) {
+				return (UserDefinedScript) script;
+			}
+		}
+		return null;
+	}
+
 	public void setGliding(boolean gliding) {
 		isGliding = gliding;
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/ScriptController.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/ScriptController.kt
@@ -114,20 +114,38 @@ class ScriptController {
     fun pack(groupName: String?, bricksToPack: List<Brick>?) {
         val scriptsToPack: MutableList<Script> = ArrayList()
         val userDefinedBrickListToPack: MutableList<UserDefinedBrick> = ArrayList()
-        bricksToPack?.forEach() {
-            if (it is ScriptBrick) {
-                if (it is UserDefinedReceiverBrick) {
-                    val userDefinedBrick = it.userDefinedBrick
+        bricksToPack?.forEach() { brick ->
+            if (brick is ScriptBrick) {
+                if (brick is UserDefinedReceiverBrick) {
+                    val userDefinedBrick = brick.userDefinedBrick
                     userDefinedBrickListToPack.add(userDefinedBrick.clone() as UserDefinedBrick)
                 }
-                val scriptToPack = it.getScript()
+                val scriptToPack = brick.getScript()
                 scriptsToPack.add(scriptToPack.clone())
             }
+            if (brick is UserDefinedBrick) {
+                val userDefinedScript = projectManager.currentSprite.getUserDefinedScript(brick.userDefinedBrickID)
+
+                if (!checkIfUserDefinedBrickDefinitionIsInBricksToPack(bricksToPack, brick)) {
+                    scriptsToPack.add(userDefinedScript)
+                    userDefinedBrickListToPack.add(brick.clone() as UserDefinedBrick)
+                }
+            }
         }
+
         BackpackListManager.getInstance()
             .addUserDefinedBrickToBackPack(groupName, userDefinedBrickListToPack)
         BackpackListManager.getInstance().addScriptToBackPack(groupName, scriptsToPack)
         BackpackListManager.getInstance().saveBackpack()
+    }
+
+    private fun checkIfUserDefinedBrickDefinitionIsInBricksToPack(bricksToPack: List<Brick>?, userDefinedBrick: UserDefinedBrick): Boolean {
+        bricksToPack?.forEach { brick ->
+            if (brick is UserDefinedReceiverBrick && brick.userDefinedBrick.userDefinedBrickID.equals(userDefinedBrick.userDefinedBrickID)) {
+                return true
+            }
+        }
+        return false
     }
 
     @Throws(IOException::class, CloneNotSupportedException::class)

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -719,7 +719,7 @@ public class ScriptFragment extends ListFragment implements
 		switch (itemId) {
 			case R.string.backpack_add:
 				List<Brick> bricksToPack = new ArrayList<>();
-				bricksToPack.add(brick);
+				brick.addToFlatList(bricksToPack);
 				showNewScriptGroupAlert(bricksToPack);
 				break;
 			case R.string.brick_context_dialog_copy_brick:


### PR DESCRIPTION
Copying userdefined bricks via the backpack results in copying the definition of the userdefined brick automatically now so that the userdefined brick can actually be used after unpacking in another sprite.

Additional remark: We also fixed another bug, where packing the backpack didn't work properly when doing it via the dialog that comes up when pressing and holding on a scriptblock. See changes in `ScriptFragment.java`

[CATROID-1272](https://jira.catrob.at/browse/CATROID-1272)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
