### PR TITLE
CATROID-1399 Bluetooth export (.catrobat, .dst)

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/ExportLaunchers.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ExportLaunchers.kt
@@ -40,7 +40,7 @@ class ExportEmbroideryFileLauncher(
     override fun startActivity() {
         val fileUri = FileProvider.getUriForFile(activity, activity.packageName + ".fileProvider", file)
         val shareIntent = Intent(Intent.ACTION_SEND)
-        shareIntent.type = "application/octet-stream"
+        shareIntent.type = "text/*"
         shareIntent.putExtra(Intent.EXTRA_STREAM, fileUri)
         shareIntent.putExtra(Intent.EXTRA_SUBJECT, file.name)
 


### PR DESCRIPTION
MIME-Type "application/octet-stream" is by default not supported to Bluetooth sharing. (Usually depends on android version and OEM implementation)
Changing the MIME Type to "text/*" enables the option to share via Bluetooth.
Note: "application/octet-stream" is the correct MIME Type for .dst, but disables the option to share the files via Bluetooth on some devices.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
