### PR TITLE
CATROID-1421 Extend copy/cut/paste feature across formula editor sessions

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/AdvancedClipboardTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/AdvancedClipboardTest.kt
@@ -1,0 +1,381 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2023 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.uiespresso.formulaeditor
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.doubleClick
+import androidx.test.espresso.matcher.RootMatchers.isPlatformPopup
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.catrobat.catroid.CatroidApplication
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.WaitForConditionAction.Companion.waitFor
+import org.catrobat.catroid.common.Constants
+import org.catrobat.catroid.common.FlavoredConstants
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Script
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.content.StartScript
+import org.catrobat.catroid.content.bricks.SetVariableBrick
+import org.catrobat.catroid.content.bricks.SetXBrick
+import org.catrobat.catroid.formulaeditor.Formula
+import org.catrobat.catroid.formulaeditor.FormulaElement
+import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType.COLLISION_FORMULA
+import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType.NUMBER
+import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType.OPERATOR
+import org.catrobat.catroid.formulaeditor.FormulaElement.ElementType.USER_VARIABLE
+import org.catrobat.catroid.formulaeditor.UserVariable
+import org.catrobat.catroid.io.XstreamSerializer
+import org.catrobat.catroid.test.utils.TestUtils
+import org.catrobat.catroid.ui.ProjectListActivity
+import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor
+import org.catrobat.catroid.uiespresso.util.rules.BaseActivityTestRule
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class AdvancedClipboardTest {
+
+    @get:Rule
+    val activityTestRule = BaseActivityTestRule(ProjectListActivity::class.java, false, false)
+
+    lateinit var script: Script
+    lateinit var sprite: Sprite
+    lateinit var project: Project
+
+    @Before
+    fun setUp() {
+        createProject()
+        activityTestRule.launchActivity(null)
+    }
+
+    @Test
+    fun copyAndPasteToSameSprite() {
+        openFormulaEditor()
+        onFormulaEditor().performEnterNumber(12_345)
+        onView(withId(R.id.formula_editor_edit_field)).perform(doubleClick())
+        onView(withId(R.id.copy)).inRoot(isPlatformPopup())
+            .perform(click())
+        pressBack()
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.formula_editor_edit_field)).perform(doubleClick())
+        onView(withId(R.id.paste)).inRoot(isPlatformPopup())
+            .perform(click())
+    }
+
+    @Test
+    fun cutAndPasteToSameSprite() {
+        openFormulaEditor()
+        onFormulaEditor().performEnterNumber(12_345)
+        onView(withId(R.id.formula_editor_edit_field)).perform(doubleClick())
+        onView(withId(R.id.cut)).inRoot(isPlatformPopup())
+            .perform(click())
+        pressBack()
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.formula_editor_edit_field)).perform(doubleClick())
+        onView(withId(R.id.paste)).inRoot(isPlatformPopup())
+            .perform(click())
+    }
+
+    @Test
+    fun copyAndPasteToOtherSprite() {
+        createSpriteWithBricks(project, "${spriteName}1")
+        XstreamSerializer.getInstance().saveProject(project)
+
+        openFormulaEditor()
+        onFormulaEditor().performEnterNumber(12_345)
+        onView(withId(R.id.formula_editor_edit_field)).perform(doubleClick())
+        onView(withId(R.id.copy)).inRoot(isPlatformPopup())
+            .perform(click())
+
+        pressBack()
+        pressBack()
+        onView(withText("${spriteName}1"))
+            .perform(click())
+
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.formula_editor_edit_field)).perform(doubleClick())
+        onView(withId(R.id.paste)).inRoot(isPlatformPopup())
+            .perform(click())
+    }
+
+    @Test
+    fun copyAndPasteToOtherProject() {
+        val project = createProject("${projectName}1", "${spriteName}1", "${variableName}1")
+        XstreamSerializer.getInstance().saveProject(project)
+
+        openFormulaEditor()
+        onFormulaEditor().performEnterNumber(12_345)
+        onView(withId(R.id.formula_editor_edit_field)).perform(doubleClick())
+        onView(withId(R.id.copy)).inRoot(isPlatformPopup())
+            .perform(click())
+
+        pressBack()
+        pressBack()
+        pressBack()
+
+        onView(withText("${projectName}1"))
+            .perform(waitFor(isDisplayed(), 5000))
+            .perform(click())
+        onView(withText("${spriteName}1"))
+            .perform(waitFor(isDisplayed(), 5000))
+            .perform(click())
+
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.formula_editor_edit_field)).perform(doubleClick())
+        onView(withId(R.id.paste)).inRoot(isPlatformPopup()).perform(click())
+    }
+
+    @Test
+    fun copyAndPasteToOtherSpriteWithMissingVariable() {
+        val newSprite = createSpriteWithBricks(project, "${spriteName}1", false)
+        XstreamSerializer.getInstance().saveProject(project)
+
+        onView(withText(projectName))
+            .perform(click())
+        onView(withText(spriteName))
+            .perform(click())
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.copy)).inRoot(isPlatformPopup())
+            .perform(click())
+
+        pressBack()
+        pressBack()
+        onView(withText("${spriteName}1"))
+            .perform(click())
+
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.paste)).inRoot(isPlatformPopup())
+            .perform(click())
+
+        onFormulaEditor().checkContains(CatroidApplication.getAppContext().getString(R.string.formula_editor_missing_variable))
+        Assert.assertEquals(0, newSprite.userVariables.size)
+    }
+
+    @Test
+    fun copyAndPasteToOtherSpriteWithExistingVariable() {
+        val newSprite = createSpriteWithBricks(project, "${spriteName}1")
+        XstreamSerializer.getInstance().saveProject(project)
+
+        onView(withText(projectName))
+            .perform(click())
+        onView(withText(spriteName))
+            .perform(click())
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.copy)).inRoot(isPlatformPopup())
+            .perform(click())
+
+        pressBack()
+        pressBack()
+        onView(withText("${spriteName}1"))
+            .perform(click())
+
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.paste)).inRoot(isPlatformPopup())
+            .perform(click())
+
+        onFormulaEditor().checkContains(variableName)
+        Assert.assertEquals(0, newSprite.userVariables.size)
+        Assert.assertEquals(1, project.userVariables.size)
+    }
+
+    @Test
+    fun copyAndPasteToOtherSpriteWithMissingCollisionSprite() {
+        createSpriteWithBricks(project, "${spriteName}1", false)
+        sprite.scriptList[0].brickList.removeAt(1)
+        sprite.scriptList[0].addBrick(SetXBrick(createFormulaWithCollision("${spriteName}2")))
+        XstreamSerializer.getInstance().saveProject(project)
+
+        onView(withText(projectName))
+            .perform(click())
+        onView(withText(spriteName))
+            .perform(click())
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.copy)).inRoot(isPlatformPopup())
+            .perform(click())
+
+        pressBack()
+        pressBack()
+        onView(withText("${spriteName}1"))
+            .perform(click())
+
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.paste)).inRoot(isPlatformPopup())
+            .perform(click())
+
+        onFormulaEditor().checkContains(CatroidApplication.getAppContext().getString(R.string.background))
+    }
+
+    @Test
+    fun copyAndPasteToOtherSpriteWithExistingCollisionSprite() {
+        createSpriteWithBricks(project, "${spriteName}1", false)
+        sprite.scriptList[0].brickList.removeAt(1)
+        sprite.scriptList[0].addBrick(SetXBrick(createFormulaWithCollision("${spriteName}1")))
+        XstreamSerializer.getInstance().saveProject(project)
+
+        onView(withText(projectName))
+            .perform(click())
+        onView(withText(spriteName))
+            .perform(click())
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.copy)).inRoot(isPlatformPopup())
+            .perform(click())
+
+        pressBack()
+        pressBack()
+        onView(withText("${spriteName}1"))
+            .perform(click())
+
+        onView(withId(R.id.brick_set_x_edit_text))
+            .perform(click())
+        onView(withId(R.id.paste)).inRoot(isPlatformPopup())
+            .perform(click())
+
+        onFormulaEditor().checkContains("${spriteName}1")
+    }
+
+    @After
+    fun tearDown() {
+        activityTestRule.finishActivity()
+        TestUtils.deleteProjects(projectName)
+        emptyClipboardFile()
+    }
+
+    private val projectName: String = AdvancedClipboardTest::class.java.simpleName
+    private val spriteName = "testSprite"
+    private val variableName = "testVariable"
+
+    fun createProject(
+        projectName: String = this.projectName,
+        spriteName: String = this.spriteName,
+        variableName: String = this.variableName
+    ): Project {
+        project = Project(ApplicationProvider.getApplicationContext(), projectName)
+        sprite = createSprite(project, spriteName)
+        script = StartScript()
+        script.addBrick(createSetVariableBrick(sprite, variableName))
+        script.addBrick(createSetXBrick(createFormulaWithVariable()))
+        sprite.addScript(script)
+        ProjectManager.getInstance().currentProject = project
+        ProjectManager.getInstance().currentSprite = sprite
+
+        XstreamSerializer.getInstance().saveProject(project)
+        return project
+    }
+
+    fun createSprite(currentProject: Project, spriteName: String = this.spriteName): Sprite {
+        val sprite = Sprite(spriteName)
+        currentProject.defaultScene.addSprite(sprite)
+        return sprite
+    }
+
+    private fun createSpriteWithBricks(
+        currentProject: Project,
+        spriteName: String = this.spriteName,
+        createVariable: Boolean = true,
+        formula: Formula? = null
+    ): Sprite {
+        val sprite = createSprite(currentProject, spriteName)
+        val script = StartScript()
+        if (createVariable) {
+            script.addBrick(createSetVariableBrick())
+            script.addBrick(createSetXBrick(formula))
+        } else {
+            script.addBrick(createSetXBrick())
+        }
+        sprite.addScript(script)
+        return sprite
+    }
+
+    private fun createSetVariableBrick(sprite: Sprite? = null, variableName: String = this.variableName):
+        SetVariableBrick {
+        val setVariableBrick = SetVariableBrick()
+        val userVariable = UserVariable(variableName)
+        if (sprite != null) {
+            sprite.addUserVariable(userVariable)
+        } else {
+            project.addUserVariable(userVariable)
+        }
+        setVariableBrick.userVariable = userVariable
+        return setVariableBrick
+    }
+
+    private fun createSetXBrick(formula: Formula? = null): SetXBrick {
+        return if (formula != null) {
+            SetXBrick(formula)
+        } else {
+            SetXBrick()
+        }
+    }
+
+    private fun createFormulaWithVariable(variableName: String = this.variableName): Formula {
+        val parent = FormulaElement(OPERATOR, "PLUS", null, null, null)
+        val leftChild = FormulaElement(USER_VARIABLE, variableName, parent)
+        val rightChild = FormulaElement(NUMBER, "1", parent)
+        parent.setLeftChild(leftChild)
+        parent.setRightChild(rightChild)
+        return Formula(parent)
+    }
+
+    private fun createFormulaWithCollision(collidingWith: String): Formula =
+        Formula(FormulaElement(COLLISION_FORMULA, collidingWith, null))
+
+    private fun emptyClipboardFile() {
+        val clipboardDirectory = File(FlavoredConstants.DEFAULT_ROOT_DIRECTORY, Constants.CLIPBOARD_DIRECTORY_NAME)
+        val clipboardFile = File(clipboardDirectory, Constants.CLIPBOARD_JSON_FILE_NAME)
+        if (clipboardFile.exists()) {
+            clipboardFile.writeText("")
+        }
+    }
+
+    private fun openFormulaEditor() {
+        onView(withText(projectName))
+            .perform(click())
+        onView(withText(spriteName))
+            .perform(click())
+        onView(withId(R.id.brick_set_variable_edit_text))
+            .perform(click())
+    }
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/ClipboardTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/ClipboardTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -25,12 +25,15 @@ package org.catrobat.catroid.uiespresso.formulaeditor;
 
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.R;
+import org.catrobat.catroid.common.FlavoredConstants;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.SetVariableBrick;
+import org.catrobat.catroid.formulaeditor.ClipboardManager;
 import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.io.StorageOperations;
 import org.catrobat.catroid.test.utils.TestUtils;
 import org.catrobat.catroid.ui.SpriteActivity;
 import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper;
