### PR TITLE
CATROID-1413 Fix GMS Speech Recognition on Huawei Phones

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/ActionFactory.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/ActionFactory.java
@@ -1588,9 +1588,18 @@ public class ActionFactory extends Actions {
 	}
 
 	public Action createStartListeningAction(UserVariable userVariable) {
-		StartListeningAction action = Actions.action(StartListeningAction.class);
-		action.setUserVariable(userVariable);
-		return action;
+		// This is a fix to get the StartListeningBrick to work on Huawei Phones,
+		// can be changed once HMS is fully implemented and working
+		// As soon as this is the case, remove the if-statement and only use the else-branch
+		if (get(MobileServiceAvailability.class).isHmsAvailable(ProjectManager.getInstance().getApplicationContext())) {
+			AskSpeechAction action = Actions.action(AskSpeechAction.class);
+			action.setAnswerVariable(userVariable);
+			return action;
+		} else {
+			StartListeningAction action = Actions.action(StartListeningAction.class);
+			action.setUserVariable(userVariable);
+			return action;
+		}
 	}
 
 	public Action createSetListeningLanguageAction(String listeningLanguageTag) {


### PR DESCRIPTION
Fixed GMS for the StartListeningBrick on Huawei phones.
Since GMS for the AskSpeechBrick was already working, the same concept is now also used for the StartListeningBrick.
Since Huawei phones should be using HMS anyways once it's implemented, the applied fix should be redundant as soon as this is the case.
[Ticket](https://jira.catrob.at/browse/CATROID-1413)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
