### PR TITLE
CATROID-987 Overlapping hints in Formula Editor

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/hints/HintsShownInCorrectActivityTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/hints/HintsShownInCorrectActivityTest.kt
@@ -1,0 +1,322 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2022 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.hints
+
+import android.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.content.Script
+import org.catrobat.catroid.content.bricks.SetXBrick
+import org.catrobat.catroid.ui.SpriteActivity
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_HINTS
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils.createProjectAndGetStartScript
+import org.catrobat.catroid.uiespresso.util.actions.selectTabAtPosition
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityTestRule
+import org.catrobat.catroid.utils.SnackbarUtil
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.java.KoinJavaComponent.inject
+
+@RunWith(AndroidJUnit4::class)
+class HintsShownInCorrectActivityTest {
+
+    @get:Rule
+    var baseActivityTestRule = BaseActivityTestRule(
+        SpriteActivity::class.java, true, false
+    )
+    val projectManager: ProjectManager by inject(ProjectManager::class.java)
+    private val sharedPreferences =
+        PreferenceManager.getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())
+    private val projectName: String? = HintsShownInCorrectActivityTest::class.simpleName
+    private lateinit var script: Script
+
+    private var savedBooleanValue: Boolean = false
+    private lateinit var savedShownHintsList: Set<String>
+
+    @Before
+    fun setUp() {
+        savedBooleanValue = sharedPreferences.getBoolean(SETTINGS_SHOW_HINTS, false)
+        savedShownHintsList = sharedPreferences.getStringSet(SnackbarUtil.SHOWN_HINT_LIST, HashSet<String>()) ?: HashSet()
+
+        sharedPreferences.edit()
+            .remove(SnackbarUtil.SHOWN_HINT_LIST)
+            .putBoolean(SETTINGS_SHOW_HINTS, true)
+            .apply()
+
+        script = createProjectAndGetStartScript(projectName)
+        script.addBrick(SetXBrick())
+
+        baseActivityTestRule.launchActivity(null)
+    }
+
+    @After
+    fun tearDown() {
+        sharedPreferences.edit()
+            .putBoolean(SETTINGS_SHOW_HINTS, savedBooleanValue)
+            .putStringSet(SnackbarUtil.SHOWN_HINT_LIST, savedShownHintsList)
+            .apply()
+    }
+
+    @Test
+    fun scriptsHintNotShownInFormulaEditorTest() {
+        onView(withText(R.string.hint_scripts))
+            .check(matches(isDisplayed()))
+
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+
+        onView(withText(R.string.formula_editor_intro_summary_formula_editor))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.hint_scripts))
+            .check(doesNotExist())
+    }
+
+    @Test
+    fun hintsChangeCorrectlyBeforeDismissTest() {
+        onView(withText(R.string.hint_scripts))
+            .check(matches(isDisplayed()))
+
+        onView(withId(R.id.tab_layout))
+            .perform(selectTabAtPosition(SpriteActivity.FRAGMENT_LOOKS))
+
+        onView(withText(R.string.hint_looks))
+            .check(matches(isDisplayed()))
+
+        onView(withId(R.id.tab_layout))
+            .perform(selectTabAtPosition(SpriteActivity.FRAGMENT_SOUNDS))
+
+        onView(withText(R.string.hint_sounds))
+            .check(matches(isDisplayed()))
+
+        onView(withId(R.id.tab_layout))
+            .perform(selectTabAtPosition(SpriteActivity.FRAGMENT_SCRIPTS))
+
+        onView(withText(R.string.hint_scripts))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.hint_sounds))
+            .check(doesNotExist())
+
+        onView(withText(R.string.hint_looks))
+            .check(doesNotExist())
+    }
+
+    @Test
+    fun looksHintNotShownInScriptFragment() {
+        onView(withText(R.string.got_it))
+            .perform(click())
+
+        onView(withId(R.id.tab_layout))
+            .perform(selectTabAtPosition(SpriteActivity.FRAGMENT_LOOKS))
+
+        onView(withText(R.string.hint_looks))
+            .check(matches(isDisplayed()))
+
+        onView(withId(R.id.tab_layout))
+            .perform(selectTabAtPosition(SpriteActivity.FRAGMENT_SCRIPTS))
+
+        onView(withText(R.string.hint_scripts))
+            .check(doesNotExist())
+
+        onView(withText(R.string.hint_looks))
+            .check(doesNotExist())
+    }
+
+    @Test
+    fun soundsHintNotShownInScriptFragment() {
+        onView(withText(R.string.got_it))
+            .perform(click())
+
+        onView(withId(R.id.tab_layout))
+            .perform(selectTabAtPosition(SpriteActivity.FRAGMENT_SOUNDS))
+
+        onView(withText(R.string.hint_sounds))
+            .check(matches(isDisplayed()))
+
+        onView(withId(R.id.tab_layout))
+            .perform(selectTabAtPosition(SpriteActivity.FRAGMENT_SCRIPTS))
+
+        onView(withText(R.string.hint_scripts))
+            .check(doesNotExist())
+    }
+
+    @Test
+    fun brickCategoriesHintNotShownInScriptFragment() {
+        onView(withText(R.string.hint_scripts))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.got_it))
+            .perform(click())
+
+        onView(withId(R.id.button_add))
+            .perform(click())
+
+        onView(withText(R.string.hint_category))
+            .check(matches(isDisplayed()))
+
+        pressBack()
+
+        onView(withText(R.string.hint_category))
+            .check(doesNotExist())
+    }
+
+    @Test
+    fun bricksHintNotShownInScriptFragment() {
+        onView(withText(R.string.hint_scripts))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.got_it))
+            .perform(click())
+
+        onView(withId(R.id.button_add))
+            .perform(click())
+
+        onView(withText(R.string.hint_category))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.got_it))
+            .perform(click())
+
+        onView(withText(R.string.category_event))
+            .perform(click())
+
+        onView(withText(R.string.hint_bricks))
+            .check(matches(isDisplayed()))
+
+        pressBack()
+
+        pressBack()
+
+        onView(withText(R.string.hint_bricks))
+            .check(doesNotExist())
+
+        onView(withText(R.string.hint_scripts))
+            .check(doesNotExist())
+    }
+
+    @Test
+    fun bricksHintNotShownInBrickCategoryFragment() {
+        onView(withText(R.string.hint_scripts))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.got_it))
+            .perform(click())
+
+        onView(withId(R.id.button_add))
+            .perform(click())
+
+        onView(withText(R.string.hint_category))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.got_it))
+            .perform(click())
+
+        onView(withText(R.string.category_event))
+            .perform(click())
+
+        onView(withText(R.string.hint_bricks))
+            .check(matches(isDisplayed()))
+
+        pressBack()
+
+        onView(withText(R.string.hint_bricks))
+            .check(doesNotExist())
+
+        onView(withText(R.string.hint_category))
+            .check(doesNotExist())
+    }
+
+    @Test
+    fun brickAndCategoryHintsChangeCorrectlyBeforeDismissTest() {
+        onView(withText(R.string.hint_scripts))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.got_it))
+            .perform(click())
+
+        onView(withId(R.id.button_add))
+            .perform(click())
+
+        onView(withText(R.string.hint_category))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.category_event))
+            .perform(click())
+
+        onView(withText(R.string.hint_bricks))
+            .check(matches(isDisplayed()))
+
+        pressBack()
+
+        onView(withText(R.string.hint_bricks))
+            .check(doesNotExist())
+
+        onView(withText(R.string.hint_category))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun bricksHintIsNotShownAfterChoosingBrickTest() {
+        onView(withText(R.string.hint_scripts))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.got_it))
+            .perform(click())
+
+        onView(withId(R.id.button_add))
+            .perform(click())
+
+        onView(withText(R.string.category_motion))
+            .perform(click())
+
+        onView(withText(R.string.hint_bricks))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.brick_set_y))
+            .perform(click())
+
+        onView(withText(R.string.hint_bricks))
+            .check(doesNotExist())
+
+        onView(withText(R.string.hint_category))
+            .check(doesNotExist())
+
+        onView(withText(R.string.hint_scripts))
+            .check(doesNotExist())
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -59,6 +59,8 @@ import org.catrobat.catroid.soundrecorder.SoundRecorderActivity;
 import org.catrobat.catroid.stage.StageActivity;
 import org.catrobat.catroid.stage.TestResult;
 import org.catrobat.catroid.ui.controller.RecentBrickListManager;
