### PR TITLE
CATROID-IDE-11 Adding User Defined Bricks Crashes App

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddUserDataToUserDefinedBrickFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/AddUserDataToUserDefinedBrickFragment.kt
@@ -52,7 +52,6 @@ class AddUserDataToUserDefinedBrickFragment : Fragment() {
     }
 
     private var dataTypeToAdd: UserDefinedBrickDataType? = null
-    private var activity: AppCompatActivity? = null
     private var addUserDataUserBrickEditText: TextInputEditText? = null
     private var addUserDataUserBrickTextLayout: TextInputLayout? = null
     private var scrollView: ScrollView? = null
@@ -84,7 +83,7 @@ class AddUserDataToUserDefinedBrickFragment : Fragment() {
                     as UserDefinedBrickDataType
         }
         userDefinedBrick?.let {
-            val userBrickView = userDefinedBrick?.getView(getActivity())
+            val userBrickView = userDefinedBrick?.getView(requireActivity())
             userBrickSpace.addView(userBrickView)
             userBrickTextView = userDefinedBrick?.currentUserDefinedDataTextView
         }
@@ -129,12 +128,12 @@ class AddUserDataToUserDefinedBrickFragment : Fragment() {
             }
         }
 
-        activity = getActivity() as AppCompatActivity
-        activity?.let {
-            Utils.showStandardSystemKeyboard(activity)
-            val actionBar = activity?.supportActionBar
+        val appCompatActivity = requireActivity() as AppCompatActivity
+        appCompatActivity.let {
+            Utils.showStandardSystemKeyboard(appCompatActivity)
+            val actionBar = appCompatActivity.supportActionBar
             if (actionBar != null) {
-                activity?.supportActionBar?.setTitle(R.string.category_user_bricks)
+                appCompatActivity.supportActionBar?.setTitle(R.string.category_user_bricks)
             }
         }
 
@@ -146,12 +145,12 @@ class AddUserDataToUserDefinedBrickFragment : Fragment() {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        Utils.showStandardSystemKeyboard(activity)
+        Utils.showStandardSystemKeyboard(requireActivity())
     }
 
     override fun onDetach() {
         super.onDetach()
-        Utils.hideStandardSystemKeyboard(activity)
+        Utils.hideStandardSystemKeyboard(requireActivity())
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -172,7 +171,7 @@ class AddUserDataToUserDefinedBrickFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.next) {
             val fragmentManager = parentFragmentManager
-            Utils.hideStandardSystemKeyboard(activity)
+            Utils.hideStandardSystemKeyboard(requireActivity())
             fragmentManager.let {
                 val addUserDefinedBrickFragment =
                     fragmentManager.findFragmentByTag(AddUserDefinedBrickFragment.TAG)


### PR DESCRIPTION
Bugfix: adding user defined brick crashes the app.
https://jira.catrob.at/browse/IDE-11

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
