### PR TITLE
CATROID-1199 Link to flavors from settings

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/mindstorms/nxt/LegoNXTImplTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/mindstorms/nxt/LegoNXTImplTest.java
@@ -80,10 +80,10 @@ public class LegoNXTImplTest {
 				.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext());
 
 		nxtSettingBuffer = sharedPreferences
-				.getBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, false);
+				.getBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE, false);
 
 		sharedPreferences.edit()
-				.putBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, true)
+				.putBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE, true)
 				.commit();
 
 		sensorMappingBuffer = SettingsFragment.getLegoNXTSensorMapping(ApplicationProvider.getApplicationContext());
@@ -105,7 +105,7 @@ public class LegoNXTImplTest {
 		logger.disconnectAndDestroy();
 
 		PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext()).edit()
-				.putBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, nxtSettingBuffer)
+				.putBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE, nxtSettingBuffer)
 				.commit();
 		setSensorMapping(sensorMappingBuffer);
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/rtl/RtlBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/rtl/RtlBrickTest.java
@@ -213,8 +213,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
-import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED;
-import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_EV3_BRICKS_CHECKBOX_PREFERENCE;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_AI_FACE_DETECTION_SENSORS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_AI_POSE_DETECTION_SENSORS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_AI_SPEECH_RECOGNITION_SENSORS;
@@ -224,7 +224,7 @@ import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTING
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_JUMPING_SUMO_BRICKS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_NFC_BRICKS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS;
-import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_PHIRO_BRICKS;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_RASPI_BRICKS;
 import static org.catrobat.catroid.uiespresso.util.matchers.rtl.RtlViewDirection.isViewRtl;
 import static org.hamcrest.Matchers.allOf;
@@ -247,8 +247,8 @@ public class RtlBrickTest {
 			SpriteActivity.FRAGMENT_SCRIPTS);
 
 	private Locale arLocale = new Locale("ar");
