### PR TITLE
CATROID-1531 Test: AddBrickCatblocksTest fails

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/AddBrickCatblocksTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/AddBrickCatblocksTest.kt
@@ -54,7 +54,7 @@ import org.junit.runner.RunWith
 class AddBrickCatblocksTest {
 
     companion object {
-        private const val TIMEOUT: Long = (5 * 1000).toLong()
+        private const val TIMEOUT: Long = (10 * 1000).toLong()
     }
 
     @get:Rule


### PR DESCRIPTION
The test was failing because the timeout was not enough for the SpriteActivity to load. I fixed it by increasing the timeout.  Now the behaviour should be as intended and the test passes.
Jira ticket - https://jira.catrob.at/browse/CATROID-1531

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior - 
- Changes in test itself
- [ ] Confirm that new and existing unit tests pass locally - 
- There are other tests independant of this code that don't pass
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
