### PR TITLE
CATROID-1398 Userdefined brick copy bug

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserDefinedBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/UserDefinedBrick.java
@@ -100,11 +100,6 @@ public class UserDefinedBrick extends FormulaBrick {
 		return clone;
 	}
 
-	public void clearFormulaMaps() {
-		formulaFieldToTextViewMap = HashBiMap.create(2);
-		formulaMap = new ConcurrentFormulaHashMap();
-	}
-
 	private void copyUserDefinedDataList(UserDefinedBrick userDefinedBrick) {
 		this.userDefinedBrickDataList = new ArrayList<>();
 		for (UserDefinedBrickData data : userDefinedBrick.getUserDefinedBrickDataList()) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/BrickController.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/controller/BrickController.java
@@ -54,9 +54,6 @@ public final class BrickController {
 				try {
 					if (!bricksToCopy.contains(brick.getParent())) {
 						script.addBrick(brick.clone());
-						if (brick instanceof UserDefinedBrick) {
-							((UserDefinedBrick) brick).clearFormulaMaps();
-						}
 					}
 				} catch (CloneNotSupportedException e) {
 					Log.e(TAG, Log.getStackTraceString(e));


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1398
In BrickController in the "copy" function of bricks there was a if-Statement if the brick to clone is a UserDefined brick. If yes -> delete input formula of brick. I removed this if-Statement, because it doesn't make sense to delete the input formula.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
