### PR TITLE
CATROID-1223 Implemented done and play button in Formula Editor

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ChangeVariableTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ChangeVariableTest.java
@@ -47,7 +47,10 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.hasSibling;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
@@ -133,6 +136,10 @@ public class ChangeVariableTest {
 				.performAdd(variableName)
 				.performClose();
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 	}
 
 	public void createProject() {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/InsertItemToUserListTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/InsertItemToUserListTest.java
@@ -50,7 +50,11 @@ import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorW
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class InsertItemToUserListTest {
@@ -96,6 +100,10 @@ public class InsertItemToUserListTest {
 				.performAdd(userListName, FormulaEditorDataListWrapper.ItemType.LIST)
 				.performClose();
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onBrickAtPosition(brickPosition)
 				.onFormulaTextField(R.id.brick_insert_item_into_userlist_value_edit_text)
@@ -118,6 +126,10 @@ public class InsertItemToUserListTest {
 				.performEnterNumber(indexToInsert + 1);
 
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onBrickAtPosition(brickPosition)
 				.onFormulaTextField(R.id.brick_insert_item_into_userlist_value_edit_text)

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ReplaceItemInUserListTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ReplaceItemInUserListTest.java
@@ -48,6 +48,7 @@ import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -90,6 +91,10 @@ public class ReplaceItemInUserListTest {
 		onDataList()
 				.performClose();
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onBrickAtPosition(brickPosition).onChildView(withId(R.id.replace_item_in_userlist_spinner))
 				.perform(click());
@@ -116,6 +121,10 @@ public class ReplaceItemInUserListTest {
 				.performAdd(userListName, FormulaEditorDataListWrapper.ItemType.LIST)
 				.performClose();
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onBrickAtPosition(brickPosition).onVariableSpinner(R.id.replace_item_in_userlist_spinner)
 				.perform(click());

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/SetVariableBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/SetVariableBrickTest.java
@@ -53,6 +53,7 @@ import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withChild;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -99,6 +100,10 @@ public class SetVariableBrickTest {
 		onDataList()
 				.performClose();
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onView(withText(userVariableName))
 				.check(doesNotExist());
@@ -117,6 +122,10 @@ public class SetVariableBrickTest {
 		addNewVariableViaFormulaEditor(1, userVariableName);
 
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onBrickAtPosition(1).onVariableSpinner(R.id.set_variable_spinner)
 				.performNewVariable(userVariableNameTwo);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ShowTextColorSizeAlignmentBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ShowTextColorSizeAlignmentBrickTest.java
@@ -54,6 +54,7 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -136,6 +137,10 @@ public class ShowTextColorSizeAlignmentBrickTest {
 		onFormulaEditor()
 				.performEnterFormula("1+2");
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		onView(withId(R.id.brick_show_variable_color_size_edit_color))
 				.perform(click());
 		onFormulaEditor()

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/VisualPlacementBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/VisualPlacementBrickTest.java
@@ -69,6 +69,7 @@ import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -182,6 +183,10 @@ public class VisualPlacementBrickTest {
 		onFormulaEditor()
 				.performEnterNumber(42);
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		isPlaceVisuallyEditFormulaChooserShownWithTapOnEditText(brick.getXEditTextId());
 	}
 
@@ -258,6 +263,10 @@ public class VisualPlacementBrickTest {
 		onFormulaEditor()
 				.performEnterFormula(formula);
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 	}
 
 	private void openVisualPlacementActivityFromEditTextX() {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorEditTextTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorEditTextTest.java
@@ -56,6 +56,7 @@ import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.doubleClick;
 import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -131,6 +132,10 @@ public class FormulaEditorEditTextTest {
 		onFormulaEditor()
 				.performClickOn(BACKSPACE);
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		onToast(withText(R.string.formula_editor_parse_fail))
 				.check(matches(isDisplayed()));
 		onView(isRoot()).perform(CustomActions.wait(3000));
@@ -144,6 +149,10 @@ public class FormulaEditorEditTextTest {
 		onFormulaEditor()
 				.performEnterFormula("1+1+");
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		onToast(withText(R.string.formula_editor_parse_fail))
 				.check(matches(isDisplayed()));
 		onView(isRoot()).perform(CustomActions.wait(3000));
@@ -157,6 +166,10 @@ public class FormulaEditorEditTextTest {
 		onFormulaEditor()
 				.performEnterFormula("+");
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		onToast(withText(R.string.formula_editor_parse_fail))
 				.check(matches(isDisplayed()));
 		onView(isRoot()).perform(CustomActions.wait(3000));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentTest.java
@@ -55,6 +55,7 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -83,6 +84,10 @@ public class FormulaEditorFragmentTest {
 		onFormulaEditor()
 				.performEnterNumber(0);
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
 				.perform(click());
 		onFormulaEditor()
@@ -98,6 +103,10 @@ public class FormulaEditorFragmentTest {
 		onFormulaEditor()
 				.performEnterFormula("3+");
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		UiTestUtils.onToast(withText(R.string.formula_editor_parse_fail))
 				.check(matches(isDisplayed()));
 		onView(withText(R.string.formula_editor_title))
@@ -119,6 +128,10 @@ public class FormulaEditorFragmentTest {
 		onFormulaEditor()
 				.performUndo();
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText("12 ")));
 	}
@@ -135,6 +148,10 @@ public class FormulaEditorFragmentTest {
 		onFormulaEditor()
 				.performBackspace();
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText("12 ")));
 	}
@@ -151,6 +168,10 @@ public class FormulaEditorFragmentTest {
 		onFormulaEditor()
 				.performRedo();
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText("12 ")));
 	}
@@ -175,7 +196,6 @@ public class FormulaEditorFragmentTest {
 
 		ProjectManager.getInstance().setCurrentProject(project);
 		ProjectManager.getInstance().setCurrentSprite(sprite);
-
 		return project;
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorKeyboardTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorKeyboardTest.java
@@ -49,6 +49,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -60,6 +61,10 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -75,6 +80,7 @@ public class FormulaEditorKeyboardTest {
 
 	@Before
 	public void setUp() throws Exception {
+		Intents.init();
 		createProject();
 		baseActivityTestRule.launchActivity();
 	}
@@ -88,6 +94,10 @@ public class FormulaEditorKeyboardTest {
 				.performEnterNumber(1234567890.1);
 
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText("1234567890"
@@ -108,6 +118,10 @@ public class FormulaEditorKeyboardTest {
 		onFormulaEditor().performEnterFormula("1");
 
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText("( 1 ) + 1 - 1 × 1 ÷ 1 = 1 ")));
@@ -123,6 +137,10 @@ public class FormulaEditorKeyboardTest {
 				.performEnterString("Foo");
 
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText("'Foo' ")));
@@ -157,6 +175,10 @@ public class FormulaEditorKeyboardTest {
 		onFormulaEditor()
 				.performEnterFormula("+2");
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		onView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText(activity.getString(R.string.formula_editor_sensor_x_acceleration) + " + 2 ")));
 	}
@@ -178,8 +200,16 @@ public class FormulaEditorKeyboardTest {
 		onView(withId(R.id.brick_set_variable_edit_text)).check(matches(withText("'#0074CD' ")));
 	}
 
+	@Test
+	public void doneButtonTest() {
+		onView(withId(R.id.brick_set_variable_edit_text)).perform(click());
+		onView(withId(R.id.formula_editor_keyboard_done)).perform(click());
+		intended(hasComponent(SpriteActivity.class.getName()));
+	}
+
 	@After
 	public void tearDown() throws IOException {
+		Intents.release();
 		baseActivityTestRule.finishActivity();
 		TestUtils.deleteProjects(PROJECT_NAME);
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorRevertChangesDialogTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorRevertChangesDialogTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2022 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.formulaeditor
+
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.content.bricks.PlaceAtBrick
+import org.catrobat.catroid.content.bricks.SetVariableBrick
+import org.catrobat.catroid.formulaeditor.Formula
+import org.catrobat.catroid.formulaeditor.UserVariable
+import org.catrobat.catroid.test.utils.TestUtils
+import org.catrobat.catroid.testsuites.annotations.Cat.AppUi
+import org.catrobat.catroid.testsuites.annotations.Level.Smoke
+import org.catrobat.catroid.ui.SpriteActivity
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils
+import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorDataListWrapper
+import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class FormulaEditorRevertChangesDialogTest {
+    private var brickPosition = 0
+
+    private val VARIABLE_NAME = "TestVariable"
+    private val NEW_VARIABLE_NAME = "TestVariableNew"
+    private val VARIABLE_VALUE = 5
+
+    var userVariable: UserVariable? = null
+
+    @get:Rule
+    var baseActivityTestRule: FragmentActivityTestRule<SpriteActivity> =
+        FragmentActivityTestRule<SpriteActivity>(
+            SpriteActivity::class.java,
+            SpriteActivity.EXTRA_FRAGMENT_POSITION,
+            SpriteActivity.FRAGMENT_SCRIPTS
+        )
+
+    @After
+    @Throws(Exception::class)
+    fun tearDown() {
+        TestUtils.deleteProjects(FormulaEditorRevertChangesDialogTest::class.java.name)
+    }
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        brickPosition = 1
+        val script: org.catrobat.catroid.content.Script =
+            BrickTestUtils.createProjectAndGetStartScript(
+                FormulaEditorRevertChangesDialogTest::class.java.name
+            )
+        script.addBrick(PlaceAtBrick())
+        userVariable =
+            UserVariable(VARIABLE_NAME, VARIABLE_VALUE)
+        ProjectManager.getInstance().getCurrentProject().addUserVariable(userVariable)
+        script.addBrick(SetVariableBrick(Formula(0), userVariable))
+        baseActivityTestRule.launchActivity()
+    }
+
+    @Category(AppUi::class, Smoke::class)
+    @Test
+    fun testRevertChangesDialogAppears() {
+        BrickDataInteractionWrapper.onBrickAtPosition(brickPosition)
+            .checkShowsText(R.string.brick_place_at)
+        onView(withId(R.id.brick_place_at_edit_text_x))
+            .perform(ViewActions.click())
+        onView(withText(R.string.brick_context_dialog_formula_edit_brick))
+            .perform(ViewActions.click())
+        FormulaEditorWrapper.onFormulaEditor()
+            .performOpenDataFragment()
+        FormulaEditorDataListWrapper.onDataList().onVariableAtPosition(0)
+            .performRename(NEW_VARIABLE_NAME)
+
+        FormulaEditorDataListWrapper.onDataList()
+            .performClose()
+
+        Espresso.pressBack()
+        onView(withText(R.string.formula_editor_discard_changes_dialog_title))
+            .inRoot(RootMatchers.isDialog())
+            .check(matches(ViewMatchers.isDisplayed()))
+    }
+    @Category(AppUi::class, Smoke::class)
+    @Test
+    fun testRevertChangesDialogDoesNotAppear() {
+
+        BrickDataInteractionWrapper.onBrickAtPosition(brickPosition)
+            .checkShowsText(R.string.brick_place_at)
+
+        onView(withId(R.id.brick_place_at_edit_text_x))
+            .perform(ViewActions.click())
+        onView(withText(R.string.brick_context_dialog_formula_edit_brick))
+            .perform(ViewActions.click())
+
+        Espresso.pressBack()
+        onView(withText(R.string.formula_editor_discard_changes_dialog_title))
+            .check(doesNotExist())
+    }
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorTouchesActorOrObjectTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorTouchesActorOrObjectTest.kt
@@ -31,6 +31,9 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.RootMatchers
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.runner.AndroidJUnit4
@@ -122,6 +125,10 @@ class FormulaEditorTouchesActorOrObjectTest {
         onFormulaEditor().checkShows(generateFormulaString())
 
         pressBack()
+        onView(withText(R.string.yes))
+            .inRoot(RootMatchers.isDialog())
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+            .perform(click())
         pressBack()
         pressBack()
         pressBack()

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUndoTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUndoTest.java
@@ -49,6 +49,7 @@ import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInter
 import static org.catrobat.catroid.uiespresso.content.brick.utils.ColorPickerInteractionWrapper.onColorPickerPresetButton;
 import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorDataListWrapper.onDataList;
 import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -59,7 +60,9 @@ import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
@@ -113,6 +116,11 @@ public class FormulaEditorUndoTest {
 				.performEnterFormula("745");
 
 		pressBack();
+
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onView(withId(R.id.menu_undo))
 				.check(matches(isDisplayed()));
@@ -184,6 +192,10 @@ public class FormulaEditorUndoTest {
 				.performEnterFormula("0");
 
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onView(withId(R.id.menu_undo))
 				.check(doesNotExist());
@@ -217,6 +229,11 @@ public class FormulaEditorUndoTest {
 
 		pressBack();
 
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
+
 		onView(withId(R.id.menu_undo))
 				.check(matches(isDisplayed()));
 
@@ -245,6 +262,11 @@ public class FormulaEditorUndoTest {
 
 		pressBack();
 
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
+
 		onView(withId(R.id.menu_undo))
 				.check(matches(isDisplayed()));
 
@@ -271,6 +293,11 @@ public class FormulaEditorUndoTest {
 				.performClose();
 
 		pressBack();
+
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onView(withId(R.id.menu_undo))
 				.check(matches(isDisplayed()));
@@ -302,11 +329,13 @@ public class FormulaEditorUndoTest {
 		onDataList().onVariableAtPosition(0)
 				.performRename(NEW_VARIABLE_NAME);
 
-		onDataList()
-				.performClose();
+		pressBack();
+		pressBack();
 
-		pressBack();
-		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onView(withId(R.id.menu_undo))
 				.check(matches(isDisplayed()));
@@ -317,11 +346,11 @@ public class FormulaEditorUndoTest {
 		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(NEW_VARIABLE_NAME).getValue(), VARIABLE_VALUE);
 
 		onView(withId(R.id.menu_undo))
+				.check(matches(isDisplayed()))
 				.perform(click());
 		userVariable.setName(VARIABLE_NAME);
 		onView(withId(R.id.menu_undo))
-				.check(doesNotExist());
-
+				.check(matches(not(isEnabled())));
 		assertNull(ProjectManager.getInstance().getCurrentProject().getUserVariable(NEW_VARIABLE_NAME));
 		assertNotNull(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME));
 		assertEquals(ProjectManager.getInstance().getCurrentProject().getUserVariable(VARIABLE_NAME), userVariable);
@@ -349,6 +378,10 @@ public class FormulaEditorUndoTest {
 
 		pressBack();
 
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		onView(withId(R.id.menu_undo))
 				.check(matches(isDisplayed()));
 
@@ -390,6 +423,11 @@ public class FormulaEditorUndoTest {
 
 		pressBack();
 
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
+
 		onBrickAtPosition(2)
 				.onSpinner(R.id.set_variable_spinner)
 				.checkShowsText(R.string.new_option);
@@ -428,6 +466,11 @@ public class FormulaEditorUndoTest {
 				.perform(click());
 
 		pressBack();
+
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 
 		onView(withId(R.id.brick_place_at_edit_text_x))
 				.check(matches(withText("'#0074CD' ")));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUserDefinedBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUserDefinedBrickTest.java
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.uiespresso.formulaeditor;
 
+import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.UserDefinedBrick;
@@ -48,7 +49,13 @@ import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorW
 
 import static java.util.Arrays.asList;
 
+import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class FormulaEditorUserDefinedBrickTest {
@@ -79,6 +86,10 @@ public class FormulaEditorUserDefinedBrickTest {
 		clickOnFormulaField(input.getInputFormulaField());
 		onFormulaEditor().performEnterFormula("1234");
 		pressBack();
+		onView(withText(R.string.yes))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
 		assertEquals("200 ", getValueOfFormulaField(secondInput.getInputFormulaField()));
 		assertEquals("1234 ", getValueOfFormulaField(input.getInputFormulaField()));
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/SpriteActivity.java
@@ -299,7 +299,7 @@ public class SpriteActivity extends BaseActivity {
 				return;
 			}
 		} else if (currentFragment instanceof FormulaEditorFragment) {
-			((FormulaEditorFragment) currentFragment).exitFormulaEditorFragment();
+			((FormulaEditorFragment) currentFragment).revertChangesDialog();
 			return;
 		} else if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -65,8 +65,10 @@ import org.catrobat.catroid.content.strategy.ShowFormulaEditorStrategy;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaEditorEditText;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.catrobat.catroid.formulaeditor.InternFormula;
 import org.catrobat.catroid.formulaeditor.InternFormulaKeyboardAdapter;
 import org.catrobat.catroid.formulaeditor.InternFormulaParser;
+import org.catrobat.catroid.formulaeditor.InternFormulaState;
 import org.catrobat.catroid.formulaeditor.SensorHandler;
 import org.catrobat.catroid.formulaeditor.UndoState;
 import org.catrobat.catroid.formulaeditor.UserData;
@@ -99,6 +101,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
@@ -352,6 +355,9 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 					view.setPressed(true);
 
 					switch (view.getId()) {
+						case R.id.formula_editor_keyboard_done:
+							exitFormulaEditorFragment();
+							return true;
 						case R.id.formula_editor_keyboard_compute:
 							showComputeDialog();
 							return true;
@@ -892,6 +898,38 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		}
 
 		return false;
+	}
+
+	public void revertChangesDialog() {
+		ScriptFragment fragment = (ScriptFragment) getActivity().getSupportFragmentManager().findFragmentByTag(ScriptFragment.TAG);
+		if (hasFormulaBeenChanged || formulaEditorEditText.hasChanges()
+				|| hasFileChanged() || fragment.checkVariables()) {
+			AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+			builder.setTitle(R.string.formula_editor_discard_changes_dialog_title)
+					.setMessage(R.string.formula_editor_discard_changes_dialog_message)
+					.setNegativeButton(R.string.no, (dialog, which) -> {
+						Map<Brick.FormulaField, InternFormulaState> initialStates = formulaEditorEditText
+								.getHistory().getInitialStates();
+						restoreInitialStates(initialStates);
+						ToastUtil.showError(getActivity(), R.string.formula_editor_changes_discarded);
+						onUserDismiss();
+					})
+					.setPositiveButton(R.string.yes, (dialog, which) -> {
+						exitFormulaEditorFragment();
+					})
+					.create()
+					.show();
+		} else {
+			exitFormulaEditorFragment();
+		}
+	}
+
+	private void restoreInitialStates(Map<Brick.FormulaField, InternFormulaState> initialStates) {
+		for (Map.Entry<Brick.FormulaField, InternFormulaState> state : initialStates.entrySet()) {
+			InternFormula internFormula = state.getValue().createInternFormulaFromState();
+			formulaBrick.setFormulaWithBrickField(state.getKey(),
+					new Formula(internFormula.getInternFormulaParser().parseFormula(generateScope())));
+		}
 	}
 
 	public void exitFormulaEditorFragment() {

--- a/catroid/src/main/res/drawable/outline_done_24.xml
+++ b/catroid/src/main/res/drawable/outline_done_24.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2022 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/solid_black">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>
+</vector>

--- a/catroid/src/main/res/drawable/outline_play_circle_filled_24.xml
+++ b/catroid/src/main/res/drawable/outline_play_circle_filled_24.xml
@@ -22,17 +22,13 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:state_pressed="false">
-        <shape>
-            <solid android:color="@color/formula_editor_compute_button" />
-        </shape>
-    </item>
-    <item android:state_pressed="true">
-        <shape>
-            <solid android:color="@color/formula_editor_compute_button_pressed" />
-        </shape>
-    </item>
-
-</selector>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/solid_black">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,16.5v-9l6,4.5 -6,4.5z"/>
+</vector>

--- a/catroid/src/main/res/layout/formula_editor_keyboard.xml
+++ b/catroid/src/main/res/layout/formula_editor_keyboard.xml
@@ -235,11 +235,22 @@
             android:layout_span="1"
             android:text="@string/formula_editor_decimal_mark" />
 
-        <Button
+        <ImageButton
             android:id="@+id/formula_editor_keyboard_compute"
-            style="@style/FormulaEditorComputeButton"
-            android:layout_span="2"
-            android:text="@string/formula_editor_compute" />
+            style="@style/FormulaEditorKeyboardButton"
+            android:layout_span="1"
+            android:contentDescription="@string/formula_editor_image_button_description_compute"
+            android:src="@drawable/outline_play_circle_filled_24"
+            android:layout_marginStart="@dimen/key_margin" />
+
+        <ImageButton
+            android:id="@+id/formula_editor_keyboard_done"
+            style="@style/FormulaEditorKeyboardButton"
+            android:layout_span="1"
+            android:contentDescription="@string/formula_editor_image_button_description_done"
+            android:src="@drawable/outline_done_24"
+            android:layout_marginStart="@dimen/key_margin" />
+
 
     </TableRow>
 </TableLayout>

--- a/catroid/src/main/res/values-sr/strings.xml
+++ b/catroid/src/main/res/values-sr/strings.xml
@@ -1594,7 +1594,6 @@
     <string name="formula_editor_false">false</string>
     <string name="formula_editor_decimal_mark">.</string>
     <string name="formula_editor_title">Formula editor</string>
-    <string name="formula_editor_changes_saved">Changes saved.</string>
     <string name="formula_editor_changes_discarded">Changes discarded!</string>
     <string name="formula_editor_parse_fail">Formula is not valid!</string>
     <string name="formula_nothing_selected">Define input value</string>

--- a/catroid/src/main/res/values-v25/styles.xml
+++ b/catroid/src/main/res/values-v25/styles.xml
@@ -546,11 +546,6 @@
         <item name="android:layout_below">@+id/formula_editor_keyboard_decimal_mark</item>
     </style>
 
-     <style name="FormulaEditorComputeButton" parent="@style/FormulaEditorButton">
-        <item name="android:background">@drawable/formula_editor_compute_button_selector</item>
-        <item name="android:textColor">@color/formula_editor_compute_text</item>
-    </style>
-
     <style name="FormulaEditorDeleteButton" parent="@style/FormulaEditorButton">
         <item name="android:background">@drawable/formula_editor_delete_button_selector</item>
     </style>

--- a/catroid/src/main/res/values-vi/strings.xml
+++ b/catroid/src/main/res/values-vi/strings.xml
@@ -1701,7 +1701,6 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_object_background_name">background name</string>
     <string name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string name="formula_editor_object_distance_to">distance to touch position</string>
-    <string name="formula_editor_compute">Tính toán</string>
     <string name="formula_editor_object">Đối tượng</string>
     <string name="formula_editor_functions">Functions</string>
     <string name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-zh-rCN/strings.xml
+++ b/catroid/src/main/res/values-zh-rCN/strings.xml
@@ -1676,7 +1676,6 @@ dash(-), 下划线 (_), 和 句号(.).</string>
     <string name="formula_editor_object_background_name">背景名称</string>
     <string name="formula_editor_object_number_of_backgrounds">背景数</string>
     <string name="formula_editor_object_distance_to">到目标的距离</string>
-    <string name="formula_editor_compute">计算</string>
     <string name="formula_editor_object">对象</string>
     <string name="formula_editor_functions">函数</string>
     <string name="formula_editor_logic">逻辑</string>

--- a/catroid/src/main/res/values-zh-rTW/strings.xml
+++ b/catroid/src/main/res/values-zh-rTW/strings.xml
@@ -1698,7 +1698,6 @@
     <string name="formula_editor_object_background_name">背景名稱</string>
     <string name="formula_editor_object_number_of_backgrounds">背景數量</string>
     <string name="formula_editor_object_distance_to">到觸摸位置的距離</string>
-    <string name="formula_editor_compute">計算</string>
     <string name="formula_editor_object">物件</string>
     <string name="formula_editor_functions">職能</string>
     <string name="formula_editor_logic">邏輯</string>

--- a/catroid/src/main/res/values/colors.xml
+++ b/catroid/src/main/res/values/colors.xml
@@ -52,9 +52,6 @@
     <color name="action_button">#ffab08</color>
 
     <!-- Formula Editor Colors -->
-    <color name="formula_editor_compute_button">#D3D3D3</color>
-    <color name="formula_editor_compute_button_pressed">#A9A9A9</color>
-    <color name="formula_editor_compute_text">#242424</color>
     <color name="formula_editor_delete_button">#E9E9E9</color>
     <color name="formula_editor_delete_button_pressed">#A9A9A9</color>
     <color name="formula_editor_delete_icon">#242424</color>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1937,7 +1937,6 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_object_background_name">background name</string>
     <string name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string name="formula_editor_object_distance_to">distance to touch position</string>
-    <string name="formula_editor_compute">Compute</string>
     <string name="formula_editor_object">Properties</string>
     <string name="formula_editor_functions">Functions</string>
     <string name="formula_editor_logic">Logic</string>
@@ -1981,6 +1980,8 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_operator_power">^</string>
     <string name="formula_editor_image_button_description_delete">delete</string>
     <string name="formula_editor_image_button_description_color_picker">color picker</string>
+    <string name="formula_editor_image_button_description_done">done button</string>
+    <string name="formula_editor_image_button_description_compute">play button</string>
     <string name="formula_editor_image_button_description_functions_toggle">toggle functions</string>
     <string name="formula_editor_variable_dialog_title">New variable</string>
     <string name="formula_editor_list_dialog_title">New list</string>

--- a/catroid/src/main/res/values/styles.xml
+++ b/catroid/src/main/res/values/styles.xml
@@ -538,11 +538,6 @@
         <item name="android:layout_below">@+id/formula_editor_keyboard_decimal_mark</item>
     </style>
 
-     <style name="FormulaEditorComputeButton" parent="@style/FormulaEditorButton">
-        <item name="android:background">@drawable/formula_editor_compute_button_selector</item>
-        <item name="android:textColor">@color/formula_editor_compute_text</item>
-    </style>
-
     <style name="FormulaEditorDeleteButton" parent="@style/FormulaEditorButton">
         <item name="android:background">@drawable/formula_editor_delete_button_selector</item>
     </style>


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1223
Implemented "done" and "play" button in Formula Editor. Replaced "compute" button with these 2 buttons.
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