+import org.catrobat.catroid.ui.fragment.AddBrickFragment;
+import org.catrobat.catroid.ui.fragment.BrickCategoryFragment;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import org.catrobat.catroid.ui.recyclerview.dialog.TextInputDialog;
 import org.catrobat.catroid.ui.recyclerview.dialog.dialoginterface.NewItemInterface;
@@ -71,6 +73,7 @@ import org.catrobat.catroid.ui.recyclerview.fragment.ScriptFragment;
 import org.catrobat.catroid.ui.recyclerview.fragment.SoundListFragment;
 import org.catrobat.catroid.ui.recyclerview.util.UniqueNameProvider;
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
+import org.catrobat.catroid.utils.SnackbarUtil;
 import org.catrobat.catroid.utils.ToastUtil;
 import org.catrobat.catroid.utils.Utils;
 
@@ -300,6 +303,13 @@ public class SpriteActivity extends BaseActivity {
 			((FormulaEditorFragment) currentFragment).exitFormulaEditorFragment();
 			return;
 		} else if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
+
+			if (currentFragment instanceof BrickCategoryFragment) {
+				SnackbarUtil.showHintSnackbar(this, R.string.hint_scripts);
+			} else if (currentFragment instanceof AddBrickFragment) {
+				SnackbarUtil.showHintSnackbar(this, R.string.hint_category);
+			}
+
 			getSupportFragmentManager().popBackStack();
 			return;
 		}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddBrickFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddBrickFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -43,6 +43,7 @@ import org.catrobat.catroid.content.bricks.Brick
 import org.catrobat.catroid.ui.SpriteActivity
 import org.catrobat.catroid.ui.adapter.PrototypeBrickAdapter
 import org.catrobat.catroid.ui.settingsfragments.AccessibilityProfile
