### PR TITLE
Catroid-1473 Resolve flakiness in RenameSpriteTest

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/BaseActivity.kt
@@ -169,11 +169,12 @@ abstract class BaseActivity : AppCompatActivity(), PermissionHandlingActivity {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             val tasks = activityManager.getRunningTasks(1)
-            if (tasks.isNotEmpty()) {
-                val topActivity = tasks[0].topActivity
-                if (topActivity?.packageName == context.packageName) {
-                    return false
-                }
+            if (tasks == null || tasks.isEmpty()) {
+                return true
+            }
+            val topActivity = tasks[0].topActivity
+            if (topActivity?.packageName == context.packageName) {
+                return false
             }
         } else {
             val runningProcesses = activityManager.runningAppProcesses


### PR DESCRIPTION
https://jira.catrob.at/browse/IDE-43

This test only works when the OS language of the emulator or device is set to English. Somehow the project gets created in the OS language whilst menus are translated according to setLanguageSharedPreference(...). This test is used to test functionality after switching language, this means if OS language is not set to english it probably wont work.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
