### PR TITLE
CATROID-1419 [HIGH-PRIORITY] Crash with formulas in parameter fields of "Become focus point with x y flexibility"

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/ActionFactory.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/ActionFactory.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -583,9 +583,11 @@ public class ActionFactory extends Actions {
 		return Actions.action(ClearBackgroundAction.class);
 	}
 
-	public Action createSetCameraFocusPointAction(Sprite sprite, Formula horizontal,
-			Formula vertical) {
+	public Action createSetCameraFocusPointAction(Sprite sprite, SequenceAction sequence,
+			Formula horizontal, Formula vertical) {
 		SetCameraFocusPointAction action = action(SetCameraFocusPointAction.class);
+		Scope scope = new Scope(ProjectManager.getInstance().getCurrentProject(), sprite, sequence);
+		action.setScope(scope);
 		action.setSprite(sprite);
 		action.setHorizontal(horizontal);
 		action.setVertical(vertical);

--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/SetCameraFocusPointAction.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/SetCameraFocusPointAction.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -23,20 +23,22 @@
 package org.catrobat.catroid.content.actions
 
 import com.badlogic.gdx.scenes.scene2d.Action
+import org.catrobat.catroid.content.Scope
 import org.catrobat.catroid.content.Sprite
 import org.catrobat.catroid.formulaeditor.Formula
 import org.catrobat.catroid.stage.StageActivity
 
 class SetCameraFocusPointAction : Action() {
     var sprite: Sprite? = null
+    var scope: Scope? = null
     var horizontal: Formula? = null
     var vertical: Formula? = null
 
     override fun act(delta: Float): Boolean {
         StageActivity.stageListener.cameraPositioner.horizontalFlex =
-            horizontal?.interpretFloat(null) ?: 0.0f
+            horizontal?.interpretFloat(scope) ?: 0.0f
         StageActivity.stageListener.cameraPositioner.verticalFlex =
-            vertical?.interpretFloat(null) ?: 0.0f
+            vertical?.interpretFloat(scope) ?: 0.0f
         StageActivity.stageListener.cameraPositioner.spriteToFocusOn = sprite
         return true
     }

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetCameraFocusPointBrick.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/SetCameraFocusPointBrick.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2021 The Catrobat Team
+ * Copyright (C) 2010-2022 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -52,7 +52,7 @@ class SetCameraFocusPointBrick : FormulaBrick() {
     override fun addActionToSequence(sprite: Sprite, sequence: ScriptSequenceAction) {
         sequence.addAction(
                 sprite.actionFactory.createSetCameraFocusPointAction(
-                        sprite,
+                        sprite, sequence,
                         getFormulaWithBrickField(BrickField.HORIZONTAL_FLEXIBILITY),
                         getFormulaWithBrickField(BrickField.VERTICAL_FLEXIBILITY)
                 )

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetCameraFocusPointActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/SetCameraFocusPointActionTest.java
@@ -1,0 +1,99 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2022 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.content.actions;
+
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.scenes.scene2d.Action;
+import com.badlogic.gdx.utils.GdxNativesLoader;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.ActionFactory;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.WhenScript;
+import org.catrobat.catroid.content.actions.ScriptSequenceAction;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.stage.CameraPositioner;
+import org.catrobat.catroid.stage.StageActivity;
+import org.catrobat.catroid.stage.StageListener;
+import org.catrobat.catroid.test.MockUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static junit.framework.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GdxNativesLoader.class})
+public class SetCameraFocusPointActionTest {
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	private String projectName = "testProject";
+	private Project project;
+	private Sprite sprite;
+
+	@Before
+	public void setUp() {
+		project = new Project(MockUtil.mockContextForProject(), projectName);
+		sprite = new Sprite("sprite");
+		sprite.addScript(new WhenScript());
+		project.getDefaultScene().addSprite(sprite);
+		ProjectManager.getInstance().setCurrentProject(project);
+
+		PowerMockito.mockStatic(GdxNativesLoader.class);
+		StageActivity.stageListener = Mockito.mock(StageListener.class);
+
+		int virtualWidth = project.getXmlHeader().virtualScreenWidth;
+		int virtualHeight = project.getXmlHeader().virtualScreenHeight;
+
+		int virtualWidthHalf = virtualWidth / 2;
+		int virtualHeightHalf = virtualHeight / 2;
+
+		OrthographicCamera camera = new OrthographicCamera();
+		CameraPositioner cameraPositioner = new CameraPositioner(camera, virtualHeightHalf, virtualWidthHalf);
+		StageActivity.stageListener.cameraPositioner = cameraPositioner;
+	}
+
+	@Test
+	public void testSetCameraFocusPoint() {
+		Float horizontalValue = 15f;
+		Float verticalValue = 10f;
+		ActionFactory factory = sprite.getActionFactory();
+		Formula horizontal = new Formula(horizontalValue);
+		Formula vertical = new Formula(verticalValue);
+		ScriptSequenceAction sequenceAction = new ScriptSequenceAction(sprite.getScript(0));
+		Action action = factory.createSetCameraFocusPointAction(sprite, sequenceAction, horizontal, vertical);
+		action.act(1.0f);
+
+		assertEquals(StageActivity.stageListener.cameraPositioner.getHorizontalFlex(), horizontalValue);
+		assertEquals(StageActivity.stageListener.cameraPositioner.getVerticalFlex(), verticalValue);
+	}
+}


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1419

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
