### PR TITLE
IDE-108 Catroid Change Notes Brick Color

### DIFF
--- a/catroid/src/main/res/drawable/brick_note_1h.xml
+++ b/catroid/src/main/res/drawable/brick_note_1h.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2023 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<layer-list xmlns:aapt="http://schemas.android.com/aapt"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- middle scalable backround-->
+    <item
+        android:bottom="5dp"
+        android:gravity="left|right"
+        android:top="5dp"
+        tools:width="348dp">
+        <vector
+            android:width="350dp"
+            android:height="35dp"
+            android:viewportHeight="64.748"
+            android:viewportWidth="350">
+          <path
+              android:fillColor="@color/brick_color_black"
+              android:pathData="M0,0h350v100h-350z" />
+        </vector>
+    </item>
+
+    <!-- top -->
+    <item android:gravity="top|left|right">
+        <vector
+            android:width="350dp"
+            android:height="72dp"
+            android:viewportHeight="72.748"
+            android:viewportWidth="350">
+            <path
+                android:fillColor="@color/brick_color_black"
+                android:pathData="M0,2.000l11,0l1.75,4.125l19.5,0l1.75,-4.125l320,0l0,4.125l-355,0l0,-4.125z" />
+
+            <path
+                android:fillColor="#383838"
+                android:pathData="M347.736,0l-315.056,0.001l0,0.008l-1.749,4.117l-16.858,0l-1.752,-4.126l-0.019,0.008l0,-0.007l-12.302,0l0,2l10.998,0l1.748,4.115l0.005,-0.002l0,0.012l19.502,0l0,-0.003l0.002,0.001l1.752,-4.123l320,-0.001l0,-2z" />
+            <path
+                android:fillAlpha="0.4"
+                android:fillColor="#fff"
+                android:pathData="M347.736,2.063l-313.753,-0.063l0,0.003l-0.008,-0.003l-1.751,4.125l-19.484,0l-1.74,-4.098l0,-0.027l-11,0l0,2l9.665,0l1.753,4.127l0.005,-0.002l22.115,0l0,-0.001l0.008,0.003l1.753,-4.127l320,0.063l0,-2z"
+                android:strokeAlpha="0.4" />
+        </vector>
+    </item>
+
+    <!-- middle path for bars on the left -->
+    <item android:gravity="center|left|right">
+       <vector
+           android:width="348dp"
+           android:height="72dp"
+           android:viewportHeight="69"
+           android:viewportWidth="348">
+            <group>
+            <clip-path android:pathData="M8.5,27.5h29v5h-29z" />
+            <group>
+              <path
+                  android:fillAlpha="0.01"
+                  android:pathData="M7.271,27.5h31.458v7.636h-31.458z"
+                  android:strokeAlpha="0.5"
+                  android:fillColor="#fff">
+              </path>
+              <path
+                  android:pathData="M7.271,27.5h31.458v1h-31.458z"
+                  android:strokeAlpha="0.5"
+                  android:fillColor="#323331">
+                 </path>
+                 <path
+                     android:pathData="M7.271,27.5h1.5v7.636h-1.5z"
+                     android:strokeAlpha="0.5"
+                     android:fillColor="#323331">
+                  </path>
+                <path
+                    android:pathData="M38.729,27.5h-1.5v7.636h1.5z"
+                    android:strokeAlpha="0.5"
+                    android:fillColor="#323331">
+                  </path>
+             </group>
+            </group>
+             <group>
+             <clip-path android:pathData="M8.5,33.5h29v5h-29z" />
+             <group>
+               <path
+                   android:fillAlpha="0.01"
+                   android:pathData="M7.271,33.5h31.458v7.636h-31.458z"
+                   android:strokeAlpha="0.5"
+                   android:fillColor="#fff"/>
+                <path
+                    android:pathData="M7.271,33.5h31.458v1h-31.458z"
+                    android:strokeAlpha="0.5"
+                    android:fillColor="#323331">
+                 </path>
+                 <path
+                     android:pathData="M7.271,33.5h1.5v7.636h-1.5z"
+                     android:strokeAlpha="0.5"
+                     android:fillColor="#323331">
+                  </path>
+                <path
+                    android:pathData="M38.729,33.5h-1.5v7.636h1.5z"
+                    android:strokeAlpha="0.5"
+                    android:fillColor="#323331">
+                  </path>
+            </group>
+            </group>
+            <group>
+             <clip-path android:pathData="M8.5,39.5h29v5h-29z" />
+             <group>
+               <path
+                   android:fillAlpha="0.01"
+                   android:pathData="M7.271,39.5h31.458v7.636h-31.458z"
+                   android:strokeAlpha="0.5"
+                   android:fillColor="#fff"/>
+                 <path
+                     android:pathData="M7.271,39.5h31.458v1h-31.458z"
+                     android:strokeAlpha="0.5"
+                     android:fillColor="#323331">
+                 </path>
+                 <path
+                     android:pathData="M7.271,39.5h1.5v7.636h-1.5z"
+                     android:strokeAlpha="0.5"
+                     android:fillColor="#323331">
+                  </path>
+                <path
+                    android:pathData="M38.729,39.5h-1.5v7.636h1.5z"
+                    android:strokeAlpha="0.5"
+                    android:fillColor="#323331">
+                </path>
+
+ </group>
+
+</group>
+<path android:pathData="M0,16h348v40h-348z"/>
+</vector>
+</item>
+
+    <!-- bottom -->
+    <item android:gravity="bottom|left|right">
+        <vector
+            android:width="350dp"
+            android:height="72dp"
+            android:viewportHeight="72.748"
+            android:viewportWidth="351.887">
+           <path
+               android:fillColor="@color/brick_color_black"
+               android:pathData="M0,66.661l12.318,-0.004l1.75,4.125l16.857,0.014l1.75,-4.125l12.367,-0.004l-45.042,-0.006z" />
+           <path
+               android:fillColor="#323331"
+               android:pathData="M347.736,66.657l-315.056,0.001l0,0.008l-1.749,4.117l-16.858,0l-1.752,-4.126l-0.019,0.008l0,-0.007l-12.302,0l0,2l10.998,0l1.748,4.115l0.005,-0.002l0,0.012l19.502,0l0,-0.003l0.002,0.001l1.752,-4.123l317.729,-0.001l0,-2z" />
+        </vector>
+      </item>
+</layer-list>

