### PR TITLE
CATROID-1339 "Add to backpack" option missing for "Define" bricks

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickContextMenuTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/bricks/BrickContextMenuTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -27,6 +27,7 @@ import org.catrobat.catroid.R
 import org.catrobat.catroid.content.bricks.AssertEqualsBrick
 import org.catrobat.catroid.content.bricks.AssertUserListsBrick
 import org.catrobat.catroid.content.bricks.Brick
+import org.catrobat.catroid.content.bricks.EmptyEventBrick
 import org.catrobat.catroid.content.bricks.FadeParticleEffectBrick
 import org.catrobat.catroid.content.bricks.FlashBrick
 import org.catrobat.catroid.content.bricks.ForItemInUserListBrick
@@ -41,7 +42,14 @@ import org.catrobat.catroid.content.bricks.SetVolumeToBrick
 import org.catrobat.catroid.content.bricks.SetXBrick
 import org.catrobat.catroid.content.bricks.UserDefinedBrick
 import org.catrobat.catroid.content.bricks.UserDefinedReceiverBrick
+import org.catrobat.catroid.content.bricks.WhenBounceOffBrick
+import org.catrobat.catroid.content.bricks.WhenBrick
+import org.catrobat.catroid.content.bricks.WhenClonedBrick
+import org.catrobat.catroid.content.bricks.WhenGamepadButtonBrick
+import org.catrobat.catroid.content.bricks.WhenNfcBrick
+import org.catrobat.catroid.content.bricks.WhenRaspiPinChangedBrick
 import org.catrobat.catroid.content.bricks.WhenStartedBrick
+import org.catrobat.catroid.content.bricks.WhenTouchDownBrick
 import org.catrobat.catroid.ui.recyclerview.fragment.ScriptFragment.getContextMenuItems
 import org.catrobat.catroid.userbrick.UserDefinedBrickInput
 import org.catrobat.catroid.userbrick.UserDefinedBrickLabel
@@ -83,7 +91,15 @@ class BrickContextMenuTest(
             arrayOf(FadeParticleEffectBrick(), false, false),
             arrayOf(ParticleEffectAdditivityBrick(), false, false),
             arrayOf(FlashBrick(), false, false),
-            arrayOf(ReadVariableFromDeviceBrick(), false, false)
+            arrayOf(ReadVariableFromDeviceBrick(), false, false),
+            arrayOf(EmptyEventBrick(), false, false),
+            arrayOf(WhenBounceOffBrick(), false, false),
+            arrayOf(WhenBrick(), false, false),
+            arrayOf(WhenClonedBrick(), false, false),
+            arrayOf(WhenGamepadButtonBrick(), false, false),
+            arrayOf(WhenNfcBrick(), false, false),
+            arrayOf(WhenRaspiPinChangedBrick(), false, false),
+            arrayOf(WhenTouchDownBrick(), false, false)
             )
     }
 
@@ -120,7 +136,7 @@ class BrickContextMenuTest(
     @Test
     fun testExpectedCommentOut() {
         val showsCommentOut: Boolean = when (brick) {
-            is UserDefinedReceiverBrick -> !contextMenuItems.contains(R.string.brick_context_dialog_comment_out_script)
+            is UserDefinedReceiverBrick, is EmptyEventBrick -> !contextMenuItems.contains(R.string.brick_context_dialog_comment_out_script)
             is ScriptBrick -> contextMenuItems.contains(R.string.brick_context_dialog_comment_out_script)
             else -> contextMenuItems.contains(R.string.brick_context_dialog_comment_out)
         }
@@ -132,7 +148,7 @@ class BrickContextMenuTest(
         brick.isCommentedOut = true
         contextMenuItems.addAll(getContextMenuItems(brick))
         val showsCommentIn: Boolean = when (brick) {
-            is UserDefinedReceiverBrick -> !contextMenuItems.contains(R.string.brick_context_dialog_comment_in)
+            is UserDefinedReceiverBrick, is EmptyEventBrick -> !contextMenuItems.contains(R.string.brick_context_dialog_comment_in)
             is ScriptBrick -> contextMenuItems.contains(R.string.brick_context_dialog_comment_in_script)
             else -> contextMenuItems.contains(R.string.brick_context_dialog_comment_in)
         }
@@ -152,5 +168,14 @@ class BrickContextMenuTest(
     @Test
     fun testExpectedHelp() {
         assertTrue(contextMenuItems.contains(R.string.brick_context_dialog_help))
+    }
+
+    @Test
+    fun testExpectedAddToBackpack() {
+        val showsAddToBackpack: Boolean = when (brick) {
+            is UserDefinedReceiverBrick, is ScriptBrick -> contextMenuItems.contains(R.string.backpack_add)
+            else -> !contextMenuItems.contains(R.string.backpack_add)
+        }
+        assertTrue(showsAddToBackpack)
     }
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -662,6 +662,7 @@ public class ScriptFragment extends ListFragment implements
 		List<Integer> items = new ArrayList<>();
 
 		if (brick instanceof UserDefinedReceiverBrick) {
+			items.add(R.string.backpack_add);
 			items.add(R.string.brick_context_dialog_delete_definition);
 			items.add(R.string.brick_context_dialog_move_definition);
 			items.add(R.string.brick_context_dialog_help);


### PR DESCRIPTION
Definitionbricks for Userdefined Bricks now have the option "add to backpack" in their context menu

https://jira.catrob.at/browse/CATROID-1339

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