+import org.catrobat.catroid.utils.SnackbarUtil
 import org.catrobat.catroid.utils.ToastUtil
 import org.koin.java.KoinJavaComponent.inject
 
@@ -101,6 +102,7 @@ class AddBrickFragment : ListFragment() {
     override fun onResume() {
         super.onResume()
         setupSelectedBrickCategory()
+        SnackbarUtil.showHintSnackbar(activity, R.string.hint_bricks)
     }
 
     override fun onStart() {
@@ -153,6 +155,7 @@ fun addBrickToScript(brick: Brick, activity: SpriteActivity, addBrickListener: A
     try {
         val brickToAdd = brick.clone()
         addBrickListener?.addBrick(brickToAdd)
+        SnackbarUtil.showHintSnackbar(activity, R.string.hint_scripts)
         val fragmentTransaction = parentFragmentManager.beginTransaction()
         val categoryFragment = parentFragmentManager.findFragmentByTag(BrickCategoryFragment.BRICK_CATEGORY_FRAGMENT_TAG)
         if (categoryFragment != null) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/BrickCategoryFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/BrickCategoryFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -93,7 +93,6 @@ class BrickCategoryFragment : ListFragment() {
                     return@setOnItemClickListener
                 }
                 scriptFragment?.onCategorySelected(adapter?.getItem(position)) ?: return@setOnItemClickListener
-                SnackbarUtil.showHintSnackbar(activity, R.string.hint_bricks)
             }
     }
 
@@ -101,6 +100,7 @@ class BrickCategoryFragment : ListFragment() {
         super.onResume()
         hideBottomBar(activity)
         setupBrickCategories()
+        SnackbarUtil.showHintSnackbar(activity, R.string.hint_category)
     }
 
     override fun onPause() {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -211,10 +211,12 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 	@Override
 	public void onResume() {
 		super.onResume();
-		if (SnackbarUtil.areHintsEnabled(this.getActivity())
-				&& !wasHintAlreadyShown(getActivity(), getActivity().getResources()
-				.getResourceName(R.string.formula_editor_intro_title_formula_editor))) {
-			new FormulaEditorIntroDialog(this, R.style.StageDialog).show();
+		if (SnackbarUtil.areHintsEnabled(this.getActivity())) {
+			SnackbarUtil.dismissAllHints();
+			if (!wasHintAlreadyShown(getActivity(), getActivity().getResources()
+					.getResourceName(R.string.formula_editor_intro_title_formula_editor))) {
+				new FormulaEditorIntroDialog(this, R.style.StageDialog).show();
+			}
 		}
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CatblocksScriptFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CatblocksScriptFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -53,7 +53,6 @@ import org.catrobat.catroid.ui.fragment.BrickCategoryFragment
 import org.catrobat.catroid.ui.fragment.BrickCategoryFragment.OnCategorySelectedListener
 import org.catrobat.catroid.ui.fragment.UserDefinedBrickListFragment
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment
-import org.catrobat.catroid.utils.SnackbarUtil
 import org.json.JSONArray
 import org.koin.java.KoinJavaComponent.inject
 import java.util.Locale
@@ -351,8 +350,6 @@ class CatblocksScriptFragment(
             )
             .addToBackStack(BrickCategoryFragment.BRICK_CATEGORY_FRAGMENT_TAG)
             .commit()
-
-        SnackbarUtil.showHintSnackbar(activity, R.string.hint_category)
     }
 
     override fun onCategorySelected(category: String?) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/LookListFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -60,7 +60,6 @@ class LookListFragment : RecyclerViewFragment<LookData?>() {
     }
 
     override fun initializeAdapter() {
-        SnackbarUtil.showHintSnackbar(requireActivity(), R.string.hint_looks)
         sharedPreferenceDetailsKey = SHOW_DETAILS_LOOKS_PREFERENCE_KEY
         val items = projectManager.currentSprite.lookList
         adapter = LookAdapter(items)
@@ -73,6 +72,11 @@ class LookListFragment : RecyclerViewFragment<LookData?>() {
         menu.findItem(R.id.catblocks_reorder_scripts).isVisible = false
         menu.findItem(R.id.catblocks).isVisible = false
         menu.findItem(R.id.find).isVisible = false
+    }
+
+    override fun onResume() {
+        super.onResume()
+        SnackbarUtil.showHintSnackbar(requireActivity(), R.string.hint_looks)
     }
 
     override fun packItems(selectedItems: List<LookData?>) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -317,7 +317,6 @@ public class ScriptFragment extends ListFragment implements
 		});
 
 		setHasOptionsMenu(true);
-		SnackbarUtil.showHintSnackbar(getActivity(), R.string.hint_scripts);
 		return view;
 	}
 
@@ -405,6 +404,7 @@ public class ScriptFragment extends ListFragment implements
 		}
 
 		scrollToFocusItem();
+		SnackbarUtil.showHintSnackbar(getActivity(), R.string.hint_scripts);
 	}
 
 	@Override
