### PR TITLE
IDE-83 Missing "Ripples" on the left side of groups of objects to move them

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/GroupSpriteMoveTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/GroupSpriteMoveTest.kt
@@ -1,0 +1,227 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2023 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment
+
+import android.view.View
+import android.view.ViewConfiguration
+import androidx.annotation.NonNull
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.GeneralLocation
+import androidx.test.espresso.action.MotionEvents
+import androidx.test.espresso.action.Press
+import androidx.test.espresso.matcher.ViewMatchers.withSubstring
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.content.GroupItemSprite
+import org.catrobat.catroid.content.GroupSprite
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.test.utils.TestUtils
+import org.catrobat.catroid.ui.ProjectActivity
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
+import org.hamcrest.Matcher
+import org.hamcrest.core.IsAnything
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GroupSpriteMoveTest {
+
+    private lateinit var project: Project
+    var projectName = "GroupSpriteMoveTest"
+    private val sprite1 = "1"
+    private val sprite2 = "3"
+    private val sprite3 = "5"
+    private val group1 = "2"
+    private val group2 = "4"
+    private val listGroupItems = listOf("3", "5")
+    private val listNotGroupItems = listOf("1")
+    private val listGroups = listOf("2", "4")
+    private val listAfterNoMove = listOf(1, 2, 3, 4, 5)
+    private val listAfterFirstMove = listOf(2, 3, 1, 4, 5)
+    private val listAfterSecondMove = listOf(1, 2, 3, 4, 5)
+    private val listAfterThirdMove = listOf(1, 4, 5, 2, 3)
+    private val listAfterFourthMove = listOf(1, 2, 3, 4, 5)
+    private val oneBlock: Float = 350f
+    private val listAfterMove = listOf(listAfterNoMove, listAfterFirstMove,
+        listAfterSecondMove, listAfterThirdMove, listAfterFourthMove)
+
+    @Rule
+    @JvmField
+    var baseActivityTestRule = FragmentActivityTestRule(
+        ProjectActivity::class.java, ProjectActivity.EXTRA_FRAGMENT_POSITION,
+        ProjectActivity.FRAGMENT_SPRITES
+    )
+
+    @Before
+    fun setUp() {
+        createProject(projectName)
+        baseActivityTestRule.launchActivity()
+    }
+
+    @After
+    fun tearDown() {
+        baseActivityTestRule.finishActivity()
+        TestUtils.deleteProjects(projectName)
+    }
+
+    private fun checkList(indexMove: Int) {
+        val list = project.defaultScene.spriteList
+        val checkList = listAfterMove[indexMove]
+
+        for ((index, item) in list.withIndex()) {
+            if (index == 0) {
+                continue
+            }
+            val name = checkList[index - 1].toString()
+            Assert.assertEquals(item.name, name)
+            when (item.name) {
+                in listGroups -> Assert.assertTrue(item is GroupSprite)
+                in listGroupItems -> Assert.assertTrue(item is GroupItemSprite)
+                in listNotGroupItems -> Assert.assertTrue(item is Sprite)
+            }
+        }
+    }
+
+    @Test
+    fun testMoveGroup() {
+        var index = 0
+        checkList(index++)
+        onView(
+                withSubstring("2")
+            ).perform(
+            DragAndDrop(oneBlock)
+        )
+        checkList(index++)
+        onView(
+            withSubstring("2")
+        ).perform(
+            DragAndDrop(-2f*oneBlock)
+        )
+        checkList(index++)
+        onView(
+            withSubstring("2")
+        ).perform(
+            DragAndDrop(-2f*oneBlock)
+        )
+        checkList(index++)
+        onView(
+            withSubstring("2")
+        ).perform(
+            DragAndDrop(2f*oneBlock)
+        )
+        checkList(index)
+    }
+
+    fun createProject(projectName: String?) {
+        project = Project(ApplicationProvider.getApplicationContext(), projectName)
+
+        ProjectManager.getInstance().currentProject = project
+        ProjectManager.getInstance().currentlyEditedScene = project.defaultScene
+
+        project.defaultScene.addSprite(Sprite(sprite1))
+
+        val groupSprite1 = GroupSprite(group1)
+        project.defaultScene.addSprite(groupSprite1)
+
+        var sprite = Sprite(sprite2)
+        sprite.setConvertToGroupItemSprite(true)
+        sprite = sprite.convert()
+        project.defaultScene.addSprite(sprite)
+
+        val groupSprite2 = GroupSprite(group2)
+        project.defaultScene.addSprite(groupSprite2)
+
+        sprite = Sprite(sprite3)
+        sprite.setConvertToGroupItemSprite(true)
+        sprite = sprite.convert()
+        project.defaultScene.addSprite(sprite)
+
+        groupSprite1.isCollapsed = false
+        groupSprite2.isCollapsed = false
+    }
+}
+
+// from https://stackoverflow.com/questions/35297442/drag-drop-espresso and slightly adjusted
+class DragAndDrop(private val offset: Float) : ViewAction {
+    @NonNull
+    private fun anyView(): Matcher<View> = IsAnything()
+
+    override fun getConstraints(): Matcher<View> = anyView()
+
+    override fun getDescription(): String = "DragAndDrop"
+
+    override fun perform(uiController: UiController, view: View) {
+        val recyclerView: AppCompatTextView = view as AppCompatTextView
+
+        uiController.loopMainThreadUntilIdle()
+
+        val sourceViewCenter = GeneralLocation.VISIBLE_CENTER.calculateCoordinates(recyclerView)
+        val targetViewCenter = sourceViewCenter.clone()
+        targetViewCenter[1] = targetViewCenter[1] - offset
+        val fingerPrecision = Press.FINGER.describePrecision()
+        val downEvent = MotionEvents.sendDown(uiController, sourceViewCenter, fingerPrecision).down
+        try {
+            // Factor 1.5 is needed, otherwise a long press is not safely detected.
+            val longPressTimeout = (ViewConfiguration.getLongPressTimeout() * 2f).toLong()
+            uiController.loopMainThreadForAtLeast(longPressTimeout)
+            // Drag to the position
+            uiController.loopMainThreadUntilIdle()
+
+            val steps = interpolate(sourceViewCenter, targetViewCenter)
+
+            for (element in steps) {
+                if (!MotionEvents.sendMovement(uiController, downEvent, element)) {
+                    MotionEvents.sendCancel(uiController, downEvent)
+                }
+            }
+            // Release
+            if (!MotionEvents.sendUp(uiController, downEvent, targetViewCenter)) {
+                MotionEvents.sendCancel(uiController, downEvent)
+            }
+        } finally {
+            downEvent.recycle()
+        }
+    }
+
+    private val SWIPE_EVENT_COUNT = 10
+
+    private fun interpolate(start: FloatArray, end: FloatArray): Array<FloatArray> {
+        val res = Array(SWIPE_EVENT_COUNT) { FloatArray(2) }
+
+        for (i in 1..SWIPE_EVENT_COUNT) {
+            res[i - 1][0] = start[0] + (end[0] - start[0]) * i / SWIPE_EVENT_COUNT
+            res[i - 1][1] = start[1] + (end[1] - start[1]) * i / SWIPE_EVENT_COUNT
+        }
+        return res
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/MultiViewSpriteAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/MultiViewSpriteAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -162,6 +162,58 @@ public class MultiViewSpriteAdapter extends SpriteAdapter {
 		Sprite toItem = items.get(targetPosition);
 
 		if (fromItem instanceof GroupSprite) {
+			int last = sourcePosition;
+			if (last + 1 < items.size()) {
+				Sprite groupItem = items.get(last + 1);
+				while (groupItem instanceof GroupItemSprite) {
+					last++;
+					if (last + 1 >= items.size()) {
+						break;
+					}
+					groupItem = items.get(last + 1);
+				}
+			}
+
+			if (toItem instanceof GroupItemSprite) {
+				return false;
+			} else if (toItem instanceof GroupSprite) {
+				int lastTarget = targetPosition;
+
+				if (lastTarget + 1 < items.size()) {
+					Sprite groupItem = items.get(lastTarget + 1);
+					while (groupItem instanceof GroupItemSprite) {
+						lastTarget++;
+						if (lastTarget + 1 >= items.size()) {
+							break;
+						}
+						groupItem = items.get(lastTarget + 1);
+					}
+				}
+				int s1 = (last - sourcePosition) + 1;
+				int s2 = (lastTarget - targetPosition) + 1;
+				if (targetPosition > sourcePosition) {
+					for (int i = 0; i < s1; i++) {
+						super.onItemMove(sourcePosition, lastTarget);
+					}
+				} else {
+					for (int i = 0; i < s2; i++) {
+						super.onItemMove(targetPosition, last);
+					}
+				}
+			} else {
+				int count = 0;
+				if (targetPosition < sourcePosition) {
+					for (int i = sourcePosition; i <= last; i++) {
+						super.onItemMove(i, targetPosition + count);
+						count++;
+					}
+				} else {
+					for (int i = last; i >= sourcePosition; i--) {
+						super.onItemMove(targetPosition - count, i);
+						count++;
+					}
+				}
+			}
 			return true;
 		}
 

--- a/catroid/src/main/res/layout/view_holder_sprite_group.xml
+++ b/catroid/src/main/res/layout/view_holder_sprite_group.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
+  ~ Copyright (C) 2010-2023 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -33,6 +33,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="Overdraw"
     android:background="@drawable/button_background_selector">
+    <ImageView
+        android:id="@+id/ic_ripples"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_ripples"
+        android:layout_gravity="center_vertical"
+        android:layout_marginEnd="@dimen/img_margin"/>
 
     <CheckBox
         android:id="@+id/checkbox"


### PR DESCRIPTION
Missing "Ripples" on the left side of groups of objects to move them

- Add Ripples to sprite group
- Implement logic to correctly move groups
- Add UI test case to validate the correct behaviour when moved

https://jira.catrob.at/browse/IDE-83

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
