### PR TITLE
CATROID-1158 fix input field hidden behind keyboard

### DIFF
--- a/catroid/src/main/res/layout/activity_upload.xml
+++ b/catroid/src/main/res/layout/activity_upload.xml
@@ -22,7 +22,6 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -33,6 +32,9 @@
 
     <include layout="@layout/progress_bar" />
 
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
     <LinearLayout
         android:id="@+id/upload_layout"
         android:layout_width="match_parent"
@@ -40,6 +42,7 @@
         android:paddingTop="@dimen/dialog_content_area_padding_top"
         android:paddingStart="@dimen/dialog_content_area_padding"
         android:paddingEnd="@dimen/dialog_content_area_padding"
+        android:paddingBottom="@dimen/padding_for_scrolling"
         android:orientation="vertical">
 
         <ImageView
@@ -103,7 +106,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minLines="1"
-                android:selectAllOnFocus="true" />
+                android:selectAllOnFocus="true"/>
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -136,4 +139,5 @@
     </LinearLayout>
 
     </LinearLayout>
+    </ScrollView>
 </LinearLayout>

--- a/catroid/src/main/res/values/dimens.xml
+++ b/catroid/src/main/res/values/dimens.xml
@@ -82,6 +82,12 @@
     <dimen name="sprite_group_item_view_holder_padding">40dp</dimen>
     <dimen name="checkbox_margin">16dp</dimen>
 
+    <!-- Flow Layout -->
+    <dimen name="brick_flow_layout_vertical_spacing">0dp</dimen>
+    <dimen name="brick_flow_layout_horizontal_spacing">3dp</dimen>
+    <!-- Padding -->
+    <dimen name="padding_for_scrolling">150dp</dimen>
+
     <!-- Activity -->
     <dimen name="activity_text_view_margin_large" >35dp</dimen >
 


### PR DESCRIPTION
[CATROID-1158](https://jira.catrob.at/browse/CATROID-1158) Input field hidden behind keyboard, cannot be scrolled up

Make linear layout scrollable, so that the input field is no longer hidden behind the keyboard.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
