### PR TITLE
CATROID-1422 Reverse "Keep original aspect ratio" project option

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/ProjectOptionsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/ProjectOptionsTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -96,9 +96,9 @@ import static androidx.test.espresso.intent.matcher.IntentMatchers.hasCategories
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtras;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasType;
+import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
 import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.isNotChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -293,7 +293,7 @@ public class ProjectOptionsTest {
 				.perform(click());
 
 		onView(withId(R.id.project_options_aspect_ratio))
-				.check(matches(isNotChecked()));
+				.check(matches(isChecked()));
 
 		pressBack();
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ProjectOptionsFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/ProjectOptionsFragment.kt
@@ -151,7 +151,7 @@ class ProjectOptionsFragment : Fragment() {
 
     private fun setupProjectAspectRatio() {
         binding.projectOptionsAspectRatio.apply {
-            isChecked = project?.screenMode == ScreenModes.STRETCH
+            isChecked = project?.screenMode == ScreenModes.MAXIMIZE
             setOnCheckedChangeListener { _, isChecked ->
                 handleAspectRatioChecked(isChecked)
             }
@@ -184,9 +184,9 @@ class ProjectOptionsFragment : Fragment() {
 
     private fun handleAspectRatioChecked(checked: Boolean) {
         project?.screenMode = if (checked) {
-            ScreenModes.STRETCH
-        } else {
             ScreenModes.MAXIMIZE
+        } else {
+            ScreenModes.STRETCH
         }
     }
 


### PR DESCRIPTION
The ON/OFF state of the slider for the "Keep original aspect ratio" project option was reversed. ON should correspond to a project in MAXIMIZE screen mode, OFF should correspond to a project in STRETCH mode.

This PR only changes the state of the switch, not the screen mode of the project, otherwise all existing projects would have their screen mode reversed since the project options screen was released only with version 1.1.2.

https://jira.catrob.at/browse/CATROID-1422

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
