### PR TITLE
CATROID-1246 Fixed highlighting errors while parsing brackets

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
@@ -609,7 +609,8 @@ public class InternFormula {
 
 				bracketsInternTokensLastIndex = bracketsInternTokens.size() - 1;
 
-				startSelectionIndex = internTokenFormulaList.indexOf(bracketsInternTokens.get(0));
+				startSelectionIndex = internTokenFormulaList.indexOf(bracketsInternTokens
+						.get(bracketsInternTokensLastIndex));
 				endSelectionIndex = internTokenFormulaList.indexOf(bracketsInternTokens
 						.get(bracketsInternTokensLastIndex));
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaUtils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaUtils.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2018 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -254,6 +254,9 @@ public final class InternFormulaUtils {
 
 		do {
 			if (bracketsIndex >= internTokenList.size()) {
+				if (nestedBracketsCounter != 0) {
+					return bracketInternTokenListToReturn;
+				}
 				return null;
 			}
 			tempSearchToken = internTokenList.get(bracketsIndex);
@@ -292,6 +295,10 @@ public final class InternFormulaUtils {
 
 		do {
 			if (bracketSearchIndex < 0) {
+				if (nestedBracketsCounter != 0) {
+					Collections.reverse(bracketInternTokenListToReturn);
+					return bracketInternTokenListToReturn;
+				}
 				return null;
 			}
 			tempSearchToken = internTokenList.get(bracketSearchIndex);


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1246
Fixed the highlighting errors while parsing wrong parentheses. If bracketsIndex exceeds some threshold then additional check has to be made if the (nested) parentheses are _parallell_ -> so "(2-3))" should be invalid. 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
