### PR TITLE
IDE-63 Create a Catblocks Advanced Mode Checkbox in Settings

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/AdvancedModeSettingsTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/AdvancedModeSettingsTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2023 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment
+
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.web.assertion.WebViewAssertions
+import androidx.test.espresso.web.matcher.DomMatchers
+import androidx.test.espresso.web.sugar.Web
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
+import androidx.test.uiautomator.Until
+import org.catrobat.catroid.R
+import org.catrobat.catroid.UiTestCatroidApplication.Companion.projectManager
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.ui.SpriteActivity
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AdvancedModeSettingsTest {
+
+    companion object {
+        private const val TIMEOUT: Long = (5 * 1000).toLong()
+    }
+
+    @get:Rule
+    var baseActivityTestRule = FragmentActivityTestRule(
+        SpriteActivity::class.java, SpriteActivity.EXTRA_FRAGMENT_POSITION,
+        SpriteActivity.FRAGMENT_SCRIPTS
+    )
+
+    @Before
+    fun setUp() {
+        SettingsFragment.setUseCatBlocks(ApplicationProvider.getApplicationContext(), false)
+        SettingsFragment.setCatBlocksAdvancedMode(ApplicationProvider.getApplicationContext(), true)
+        createProject()
+        baseActivityTestRule.launchActivity()
+    }
+
+    @After
+    fun tearDown() {
+        SettingsFragment.setUseCatBlocks(ApplicationProvider.getApplicationContext(), false)
+        SettingsFragment.setCatBlocksAdvancedMode(ApplicationProvider.getApplicationContext(), false)
+        baseActivityTestRule.finishActivity()
+    }
+
+    @Test
+    fun advancedMode2DSwitch() {
+        val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        uiDevice.wait(Until.findObject(By.clazz(WebView::class.java)), TIMEOUT)
+
+        val view2D = uiDevice.findObject(
+            UiSelector().resourceId("catblocksWebView")
+        )
+        Web.onWebView().check(
+            WebViewAssertions.webContent(
+                DomMatchers.hasElementWithXpath(
+                    "//*[@id=\"catroid-catblocks-container\"]/div/svg[1]/g"
+                )
+            )
+        )
+        Assert.assertTrue(view2D.exists())
+
+        Espresso.openContextualActionModeOverflowMenu()
+        Espresso.onView(withText(R.string.undo)).check(ViewAssertions.doesNotExist())
+        Espresso.onView(withText(R.string.backpack)).check(ViewAssertions.doesNotExist())
+        Espresso.onView(withText(R.string.copy)).check(ViewAssertions.doesNotExist())
+        Espresso.onView(withText(R.string.catblocks_reorder)).check(ViewAssertions.matches(
+            isDisplayed()))
+
+        Espresso.onView(withText(R.string.catblocks)).perform(ViewActions.click())
+
+        Espresso.openContextualActionModeOverflowMenu()
+
+        Espresso.onView(withText(R.string.backpack)).check(ViewAssertions.matches(isDisplayed()))
+        Espresso.onView(withText(R.string.copy)).check(ViewAssertions.matches(isDisplayed()))
+        Espresso.onView(withText(R.string.comment_in_out))
+            .check(ViewAssertions.matches(isDisplayed()))
+    }
+
+    private fun createProject() {
+        val projectName = javaClass.simpleName
+        val project = Project(ApplicationProvider.getApplicationContext(), projectName)
+        val sprite = Sprite("testSprite")
+        project.defaultScene.addSprite(sprite)
+        projectManager.currentProject = project
+        projectManager.currentSprite = sprite
+    }
+}

--- a/catroid/src/main/assets/catblocks/index.html
+++ b/catroid/src/main/assets/catblocks/index.html
@@ -14,7 +14,9 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.15.0/css/mdb.min.css" rel="stylesheet" />
-  <link href="main.css?a54aa1ae5714dedd3117" rel="stylesheet"></head>
+    <link href="main.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro">
+  </head>
 
   <body>
     <div id="catroid-catblocks-container"></div>
@@ -56,7 +58,8 @@
           noImageFound: 'No_Image_Available.jpg',
           renderLooks: false,
           renderSounds: false,
