### PR TITLE
[MAINTENANCE] Fix for cannot resolve symbol error IDE version > 2021.1.1

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -362,6 +362,7 @@ dependencies {
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
+    androidTestImplementation project(path: ':catroid')
     androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
     androidTestImplementation ('androidx.arch.core:core-testing:2.1.0') {
         exclude group: 'org.mockito', module: 'mockito-core'


### PR DESCRIPTION
Android Studio versions > 2021.1.1 (Bumblebee) had the issue of not be able to resolve some of the import links. 

When using a newer Android Studio version this PR should fix this error by adding a test implementation dependency to the main project.

Second step was to enable all Gradle tasks (only needs to be done if not all Gradle tasks are visible):

1. Go to Android Studio `File -> Settings`
2. Left side go to `Experimental -> Gradle` 
3. Uncheck all 4 options under the Gradle option 

![image](https://user-images.githubusercontent.com/26577676/214554709-eeca7220-94ca-43b8-9b58-a6de3bf2b588.png)


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
