### PR TITLE
IDE-166 Fix Bug where 1D Script View is reset to English

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CatblocksScriptFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CatblocksScriptFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -106,18 +106,17 @@ class CatblocksScriptFragment(
         }
 
         setHasOptionsMenu(true)
-
         val view = View.inflate(activity, R.layout.fragment_catblocks, null)
         val webView = view.findViewById<WebView>(R.id.catblocksWebView)
         initWebView(webView)
         this.webview = webView
+
         return view
     }
 
     @SuppressLint("SetJavaScriptEnabled")
     private fun initWebView(catblocksWebView: WebView) {
         catblocksWebView.settings.javaScriptEnabled = true
-
         if (BuildConfig.FEATURE_CATBLOCKS_DEBUGABLE) {
             WebView.setWebContentsDebuggingEnabled(true)
         }
@@ -197,7 +196,6 @@ class CatblocksScriptFragment(
 
         override fun run() {
             SettingsFragment.setUseCatBlocks(context, false)
-
             val scriptFragment: ScriptFragment = if (brickToFocus == null) {
                 ScriptFragment()
             } else if (brickToFocus is ScriptBrick) {
@@ -205,7 +203,6 @@ class CatblocksScriptFragment(
             } else {
                 ScriptFragment.newInstance(brickToFocus)
             }
-
             val fragmentTransaction = parentFragmentManager.beginTransaction()
             fragmentTransaction.replace(
                 R.id.fragment_container, scriptFragment,
@@ -240,8 +237,7 @@ class CatblocksScriptFragment(
         }
 
         @JavascriptInterface
-        fun getCurrentLanguage(): String =
-            Locale.getDefault().toString().replace("_", "-")
+        fun getCurrentLanguage(): String = Locale.getDefault().toString().replace("_", "-")
 
         @JavascriptInterface
         fun isRTL(): Boolean {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -289,6 +289,7 @@ public class ScriptFragment extends ListFragment implements
 		listView.setClipToPadding(false);
 
 		activity = (SpriteActivity) getActivity();
+		SettingsFragment.setToChosenLanguage(activity);
 
 		scriptFinder = view.findViewById(R.id.findview);
 		scriptFinder.setOnResultFoundListener((sceneIndex, spriteIndex, brickIndex, totalResults,
@@ -898,7 +899,7 @@ public class ScriptFragment extends ListFragment implements
 
 		CatblocksScriptFragment catblocksFragment = new CatblocksScriptFragment(firstVisibleBrickID);
 
-		FragmentTransaction fragmentTransaction = getFragmentManager().beginTransaction();
+		FragmentTransaction fragmentTransaction = getParentFragmentManager().beginTransaction();
 		fragmentTransaction.replace(R.id.fragment_container, catblocksFragment,
 				CatblocksScriptFragment.Companion.getTAG());
 		fragmentTransaction.commit();


### PR DESCRIPTION
Fixed a bug bug where the 1D Script View is reset to English, when language was changed before.
https://jira.catrob.at/browse/IDE-166

Added SettingsFragment.setToChosenLanguage() in onCreateView of ScriptFragment so that the previously selected language gets applied.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
