### PR TITLE
CATROID-1307 Make whole formula editor scrollable

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/AddUserListToActiveFormulaUITest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/AddUserListToActiveFormulaUITest.java
@@ -137,6 +137,7 @@ public class AddUserListToActiveFormulaUITest {
 		onBrickAtPosition(1).performEditFormula();
 		String listFunction =
 				getResourcesString(formulaName) + getResourcesString(formulaParameters);
+		onFormulaEditor().performBackspace();
 		onFormulaEditor().performOpenCategory(FUNCTIONS).performSelect(listFunction);
 		onFormulaEditor().checkShows(generateExpectedOutput(expectedOutput));
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFunctionListTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFunctionListTest.java
@@ -125,7 +125,7 @@ public class FormulaEditorFunctionListTest {
 		String formulaEditorFunctionParameterString = UiTestUtils.getResourcesString(formulaEditorFunctionParameter);
 		String editorFunction = formulaEditorFunctionString + formulaEditorFunctionParameterString;
 		String selectedFunctionString = getSelectedFunctionString(editorFunction);
-
+		onFormulaEditor().performBackspace();
 		onFormulaEditor()
 				.performOpenCategory(FormulaEditorWrapper.Category.FUNCTIONS)
 				.performSelect(editorFunction);

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorTest.java
@@ -33,6 +33,7 @@ import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.testsuites.annotations.Cat;
 import org.catrobat.catroid.testsuites.annotations.Level;
 import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper;
 import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
 import org.junit.After;
 import org.junit.Before;
@@ -41,15 +42,23 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Collections;
+
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+import static org.hamcrest.Matchers.not;
 
+import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class FormulaEditorTest {
@@ -74,6 +83,22 @@ public class FormulaEditorTest {
 		onFormulaEditor()
 				.performEnterNumber(12345.678);
 		pressBack();
+	}
+
+	@Test
+	public void wholeScreenScrollableTest() {
+		onView(withId(R.id.brick_set_variable_edit_text))
+				.perform(click());
+		String largeInputString = String.join("", Collections.nCopies(500, "0"));
+		onView(FormulaEditorWrapper.Control.TEXT)
+				.perform(click());
+		onView(withId(R.id.input_edit_text))
+				.perform(replaceText(largeInputString));
+		closeSoftKeyboard();
+		onView(withText(R.string.ok))
+				.perform(click());
+		onView(withId(R.id.formula_editor_keyboard_function))
+				.check(matches(not(isDisplayed())));
 	}
 
 	@After

--- a/catroid/src/main/res/layout/fragment_formula_editor.xml
+++ b/catroid/src/main/res/layout/fragment_formula_editor.xml
@@ -21,24 +21,24 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:theme="@android:style/Theme.Light" >
+    android:layout_height="wrap_content"
+    android:fillViewport="true">
 
     <LinearLayout
         android:id="@+id/formula_editor_brick_and_formula"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:weightSum="100">
 
         <LinearLayout
             android:id="@+id/formula_editor_brick_space"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/brick_space_padding_formular_editor"
+            android:layout_weight="10"
             android:paddingBottom="@dimen/brick_space_padding_formular_editor"
             android:background="@color/toolbar_background"
             android:orientation="vertical"/>
@@ -61,20 +61,16 @@
                 android:inputType="textMultiLine"
                 android:lineSpacingExtra="5dp"
                 android:maxLines="20"
-                android:scrollbarStyle="insideInset"
-                android:scrollbars="vertical"
                 android:textColor="@color/solid_black"
                 android:textSize="?attr/x_large" />
         </FrameLayout>
 
+        <include
+            android:id="@+id/formula_editor_keyboardview"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:layout_weight="90"
+            android:layout_gravity="bottom"
+            layout="@layout/formula_editor_keyboard" />
     </LinearLayout>
-
-    <include
-        android:id="@+id/formula_editor_keyboardview"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:layout_gravity="bottom"
-        layout="@layout/formula_editor_keyboard" />
-
-</LinearLayout>
+</ScrollView>


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1307
Formula editor made now scroll-able. Made ScrollView in fragment_formula_editor.xml and adjusted the rest that it fits accordingly.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
