### PR TITLE
CATROID-1469 Test: testCloneValues failing

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/look/PhysicsLookPositionAndAngleTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/physics/look/PhysicsLookPositionAndAngleTest.java
@@ -39,6 +39,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static junit.framework.Assert.assertEquals;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -111,12 +112,14 @@ public class PhysicsLookPositionAndAngleTest {
 	public void testCloneValues() {
 		Sprite cloneSprite = mock(Sprite.class);
 		PhysicsObject clonePhysicsObject = mock(PhysicsObject.class);
+
 		when(physicsWorldSpy.getPhysicsObject(cloneSprite)).thenReturn(clonePhysicsObject);
 		PhysicsLook cloneLook = new PhysicsLook(cloneSprite, physicsWorldSpy);
 
 		PhysicsWorld.activeArea = new Vector2(0.0f, 0.0f);
 		when(clonePhysicsObject.getMassCenter()).thenReturn(new Vector2(0.0f, 0.0f));
 		when(clonePhysicsObject.getCircumference()).thenReturn(0.0f);
+		doNothing().when(clonePhysicsObject).setFixedRotation(false);
 
 		physicsLook.setBrightnessInUserInterfaceDimensionUnit(32);
 		physicsLook.copyTo(cloneLook);

--- a/catroid/src/main/java/org/catrobat/catroid/physics/PhysicsObject.java
+++ b/catroid/src/main/java/org/catrobat/catroid/physics/PhysicsObject.java
@@ -314,7 +314,7 @@ public class PhysicsObject {
 		return body.getGravityScale();
 	}
 
-	void setFixedRotation(boolean flag) {
+	public void setFixedRotation(boolean flag) {
 		body.setFixedRotation(flag);
 	}
 


### PR DESCRIPTION
Fixed by mocking the problematic method "setFixedRotation" in the physics object.
This required it to make the method public.

https://jira.catrob.at/browse/CATROID-1469

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
