### PR TITLE
IDE-14 XML issue with WhenBounceOff-Brick (Catblocks related)

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/WhenBounceOffScript.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/WhenBounceOffScript.java
@@ -31,7 +31,7 @@ import org.catrobat.catroid.content.eventids.EventId;
 public class WhenBounceOffScript extends Script {
 
 	private static final long serialVersionUID = 1L;
-	private String spriteToBounceOffName;
+	private String spriteToBounceOffName = "";
 
 	private transient Sprite spriteToBounceOff;
 
@@ -39,7 +39,11 @@ public class WhenBounceOffScript extends Script {
 	}
 
 	public WhenBounceOffScript(String spriteToBounceOffName) {
-		this.spriteToBounceOffName = spriteToBounceOffName;
+		if(spriteToBounceOffName == null) {
+			this.spriteToBounceOffName = "";
+		} else {
+			this.spriteToBounceOffName = spriteToBounceOffName;
+		}
 	}
 
 	@Override
@@ -51,21 +55,26 @@ public class WhenBounceOffScript extends Script {
 	}
 
 	public String getSpriteToBounceOffName() {
+		if(spriteToBounceOffName.isEmpty()) {
+			return null;
+		}
 		return spriteToBounceOffName;
 	}
 
 	public void setSpriteToBounceOffName(String spriteToCollideWithName) {
-		this.spriteToBounceOffName = spriteToCollideWithName;
+		if(spriteToCollideWithName == null) {
+			this.spriteToBounceOffName = "";
+		} else {
+			this.spriteToBounceOffName = spriteToCollideWithName;
+		}
 		updateSpriteToCollideWith(ProjectManager.getInstance().getCurrentlyEditedScene());
 	}
 
 	public void updateSpriteToCollideWith(Scene scene) {
-		if (spriteToBounceOffName == null) {
-			spriteToBounceOffName = null;
-		} else {
+		if(!spriteToBounceOffName.isEmpty()){
 			spriteToBounceOff = scene.getSprite(spriteToBounceOffName);
 			if (spriteToBounceOff == null) {
-				spriteToBounceOffName = null;
+				spriteToBounceOffName = "";
 			}
 		}
 	}


### PR DESCRIPTION
https://jira.catrob.at/browse/IDE-14 (ticket was moved / renamed)

Null values aren't serialized so they are basically missing in the XML. Changed the string to be class internally empty. To dont have confilcts with access from other code parts the getter methods are transformed to retunr null values if the string is empty. This is necessary because other code parts are calculating with "If spriteName == null ..." and do actions based on this null check.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
