### PR TITLE
IDE-78 Middle brick of "if-then-else" enclosing brick can't be moved

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/CompositeMiddleBrickMoveTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/CompositeMiddleBrickMoveTest.kt
@@ -1,0 +1,225 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2023 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.content.brick.app
+
+import android.view.View
+import android.view.ViewConfiguration
+import androidx.annotation.NonNull
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.GeneralLocation
+import androidx.test.espresso.action.MotionEvents
+import androidx.test.espresso.action.Press
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Script
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.content.StartScript
+import org.catrobat.catroid.content.bricks.ChangeSizeByNBrick
+import org.catrobat.catroid.content.bricks.IfLogicBeginBrick
+import org.catrobat.catroid.content.bricks.RepeatBrick
+import org.catrobat.catroid.test.utils.TestUtils
+import org.catrobat.catroid.ui.SpriteActivity
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
+import org.hamcrest.Matcher
+import org.hamcrest.core.IsAnything
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class CompositeMiddleBrickMoveTest {
+    private lateinit var project: Project
+    private val oneBlockDown: Float = -310f
+    private val oneBlockUp: Float = 360f
+    private lateinit var ifBrick: IfLogicBeginBrick
+
+    @Rule
+    @JvmField
+    var baseActivityTestRule = FragmentActivityTestRule(
+        SpriteActivity::class.java,
+        SpriteActivity.EXTRA_FRAGMENT_POSITION,
+        SpriteActivity.FRAGMENT_SCRIPTS
+    )
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        createProject(this.javaClass.simpleName)
+        baseActivityTestRule.launchActivity()
+    }
+
+    @Test
+    fun testMoveEndBrick() {
+        Assert.assertEquals(ifBrick.nestedBricks.size, 1)
+        Assert.assertEquals(ifBrick.secondaryNestedBricks.size, 1)
+
+        onView(
+            withId(R.id.brick_if_else_label)
+        ).perform(
+            DragAndDrop(oneBlockUp * 3)
+        )
+        Assert.assertEquals(ifBrick.nestedBricks.size, 1)
+        Assert.assertEquals(ifBrick.secondaryNestedBricks.size, 1)
+        onView(
+            withId(R.id.brick_if_else_label)
+        ).perform(
+            DragAndDrop(oneBlockDown * 3)
+        )
+        Assert.assertEquals(ifBrick.nestedBricks.size, 1)
+        Assert.assertEquals(ifBrick.secondaryNestedBricks.size, 1)
+
+        onView(
+            withId(R.id.brick_if_else_label)
+        ).perform(
+            DragAndDrop(oneBlockDown)
+        )
+
+        Assert.assertEquals(ifBrick.nestedBricks.size, 2)
+        Assert.assertEquals(ifBrick.secondaryNestedBricks.size, 0)
+        onView(
+            withId(R.id.brick_if_else_label)
+        ).perform(
+            DragAndDrop(oneBlockUp)
+        )
+
+        Assert.assertEquals(ifBrick.nestedBricks.size, 2)
+        Assert.assertEquals(ifBrick.secondaryNestedBricks.size, 0)
+        onView(
+            withId(R.id.brick_if_else_label)
+        ).perform(
+            DragAndDrop(oneBlockUp*2.6f)
+        )
+
+        Assert.assertEquals(ifBrick.nestedBricks.size, 1)
+        Assert.assertEquals(ifBrick.secondaryNestedBricks.size, 1)
+
+        onView(
+            withId(R.id.brick_if_else_label)
+        ).perform(
+            DragAndDrop(oneBlockUp)
+        )
+        Assert.assertEquals(ifBrick.nestedBricks.size, 0)
+        Assert.assertEquals(ifBrick.secondaryNestedBricks.size, 2)
+
+        onView(
+            withId(R.id.brick_if_else_label)
+        ).perform(
+            DragAndDrop(oneBlockDown)
+        )
+        onView(
+            withId(R.id.brick_if_else_label)
+        ).perform(
+            DragAndDrop(oneBlockDown)
+        )
+        Assert.assertEquals(ifBrick.nestedBricks.size, 2)
+        Assert.assertEquals(ifBrick.secondaryNestedBricks.size, 0)
+    }
+
+    @After
+    @Throws(Exception::class)
+    fun tearDown() {
+        TestUtils.deleteProjects(this.javaClass.simpleName)
+    }
+
+    private fun createProject(projectName: String) {
+        project = Project(ApplicationProvider.getApplicationContext(), projectName)
+        val sprite = Sprite("testSprite")
+        val script: Script = StartScript()
+        ifBrick = IfLogicBeginBrick()
+        val changeSizeBrick = ChangeSizeByNBrick(2.0)
+        val repeatBrick = RepeatBrick()
+        repeatBrick.addBrick(ChangeSizeByNBrick(3.0))
+        ifBrick.addBrickToIfBranch(changeSizeBrick)
+        ifBrick.addBrickToElseBranch(repeatBrick)
+        script.addBrick(ifBrick)
+        script.addBrick(RepeatBrick())
+        sprite.addScript(script)
+
+        project.defaultScene.addSprite(sprite)
+        ProjectManager.getInstance().currentProject = project
+        ProjectManager.getInstance().currentSprite = sprite
+    }
+}
+
+// from https://stackoverflow.com/questions/35297442/drag-drop-espresso and slightly adjusted
+class DragAndDrop(private val offset: Float) : ViewAction {
+    @NonNull
+    private fun anyView(): Matcher<View> = IsAnything()
+
+    override fun getConstraints(): Matcher<View> = anyView()
+
+    override fun getDescription(): String = "DragAndDrop"
+
+    override fun perform(uiController: UiController, view: View) {
+        val recyclerView: AppCompatTextView = view as AppCompatTextView
+
+        uiController.loopMainThreadUntilIdle()
+
+        val sourceViewCenter = GeneralLocation.VISIBLE_CENTER.calculateCoordinates(recyclerView)
+        val targetViewCenter = sourceViewCenter.clone()
+        targetViewCenter[1] = targetViewCenter[1] - offset
+        val fingerPrecision = Press.FINGER.describePrecision()
+        val downEvent = MotionEvents.sendDown(uiController, sourceViewCenter, fingerPrecision).down
+        try {
+            // Factor 1.5 is needed, otherwise a long press is not safely detected.
+            val longPressTimeout = (ViewConfiguration.getLongPressTimeout() * 2f).toLong()
+            uiController.loopMainThreadForAtLeast(longPressTimeout)
+            // Drag to the position
+            uiController.loopMainThreadUntilIdle()
+
+            val steps = interpolate(sourceViewCenter, targetViewCenter)
+
+            for (element in steps) {
+                if (!MotionEvents.sendMovement(uiController, downEvent, element)) {
+                    MotionEvents.sendCancel(uiController, downEvent)
+                }
+            }
+            // Release
+            if (!MotionEvents.sendUp(uiController, downEvent, targetViewCenter)) {
+                MotionEvents.sendCancel(uiController, downEvent)
+            }
+        } finally {
+            downEvent.recycle()
+        }
+    }
+
+    private val SWIPE_EVENT_COUNT = 10
+
+    private fun interpolate(start: FloatArray, end: FloatArray): Array<FloatArray> {
+        val res = Array(SWIPE_EVENT_COUNT) { FloatArray(2) }
+
+        for (i in 1..SWIPE_EVENT_COUNT) {
+            res[i - 1][0] = start[0] + (end[0] - start[0]) * i / SWIPE_EVENT_COUNT
+            res[i - 1][1] = start[1] + (end[1] - start[1]) * i / SWIPE_EVENT_COUNT
+        }
+        return res
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dragndrop/BrickListView.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dragndrop/BrickListView.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -35,11 +35,12 @@ import android.graphics.drawable.BitmapDrawable
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
+import java.util.ArrayList
 import android.widget.ListAdapter
 import android.widget.ListView
 import androidx.annotation.VisibleForTesting
 import org.catrobat.catroid.content.bricks.Brick
-import java.util.ArrayList
+import org.catrobat.catroid.content.bricks.CompositeBrick
 
 private const val SMOOTH_SCROLL_BY = 15
 private const val ANIMATION_DURATION = 250
@@ -102,13 +103,23 @@ class BrickListView : ListView {
 
     fun startMoving(brickToMove: Brick?) {
         cancelMove()
-        val flatList: MutableList<Brick> = ArrayList()
-        brickToMove?.addToFlatList(flatList)
-        if (brickToMove !== flatList[0]) {
+        if (brickToMove == null) {
             return
         }
-        this.brickToMove = flatList[0]
-        flatList.removeAt(0)
+        val flatList: MutableList<Brick> = ArrayList()
+        brickToMove.addToFlatList(flatList)
+        if (brickToMove.parent is CompositeBrick &&
+            brickToMove.parent.consistsOfMultipleParts() &&
+            brickToMove.allParts.indexOf(brickToMove) == 1 &&
+            brickToMove.allParts.size == 3) {
+            this.brickToMove = brickToMove
+            flatList.clear()
+        } else if (brickToMove !== flatList[0]) {
+            return
+        } else {
+            this.brickToMove = flatList[0]
+            flatList.removeAt(0)
+        }
 
         upperScrollBound = height / UPPER_SCROLL_BOUND_DIVISOR
         lowerScrollBound = height / LOWER_SCROLL_BOUND_DIVISOR


### PR DESCRIPTION
IDE-78 Else Brick of if-then-else brick could not be moved

- Add possibility to move the else part of the if-then-else
- Add the logic to handle move operations
- Add UI unit test

https://jira.catrob.at/browse/IDE-78

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
