### PR TITLE
CATROID-1465 Add sprite from library gets downloaded to current project

### DIFF
--- a/catroid/src/catroid/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/catroid/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -52,7 +52,7 @@ public final class FlavoredConstants {
 			Environment.getExternalStorageDirectory(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
-	public static final String LIBRARY_BASE_URL = BASE_URL_HTTPS + "download-media/";
+	public static final String LIBRARY_BASE_URL = MAIN_URL_HTTPS + "/app/download-media/";
 	public static final String LIBRARY_LOOKS_URL = BASE_URL_HTTPS + "media-library/looks";
 	public static final String LIBRARY_OBJECT_URL = BASE_URL_HTTPS + "media-library/objects";
 	public static final String LIBRARY_BACKGROUNDS_URL_PORTRAIT = BASE_URL_HTTPS + "media-library/backgrounds-portrait";

--- a/catroid/src/createAtSchool/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/createAtSchool/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -52,7 +52,7 @@ public final class FlavoredConstants {
 			Environment.getExternalStorageDirectory().getAbsolutePath(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
-	public static final String LIBRARY_BASE_URL = BASE_URL_HTTPS + "download-media/";
+	public static final String LIBRARY_BASE_URL = MAIN_URL_HTTPS + "/app/download-media/";
 	public static final String LIBRARY_LOOKS_URL = BASE_URL_HTTPS + "media-library/looks";
 	public static final String LIBRARY_OBJECT_URL = BASE_URL_HTTPS + "media-library/objects";
 	public static final String LIBRARY_BACKGROUNDS_URL_PORTRAIT = BASE_URL_HTTPS + "media-library/backgrounds-portrait";

--- a/catroid/src/embroideryDesigner/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/embroideryDesigner/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -52,7 +52,7 @@ public final class FlavoredConstants {
 			Environment.getExternalStorageDirectory().getAbsolutePath(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
-	public static final String LIBRARY_BASE_URL = BASE_URL_HTTPS + "download-media/";
+	public static final String LIBRARY_BASE_URL = MAIN_URL_HTTPS + "/app/download-media/";
 	public static final String LIBRARY_LOOKS_URL = BASE_URL_HTTPS + "media-library/looks";
 	public static final String LIBRARY_OBJECT_URL = BASE_URL_HTTPS + "media-library/objects";
 	public static final String LIBRARY_BACKGROUNDS_URL_PORTRAIT = BASE_URL_HTTPS + "media-library/backgrounds-portrait";

--- a/catroid/src/lunaAndCat/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/lunaAndCat/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -52,7 +52,7 @@ public final class FlavoredConstants {
 			Environment.getExternalStorageDirectory().getAbsolutePath(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
-	public static final String LIBRARY_BASE_URL = BASE_URL_HTTPS + "download-media/";
+	public static final String LIBRARY_BASE_URL = MAIN_URL_HTTPS + "/app/download-media/";
 	public static final String LIBRARY_LOOKS_URL = BASE_URL_HTTPS + "media-library/looks";
 	public static final String LIBRARY_OBJECT_URL = BASE_URL_HTTPS + "media-library/objects";
 	public static final String LIBRARY_BACKGROUNDS_URL_PORTRAIT = BASE_URL_HTTPS + "media-library/backgrounds-portrait";

--- a/catroid/src/mindstorms/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/mindstorms/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -52,7 +52,7 @@ public final class FlavoredConstants {
 			Environment.getExternalStorageDirectory().getAbsolutePath(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
-	public static final String LIBRARY_BASE_URL = BASE_URL_HTTPS + "download-media/";
+	public static final String LIBRARY_BASE_URL = MAIN_URL_HTTPS + "/app/download-media/";
 	public static final String LIBRARY_LOOKS_URL = BASE_URL_HTTPS + "media-library/looks";
 	public static final String LIBRARY_OBJECT_URL = BASE_URL_HTTPS + "media-library/objects";
 	public static final String LIBRARY_BACKGROUNDS_URL_PORTRAIT = BASE_URL_HTTPS + "media-library/backgrounds-portrait";

--- a/catroid/src/phiro/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/phiro/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -52,7 +52,7 @@ public final class FlavoredConstants {
 			Environment.getExternalStorageDirectory().getAbsolutePath(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
-	public static final String LIBRARY_BASE_URL = BASE_URL_HTTPS + "download-media/";
+	public static final String LIBRARY_BASE_URL = MAIN_URL_HTTPS + "/app/download-media/";
 	public static final String LIBRARY_LOOKS_URL = BASE_URL_HTTPS + "media-library/looks";
 	public static final String LIBRARY_OBJECT_URL = BASE_URL_HTTPS + "media-library/objects";
 	public static final String LIBRARY_BACKGROUNDS_URL_PORTRAIT = BASE_URL_HTTPS + "media-library/backgrounds-portrait";

--- a/catroid/src/pocketCodeBeta/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/pocketCodeBeta/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -52,7 +52,7 @@ public final class FlavoredConstants {
 			Environment.getExternalStorageDirectory(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
-	public static final String LIBRARY_BASE_URL = BASE_URL_HTTPS + "download-media/";
+	public static final String LIBRARY_BASE_URL = MAIN_URL_HTTPS + "/app/download-media/";
 	public static final String LIBRARY_LOOKS_URL = BASE_URL_HTTPS + "media-library/looks";
 	public static final String LIBRARY_OBJECT_URL = BASE_URL_HTTPS + "media-library/objects";
 	public static final String LIBRARY_BACKGROUNDS_URL_PORTRAIT = BASE_URL_HTTPS + "media-library/backgrounds-portrait";

--- a/catroid/src/standalone/java/org/catrobat/catroid/common/FlavoredConstants.java
+++ b/catroid/src/standalone/java/org/catrobat/catroid/common/FlavoredConstants.java
@@ -52,7 +52,7 @@ public final class FlavoredConstants {
 			Environment.getExternalStorageDirectory().getAbsolutePath(), POCKET_CODE_EXTERNAL_STORAGE_FOLDER_NAME);
 
 	// Media Library:
-	public static final String LIBRARY_BASE_URL = BASE_URL_HTTPS + "download-media/";
+	public static final String LIBRARY_BASE_URL = MAIN_URL_HTTPS + "/app/download-media/";
 	public static final String LIBRARY_LOOKS_URL = BASE_URL_HTTPS + "media-library/looks";
 	public static final String LIBRARY_OBJECT_URL = BASE_URL_HTTPS + "media-library/objects";
 	public static final String LIBRARY_BACKGROUNDS_URL_PORTRAIT = BASE_URL_HTTPS + "media-library/backgrounds-portrait";


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1465
Fixed the problem, that after downloading a sprite from the Library the sprite gets added as a new project. Had to use the BASE_APP_URL_HTTPS and some other checks in order to ensure that we download a valid sprite,

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
