### PR TITLE
CATROID-1407 PenLines don't work if screenMode is changed to STRETCH

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/PenScreenModeTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/stage/PenScreenModeTest.java
@@ -1,0 +1,124 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2022 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.stage;
+
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.ScreenModes;
+import org.catrobat.catroid.common.ScreenValues;
+import org.catrobat.catroid.content.Project;
+import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.StartScript;
+import org.catrobat.catroid.content.bricks.MoveNStepsBrick;
+import org.catrobat.catroid.content.bricks.PenDownBrick;
+import org.catrobat.catroid.content.bricks.PenUpBrick;
+import org.catrobat.catroid.content.bricks.PlaceAtBrick;
+import org.catrobat.catroid.content.bricks.SetPenColorBrick;
+import org.catrobat.catroid.content.bricks.SetPenSizeBrick;
+import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.io.XstreamSerializer;
+import org.catrobat.catroid.stage.StageActivity;
+import org.catrobat.catroid.uiespresso.util.matchers.StageMatchers;
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityTestRule;
+import org.catrobat.catroid.utils.ScreenValueHandler;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isFocusable;
+
+@RunWith(AndroidJUnit4.class)
+public class PenScreenModeTest {
+
+	private static final int PROJECT_WIDTH = 480;
+	private static final int PROJECT_HEIGHT = 800;
+
+	Project project;
+	byte[] colorToCheck = {0, (byte) 0, (byte) 255, (byte) 255};
+
+	@Rule
+	public BaseActivityTestRule<StageActivity> baseActivityTestRule = new
+			BaseActivityTestRule<>(StageActivity.class, true, false);
+
+	@Before
+	public void setUp() throws Exception {
+		project = createProject("penStretchProject");
+	}
+
+	@Test
+	public void checkForPenLineStretch() {
+		project.setScreenMode(ScreenModes.STRETCH);
+
+		baseActivityTestRule.launchActivity(null);
+
+		onView(isFocusable()).check(matches(StageMatchers.isColorAtPx(colorToCheck, 100, 100)));
+	}
+
+	@Test
+	public void checkForPenLineMaximize() {
+		project.setScreenMode(ScreenModes.MAXIMIZE);
+
+		baseActivityTestRule.launchActivity(null);
+
+		onView(isFocusable()).check(matches(StageMatchers.isColorAtPx(colorToCheck, 100, 100)));
+	}
+
+	public Project createProject(String projectName) throws IOException {
+		ScreenValues.SCREEN_HEIGHT = PROJECT_HEIGHT;
+		ScreenValues.SCREEN_WIDTH = PROJECT_WIDTH;
+
+		Project project = new Project(ApplicationProvider.getApplicationContext(), projectName);
+
+		Sprite sprite = new Sprite("penSprite");
+		StartScript startScript = new StartScript();
+
+		startScript.addBrick(new PlaceAtBrick(0, 0));
+		startScript.addBrick(new SetPenSizeBrick(10000));
+		startScript.addBrick(new SetPenColorBrick(new Formula(0), new Formula(0),
+				new Formula(255)));
+		startScript.addBrick(new PenDownBrick());
+		startScript.addBrick(new MoveNStepsBrick(300));
+		startScript.addBrick(new PenUpBrick());
+		sprite.addScript(startScript);
+
+		project.getDefaultScene().addSprite(sprite);
+
+		XstreamSerializer.getInstance().saveProject(project);
+
+		XstreamSerializer.getInstance().saveProject(project);
+		ProjectManager.getInstance().setCurrentProject(project);
+		ProjectManager.getInstance().setCurrentSprite(sprite);
+		ScreenValueHandler.updateScreenWidthAndHeight(InstrumentationRegistry.getInstrumentation().getContext());
+
+		return project;
+	}
+}

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -189,6 +189,8 @@ public class StageListener implements ApplicationListener {
 		} else {
 			stage.getRoot().clear();
 		}
+		screenshotWidth = ScreenValues.getScreenWidthForProject(project);
+		screenshotHeight = ScreenValues.getScreenHeightForProject(project);
 		initScreenMode();
 		initStageInputListener();
 		screenshotSaver = new ScreenshotSaver(Gdx.files, getScreenshotPath(), screenshotWidth,


### PR DESCRIPTION
Fixed by setting initial values for screenshot sizes, which are used in calculating the viewport.

Jira Ticket: https://jira.catrob.at/browse/CATROID-1407

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
