### PR TITLE
CATROID-1058 Fixed edit look with clones and added tests

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/LookController.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/LookController.kt
@@ -42,7 +42,8 @@ class LookController {
             uniqueNameProvider.getUniqueNameInNameables(lookToCopy?.name, dstSprite?.lookList)
         val dstDir = dstScene?.let { getImageDir(it) }
         val file = StorageOperations.copyFileToDir(lookToCopy?.file, dstDir)
-        return LookData(name, file)
+        val newLookData = LookData(name, file)
+        return newLookData
     }
 
     @Throws(IOException::class)

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SpriteController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/SpriteController.java
@@ -61,6 +61,7 @@ public class SpriteController {
 	public Sprite copy(Sprite spriteToCopy, Project dstProject, Scene dstScene) throws IOException {
 		String name = uniqueNameProvider.getUniqueNameInNameables(spriteToCopy.getName(), dstScene.getSpriteList());
 		Sprite sprite = new SpriteFactory().newInstance(spriteToCopy.getClass().getSimpleName(), name);
+		sprite.isClone = spriteToCopy.isClone;
 
 		for (LookData look : spriteToCopy.getLookList()) {
 			sprite.getLookList().add(lookController.copy(look, dstScene, sprite));
@@ -112,7 +113,8 @@ public class SpriteController {
 		sprite.setActionFactory(spriteToCopy.getActionFactory());
 
 		for (LookData look : spriteToCopy.getLookList()) {
-			sprite.getLookList().add(new LookData(look.getName(), look.getFile()));
+			LookData lookData = new LookData(look.getName(), look.getFile());
+			sprite.getLookList().add(lookData);
 		}
 
 		sprite.getSoundList().addAll(spriteToCopy.getSoundList());

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/EditLookActionTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/EditLookActionTest.kt
@@ -34,6 +34,7 @@ import org.catrobat.catroid.content.actions.EditLookAction
 import org.catrobat.catroid.content.actions.SetNextLookAction
 import org.catrobat.catroid.io.StorageOperations
 import org.catrobat.catroid.io.XstreamSerializer
+import org.catrobat.catroid.stage.StageActivity
 import org.catrobat.catroid.test.MockUtil
 import org.junit.Before
 import org.junit.Test
@@ -44,16 +45,33 @@ import org.powermock.api.mockito.PowerMockito
 import org.powermock.core.classloader.annotations.PrepareForTest
 import org.powermock.modules.junit4.PowerMockRunner
 import java.io.File
+import java.io.IOException
+import java.lang.ref.WeakReference
 
 @RunWith(PowerMockRunner::class)
 @PrepareForTest(StorageOperations::class, XstreamSerializer::class, GdxNativesLoader::class)
 class EditLookActionTest {
     private lateinit var projectMock: Project
     private lateinit var testSequence: SequenceAction
+    private lateinit var stageActivity: StageActivity
     private val xstreamSerializerMock = PowerMockito.mock(XstreamSerializer::class.java)
     private val lookDataFile = mock(File::class.java)
+    private val lookDataFileTemp = mock(File::class.java)
     private val lookDataFileEdited = mock(File::class.java)
     private val lookData = LookData("firstLook", lookDataFile)
+
+    private fun doEditLookAction(sprite: Sprite) {
+        if (sprite.lookList.isEmpty()) {
+            sprite.lookList.add(lookData)
+            sprite.look.lookData = lookData
+        }
+        val setNewLookAction = sprite.actionFactory.createSetNextLookAction(sprite, testSequence)
+        val editLookAction = sprite.actionFactory.createEditLookAction(
+            sprite, testSequence, setNewLookAction as SetNextLookAction) as EditLookAction
+        editLookAction.restart()
+        editLookAction.onIntentResult(-1, null)
+        setNewLookAction.act(1f)
+    }
 
     @Before
     fun setUp() {
@@ -64,9 +82,14 @@ class EditLookActionTest {
         PowerMockito.mockStatic(XstreamSerializer::class.java)
         PowerMockito.mockStatic(GdxNativesLoader::class.java)
         PowerMockito.mockStatic(StorageOperations::class.java)
-        Mockito.`when`(StorageOperations.duplicateFile(lookDataFile)).thenReturn(lookDataFileEdited)
+        Mockito.`when`(StorageOperations.duplicateFile(lookDataFile)).thenReturn(lookDataFileTemp)
+        Mockito.`when`(StorageOperations.duplicateFile(lookDataFileTemp))
+            .thenReturn(lookDataFileEdited)
         Mockito.`when`(XstreamSerializer.getInstance()).thenReturn(xstreamSerializerMock)
         Mockito.`when`(xstreamSerializerMock.saveProject(projectMock)).thenReturn(true)
+
+        stageActivity = StageActivity()
+        StageActivity.activeStageActivity = WeakReference<StageActivity>(stageActivity)
     }
 
     @Test
@@ -75,6 +98,7 @@ class EditLookActionTest {
             val setNewLookAction = actionFactory.createSetNextLookAction(this, testSequence)
             val editLookAction = actionFactory.createEditLookAction(
                 this, testSequence, setNewLookAction as SetNextLookAction) as EditLookAction
+            editLookAction.protectOriginalLookData()
             editLookAction.setLookData()
             setNewLookAction.act(1f)
             Assert.assertEquals(0, this.lookList.size)
@@ -82,15 +106,102 @@ class EditLookActionTest {
     }
 
     @Test
-    fun testWithSingleLookList() {
+    fun testSizeOfLookListWhenSpriteIsNoClone() {
+        with(Sprite()) {
+            doEditLookAction(this)
+            Assert.assertEquals(1, this.lookList.size)
+        }
+    }
+
+    @Test
+    fun testSizeOfLookListWhenSpriteIsClone() {
+        with(Sprite()) {
+            this.isClone = true
+            doEditLookAction(this)
+            Assert.assertEquals(1, this.lookList.size)
+        }
+    }
+
+    @Test
+    fun testFileFlowWhenSpriteIsNoClone() {
+        with(Sprite()) {
+            doEditLookAction(this)
+            Assert.assertEquals(lookDataFileEdited, this.lookList[0].file)
+        }
+    }
+
+    @Test
+    fun testFileFlowWhenSpriteIsClone() {
+        with(Sprite()) {
+            this.isClone = true
+            doEditLookAction(this)
+            Assert.assertEquals(lookDataFileEdited, this.lookList[0].file)
+        }
+    }
+
+    @Test
+    fun testFileFlowWhenSpriteIsNoCloneInALoop() {
+        with(Sprite()) {
+            repeat(10) {
+                if (this.lookList.isNotEmpty()) {
+                    this.lookList[0].file = lookDataFile
+                }
+                doEditLookAction(this)
+            }
+            Assert.assertEquals(lookDataFileEdited, this.lookList[0].file)
+            Assert.assertEquals(1, this.lookList.size)
+        }
+    }
+
+    @Test
+    fun testFileFlowWhenSpriteIsCloneInALoop() {
+        with(Sprite()) {
+            this.isClone = true
+            repeat(10) {
+                if (this.lookList.isNotEmpty()) {
+                    this.lookList[0].file = lookDataFile
+                }
+                doEditLookAction(this)
+            }
+            Assert.assertEquals(lookDataFileEdited, this.lookList[0].file)
+            Assert.assertEquals(1, this.lookList.size)
+        }
+    }
+
+    @Test
+    fun testIfLookDataIsNoCopyWhenSpriteIsNoClone() {
+        with(Sprite()) {
+            doEditLookAction(this)
+            Assert.assertFalse(this.look.lookData.isCopy)
+        }
+    }
+
+    @Test
+    fun testIfLookDataIsCopyWhenSpriteIsClone() {
+        with(Sprite()) {
+            this.isClone = true
+            doEditLookAction(this)
+            Assert.assertTrue(this.look.lookData.isCopy)
+        }
+    }
+
+    @Test
+    fun testIfFileStaysUnchangedWhenExceptionIsThrown() {
+        val lookDataFileMock = mock(File::class.java)
+        Mockito.`when`(StorageOperations.duplicateFile(lookDataFileMock))
+            .thenThrow(IOException::class.java)
+        lookData.file = lookDataFileMock
+
         with(Sprite()) {
             this.lookList.add(lookData)
             this.look.lookData = lookData
-            val setNewLookAction = actionFactory.createSetNextLookAction(this, testSequence)
-            val editLookAction = actionFactory.createEditLookAction(
+            this.isClone = true
+            val setNewLookAction = this.actionFactory.createSetNextLookAction(this, testSequence)
+            val editLookAction = this.actionFactory.createEditLookAction(
                 this, testSequence, setNewLookAction as SetNextLookAction) as EditLookAction
+            editLookAction.protectOriginalLookData()
             editLookAction.setLookData()
-            Assert.assertEquals(lookDataFileEdited, this.lookList[0].file)
+            Assert.assertEquals(lookDataFileMock, this.look.lookData.file)
         }
     }
 }


### PR DESCRIPTION
Fixed the problem that the original look file was deleted when a clone was created. The looks of clones are now independent of the look of the orignal sprite.
Also added some new tests.

https://jira.catrob.at/browse/CATROID-1058

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
