### PR TITLE
CATROID-1374 Scene View - image preview is not copied

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SceneControllerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/controller/SceneControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -37,8 +37,6 @@ import org.catrobat.catroid.content.bricks.HideTextBrick;
 import org.catrobat.catroid.content.bricks.PlaceAtBrick;
 import org.catrobat.catroid.formulaeditor.UserList;
 import org.catrobat.catroid.formulaeditor.UserVariable;
-import org.catrobat.catroid.io.ResourceImporter;
-import org.catrobat.catroid.io.StorageOperations;
 import org.catrobat.catroid.io.XstreamSerializer;
 import org.catrobat.catroid.ui.controller.BackpackListManager;
 import org.catrobat.catroid.ui.recyclerview.controller.SceneController;
@@ -52,16 +50,22 @@ import java.io.IOException;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.platform.app.InstrumentationRegistry;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
 import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME;
+import static org.catrobat.catroid.common.Constants.SCREENSHOT_AUTOMATIC_FILE_NAME;
+import static org.catrobat.catroid.common.Constants.SCREENSHOT_MANUAL_FILE_NAME;
 import static org.catrobat.catroid.common.Constants.SOUND_DIRECTORY_NAME;
+import static org.catrobat.catroid.io.ResourceImporter.createImageFileFromResourcesInDirectory;
+import static org.catrobat.catroid.io.ResourceImporter.createSoundFileFromResourcesInDirectory;
+import static org.catrobat.catroid.io.StorageOperations.deleteDir;
 import static org.catrobat.catroid.test.utils.TestUtils.clearBackPack;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileDoesNotExist;
 import static org.catrobat.catroid.uiespresso.util.FileTestUtils.assertFileExists;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
 @RunWith(AndroidJUnit4.class)
 public class SceneControllerTest {
@@ -69,7 +73,7 @@ public class SceneControllerTest {
 	private Project project;
 	private Scene scene;
 	private BackpackListManager backpackListManager;
-	private String newName = "new Scene Name";
+	private final String newName = "new Scene Name";
 
 	@Before
 	public void setUp() throws IOException {
@@ -107,25 +111,33 @@ public class SceneControllerTest {
 		assertEquals(scene.getSpriteList().size(), copy.getSpriteList().size());
 
 		for (int i = 0; i < copy.getSpriteList().size(); i++) {
-			assertEquals(
-					scene.getSpriteList().get(i).getLookList().size(),
-					copy.getSpriteList().get(i).getLookList().size());
-
-			assertEquals(
-					scene.getSpriteList().get(i).getSoundList().size(),
-					copy.getSpriteList().get(i).getSoundList().size());
-
-			assertEquals(
-					scene.getSpriteList().get(i).getNumberOfScripts(),
-					copy.getSpriteList().get(i).getNumberOfScripts());
-
-			assertEquals(
-					scene.getSpriteList().get(i).getNumberOfBricks(),
-					copy.getSpriteList().get(i).getNumberOfBricks());
+			assertEquals(scene.getSpriteList().get(i).getLookList().size(), copy.getSpriteList().get(i).getLookList().size());
+			assertEquals(scene.getSpriteList().get(i).getSoundList().size(), copy.getSpriteList().get(i).getSoundList().size());
+			assertEquals(scene.getSpriteList().get(i).getNumberOfScripts(), copy.getSpriteList().get(i).getNumberOfScripts());
+			assertEquals(scene.getSpriteList().get(i).getNumberOfBricks(), copy.getSpriteList().get(i).getNumberOfBricks());
 		}
 
+		assertScreenshotFileExistsInScene(SCREENSHOT_AUTOMATIC_FILE_NAME, copy);
 		assertLookFileExistsInScene(copy.getSpriteList().get(1).getLookList().get(0).getFile().getName(), copy);
 		assertSoundFileExistsInScene(copy.getSpriteList().get(1).getSoundList().get(0).getFile().getName(), copy);
+	}
+
+	@Test
+	public void testCopySceneWithManualScreenshot() throws IOException {
+		createImageFileFromResourcesInDirectory(
+				getInstrumentation().getContext().getResources(),
+				org.catrobat.catroid.test.R.raw.icon,
+				new File(scene.getDirectory().getPath()),
+				SCREENSHOT_MANUAL_FILE_NAME,
+				1);
+
+		XstreamSerializer.getInstance().saveProject(project);
+
+		SceneController controller = new SceneController();
+		Scene copy = controller.copy(scene, project);
+
+		assertScreenshotFileExistsInScene(SCREENSHOT_MANUAL_FILE_NAME, copy);
+		assertFileDoesNotExist(new File(copy.getDirectory(), SCREENSHOT_AUTOMATIC_FILE_NAME));
 	}
 
 	@Test
@@ -160,37 +172,21 @@ public class SceneControllerTest {
 
 		assertEquals(0, BackpackListManager.getInstance().getScenes().size());
 
-		assertEquals(new File(backpackListManager.backpackSceneDirectory, packedScene.getName()),
-				packedScene.getDirectory());
+		assertEquals(new File(backpackListManager.backpackSceneDirectory, packedScene.getName()), packedScene.getDirectory());
 		assertFileExists(packedScene.getDirectory());
 
 		assertEquals(scene.getSpriteList().size(), packedScene.getSpriteList().size());
 
 		for (int i = 0; i < packedScene.getSpriteList().size(); i++) {
-			assertEquals(
-					scene.getSpriteList().get(i).getLookList().size(),
-					packedScene.getSpriteList().get(i).getLookList().size());
-
-			assertEquals(
-					scene.getSpriteList().get(i).getSoundList().size(),
-					packedScene.getSpriteList().get(i).getSoundList().size());
-
-			assertEquals(
-					scene.getSpriteList().get(i).getNumberOfScripts(),
-					packedScene.getSpriteList().get(i).getNumberOfScripts());
-
-			assertEquals(
-					scene.getSpriteList().get(i).getNumberOfBricks(),
-					packedScene.getSpriteList().get(i).getNumberOfBricks());
+			assertEquals(scene.getSpriteList().get(i).getLookList().size(), packedScene.getSpriteList().get(i).getLookList().size());
+			assertEquals(scene.getSpriteList().get(i).getSoundList().size(), packedScene.getSpriteList().get(i).getSoundList().size());
+			assertEquals(scene.getSpriteList().get(i).getNumberOfScripts(), packedScene.getSpriteList().get(i).getNumberOfScripts());
+			assertEquals(scene.getSpriteList().get(i).getNumberOfBricks(), packedScene.getSpriteList().get(i).getNumberOfBricks());
 		}
 
-		assertLookFileExistsInScene(
-				packedScene.getSpriteList().get(1).getLookList().get(0).getFile().getName(),
-				packedScene);
-
-		assertSoundFileExistsInScene(
-				packedScene.getSpriteList().get(1).getSoundList().get(0).getFile().getName(),
-				packedScene);
+		assertScreenshotFileExistsInScene(SCREENSHOT_AUTOMATIC_FILE_NAME, packedScene);
+		assertLookFileExistsInScene(packedScene.getSpriteList().get(1).getLookList().get(0).getFile().getName(), packedScene);
+		assertSoundFileExistsInScene(packedScene.getSpriteList().get(1).getSoundList().get(0).getFile().getName(), packedScene);
 	}
 
 	@Test
@@ -207,30 +203,19 @@ public class SceneControllerTest {
 		assertEquals(scene.getSpriteList().size(), unpackedScene.getSpriteList().size());
 
 		for (int i = 0; i < unpackedScene.getSpriteList().size(); i++) {
-			assertEquals(
-					scene.getSpriteList().get(i).getLookList().size(),
-					unpackedScene.getSpriteList().get(i).getLookList().size());
-
-			assertEquals(
-					scene.getSpriteList().get(i).getSoundList().size(),
-					unpackedScene.getSpriteList().get(i).getSoundList().size());
-
-			assertEquals(
-					scene.getSpriteList().get(i).getNumberOfScripts(),
-					unpackedScene.getSpriteList().get(i).getNumberOfScripts());
-
-			assertEquals(
-					scene.getSpriteList().get(i).getNumberOfBricks(),
-					unpackedScene.getSpriteList().get(i).getNumberOfBricks());
+			assertEquals(scene.getSpriteList().get(i).getLookList().size(), unpackedScene.getSpriteList().get(i).getLookList().size());
+			assertEquals(scene.getSpriteList().get(i).getSoundList().size(), unpackedScene.getSpriteList().get(i).getSoundList().size());
+			assertEquals(scene.getSpriteList().get(i).getNumberOfScripts(), unpackedScene.getSpriteList().get(i).getNumberOfScripts());
+			assertEquals(scene.getSpriteList().get(i).getNumberOfBricks(), unpackedScene.getSpriteList().get(i).getNumberOfBricks());
 		}
 
-		assertLookFileExistsInScene(
-				unpackedScene.getSpriteList().get(1).getLookList().get(0).getFile().getName(),
-				unpackedScene);
+		assertScreenshotFileExistsInScene(SCREENSHOT_AUTOMATIC_FILE_NAME, unpackedScene);
+		assertLookFileExistsInScene(unpackedScene.getSpriteList().get(1).getLookList().get(0).getFile().getName(), unpackedScene);
+		assertSoundFileExistsInScene(unpackedScene.getSpriteList().get(1).getSoundList().get(0).getFile().getName(), unpackedScene);
+	}
 
-		assertSoundFileExistsInScene(
-				unpackedScene.getSpriteList().get(1).getSoundList().get(0).getFile().getName(),
-				unpackedScene);
+	private void assertScreenshotFileExistsInScene(String fileName, Scene scene) {
+		assertFileExists(new File(scene.getDirectory(), fileName));
 	}
 
 	private void assertLookFileExistsInScene(String fileName, Scene scene) {
@@ -264,8 +249,15 @@ public class SceneControllerTest {
 
 		XstreamSerializer.getInstance().saveProject(project);
 
-		File imageFile = ResourceImporter.createImageFileFromResourcesInDirectory(
-				InstrumentationRegistry.getInstrumentation().getContext().getResources(),
+		createImageFileFromResourcesInDirectory(
+				getInstrumentation().getContext().getResources(),
+				org.catrobat.catroid.test.R.raw.icon,
+				new File(scene.getDirectory().getPath()),
+				SCREENSHOT_AUTOMATIC_FILE_NAME,
+				1);
+
+		File imageFile = createImageFileFromResourcesInDirectory(
+				getInstrumentation().getContext().getResources(),
 				org.catrobat.catroid.test.R.raw.red_image,
 				new File(project.getDefaultScene().getDirectory(), IMAGE_DIRECTORY_NAME),
 				"red_image.png",
@@ -273,8 +265,8 @@ public class SceneControllerTest {
 
 		sprite.getLookList().add(new LookData("testLook", imageFile));
 
-		File soundFile = ResourceImporter.createSoundFileFromResourcesInDirectory(
-				InstrumentationRegistry.getInstrumentation().getContext().getResources(),
+		File soundFile = createSoundFileFromResourcesInDirectory(
+				getInstrumentation().getContext().getResources(),
 				org.catrobat.catroid.test.R.raw.longsound,
 				new File(project.getDefaultScene().getDirectory(), SOUND_DIRECTORY_NAME),
 				"longsound.mp3");
@@ -286,7 +278,7 @@ public class SceneControllerTest {
 
 	private void deleteProject() throws IOException {
 		if (project.getDirectory().exists()) {
-			StorageOperations.deleteDir(project.getDirectory());
+			deleteDir(project.getDirectory());
 		}
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SceneController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SceneController.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -42,8 +42,11 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.catrobat.catroid.common.Constants.IMAGE_DIRECTORY_NAME;
+import static org.catrobat.catroid.common.Constants.SCREENSHOT_AUTOMATIC_FILE_NAME;
+import static org.catrobat.catroid.common.Constants.SCREENSHOT_MANUAL_FILE_NAME;
 import static org.catrobat.catroid.common.Constants.SOUND_DIRECTORY_NAME;
 import static org.catrobat.catroid.common.Constants.Z_INDEX_BACKGROUND;
+import static org.catrobat.catroid.io.StorageOperations.copyFileToDir;
 
 public class SceneController {
 
@@ -108,7 +111,25 @@ public class SceneController {
 			scene.getSpriteList().add(spriteController.copy(sprite, dstProject, scene));
 		}
 
+		copyScreenshot(sceneToCopy.getDirectory(), scene.getDirectory());
+
 		return scene;
+	}
+
+	private void copyScreenshot(File sourceDirectory, File destinationDirectory) {
+		File screenshotFile = new File(sourceDirectory, SCREENSHOT_MANUAL_FILE_NAME);
+
+		if (!screenshotFile.exists()) {
+			screenshotFile = new File(sourceDirectory, SCREENSHOT_AUTOMATIC_FILE_NAME);
+		}
+
+		if (screenshotFile.exists()) {
+			try {
+				copyFileToDir(screenshotFile, destinationDirectory);
+			} catch (IOException exception) {
+				Log.e(TAG, Log.getStackTraceString(exception));
+			}
+		}
 	}
 
 	public void delete(Scene sceneToDelete) throws IOException {
@@ -131,6 +152,8 @@ public class SceneController {
 		for (Sprite sprite : sceneToPack.getSpriteList()) {
 			scene.getSpriteList().add(spriteController.copy(sprite, null, scene));
 		}
+
+		copyScreenshot(sceneToPack.getDirectory(), scene.getDirectory());
 
 		return scene;
 	}


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1374

- Added copying the screenshot of scenes for the backpack feature.
- If there exist a manual and an automatic screenshot, then only the manual screenshot is copied.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