@@ -41,13 +44,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.catrobat.catroid.WaitForConditionAction.waitFor;
+import static org.catrobat.catroid.common.Constants.CLIPBOARD_DIRECTORY_NAME;
 import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
 import static org.hamcrest.Matchers.not;
 
@@ -157,6 +163,7 @@ public class ClipboardTest {
 	public void checkUndoVisibleAfterCutOperation() {
 		onView(withId(R.id.brick_set_variable_edit_text)).perform(click());
 		onView(withId(R.id.menu_undo)).check(matches(not(isEnabled())));
+		onView(withId(R.id.cut)).inRoot(isPlatformPopup()).perform(waitFor(isDisplayed(), 10000));
 		onView(withId(R.id.cut)).inRoot(isPlatformPopup()).perform(click());
 		onFormulaEditor().checkShows("");
 		onView(withId(R.id.menu_undo)).check(matches(isEnabled()));
@@ -180,5 +187,14 @@ public class ClipboardTest {
 	public void tearDown() throws IOException {
 		baseActivityTestRule.finishActivity();
 		TestUtils.deleteProjects(PROJECT_NAME);
+		this.deleteClipboard();
+	}
+
+	private void deleteClipboard() throws IOException {
+		ClipboardManager.INSTANCE.setClipboardContent(new ArrayList());
+		File clipboardDirectory = new File(FlavoredConstants.DEFAULT_ROOT_DIRECTORY, CLIPBOARD_DIRECTORY_NAME);
+		if (clipboardDirectory.exists() && clipboardDirectory.isDirectory()) {
+			StorageOperations.deleteDir(clipboardDirectory);
+		}
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/FormulaEditorWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/FormulaEditorWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -47,6 +47,7 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withParent;
+import static androidx.test.espresso.matcher.ViewMatchers.withSubstring;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 public final class FormulaEditorWrapper extends ViewInteractionWrapper {
@@ -116,6 +117,12 @@ public final class FormulaEditorWrapper extends ViewInteractionWrapper {
 	public FormulaEditorWrapper checkShows(String expected) {
 		onView(FORMULA_EDITOR_TEXT_FIELD_MATCHER)
 				.check(matches(withText(equalToIgnoringWhiteSpace(expected))));
+		return new FormulaEditorWrapper();
+	}
+
+	public FormulaEditorWrapper checkContains(String expected) {
+		onView(FORMULA_EDITOR_TEXT_FIELD_MATCHER)
+				.check(matches(withSubstring(expected)));
 		return new FormulaEditorWrapper();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/Constants.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -100,6 +100,10 @@ public final class Constants {
 	public static final String BACKBACK_SCENES_DIRECTORY_NAME = "scenes";
 	public static final String BACKPACK_SOUND_DIRECTORY_NAME = "backpack_sound";
 	public static final String BACKPACK_IMAGE_DIRECTORY_NAME = "backpack_image";
+
+	// Clipboard Directories
+	public static final String CLIPBOARD_DIRECTORY_NAME = "clipboard";
+	public static final String CLIPBOARD_JSON_FILE_NAME = "clipboard.json";
 
 	// Trusted domains for Web access bricks
 	public static final String TRUSTED_DOMAINS_FILE_NAME = "trustedDomains.json";

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Clipboard.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Clipboard.kt
@@ -20,12 +20,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.catroid.formulaeditor;
 
-import java.io.Serializable;
+package org.catrobat.catroid.formulaeditor
 
-public enum InternTokenType implements Serializable {
-	NUMBER, OPERATOR, FUNCTION_NAME, BRACKET_OPEN, BRACKET_CLOSE, SENSOR, FUNCTION_PARAMETERS_BRACKET_OPEN,
-	FUNCTION_PARAMETERS_BRACKET_CLOSE, FUNCTION_PARAMETER_DELIMITER, PERIOD, USER_VARIABLE,
-	USER_LIST, USER_DEFINED_BRICK_INPUT, COLLISION_FORMULA, STRING, PARSER_END_OF_FILE,
-}
+data class Clipboard(var content: List<InternToken> = ArrayList())

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/ClipboardManager.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/ClipboardManager.kt
@@ -1,0 +1,150 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2023 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.formulaeditor
+
+import org.catrobat.catroid.CatroidApplication.getAppContext
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.common.Constants.CLIPBOARD_DIRECTORY_NAME
+import org.catrobat.catroid.common.Constants.CLIPBOARD_JSON_FILE_NAME
+import org.catrobat.catroid.common.FlavoredConstants.DEFAULT_ROOT_DIRECTORY
+import org.catrobat.catroid.formulaeditor.InternTokenType.COLLISION_FORMULA
+import org.catrobat.catroid.formulaeditor.InternTokenType.STRING
+import org.catrobat.catroid.formulaeditor.InternTokenType.USER_LIST
+import org.catrobat.catroid.formulaeditor.InternTokenType.USER_VARIABLE
+import org.koin.java.KoinJavaComponent.inject
+import java.io.File
+
+object ClipboardManager {
+
+    private val clipboardDirectory = File(DEFAULT_ROOT_DIRECTORY, CLIPBOARD_DIRECTORY_NAME)
+    private val clipboardFile = File(clipboardDirectory, CLIPBOARD_JSON_FILE_NAME)
+
+    private var clipboard = Clipboard()
+
+    private val clipboardSerializer = ClipboardSerializer(clipboardFile)
+
+    private val projectManager: ProjectManager by inject(ProjectManager::class.java)
+
+    init {
+        createClipboardDirectories()
+    }
+
+    private fun createClipboardDirectories() {
+        if (!DEFAULT_ROOT_DIRECTORY.exists()) {
+            DEFAULT_ROOT_DIRECTORY.mkdir()
+        }
+        if (!clipboardDirectory.exists()) {
+            clipboardDirectory.mkdir()
+        }
+    }
+
+    fun getClipboardContent(): List<InternToken> = adaptMissingUserDataAndSprites()
+
+    fun setClipboardContent(content: List<InternToken>) {
+        val temporaryList: MutableList<InternToken> = java.util.ArrayList()
+        for (token in content) {
+            temporaryList.add(token.deepCopy())
+        }
+        clipboard.content = temporaryList
+    }
+
+    fun saveClipboard() {
+        createClipboardDirectories()
+        clipboardSerializer.saveClipboard(clipboard)
+    }
+
+    fun loadClipboard() {
+        if (clipboard.content.isEmpty()) {
+            clipboard = clipboardSerializer.loadClipboard()
+        }
+    }
+
+    fun isClipboardEmpty(): Boolean = clipboard.content.isEmpty()
+
+    private fun adaptMissingUserDataAndSprites(): List<InternToken> {
+        if (clipboard.content.isEmpty()) {
+            return listOf()
+        }
+
+        val userVariableNames = collectUserVariableNames()
+        val userListNames = collectUserListNames()
+        val spriteNames = collectSpriteNames()
+
+        val adaptedContent = ArrayList<InternToken>()
+
+        clipboard.content.forEach { internToken ->
+            var token = internToken.deepCopy()
+
+            when (internToken.internTokenType) {
+                USER_VARIABLE ->
+                    if (!userVariableNames.contains(internToken.tokenStringValue)) {
+                        token = InternToken(STRING,
+                                        "${getAppContext().getString(R.string.formula_editor_missing_variable)} ${internToken.tokenStringValue}")
+                    }
+                USER_LIST ->
+                    if (!userListNames.contains(internToken.tokenStringValue)) {
+                        token = InternToken(STRING,
+                                            "${getAppContext().getString(R.string.formula_editor_missing_list)} ${internToken.tokenStringValue}")
+                    }
+                COLLISION_FORMULA ->
+                    if (!spriteNames.contains(internToken.tokenStringValue)) {
+                        token = InternToken(COLLISION_FORMULA, getAppContext().getString(R.string.background))
+                    }
+                else -> {}
+            }
+
+            adaptedContent.add(token)
+        }
+
+        return adaptedContent
+    }
+
+    private fun collectUserVariableNames(): List<String> {
+        val userVariableNameList = ArrayList<String>()
+        projectManager.currentProject.userVariables.forEach { variable -> userVariableNameList.add(variable.name) }
+        projectManager.currentProject.multiplayerVariables.forEach { variable -> userVariableNameList.add(variable.name) }
+        projectManager.currentSprite.userVariables.forEach { variable -> userVariableNameList.add(variable.name) }
+        return userVariableNameList
+    }
+
+    private fun collectUserListNames(): List<String> {
+        val userListNameList = ArrayList<String>()
+        projectManager.currentProject.userLists.forEach { list -> userListNameList.add(list.name) }
+        projectManager.currentSprite.userLists.forEach { list -> userListNameList.add(list.name) }
+        return userListNameList
+    }
+
+    private fun collectSpriteNames(): Set<String> {
+        val objectNameSet = HashSet<String>()
+        projectManager.currentProject.sceneList.forEach { scene ->
+            scene.spriteList.forEach { sprite ->
+                if (sprite.name != "Background") {
+                    objectNameSet.add(sprite.name)
+                }
+            }
+        }
+        return objectNameSet
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/ClipboardSerializer.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/ClipboardSerializer.kt
@@ -20,12 +20,29 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.catrobat.catroid.formulaeditor;
 
-import java.io.Serializable;
+package org.catrobat.catroid.formulaeditor
 
-public enum InternTokenType implements Serializable {
-	NUMBER, OPERATOR, FUNCTION_NAME, BRACKET_OPEN, BRACKET_CLOSE, SENSOR, FUNCTION_PARAMETERS_BRACKET_OPEN,
-	FUNCTION_PARAMETERS_BRACKET_CLOSE, FUNCTION_PARAMETER_DELIMITER, PERIOD, USER_VARIABLE,
-	USER_LIST, USER_DEFINED_BRICK_INPUT, COLLISION_FORMULA, STRING, PARSER_END_OF_FILE,
+import androidx.annotation.VisibleForTesting
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import java.io.File
+
+class ClipboardSerializer(private val clipBoardFile: File) {
+    @VisibleForTesting
+    var clipboardGson: Gson = GsonBuilder().enableComplexMapKeySerialization().setPrettyPrinting().create()
+
+    fun saveClipboard(clipboard: Clipboard) {
+        val jsonString = clipboardGson.toJson(clipboard)
+        clipBoardFile.writeText(jsonString, Charsets.US_ASCII)
+    }
+
+    fun loadClipboard(): Clipboard {
+        if (!clipBoardFile.exists()) {
+            return Clipboard()
+        }
+
+        val jsonString = clipBoardFile.readText(Charsets.US_ASCII)
+        return clipboardGson.fromJson(jsonString, Clipboard::class.java) ?: Clipboard()
+    }
 }

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -26,9 +26,10 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.sensing.CollisionDetection;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class InternToken {
+public class InternToken implements Serializable {
 
 	private String tokenStringValue = "";
 	private InternTokenType internTokenType;

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
+  ~ Copyright (C) 2010-2023 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -2119,6 +2119,8 @@ needs read and write access to it. You can always change permissions through you
     <string name="warning_formula_recognized">You entered a text that looks like a formula. If you want to use functions,
         sensors, variables and other formula elements, please select them instead using the
         buttons in the formula editor.</string>
+        <string name="formula_editor_missing_variable">missing variable</string>
+        <string name="formula_editor_missing_list">missing list</string>
     <!--  -->
 
 

--- a/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/ClipboardSerializerTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/ClipboardSerializerTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2023 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.formulaeditor
+
+import org.catrobat.catroid.formulaeditor.Clipboard
+import org.catrobat.catroid.formulaeditor.ClipboardSerializer
+import org.catrobat.catroid.formulaeditor.InternToken
+import org.catrobat.catroid.formulaeditor.InternTokenType.NUMBER
+import org.catrobat.catroid.formulaeditor.Operators.PLUS
+import org.catrobat.catroid.test.formulaeditor.FormulaEditorTestUtil.buildBinaryOperator
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.io.File
+
+@RunWith(JUnit4::class)
+class ClipboardSerializerTest {
+
+    private val clipboardSerializer = ClipboardSerializer(File(""))
+
+    @Test
+    fun testSerializeAndDeserialize() {
+        val formula: List<InternToken> = buildBinaryOperator(NUMBER, "1", PLUS, NUMBER, "1")
+
+        val jsonString = clipboardSerializer.clipboardGson.toJson(Clipboard(formula))
+        val retrievedFormula: Clipboard = clipboardSerializer.clipboardGson.fromJson(jsonString, Clipboard::class.java)
+
+        for (i in formula.indices) {
+            Assert.assertEquals(formula[i].internTokenType, retrievedFormula.content[i].internTokenType)
+            Assert.assertEquals(formula[i].tokenStringValue, retrievedFormula.content[i].tokenStringValue)
+        }
+    }
+}


### PR DESCRIPTION
https://jira.catrob.at/browse/IDE-34

With this ticket the copy/cut/paste feature is expanded to be persistent across formular editor sessions. This is done by writing the current content of the clipboard to a file called `clipboard.json` on copy and cut. Due to this the clipboard is also available after the app was closed. Whenever a paste happens, the clipboard is either read from a variable or from the file if the variable is not initialized. 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
