### PR TITLE
IDE-103 changed color of Actors and Object to #EAB7D5

### DIFF
--- a/catroid/src/lunaAndCat/res/values/colors.xml
+++ b/catroid/src/lunaAndCat/res/values/colors.xml
@@ -29,6 +29,7 @@
 
     <!-- Text Colors -->
     <color name="toolbar_title">@color/accent</color>
+    <color name="view_holder_headline">@color/accent</color>
     <color name="view_holder_item_title">@color/accent</color>
     <color name="view_holder_item_details">@color/accent</color>
 


### PR DESCRIPTION
Changed the color of Actors and Object in Luna and Cat to #EAB7D5 so that it is consistent with the the other text colors.
https://jira.catrob.at/browse/IDE-103

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
