### PR TITLE
CATROID-847 Floating + and play buttons may cover parameter field in lowest bricks

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -40,6 +40,7 @@ import android.view.inputmethod.InputMethodManager;
 import org.catrobat.catroid.BuildConfig;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.ScreenValues;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Script;
@@ -274,7 +275,9 @@ public class ScriptFragment extends ListFragment implements
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 		View view = View.inflate(getActivity(), R.layout.fragment_script, null);
 		listView = view.findViewById(android.R.id.list);
-
+		int bottomListPadding = ScreenValues.SCREEN_HEIGHT/3;
+		listView.setPadding(0,0,0,bottomListPadding);
+		listView.setClipToPadding(false);
 		activity = (SpriteActivity) getActivity();
 
 		scriptFinder = view.findViewById(R.id.findview);

--- a/catroid/src/main/res/layout/fragment_list_view.xml
+++ b/catroid/src/main/res/layout/fragment_list_view.xml
@@ -43,7 +43,9 @@
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layoutManager="LinearLayoutManager">
+        app:layoutManager="LinearLayoutManager"
+        android:paddingBottom="200dp"
+        android:clipToPadding="false">
     </androidx.recyclerview.widget.RecyclerView>
 
 </FrameLayout>


### PR DESCRIPTION
Adds padding to brick view where buttons could cover-up fields.
Padding was also added for fragment_list_view, where similiar problems can occur.

https://jira.catrob.at/browse/CATROID-847

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
