### PR TITLE
CATROID-1313 Line breaks and extra spaces are ignored in Say and Think word balloons

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/ShowBubbleActor.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/ShowBubbleActor.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -289,7 +289,7 @@ public class ShowBubbleActor extends Actor {
 	public static ArrayList<String> formatStringForBubbleBricks(String text) {
 		text = text.trim();
 		ArrayList<String> words = new ArrayList<>();
-		for (String word : Arrays.asList(text.split(" "))) {
+		for (String word : Arrays.asList(text.split(" |((?<=\\n)|(?=\\n))"))) {
 			words.addAll(splitLongWordIntoSubStrings(word, Constants.MAX_STRING_LENGTH_BUBBLES));
 		}
 		return concatWordsIntoLines(words, Constants.MAX_STRING_LENGTH_BUBBLES);
@@ -309,7 +309,10 @@ public class ShowBubbleActor extends Actor {
 		ArrayList<String> lines = new ArrayList<>();
 		StringBuilder line = new StringBuilder(words.get(0));
 		for (String word : words.subList(1, words.size())) {
-			if (line.length() + word.length() < maxLineLength) {
+			if (word.equals("\n")) {
+				lines.add(line.toString());
+				line = new StringBuilder();
+			} else if (line.length() + word.length() < maxLineLength) {
 				line.append(' ').append(word);
 			} else {
 				lines.add(line.toString());

--- a/catroid/src/test/java/org/catrobat/catroid/test/utiltests/UtilsTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/utiltests/UtilsTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -333,6 +333,28 @@ public class UtilsTest {
 		List<String> expectedResultList = Arrays.asList(expectedResult);
 
 		List<String> resultList = ShowBubbleActor.formatStringForBubbleBricks(testFirstCharWhitespace);
+
+		assertNotNull(resultList);
+		assertEquals(expectedResultList, resultList);
+	}
+
+	@Test
+	public void testLineBreakStringForBubbleBricks() {
+		String testLineBreaks = "This\n   is a Test\n\n to Test   \n the line break\n";
+		String[] expectedResult = {"This", "   is a Test", "", " to Test   ", " the line break"};
+		List<String> expectedResultList = Arrays.asList(expectedResult);
+
+		List<String> resultList = ShowBubbleActor.formatStringForBubbleBricks(testLineBreaks);
+
+		assertNotNull(resultList);
+		assertEquals(expectedResultList, resultList);
+
+		testLineBreaks = "This\n tests\n many\n linebraks\n\n\n\n\n in a\n\n row";
+		String[] expectedResult2 = {"This", " tests", " many", " linebraks", "", "", "", "",
+				" in a", "", " row"};
+		expectedResultList = Arrays.asList(expectedResult2);
+
+		resultList = ShowBubbleActor.formatStringForBubbleBricks(testLineBreaks);
 
 		assertNotNull(resultList);
 		assertEquals(expectedResultList, resultList);


### PR DESCRIPTION
Fixed issue, where line breaks in the think/say balloons were ignored.
The problem was, that the text is parsed into lines, but "\n" character
was treated as a regular character, and did not invoke a new line.
Added test to verify the changes.

This pull request fixes an issue, where line breaks from the think/say balloons were ignored, and adds a test to verify this change.
https://jira.catrob.at/browse/CATROID-1313

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
