### PR TITLE
CATROID-1353 Create Empty Object Option

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/AddNewActorOrLookDialogTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/AddNewActorOrLookDialogTest.kt
@@ -85,6 +85,8 @@ class AddNewActorOrLookDialogTest {
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
         Espresso.onView(ViewMatchers.withId(R.id.dialog_new_look_from_local))
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        Espresso.onView(ViewMatchers.withId(R.id.dialog_new_look_empty_object))
+            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
     }
 
     @Test

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectActivity.kt
@@ -438,6 +438,10 @@ class ProjectActivity : BaseCastActivity() {
                 .startActivityForResult(SPRITE_FROM_LOCAL)
             alertDialog.dismiss()
         }
+        dialogNewActorBinding.dialogNewLookEmptyObject.setOnClickListener {
+            addEmptySpriteObject()
+            alertDialog.dismiss()
+        }
         alertDialog.show()
     }
 

--- a/catroid/src/main/res/layout/dialog_new_actor.xml
+++ b/catroid/src/main/res/layout/dialog_new_actor.xml
@@ -104,6 +104,7 @@ android:paddingBottom="@dimen/dialog_content_area_padding_top">
         <TableRow
             android:layout_width="match_parent"
             android:layout_height="match_parent">
+
              <TextView
                  android:id="@+id/dialog_new_look_from_local"
                  android:background="@drawable/new_object_dialog_selector"
@@ -111,6 +112,15 @@ android:paddingBottom="@dimen/dialog_content_area_padding_top">
                  android:text="@string/add_look_from_local_project"
                  android:textSize="?attr/medium"
                  app:drawableTopCompat="@drawable/ic_library_add" />
+
+            <TextView
+                android:id="@+id/dialog_new_look_empty_object"
+                android:background="@drawable/new_object_dialog_selector"
+                android:gravity="center"
+                android:text="@string/add_look_empty_object"
+                android:textSize="?attr/medium"
+                app:drawableTopCompat="@drawable/ic_plus"
+                app:drawableTint="@color/solid_white" />
         </TableRow>
     </TableLayout>
 </ScrollView>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -698,6 +698,7 @@
     <string name="add_look_choose_image">Gallery</string>
     <string name="add_look_media_library">Looks</string>
     <string name="add_look_from_local_project">Local projects</string>
+    <string name="add_look_empty_object">Empty Object</string>
     <!--  -->
 
     <!-- NewSoundDialog -->


### PR DESCRIPTION
Adds a new option in the "new Object and Actors" dialog to create an empty object. Also adds a test in AddNewActorOrLookDialogTest.kt

https://jira.catrob.at/browse/CATROID-1353

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
