### PR TITLE
CATROID-855 SetSizeToBrick isn't changing touch area of clones

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/TouchesFingerTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/sensing/TouchesFingerTest.java
@@ -24,8 +24,10 @@
 package org.catrobat.catroid.test.sensing;
 
 import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.common.ScreenValues;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.XmlHeader;
 import org.catrobat.catroid.io.XstreamSerializer;
 import org.catrobat.catroid.sensing.CollisionDetection;
 import org.catrobat.catroid.test.physics.collision.CollisionTestUtils;
@@ -40,8 +42,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import static junit.framework.Assert.assertEquals;
-
-import static org.junit.Assert.assertNotEquals;
 
 @RunWith(AndroidJUnit4.class)
 public class TouchesFingerTest {
@@ -65,14 +65,8 @@ public class TouchesFingerTest {
 
 	@Test
 	public void testBasicOneTouchingPoint() {
-		TouchUtil.reset();
-		TouchUtil.touchDown(150, 150, 1);
-		assertEquals(1d, CollisionDetection.collidesWithFinger(
-				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()));
-		TouchUtil.touchUp(1);
-		TouchUtil.touchDown(0, 0, 1);
-		assertNotEquals(1d, CollisionDetection.collidesWithFinger(
-				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()));
+		assertCollidesWithFinger(170, 0, 1d);
+		assertCollidesWithFinger(0, 0, 0d);
 	}
 
 	@Test
@@ -80,26 +74,77 @@ public class TouchesFingerTest {
 		TouchUtil.reset();
 		TouchUtil.touchDown(150, 150, 1);
 		TouchUtil.touchDown(0, 0, 2);
-		TouchUtil.touchDown(151, 151, 3);
+		TouchUtil.touchDown(225, 0, 3);
 		assertEquals(1d, CollisionDetection.collidesWithFinger(
-				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()));
+				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()),
+				0d);
 	}
 
 	@Test
 	public void testAdvancedOneTouchingPoint() {
-		TouchUtil.reset();
-		TouchUtil.touchDown(0, 0, 1);
-
-		assertNotEquals(1d, CollisionDetection.collidesWithFinger(
-				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()));
+		assertCollidesWithFinger(0, 0, 0d);
 
 		float x = sprite1.look.getXInUserInterfaceDimensionUnit();
 		float y = sprite1.look.getYInUserInterfaceDimensionUnit();
 
-		sprite1.look.setXInUserInterfaceDimensionUnit(x - 150);
-		sprite1.look.setYInUserInterfaceDimensionUnit(y - 150);
+		sprite1.look.setXInUserInterfaceDimensionUnit(x - 225);
+		sprite1.look.setYInUserInterfaceDimensionUnit(y - 225);
 
 		assertEquals(1d, CollisionDetection.collidesWithFinger(
-				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()));
+				sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()),
+				0d);
+	}
+
+	@Test
+	public void testOneTouchingPointWitRadiusLimits() {
+		XmlHeader header = project.getXmlHeader();
+		header.setVirtualScreenHeight(ScreenValues.CAST_SCREEN_HEIGHT);
+		header.setVirtualScreenWidth(ScreenValues.CAST_SCREEN_WIDTH);
+
+		assertCollidesWithFinger(-301, 0, 0d);
+		assertCollidesWithFinger(-300, 0, 1d);
+		assertCollidesWithFinger(-72, 0, 1d);
+		assertCollidesWithFinger(-71, 0, 0d);
+		assertCollidesWithFinger(76, 0, 0d);
+		assertCollidesWithFinger(77, 0, 1d);
+		assertCollidesWithFinger(299, 0, 1d);
+		assertCollidesWithFinger(300, 0, 0d);
+		assertCollidesWithFinger(0, -292, 0d);
+		assertCollidesWithFinger(0, -291, 1d);
+		assertCollidesWithFinger(0, -69, 1d);
+		assertCollidesWithFinger(0, -68, 0d);
+		assertCollidesWithFinger(0, 74, 0d);
+		assertCollidesWithFinger(0, 75, 1d);
+		assertCollidesWithFinger(0, 300, 1d);
+		assertCollidesWithFinger(0, 301, 0d);
+
+		header.setVirtualScreenHeight(480);
+		header.setVirtualScreenWidth(640);
+
+		assertCollidesWithFinger(-276, 0, 0d);
+		assertCollidesWithFinger(-275, 0, 1d);
+		assertCollidesWithFinger(-151, 0, 1d);
+		assertCollidesWithFinger(-150, 0, 0d);
+		assertCollidesWithFinger(149, 0, 0d);
+		assertCollidesWithFinger(150, 0, 1d);
+		assertCollidesWithFinger(274, 0, 1d);
+		assertCollidesWithFinger(275, 0, 0d);
+		assertCollidesWithFinger(0, -267, 0d);
+		assertCollidesWithFinger(0, -266, 1d);
+		assertCollidesWithFinger(0, -146, 1d);
+		assertCollidesWithFinger(0, -145, 0d);
+		assertCollidesWithFinger(0, 150, 0d);
+		assertCollidesWithFinger(0, 151, 1d);
+		assertCollidesWithFinger(0, 275, 1d);
+		assertCollidesWithFinger(0, 276, 0d);
+	}
+
+	private void assertCollidesWithFinger(float x, float y, double expected) {
+		TouchUtil.reset();
+		TouchUtil.touchDown(x, y, 1);
+		assertEquals(String.format("Failed with params: x: %f, y: %f!", x, y), expected,
+				CollisionDetection.collidesWithFinger(
+						sprite1.look.getCurrentCollisionPolygon(), TouchUtil.getCurrentTouchingPoints()),
+				0d);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionDetection.java
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/CollisionDetection.java
@@ -30,11 +30,14 @@ import com.badlogic.gdx.math.Polygon;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 
+import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.Constants;
+import org.catrobat.catroid.common.ScreenValues;
 import org.catrobat.catroid.content.Look;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.XmlHeader;
 
 import java.util.ArrayList;
 
@@ -181,7 +184,10 @@ public final class CollisionDetection {
 		Vector2 start = new Vector2();
 		Vector2 end = new Vector2();
 		Vector2 center = new Vector2();
-		float touchRadius = Constants.COLLISION_WITH_FINGER_TOUCH_RADIUS;
+		XmlHeader header = ProjectManager.getInstance().getCurrentProject().getXmlHeader();
+
+		float displayFactor = (float) header.virtualScreenWidth / ScreenValues.CAST_SCREEN_WIDTH;
+		float touchRadius = Constants.COLLISION_WITH_FINGER_TOUCH_RADIUS * displayFactor;
 
 		for (PointF point : touchingPoints) {
 			center.set(point.x, point.y);
@@ -211,7 +217,7 @@ public final class CollisionDetection {
 					if (Intersector.intersectSegmentCircle(start, end, center, touchRadius * touchRadius)) {
 						return 1d;
 					}
-					if (polygon.contains(point.x, point.y)) {
+					if (boundingRectangle.contains(point.x, point.y)) {
 						containedIn++;
 					}
 				}


### PR DESCRIPTION
Solves the issue with the touch radius for different resolutions.
Update the touchRadius in the CollisionDetection to be dependent on the resolution.

ticket reference: https://jira.catrob.at/browse/CATROID-855

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