--- a/catroid/src/main/res/layout/brick_note.xml
+++ b/catroid/src/main/res/layout/brick_note.xml
@@ -37,7 +37,7 @@
 
     <org.catrobat.catroid.ui.BrickLayout
         android:id="@+id/brick_note_layout"
-        style="@style/BrickContainer.Control.Small">
+        style="@style/BrickContainer.Control.NoteBrick">
 
         <include layout="@layout/icon_brick_category_control" />
 

--- a/catroid/src/main/res/values-v25/styles.xml
+++ b/catroid/src/main/res/values-v25/styles.xml
@@ -489,6 +489,11 @@
         <item name="android:background">@drawable/brick_lightorange_3h</item>
     </style>
 
+    <style name="BrickContainer.Control.NoteBrick">
+        <item name="android:minHeight">@dimen/brick_height_small</item>
+        <item name="android:background">@drawable/brick_note_1h</item>
+    </style>
+
     <style name ="BrickContainer.UserDefinedBrick" />
 
     <style name="BrickContainer.UserDefinedBrick.Medium">

--- a/catroid/src/main/res/values/colors.xml
+++ b/catroid/src/main/res/values/colors.xml
@@ -135,5 +135,6 @@
      <color name="brick_color_violet">#8f4cba</color>
      <color name="brick_color_grey">#AAAAAA</color>
      <color name="brick_color_white">#FFFFFF</color>
+     <color name="brick_color_black">#323331</color>
 
     </resources>


### PR DESCRIPTION
Change the color of the NoteBrick to a darker one, so that it stands out from the other control bricks.
https://jira.catrob.at/browse/IDE-108

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
