### PR TITLE
CATRIOD-1319: Multiplayer Bluetooth connection should be kept as long as possible 

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/multiplayer/MultiplayerTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/devices/multiplayer/MultiplayerTest.kt
@@ -96,6 +96,14 @@ class MultiplayerTest {
         assertEquals(project.getMultiplayerVariable(MULTIVARIABLE_NAME).value, INITIAL_VALUE)
     }
 
+    @Test
+    fun testIsAlive() {
+        assertEquals(true, multiplayer?.isAlive)
+
+        multiplayer?.disconnect()
+        assertEquals(false, multiplayer?.isAlive)
+    }
+
     companion object {
         private val PROJECT_NAME = MultiplayerTest::class.simpleName
         private const val MULTIVARIABLE_NAME = "MultiVariable"

--- a/catroid/src/main/java/org/catrobat/catroid/devices/multiplayer/Multiplayer.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/multiplayer/Multiplayer.kt
@@ -104,7 +104,7 @@ class Multiplayer : MultiplayerInterface {
         }
     }
 
-    override fun isAlive(): Boolean = false
+    override fun isAlive(): Boolean = !(inputStream == null || outputStream == null)
 
     override fun getBluetoothDeviceUUID(): UUID = MULTIPLAYER_UUID
 
@@ -123,7 +123,7 @@ class Multiplayer : MultiplayerInterface {
                         }
                     } catch (exception: IOException) {
                         Log.d(TAG, "Input stream was disconnected", exception)
-                        inputStream = null
+                        disconnect()
                         break
                     }
                 }
@@ -147,7 +147,7 @@ class Multiplayer : MultiplayerInterface {
             outputStream?.write(SerializationUtils.serialize(message))
         } catch (exception: IOException) {
             Log.d(TAG, "Error occurred when sending data", exception)
-            outputStream = null
+            disconnect()
         }
     }
 


### PR DESCRIPTION
The Bluetooth connection should be kept as long as the user doesn't exit Catroid or until the Bluetooth connection is otherwise stopped by the user.
https://jira.catrob.at/browse/CATROID-1319

Removed disconnect in isDeviceConnectedAndAlive to keep connection open.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