-          readOnly: false
+          readOnly: false,
+          advancedMode: Android.isAdvancedMode()
         }).then(() => {
           const programXML = Android.getCurrentProject();
           const scene = Android.getSceneNameToDisplay();

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CatblocksScriptFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CatblocksScriptFragment.kt
@@ -64,6 +64,7 @@ class CatblocksScriptFragment(
 ) : Fragment() {
 
     private var webview: WebView? = null
+    private var advancedMode: Boolean = false
 
     companion object {
         val TAG: String = CatblocksScriptFragment::class.java.simpleName
@@ -412,6 +413,11 @@ class CatblocksScriptFragment(
             val brickCategoryInfos = getAvailableBrickCategories()
 
             return Gson().toJson(brickCategoryInfos)
+        }
+
+        @JavascriptInterface
+        fun isAdvancedMode(): Boolean {
+            return advancedMode
         }
     }
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -130,6 +130,8 @@ public class SettingsFragment extends PreferenceFragment {
 	public static final String TAG = SettingsFragment.class.getSimpleName();
 
 	public static final String SETTINGS_USE_CATBLOCKS = "settings_use_catblocks";
+	public static final String SETTINGS_CATBLOCKS_ADV_MODE = "setting_enable_catblocks_advanced_mode";
+	public static final String SETTINGS_CATBLOCKS_SWITCHED = "setting_catblocks_switched";
 
 	@SuppressWarnings("deprecation")
 	@Override
@@ -578,6 +580,26 @@ public class SettingsFragment extends PreferenceFragment {
 	public static void setUseCatBlocks(Context context, boolean useCatBlocks) {
 		getSharedPreferences(context).edit()
 				.putBoolean(SETTINGS_USE_CATBLOCKS, useCatBlocks)
+				.apply();
+	}
+
+	public static boolean getCatBlocksAdvancedMode(Context context) {
+		return getBooleanSharedPreference(false, SETTINGS_CATBLOCKS_ADV_MODE, context);
+	}
+
+	public static void setCatBlocksAdvancedMode(Context context, boolean advancedMode) {
+		getSharedPreferences(context).edit()
+				.putBoolean(SETTINGS_CATBLOCKS_ADV_MODE, advancedMode)
+				.apply();
+	}
+
+	public static boolean getCatBlocksSwitched(Context context) {
+		return getBooleanSharedPreference(false, SETTINGS_CATBLOCKS_SWITCHED, context);
+	}
+
+	public static void setCatBlocksSwitched(Context context, boolean catBlocksSwitched) {
+		getSharedPreferences(context).edit()
+				.putBoolean(SETTINGS_CATBLOCKS_SWITCHED, catBlocksSwitched)
 				.apply();
 	}
 }

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -171,6 +171,8 @@
     <string name="preference_title_ai_object_recognition">Object recognition</string>
     <string name="preference_description_ai_object_recognition">Enable object recognition and tracking sensors</string>
 
+    <string name="preference_title_catblocks_advanced_mode">Advanced mode</string>
+    <string name="preference_description_catblocks_advanced_mode">Change to text-oriented interface</string>
     <string name="preference_title_accessibility">Accessibility</string>
     <string name="preference_description_accessibility">Change the app\'s appearance</string>
     <string name="preference_title_accessibility_profiles">Accessibility profiles</string>

--- a/catroid/src/main/res/xml/preferences.xml
+++ b/catroid/src/main/res/xml/preferences.xml
@@ -105,6 +105,12 @@
         android:summary="@string/preference_description_cast_feature_globally_enabled"
         android:title="@string/preference_title_cast_feature_globally_enabled" />
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="setting_enable_catblocks_advanced_mode"
+        android:summary="@string/preference_description_catblocks_advanced_mode"
+        android:title="@string/preference_title_catblocks_advanced_mode" />
+
     <PreferenceScreen
         android:key="setting_accessibility_screen"
         android:summary="@string/preference_description_accessibility"


### PR DESCRIPTION
Created a checkbox in settings between Chromecast and Accessibility for activating Catblocks Advanced Mode.
https://jira.catrob.at/browse/IDE-63

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