-	private List<String> allPeripheralCategories = new ArrayList<>(Arrays.asList(SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED,
-			SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED, SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS, SETTINGS_SHOW_PHIRO_BRICKS,
+	private List<String> allPeripheralCategories = new ArrayList<>(Arrays.asList(SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE,
+			SETTINGS_MINDSTORMS_EV3_BRICKS_CHECKBOX_PREFERENCE, SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS, SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE,
 			SETTINGS_SHOW_ARDUINO_BRICKS, SETTINGS_SHOW_RASPI_BRICKS, SETTINGS_SHOW_NFC_BRICKS,
 			SETTINGS_SHOW_JUMPING_SUMO_BRICKS, SETTINGS_SHOW_AI_SPEECH_RECOGNITION_SENSORS,
 			SETTINGS_SHOW_AI_SPEECH_SYNTHETIZATION_SENSORS,

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorSensorListTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorSensorListTest.kt
@@ -792,10 +792,10 @@ class FormulaEditorSensorListTest(
 
         private val allShowBrickSettings: List<String> = listOf(
             SettingsFragment.SETTINGS_SHOW_ARDUINO_BRICKS,
-            SettingsFragment.SETTINGS_SHOW_PHIRO_BRICKS,
+            SettingsFragment.SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE,
             SettingsFragment.SETTINGS_SHOW_NFC_BRICKS,
-            SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED,
-            SettingsFragment.SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED,
+            SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE,
+            SettingsFragment.SETTINGS_MINDSTORMS_EV3_BRICKS_CHECKBOX_PREFERENCE,
             SettingsFragment.SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS,
             SettingsFragment.SETTINGS_SHOW_RASPI_BRICKS,
             SettingsFragment.SETTINGS_CAST_GLOBALLY_ENABLED,

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsFragmentTest.java
@@ -28,8 +28,10 @@ import android.app.Instrumentation;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.os.Build;
 import android.preference.PreferenceManager;
 
+import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.testsuites.annotations.Cat;
@@ -64,9 +66,9 @@ import static org.catrobat.catroid.common.SharedPreferenceKeys.DEVICE_LANGUAGE;
 import static org.catrobat.catroid.common.SharedPreferenceKeys.LANGUAGE_TAGS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_CAST_GLOBALLY_ENABLED;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_CRASH_REPORTS;
-import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_EV3_BRICKS_CHECKBOX_PREFERENCE;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_EV3_SHOW_SENSOR_INFO_BOX_DISABLED;
-import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MULTIPLAYER_VARIABLES_ENABLED;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_AI_FACE_DETECTION_SENSORS;
@@ -75,11 +77,12 @@ import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTING
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_AI_SPEECH_SYNTHETIZATION_SENSORS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_AI_TEXT_RECOGNITION_SENSORS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_ARDUINO_BRICKS;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_EMBROIDERY_BRICKS_CHECKBOX_PREFERENCE;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_HINTS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_JUMPING_SUMO_BRICKS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_NFC_BRICKS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS;
-import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_PHIRO_BRICKS;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_RASPI_BRICKS;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -108,9 +111,12 @@ public class SettingsFragmentTest {
 			BaseActivityTestRule<>(SettingsActivity.class, true, false);
 
 	private List<String> allSettings = new ArrayList<>(Arrays.asList(SETTINGS_SHOW_ARDUINO_BRICKS,
-			SETTINGS_SHOW_PHIRO_BRICKS, SETTINGS_SHOW_NFC_BRICKS, SETTINGS_SHOW_HINTS, SETTINGS_CRASH_REPORTS,
-			SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED,
-			SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED, SETTINGS_MINDSTORMS_EV3_SHOW_SENSOR_INFO_BOX_DISABLED,
+			SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE, SETTINGS_SHOW_NFC_BRICKS, SETTINGS_SHOW_HINTS,
+			SETTINGS_CRASH_REPORTS, SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE,
+			SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED,
+			SETTINGS_MINDSTORMS_EV3_BRICKS_CHECKBOX_PREFERENCE,
+			SETTINGS_MINDSTORMS_EV3_SHOW_SENSOR_INFO_BOX_DISABLED,
+			SETTINGS_SHOW_EMBROIDERY_BRICKS_CHECKBOX_PREFERENCE,
 			SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS, SETTINGS_SHOW_JUMPING_SUMO_BRICKS,
 			SETTINGS_SHOW_RASPI_BRICKS, SETTINGS_MULTIPLAYER_VARIABLES_ENABLED,
 			SETTINGS_CAST_GLOBALLY_ENABLED, SETTINGS_SHOW_AI_SPEECH_RECOGNITION_SENSORS,
@@ -168,7 +174,19 @@ public class SettingsFragmentTest {
 	@Test
 	public void basicSettingsTest() {
 		checkPreference(R.string.preference_title_enable_arduino_bricks, SETTINGS_SHOW_ARDUINO_BRICKS);
-		checkPreference(R.string.preference_title_enable_phiro_bricks, SETTINGS_SHOW_PHIRO_BRICKS);
+
+		if (BuildConfig.FLAVOR.equals(Constants.FLAVOR_PHIRO)) {
+			checkPreference(R.string.preference_title_enable_phiro_bricks, SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE);
+		} else {
+			openAppstoreDialog(R.string.preference_title_enable_phiro_bricks);
+		}
+
+		if (BuildConfig.FLAVOR.equals(Constants.FLAVOR_EMBROIDERY_DESIGNER)) {
+			checkPreference(R.string.preference_title_enable_embroidery_bricks, SETTINGS_SHOW_EMBROIDERY_BRICKS_CHECKBOX_PREFERENCE);
+		} else {
+			openAppstoreDialog(R.string.preference_title_enable_embroidery_bricks);
+		}
+
 		checkPreference(R.string.preference_title_enable_jumpingsumo_bricks, SETTINGS_SHOW_JUMPING_SUMO_BRICKS);
 		checkPreference(R.string.preference_title_enable_nfc_bricks, SETTINGS_SHOW_NFC_BRICKS);
 		checkPreference(R.string.preference_title_enable_hints, SETTINGS_SHOW_HINTS);
@@ -196,7 +214,12 @@ public class SettingsFragmentTest {
 		onData(PreferenceMatchers.withTitle(R.string.preference_title_enable_mindstorms_nxt_bricks))
 				.perform(click());
 
-		checkPreference(R.string.preference_title_enable_mindstorms_nxt_bricks, SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED);
+		if (BuildConfig.FLAVOR.equals(Constants.FLAVOR_LEGO_NXT_EV3)) {
+			checkPreference(R.string.preference_title_enable_mindstorms_nxt_bricks, SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE);
+		} else {
+			openAppstoreDialog(R.string.preference_title_enable_mindstorms_nxt_bricks);
+		}
+
 		checkPreference(R.string.preference_disable_nxt_info_dialog, SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED);
 	}
 
@@ -206,7 +229,12 @@ public class SettingsFragmentTest {
 		onData(PreferenceMatchers.withTitle(R.string.preference_title_enable_mindstorms_ev3_bricks))
 				.perform(click());
 
-		checkPreference(R.string.preference_title_enable_mindstorms_ev3_bricks, SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED);
+		if (BuildConfig.FLAVOR.equals(Constants.FLAVOR_LEGO_NXT_EV3)) {
+			checkPreference(R.string.preference_title_enable_mindstorms_ev3_bricks, SETTINGS_MINDSTORMS_EV3_BRICKS_CHECKBOX_PREFERENCE);
+		} else {
+			openAppstoreDialog(R.string.preference_title_enable_mindstorms_ev3_bricks);
+		}
+
 		checkPreference(R.string.preference_disable_nxt_info_dialog,
 				SETTINGS_MINDSTORMS_EV3_SHOW_SENSOR_INFO_BOX_DISABLED);
 	}
@@ -295,5 +323,21 @@ public class SettingsFragmentTest {
 				.perform(click());
 
 		assertTrue(sharedPreferences.getBoolean(sharedPreferenceTag, false));
+	}
+
+	private void openAppstoreDialog(int displayedTitleResourceString) {
+		onData(PreferenceMatchers.withTitle(displayedTitleResourceString))
+				.perform(click());
+
+		if (!Build.BRAND.equals(Constants.DEVICE_BRAND_HUAWEI)) {
+			onView(withText(R.string.preference_dialog_google_play))
+					.check(matches(isDisplayed()));
+		} else {
+			onView(withText(R.string.preference_dialog_appgallery))
+					.check(matches(isDisplayed()));
+		}
+
+		onView(withText(R.string.cancel_button_text))
+				.perform(click());
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/LegoSensorPortConfigDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/LegoSensorPortConfigDialogTest.java
@@ -83,10 +83,10 @@ public class LegoSensorPortConfigDialogTest {
 				.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext());
 
 		nxtSettingBuffer = sharedPreferences
-				.getBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, false);
+				.getBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE, false);
 
 		sharedPreferences.edit()
-				.putBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, true)
+				.putBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE, true)
 				.commit();
 
 		sensorMappingBuffer = SettingsFragment.getLegoNXTSensorMapping(ApplicationProvider.getApplicationContext());
@@ -130,7 +130,7 @@ public class LegoSensorPortConfigDialogTest {
 	@After
 	public void tearDown() throws IOException {
 		PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext()).edit()
-				.putBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, nxtSettingBuffer)
+				.putBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE, nxtSettingBuffer)
 				.commit();
 
 		SettingsFragment

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/regression/activitydestroy/LegoConfigDialogActivityRecreationRegressionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/regression/activitydestroy/LegoConfigDialogActivityRecreationRegressionTest.java
@@ -75,7 +75,7 @@ public class LegoConfigDialogActivityRecreationRegressionTest {
 		script.addBrick(new ChangeSizeByNBrick(0));
 
 		nxtSettingBuffer = PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())
-				.getBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, false);
+				.getBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE, false);
 
 		setNXTBrickSetting(true);
 
@@ -118,7 +118,7 @@ public class LegoConfigDialogActivityRecreationRegressionTest {
 
 	private void setNXTBrickSetting(boolean bricksEnabled) {
 		PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext()).edit()
-				.putBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, bricksEnabled)
+				.putBoolean(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE, bricksEnabled)
 				.commit();
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -360,6 +360,22 @@ public final class Constants {
 			ExifInterface.TAG_CAMARA_OWNER_NAME
 	));
 
+	public static final String FLAVOR_POCKET_CODE = "catroid";
+	public static final String FLAVOR_EMBROIDERY_DESIGNER = "embroideryDesigner";
+	public static final String FLAVOR_LEGO_NXT_EV3 = "mindstorms";
+	public static final String FLAVOR_PHIRO = "phiro";
+	public static final String FLAVOR_LUNA_AND_CAT = "lunaAndCat";
+	public static final String FLAVOR_CREATE_AT_SCHOOL = "createAtSchool";
+
+	public static final String PREFRENCE_PLAYSTORE_EMBROIDERY_URL = "https://play.google.com/store/apps/details?id=org.catrobat.catroid.embroiderydesigner";
+	public static final String PREFRENCE_APPGALLERY_EMBROIDERY_URL = "https://appgallery.huawei.com/app/C100085769";
+	public static final String PREFRENCE_PLAYSTORE_MINDSTORMS_URL = "https://play.google.com/store/apps/details?id=org.catrobat.catroid";
+	public static final String PREFRENCE_APPGALLERY_MINDSTORMS_URL = "https://appgallery.huawei.com/app/C100085769";
+	public static final String PREFRENCE_PLAYSTORE_PHIRO_URL = "https://play.google.com/store/apps/details?id=org.catrobat.catroid.phiro";
+	public static final String PREFRENCE_APPGALLERY_PHIRO_URL = "https://appgallery.huawei.com/app/C100085769";
+
+	public static final String DEVICE_BRAND_HUAWEI = "huawei";
+
 	private Constants() {
 		throw new AssertionError("No.");
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/AppStoreDialogFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/AppStoreDialogFragment.kt
@@ -1,0 +1,102 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2022 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.ui.recyclerview.dialog
+
+import android.app.Dialog
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import org.catrobat.catroid.R
+import org.catrobat.catroid.common.Constants
+
+class AppStoreDialogFragment : DialogFragment() {
+
+    companion object {
+        val TAG: String = AppStoreDialogFragment::class.java.simpleName
+
+        enum class Extension {
+            LEGO_NXT_EV3,
+            PHIRO,
+            EMBROIDERY
+        }
+
+        @JvmStatic
+        fun newInstance(extension: Extension): AppStoreDialogFragment {
+            val dialog = AppStoreDialogFragment()
+            dialog.extension = extension
+            return dialog
+        }
+    }
+
+    private lateinit var extension: Extension
+
+    override fun onCreateDialog(bundle: Bundle?): Dialog {
+        val view = View.inflate(activity, R.layout.dialog_google_play, null)
+
+        val text = view.findViewById<TextView>(R.id.dialog_google_play_text)
+        text.text = when (extension) {
+            Extension.LEGO_NXT_EV3 -> getString(R.string.preference_lego_dialog_text)
+            Extension.EMBROIDERY -> getString(R.string.preference_embroidery_dialog_text)
+            Extension.PHIRO -> getString(R.string.preference_phiro_dialog_text)
+        }
+
+        val builder: AlertDialog.Builder = AlertDialog.Builder(requireActivity())
+            .setTitle(getString(R.string.preference_dialog_use_full_features))
+            .setView(view)
+            .setNegativeButton(R.string.cancel_button_text, null)
+
+        val buttonText = if (android.os.Build.BRAND != Constants.DEVICE_BRAND_HUAWEI) {
+            getString(R.string.preference_dialog_google_play)
+        } else {
+            getString(R.string.preference_dialog_appgallery)
+        }
+
+        builder.setPositiveButton(buttonText) { _, _ ->
+            val intent = Intent(Intent.ACTION_VIEW)
+            intent.data = Uri.parse(getCorrectUrl())
+            startActivity(intent)
+        }
+
+        return builder.create()
+    }
+
+    private fun getCorrectUrl(): String {
+        return if (android.os.Build.BRAND != Constants.DEVICE_BRAND_HUAWEI) {
+            when (extension) {
+                Extension.LEGO_NXT_EV3 -> Constants.PREFRENCE_PLAYSTORE_MINDSTORMS_URL
+                Extension.EMBROIDERY -> Constants.PREFRENCE_PLAYSTORE_EMBROIDERY_URL
+                Extension.PHIRO -> Constants.PREFRENCE_PLAYSTORE_PHIRO_URL
+            }
+        } else {
+            when (extension) {
+                Extension.LEGO_NXT_EV3 -> Constants.PREFRENCE_APPGALLERY_MINDSTORMS_URL
+                Extension.EMBROIDERY -> Constants.PREFRENCE_APPGALLERY_EMBROIDERY_URL
+                Extension.PHIRO -> Constants.PREFRENCE_APPGALLERY_PHIRO_URL
+            }
+        }
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/Ev3SensorsSettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/Ev3SensorsSettingsFragment.java
@@ -29,18 +29,22 @@ import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
+import android.preference.PreferenceScreen;
 
 import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.devices.mindstorms.ev3.sensors.EV3Sensor;
+import org.catrobat.catroid.ui.recyclerview.dialog.AppStoreDialogFragment;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentActivity;
 
+import static org.catrobat.catroid.ui.recyclerview.dialog.AppStoreDialogFragment.Companion.Extension;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.EV3_SCREEN_KEY;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.EV3_SENSORS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.EV3_SETTINGS_CATEGORY;
-import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED;
 
 public class Ev3SensorsSettingsFragment extends PreferenceFragment {
 	public static final String TAG = Ev3SensorsSettingsFragment.class.getSimpleName();
@@ -58,21 +62,34 @@ public class Ev3SensorsSettingsFragment extends PreferenceFragment {
 
 		addPreferencesFromResource(R.xml.ev3_preferences);
 
+		CheckBoxPreference ev3CheckBoxPreference =
+				(CheckBoxPreference) findPreference(SettingsFragment.SETTINGS_MINDSTORMS_EV3_BRICKS_CHECKBOX_PREFERENCE);
+		Preference simplePreferenceField = findPreference(SettingsFragment.SETTINGS_MINDSTORMS_EV3_BRICKS_PREFERENCE);
+		PreferenceScreen preferenceScreen = getPreferenceScreen();
+
 		if (!BuildConfig.FEATURE_LEGO_EV3_ENABLED) {
 			CheckBoxPreference legoEv3Preference = (CheckBoxPreference) findPreference(EV3_SCREEN_KEY);
 			legoEv3Preference.setEnabled(false);
-			getPreferenceScreen().removePreference(legoEv3Preference);
+			preferenceScreen.removePreference(legoEv3Preference);
 		} else {
-			CheckBoxPreference ev3CheckBoxPreference = (CheckBoxPreference) findPreference(SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED);
-			final PreferenceCategory ev3ConnectionSettings = (PreferenceCategory) findPreference(EV3_SETTINGS_CATEGORY);
-			ev3ConnectionSettings.setEnabled(ev3CheckBoxPreference.isChecked());
+			if (BuildConfig.FLAVOR != Constants.FLAVOR_LEGO_NXT_EV3) {
+				preferenceScreen.removePreference(ev3CheckBoxPreference);
 
-			ev3CheckBoxPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-				public boolean onPreferenceChange(Preference preference, Object isChecked) {
+				simplePreferenceField.setOnPreferenceClickListener(preference -> {
+					AppStoreDialogFragment.newInstance(Extension.LEGO_NXT_EV3).show(((FragmentActivity) getActivity()).getSupportFragmentManager(),
+							AppStoreDialogFragment.Companion.getTAG());
+					return true;
+				});
+			} else {
+				preferenceScreen.removePreference(simplePreferenceField);
+				final PreferenceCategory ev3ConnectionSettings = (PreferenceCategory) findPreference(EV3_SETTINGS_CATEGORY);
+				ev3ConnectionSettings.setEnabled(ev3CheckBoxPreference.isChecked());
+
+				ev3CheckBoxPreference.setOnPreferenceChangeListener((preference, isChecked) -> {
 					ev3ConnectionSettings.setEnabled((Boolean) isChecked);
 					return true;
-				}
-			});
+				});
+			}
 
 			final String[] sensorPreferences = EV3_SENSORS;
 			for (String sensorPreference : sensorPreferences) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/NXTSensorsSettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/NXTSensorsSettingsFragment.java
@@ -33,10 +33,14 @@ import android.preference.PreferenceScreen;
 
 import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.devices.mindstorms.nxt.sensors.NXTSensor;
+import org.catrobat.catroid.ui.recyclerview.dialog.AppStoreDialogFragment;
+import org.catrobat.catroid.ui.recyclerview.dialog.AppStoreDialogFragment.Companion.Extension;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentActivity;
 
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.NXT_SENSORS;
 
@@ -55,21 +59,34 @@ public class NXTSensorsSettingsFragment extends PreferenceFragment {
 		SettingsFragment.setToChosenLanguage(getActivity());
 
 		addPreferencesFromResource(R.xml.nxt_preferences);
+
+		CheckBoxPreference nxtCheckBoxPreference = (CheckBoxPreference) findPreference(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE);
+		Preference simplePreferenceField = findPreference(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_PREFERENCE);
+		PreferenceScreen preferenceScreen = getPreferenceScreen();
+
 		if (!BuildConfig.FEATURE_LEGO_NXT_ENABLED) {
 			PreferenceScreen legoNxtPreference = (PreferenceScreen) findPreference(SettingsFragment.NXT_SCREEN_KEY);
 			legoNxtPreference.setEnabled(false);
-			getPreferenceScreen().removePreference(legoNxtPreference);
+			preferenceScreen.removePreference(legoNxtPreference);
 		} else {
-			CheckBoxPreference nxtCheckBoxPreference = (CheckBoxPreference) findPreference(SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED);
-			final PreferenceCategory nxtConnectionSettings = (PreferenceCategory) findPreference(SettingsFragment.NXT_SETTINGS_CATEGORY);
-			nxtConnectionSettings.setEnabled(nxtCheckBoxPreference.isChecked());
+			if (BuildConfig.FLAVOR != Constants.FLAVOR_LEGO_NXT_EV3) {
+				preferenceScreen.removePreference(nxtCheckBoxPreference);
 
-			nxtCheckBoxPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-				public boolean onPreferenceChange(Preference preference, Object isChecked) {
+				simplePreferenceField.setOnPreferenceClickListener(preference -> {
+					AppStoreDialogFragment.newInstance(Extension.LEGO_NXT_EV3).show(((FragmentActivity) getActivity()).getSupportFragmentManager(),
+							AppStoreDialogFragment.Companion.getTAG());
+					return true;
+				});
+			} else {
+				preferenceScreen.removePreference(simplePreferenceField);
+				final PreferenceCategory nxtConnectionSettings = (PreferenceCategory) findPreference(SettingsFragment.NXT_SETTINGS_CATEGORY);
+				nxtConnectionSettings.setEnabled(nxtCheckBoxPreference.isChecked());
+
+				nxtCheckBoxPreference.setOnPreferenceChangeListener((preference, isChecked) -> {
 					nxtConnectionSettings.setEnabled((Boolean) isChecked);
 					return true;
-				}
-			});
+				});
+			}
 
 			final String[] sensorPreferences = NXT_SENSORS;
 			for (String sensorPreference : sensorPreferences) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -40,12 +40,15 @@ import android.util.DisplayMetrics;
 import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.common.DroneConfigPreference;
 import org.catrobat.catroid.devices.mindstorms.ev3.sensors.EV3Sensor;
 import org.catrobat.catroid.devices.mindstorms.nxt.sensors.NXTSensor;
 import org.catrobat.catroid.formulaeditor.SensorHandler;
 import org.catrobat.catroid.sync.ProjectsCategoriesSync;
 import org.catrobat.catroid.ui.MainMenuActivity;
+import org.catrobat.catroid.ui.recyclerview.dialog.AppStoreDialogFragment;
+import org.catrobat.catroid.ui.recyclerview.dialog.AppStoreDialogFragment.Companion.Extension;
 import org.catrobat.catroid.utils.SnackbarUtil;
 
 import java.util.ArrayList;
@@ -55,6 +58,7 @@ import java.util.Locale;
 
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentActivity;
 
 import static org.catrobat.catroid.CatroidApplication.defaultSystemLanguage;
 import static org.catrobat.catroid.common.SharedPreferenceKeys.DEVICE_LANGUAGE;
@@ -64,32 +68,30 @@ import static org.koin.java.KoinJavaComponent.inject;
 
 public class SettingsFragment extends PreferenceFragment {
 
-	public static final String SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED = "settings_mindstorms_nxt_bricks_enabled";
+	public static final String SETTINGS_MINDSTORMS_NXT_BRICKS_PREFERENCE = "settings_mindstorms_nxt_bricks_preference";
+	public static final String SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE = "settings_mindstorms_nxt_bricks_checkbox_preference";
 	public static final String SETTINGS_MINDSTORMS_NXT_SHOW_SENSOR_INFO_BOX_DISABLED = "settings_mindstorms_nxt_show_sensor_info_box_disabled";
-	public static final String SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED = "settings_mindstorms_ev3_bricks_enabled";
+	public static final String SETTINGS_MINDSTORMS_EV3_BRICKS_PREFERENCE = "settings_mindstorms_ev3_bricks_preference";
+	public static final String SETTINGS_MINDSTORMS_EV3_BRICKS_CHECKBOX_PREFERENCE = "settings_mindstorms_ev3_bricks_checkbox_preference";
 	public static final String SETTINGS_MINDSTORMS_EV3_SHOW_SENSOR_INFO_BOX_DISABLED = "settings_mindstorms_ev3_show_sensor_info_box_disabled";
 	public static final String SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS = "setting_parrot_ar_drone_bricks";
 	public static final String SETTINGS_EDIT_TRUSTED_DOMAINS = "setting_trusted_domains";
 	public static final String SETTINGS_SHOW_JUMPING_SUMO_BRICKS = "setting_parrot_jumping_sumo_bricks";
-	public static final String SETTINGS_SHOW_EMBROIDERY_BRICKS = "setting_embroidery_bricks";
-	public static final String SETTINGS_SHOW_PHIRO_BRICKS = "setting_enable_phiro_bricks";
+	public static final String SETTINGS_SHOW_EMBROIDERY_BRICKS_PREFERENCE = "setting_embroidery_bricks_preference";
+	public static final String SETTINGS_SHOW_EMBROIDERY_BRICKS_CHECKBOX_PREFERENCE = "setting_embroidery_bricks_checkbox_preference";
+	public static final String SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE = "setting_enable_phiro_bricks_checkbox_preference";
+	public static final String SETTINGS_SHOW_PHIRO_BRICKS_PREFERENCE = "setting_enable_phiro_bricks_preference";
 	public static final String SETTINGS_SHOW_ARDUINO_BRICKS = "setting_arduino_bricks";
 	public static final String SETTINGS_SHOW_RASPI_BRICKS = "setting_raspi_bricks";
 	public static final String SETTINGS_SHOW_NFC_BRICKS = "setting_nfc_bricks";
 	public static final String SETTINGS_PARROT_AR_DRONE_CATROBAT_TERMS_OF_SERVICE_ACCEPTED_PERMANENTLY = "setting_parrot_ar_drone_catrobat_terms_of_service_accepted_permanently";
 	public static final String SETTINGS_CAST_GLOBALLY_ENABLED = "setting_cast_globally_enabled";
-	public static final String SETTINGS_SHOW_AI_SPEECH_RECOGNITION_SENSORS =
-			"setting_ai_speech_recognition";
-	public static final String SETTINGS_SHOW_AI_SPEECH_SYNTHETIZATION_SENSORS =
-			"setting_ai_speech_synthetization";
-	public static final String SETTINGS_SHOW_AI_FACE_DETECTION_SENSORS =
-			"setting_ai_face_detection";
-	public static final String SETTINGS_SHOW_AI_POSE_DETECTION_SENSORS =
-			"setting_ai_pose_detection";
-	public static final String SETTINGS_SHOW_AI_TEXT_RECOGNITION_SENSORS =
-			"setting_ai_text_recognition";
-	public static final String SETTINGS_SHOW_AI_OBJECT_DETECTION_SENSORS =
-			"setting_ai_object_detection";
+	public static final String SETTINGS_SHOW_AI_SPEECH_RECOGNITION_SENSORS = "setting_ai_speech_recognition";
+	public static final String SETTINGS_SHOW_AI_SPEECH_SYNTHETIZATION_SENSORS = "setting_ai_speech_synthetization";
+	public static final String SETTINGS_SHOW_AI_FACE_DETECTION_SENSORS = "setting_ai_face_detection";
+	public static final String SETTINGS_SHOW_AI_POSE_DETECTION_SENSORS = "setting_ai_pose_detection";
+	public static final String SETTINGS_SHOW_AI_TEXT_RECOGNITION_SENSORS = "setting_ai_text_recognition";
+	public static final String SETTINGS_SHOW_AI_OBJECT_DETECTION_SENSORS = "setting_ai_object_detection";
 
 	public static final String SETTINGS_MULTIPLAYER_VARIABLES_ENABLED = "setting_multiplayer_variables_enabled";
 	public static final String SETTINGS_SHOW_HINTS = "setting_enable_hints";
@@ -144,13 +146,15 @@ public class SettingsFragment extends PreferenceFragment {
 		screen = getPreferenceScreen();
 
 		if (!BuildConfig.FEATURE_EMBROIDERY_ENABLED) {
-			CheckBoxPreference embroideryPreference = (CheckBoxPreference) findPreference(SETTINGS_SHOW_EMBROIDERY_BRICKS);
+			CheckBoxPreference embroideryPreference =
+					(CheckBoxPreference) findPreference(SETTINGS_SHOW_EMBROIDERY_BRICKS_CHECKBOX_PREFERENCE);
 			embroideryPreference.setEnabled(false);
 			screen.removePreference(embroideryPreference);
 		}
 
 		if (!BuildConfig.FEATURE_PHIRO_ENABLED) {
-			CheckBoxPreference phiroPreference = (CheckBoxPreference) findPreference(SETTINGS_SHOW_PHIRO_BRICKS);
+			CheckBoxPreference phiroPreference =
+					(CheckBoxPreference) findPreference(SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE);
 			phiroPreference.setEnabled(false);
 			screen.removePreference(phiroPreference);
 		}
@@ -198,6 +202,9 @@ public class SettingsFragment extends PreferenceFragment {
 			testPreference.setEnabled(BuildConfig.DEBUG);
 			screen.removePreference(testPreference);
 		}
+
+		setCorrectPreferenceViewForEmbroidery();
+		setCorrectPreferenceViewForPhiro();
 	}
 
 	@Override
@@ -265,7 +272,7 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static boolean isEmroiderySharedPreferenceEnabled(Context context) {
-		return getBooleanSharedPreference(false, SETTINGS_SHOW_EMBROIDERY_BRICKS, context);
+		return getBooleanSharedPreference(false, SETTINGS_SHOW_EMBROIDERY_BRICKS_CHECKBOX_PREFERENCE, context);
 	}
 
 	public static boolean isDroneSharedPreferenceEnabled(Context context) {
@@ -277,15 +284,16 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static boolean isMindstormsNXTSharedPreferenceEnabled(Context context) {
-		return getBooleanSharedPreference(false, SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, context);
+		return getBooleanSharedPreference(false, SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE, context);
 	}
 
 	public static boolean isMindstormsEV3SharedPreferenceEnabled(Context context) {
-		return getBooleanSharedPreference(false, SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED, context);
+		return getBooleanSharedPreference(false, SETTINGS_MINDSTORMS_EV3_BRICKS_CHECKBOX_PREFERENCE, context);
 	}
 
 	public static boolean isPhiroSharedPreferenceEnabled(Context context) {
-		return getBooleanSharedPreference(false, SETTINGS_SHOW_PHIRO_BRICKS, context);
+		return getBooleanSharedPreference(false, SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE,
+				context);
 	}
 
 	public static boolean isCastSharedPreferenceEnabled(Context context) {
@@ -294,7 +302,7 @@ public class SettingsFragment extends PreferenceFragment {
 
 	public static void setPhiroSharedPreferenceEnabled(Context context, boolean value) {
 		getSharedPreferences(context).edit()
-				.putBoolean(SETTINGS_SHOW_PHIRO_BRICKS, value)
+				.putBoolean(SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE, value)
 				.apply();
 	}
 
@@ -484,13 +492,13 @@ public class SettingsFragment extends PreferenceFragment {
 
 	public static void enableLegoMindstormsNXTBricks(Context context) {
 		getSharedPreferences(context).edit()
-				.putBoolean(SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED, true)
+				.putBoolean(SETTINGS_MINDSTORMS_NXT_BRICKS_CHECKBOX_PREFERENCE, true)
 				.apply();
 	}
 
 	public static void enableLegoMindstormsEV3Bricks(Context context) {
 		getSharedPreferences(context).edit()
-				.putBoolean(SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED, true)
+				.putBoolean(SETTINGS_MINDSTORMS_EV3_BRICKS_CHECKBOX_PREFERENCE, true)
 				.apply();
 	}
 
@@ -579,5 +587,41 @@ public class SettingsFragment extends PreferenceFragment {
 		getSharedPreferences(context).edit()
 				.putBoolean(SETTINGS_USE_CATBLOCKS, useCatBlocks)
 				.apply();
+	}
+
+	private void setCorrectPreferenceViewForEmbroidery() {
+		CheckBoxPreference embroideryCheckBoxPreference =
+				(CheckBoxPreference) findPreference(SettingsFragment.SETTINGS_SHOW_EMBROIDERY_BRICKS_CHECKBOX_PREFERENCE);
+		Preference simplePreferenceField = findPreference(SettingsFragment.SETTINGS_SHOW_EMBROIDERY_BRICKS_PREFERENCE);
+
+		if (BuildConfig.FLAVOR != Constants.FLAVOR_EMBROIDERY_DESIGNER) {
+			getPreferenceScreen().removePreference(embroideryCheckBoxPreference);
+
+			simplePreferenceField.setOnPreferenceClickListener(preference -> {
+				AppStoreDialogFragment.newInstance(Extension.EMBROIDERY).show(((FragmentActivity) getActivity()).getSupportFragmentManager(),
+						AppStoreDialogFragment.Companion.getTAG());
+				return true;
+			});
+		} else {
+			getPreferenceScreen().removePreference(simplePreferenceField);
+		}
+	}
+
+	private void setCorrectPreferenceViewForPhiro() {
+		CheckBoxPreference phiroCheckBoxPreference =
+				(CheckBoxPreference) findPreference(SettingsFragment.SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE);
+		Preference simplePreferenceField = findPreference(SettingsFragment.SETTINGS_SHOW_PHIRO_BRICKS_PREFERENCE);
+
+		if (BuildConfig.FLAVOR != Constants.FLAVOR_PHIRO) {
+			getPreferenceScreen().removePreference(phiroCheckBoxPreference);
+
+			simplePreferenceField.setOnPreferenceClickListener(preference -> {
+				AppStoreDialogFragment.newInstance(Extension.PHIRO).show(((FragmentActivity) getActivity()).getSupportFragmentManager(),
+						AppStoreDialogFragment.Companion.getTAG());
+				return true;
+			});
+		} else {
+			getPreferenceScreen().removePreference(simplePreferenceField);
+		}
 	}
 }

--- a/catroid/src/main/res/layout/dialog_google_play.xml
+++ b/catroid/src/main/res/layout/dialog_google_play.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2022 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="@dimen/dialog_content_area_padding_top"
+    android:paddingStart="@dimen/dialog_content_area_padding"
+    android:paddingEnd="@dimen/dialog_content_area_padding">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/dialog_google_play_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="" />
+
+    </LinearLayout>
+</ScrollView>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -218,6 +218,15 @@
        delay</string>
     <string name="preference_access_title_profile_tiro">Tiro</string>
     <string name="preference_access_summary_profile_tiro">Beginner mode</string>
+    <string name="preference_dialog_use_full_features">Use full features</string>
+    <string name="preference_dialog_appgallery">AppGallery</string>
+    <string name="preference_dialog_google_play">Google Play</string>
+    <string name="preference_lego_dialog_text">To take advantage of all features of the Lego
+        Mindstorms extensions, please use Catrobat\'s Mindstorms Code EV3 NXT app.</string>
+    <string name="preference_embroidery_dialog_text">To take advantage of all features of the
+        embroidery extension, please use Catrobat\'s Embroidery Designer app.</string>
+    <string name="preference_phiro_dialog_text">To take advantage of all features of the Phiro
+        robotics extension, please use Catrobat\'s Phiro Code app.</string>
 
     <!-- Lego/Drone/Raspi/Chromecast/Embroidery -->
     <string name="preference_title_enable_quadcopter_bricks">Parrot AR.Drone 2.0 extension</string>

--- a/catroid/src/main/res/xml/ev3_preferences.xml
+++ b/catroid/src/main/res/xml/ev3_preferences.xml
@@ -28,9 +28,14 @@
         android:title="@string/preference_title_enable_mindstorms_ev3_bricks"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
+        <Preference
+            android:key="settings_mindstorms_ev3_bricks_preference"
+            android:summary="@string/preference_description_mindstorms_ev3_bricks"
+            android:title="@string/preference_title_enable_mindstorms_ev3_bricks" />
+
          <CheckBoxPreference
              android:defaultValue="@string/FEATURE_MINDSTORMS_PREFERENCES_ENABLED"
-             android:key="settings_mindstorms_ev3_bricks_enabled"
+             android:key="settings_mindstorms_ev3_bricks_checkbox_preference"
              android:summary="@string/preference_description_mindstorms_ev3_bricks"
              android:title="@string/preference_title_enable_mindstorms_ev3_bricks" />
 

--- a/catroid/src/main/res/xml/nxt_preferences.xml
+++ b/catroid/src/main/res/xml/nxt_preferences.xml
@@ -28,9 +28,14 @@
         android:title="@string/preference_title_enable_mindstorms_nxt_bricks"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
+        <Preference
+            android:key="settings_mindstorms_nxt_bricks_preference"
+            android:summary="@string/preference_description_mindstorms_nxt_bricks"
+            android:title="@string/preference_title_enable_mindstorms_nxt_bricks" />
+
         <CheckBoxPreference
             android:defaultValue="@string/FEATURE_MINDSTORMS_PREFERENCES_ENABLED"
-            android:key="settings_mindstorms_nxt_bricks_enabled"
+            android:key="settings_mindstorms_nxt_bricks_checkbox_preference"
             android:summary="@string/preference_description_mindstorms_nxt_bricks"
             android:title="@string/preference_title_enable_mindstorms_nxt_bricks" />
 

--- a/catroid/src/main/res/xml/preferences.xml
+++ b/catroid/src/main/res/xml/preferences.xml
@@ -48,9 +48,14 @@
         android:summary="@string/preference_description_multiplayer_variables_enabled"
         android:title="@string/preference_title_multiplayer_variables_enabled" />
 
+    <Preference
+        android:key="setting_embroidery_bricks_preference"
+        android:summary="@string/preference_description_embroidery_bricks"
+        android:title="@string/preference_title_enable_embroidery_bricks" />
+
     <CheckBoxPreference
         android:defaultValue="@string/FEATURE_EMBROIDERY_PREFERENCES_ENABLED"
-        android:key="setting_embroidery_bricks"
+        android:key="setting_embroidery_bricks_checkbox_preference"
         android:summary="@string/preference_description_embroidery_bricks"
         android:title="@string/preference_title_enable_embroidery_bricks" />
 
@@ -93,9 +98,14 @@
         android:summary="@string/preference_description_raspi_bricks"
         android:title="@string/preference_title_enable_raspi_bricks" />
 
+    <Preference
+        android:key="setting_enable_phiro_bricks_preference"
+        android:summary="@string/preference_description_phiro_bricks"
+        android:title="@string/preference_title_enable_phiro_bricks" />
+
     <CheckBoxPreference
         android:defaultValue="@string/FEATURE_PHIRO_PREFERENCES_ENABLED"
-        android:key="setting_enable_phiro_bricks"
+        android:key="setting_enable_phiro_bricks_checkbox_preference"
         android:summary="@string/preference_description_phiro_bricks"
         android:title="@string/preference_title_enable_phiro_bricks" />
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickAddCategoryTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/robolectric/bricks/BrickAddCategoryTest.java
@@ -56,14 +56,14 @@ import androidx.fragment.app.Fragment;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 
-import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED;
-import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_EV3_BRICKS_PREFERENCE;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_MINDSTORMS_NXT_BRICKS_PREFERENCE;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_ARDUINO_BRICKS;
-import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_EMBROIDERY_BRICKS;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_EMBROIDERY_BRICKS_PREFERENCE;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_JUMPING_SUMO_BRICKS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_NFC_BRICKS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS;
-import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_PHIRO_BRICKS;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_PHIRO_BRICKS_PREFERENCE;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_RASPI_BRICKS;
 
 @RunWith(RobolectricTestRunner.class)
@@ -73,10 +73,10 @@ public class BrickAddCategoryTest {
 	private SpriteActivity activity;
 	private BrickCategoryFragment brickCategoryFragment;
 
-	private List<String> allPeripheralCategories = new ArrayList<>(Arrays.asList(SETTINGS_MINDSTORMS_NXT_BRICKS_ENABLED,
-			SETTINGS_MINDSTORMS_EV3_BRICKS_ENABLED, SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS, SETTINGS_SHOW_PHIRO_BRICKS,
+	private List<String> allPeripheralCategories = new ArrayList<>(Arrays.asList(SETTINGS_MINDSTORMS_NXT_BRICKS_PREFERENCE,
+			SETTINGS_MINDSTORMS_EV3_BRICKS_PREFERENCE, SETTINGS_SHOW_PARROT_AR_DRONE_BRICKS, SETTINGS_SHOW_PHIRO_BRICKS_PREFERENCE,
 			SETTINGS_SHOW_ARDUINO_BRICKS, SETTINGS_SHOW_RASPI_BRICKS, SETTINGS_SHOW_NFC_BRICKS,
-			SETTINGS_SHOW_EMBROIDERY_BRICKS, SETTINGS_SHOW_JUMPING_SUMO_BRICKS));
+			SETTINGS_SHOW_EMBROIDERY_BRICKS_PREFERENCE, SETTINGS_SHOW_JUMPING_SUMO_BRICKS));
 	private List<String> enabledByThisTestPeripheralCategories = new ArrayList<>();
 
 	@Before


### PR DESCRIPTION
Instead of being able to toggle the extension on and off a dialog for downloading the extension's app is shown. Depending of the extension

Remark: We expanded the `SettingsFragmentTest` so the this functionality can be tested, but we didn't find a way to automatically test the different flavors!

Remark: Some apps are not available in the Huawai Appgallery, so we put in the link to pocket code in those dialogs for now!

https://jira.catrob.at/browse/CATROID-1199

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
