### PR TITLE
Revert "Version increase for v1.1.0"

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -99,8 +99,8 @@ ext.copyGoogleServicesFile = { flavorName, flavorId ->
     }
 }
 
-def defaultVersionCode = 86
-def defaultVersionName = "1.1.0"
+def defaultVersionCode = 85
+def defaultVersionName = "1.0.3"
 
 android {
     compileSdkVersion 30


### PR DESCRIPTION
Reverts Catrobat/Catroid#4510

Reason: defaultVersionCode 86 was already consumed last year in a release attempt.