### PR TITLE
TEST-FIX Fix for changed behaviour of renaming sprites

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.kt
@@ -169,6 +169,9 @@ abstract class BaseActivity : AppCompatActivity(), PermissionHandlingActivity {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             val tasks = activityManager.getRunningTasks(1)
+            if (tasks == null || tasks.isEmpty()) {
+                return true
+            }
             val topActivity = tasks[0].topActivity
             if (topActivity?.packageName == context.packageName) {
                 return false


### PR DESCRIPTION
Before this fix renaming to already in use names resulted in renaming with a " (x)" postfix. Due to usability changes it now isn't possible anymore to click the "OK" button of the rename dialog. Therefore no renaming will happen which was checked in this test. Two fixes were applied to solve the issues with the `RenameSpriteTest.kt`

1. Resolving an index out of bound access in BaseActivity which gets launched on start -> This caused flakiness -> `@Flaky`  annotations were removed from the tests
2. Check that "OK" button is not enabled when try to rename to already in use

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
