### PR TITLE
CATROID-1479 Test: testFunctionDeletion fails

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
@@ -426,6 +426,9 @@ public class FormulaEditorEditText extends EditText implements OnTouchListener {
 	}
 
 	public boolean isThereSomethingToDelete() {
+		if (internFormula == null) {
+			return false;
+		}
 		return internFormula.isThereSomethingToDelete();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -732,6 +732,7 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		menu.findItem(R.id.menu_redo).setVisible(true);
 
 		super.onPrepareOptionsMenu(menu);
+		updateButtonsOnKeyboard();
 	}
 
 	@Override
@@ -1076,7 +1077,10 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 
 	public void updateButtonsOnKeyboardAndInvalidateOptionsMenu() {
 		getActivity().invalidateOptionsMenu();
+		updateButtonsOnKeyboard();
+	}
 
+	public void updateButtonsOnKeyboard() {
 		ImageButton backspaceOnKeyboard = getActivity().findViewById(R.id.formula_editor_keyboard_delete);
 		if (!formulaEditorEditText.isThereSomethingToDelete()) {
 			backspaceOnKeyboard.setAlpha(255 / 3);


### PR DESCRIPTION
The test was failing because the back button in the formula editor was not set active again after exiting the function menu. I fixed this adding a call to set it active if necessary. Now the behaviour should be as intended and the test passes.

https://jira.catrob.at/browse/CATROID-1479

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
