### PR TITLE
CATROID-1375 Pen brick doesnt work correctly for x axis

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PenDownActionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/actions/PenDownActionTest.java
@@ -116,6 +116,24 @@ public class PenDownActionTest {
 	}
 
 	@Test
+	public void testPositionChangeX() {
+		assertEquals(0f, sprite.look.getXInUserInterfaceDimensionUnit());
+		assertEquals(0f, sprite.look.getYInUserInterfaceDimensionUnit());
+
+		sprite.getActionFactory().createPlaceAtAction(sprite, new SequenceAction(), new Formula(0f),
+				new Formula(0f)).act(1.0f);
+
+		sprite.getActionFactory().createPenDownAction(sprite).act(1.0f);
+		sprite.getActionFactory().createPlaceAtAction(sprite, new SequenceAction(), xMovement,
+				new Formula(0f)).act(1.0f);
+
+		Queue<Queue<PointF>> positions = sprite.penConfiguration.getPositions();
+		assertEquals(0f, positions.first().removeFirst().x);
+		assertEquals(X_MOVEMENT, positions.first().first().x);
+		assertEquals(0f, positions.first().removeFirst().y);
+	}
+
+	@Test
 	public void testAfterBecomeFocusPoint() {
 		assertEquals(0f, sprite.look.getXInUserInterfaceDimensionUnit());
 		assertEquals(0f, sprite.look.getYInUserInterfaceDimensionUnit());

--- a/catroid/src/main/java/org/catrobat/catroid/content/Look.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Look.java
@@ -437,12 +437,12 @@ public class Look extends Image {
 	public void setPositionInUserInterfaceDimensionUnit(float x, float y) {
 		adjustSimultaneousMovementXY(x, y);
 		setXInUserInterfaceDimensionUnit(x);
-		adjustSimultaneousMovementXY(this.getX(), y);
+		adjustSimultaneousMovementXY(getXInUserInterfaceDimensionUnit(), y);
 		setYInUserInterfaceDimensionUnit(y);
 	}
 
 	private void adjustSimultaneousMovementXY(float x, float y) {
-		simultaneousMovementXY = x != this.getX() && y != this.getY();
+		simultaneousMovementXY = x != getXInUserInterfaceDimensionUnit() && y != getYInUserInterfaceDimensionUnit();
 	}
 
 	public void changeXInUserInterfaceDimensionUnit(float changeX) {


### PR DESCRIPTION
Fixed this bug by using the correct user dimension units instead of the plain x and y's

https://jira.catrob.at/browse/CATROID-1375

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
