### PR TITLE
CATROID-554 Data overview in formula editor becomes unusable

### DIFF
--- a/catroid/src/main/res/values/dimens.xml
+++ b/catroid/src/main/res/values/dimens.xml
@@ -64,7 +64,7 @@
     <dimen name="brick_space_padding_formular_editor">8dp</dimen>
     <dimen name="brick_top_space_padding_control">35dp</dimen>
     <dimen name="brick_space_padding">8dp</dimen>
-    <dimen name="data_view_space">100dp</dimen>
+    <dimen name="data_view_space">200dp</dimen>
     <dimen name="data_view_space_spinner_text">400dp</dimen>
     <dimen name="edit_text_baseline_spacing">10dp</dimen>
 


### PR DESCRIPTION
[CATROID-554](https://jira.catrob.at/browse/CATROID-554) 

Increased minWidth for DataView in Formula Editor.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