@@ -504,8 +504,6 @@ public class ScriptFragment extends ListFragment implements
 				.add(R.id.fragment_container, brickCategoryFragment, BrickCategoryFragment.BRICK_CATEGORY_FRAGMENT_TAG)
 				.addToBackStack(BrickCategoryFragment.BRICK_CATEGORY_FRAGMENT_TAG)
 				.commit();
-
-		SnackbarUtil.showHintSnackbar(getActivity(), R.string.hint_category);
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SoundListFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SoundListFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -55,12 +55,16 @@ class SoundListFragment : RecyclerViewFragment<SoundInfo?>() {
     }
 
     override fun initializeAdapter() {
-        SnackbarUtil.showHintSnackbar(requireActivity(), R.string.hint_sounds)
         sharedPreferenceDetailsKey = SharedPreferenceKeys.SHOW_DETAILS_SOUNDS_PREFERENCE_KEY
         val items = projectManager.currentSprite.soundList
         adapter = SoundAdapter(items)
         emptyView.setText(R.string.fragment_sound_text_description)
         onAdapterReady()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        SnackbarUtil.showHintSnackbar(requireActivity(), R.string.hint_sounds)
     }
 
     override fun onPause() {

--- a/catroid/src/main/java/org/catrobat/catroid/utils/SnackbarUtil.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/SnackbarUtil.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -34,6 +34,7 @@ import com.google.android.material.snackbar.Snackbar;
 import org.catrobat.catroid.R;
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -53,7 +54,10 @@ public final class SnackbarUtil {
 
 	public static final String SHOWN_HINT_LIST = "shown_hint_list";
 
+	private static final HashMap<Integer, Snackbar> CURRENTLY_SHOWN_HINTS = new HashMap<>();
+
 	public static void showHintSnackbar(final Activity activity, @StringRes int resourceId) {
+		dismissAllHints();
 		final String messageId = activity.getResources().getResourceName(resourceId);
 
 		if (areHintsEnabled(activity) && !wasHintDialogAlreadyShown(activity)) {
@@ -78,6 +82,19 @@ public final class SnackbarUtil {
 				setHintShown(activity, messageId);
 			}
 		});
+
+		snackbar.addCallback(new Snackbar.Callback() {
+			@Override
+			public void onShown(Snackbar snackbar) {
+				CURRENTLY_SHOWN_HINTS.put(resourceId, snackbar);
+			}
+
+			@Override
+			public void onDismissed(Snackbar snackbar, int event) {
+				CURRENTLY_SHOWN_HINTS.remove(resourceId);
+			}
+		});
+
 		snackbar.setActionTextColor(ContextCompat.getColor(activity, R.color.solid_black));
 		View snackbarView = snackbar.getView();
 		TextView textView = snackbarView.findViewById(com.google.android.material.R.id.snackbar_text);
@@ -146,5 +163,11 @@ public final class SnackbarUtil {
 	protected static void handleShowHints(Activity activity, @StringRes int resourceId) {
 		setHintDialogShown(activity);
 		hintSnackbar(activity, resourceId);
+	}
+
+	public static void dismissAllHints() {
+		for (Snackbar hint : CURRENTLY_SHOWN_HINTS.values()) {
+			hint.dismiss();
+		}
 	}
 }


### PR DESCRIPTION
When hints are enabled, the hint for the scripts is not dismissed yet and the formula editor is opened, the hint for the script hides the lower part of the screen, where hints for the formula editor are shown

https://jira.catrob.at/browse/CATROID-987

Additionally we looked through all hints and found out that other hints were shown in the wrong places aswell. All hints are now only shown in the Fragment/Activity they should be shown in.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
