### PR TITLE
CATROID-988 Bug fixed, where object name and background can be equal

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -22,6 +22,7 @@
  */
 package org.catrobat.catroid.content;
 
+import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
 
@@ -40,6 +41,7 @@ import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.io.XStreamFieldKeyOrder;
 import org.catrobat.catroid.physics.content.ActionPhysicsFactory;
 import org.catrobat.catroid.stage.StageActivity;
+import org.catrobat.catroid.ui.recyclerview.util.UniqueNameProvider;
 import org.catrobat.catroid.utils.FileMetaDataExtractor;
 import org.catrobat.catroid.utils.ScreenValueHandler;
 import org.catrobat.catroid.utils.Utils;
@@ -524,6 +526,29 @@ public class Project implements Serializable {
 	public void checkForInvisibleSprites() {
 		for (Scene scene : sceneList) {
 			scene.checkForInvisibleSprites();
+		}
+	}
+
+	public List<String> getSpriteNames(List<Sprite> spriteList) {
+		List<String> spriteNames = new ArrayList<>();
+		for (int sprite = 0; sprite < spriteList.size(); ++sprite) {
+			spriteNames.add(spriteList.get(sprite).getName());
+		}
+		return spriteNames;
+	}
+
+	public void checkIfSpriteNameEqualBackground(Activity activity) {
+		List<Sprite> spriteList =
+				new ArrayList<>(this.getSpriteListWithClones());
+		List<String> spriteNames = getSpriteNames(spriteList);
+		for (int sprite = 1; sprite < spriteList.size(); ++sprite) {
+			if (spriteList.get(sprite).getName().matches("[\\s]*" + activity.getString(R.string.background)
+					+ "[\\s]*")) {
+				UniqueNameProvider name = new UniqueNameProvider();
+				String newSpriteName = name.getUniqueName(activity.getString(R.string.background), spriteNames);
+				spriteList.get(sprite).setName(newSpriteName);
+				return;
+			}
 		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -118,6 +118,7 @@ class ProjectActivity : BaseCastActivity() {
                 handlePlayButton()
             }
         }
+        projectManager.currentProject.checkIfSpriteNameEqualBackground(this)
     }
 
     private fun loadFragment(fragmentPosition: Int) {


### PR DESCRIPTION
Jira ticket: https://jira.catrob.at/browse/CATROID-988
Object name could have the same name as background in another language, if corresponding language change was made is fixed. Also added uiespresso test to confirm implementation.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
