### PR TITLE
IDE-129 delete automatic screenshot if manual screenshot exists

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/io/ProjectAndSceneScreenshotLoader.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/ProjectAndSceneScreenshotLoader.java
@@ -241,7 +241,7 @@ public class ProjectAndSceneScreenshotLoader {
 				File projectDir = new File(DEFAULT_ROOT_DIRECTORY, projectAndSceneScreenshotData.projectName);
 				manualScreenshotFile = new File(projectDir, SCREENSHOT_MANUAL_FILE_NAME);
 				automaticScreenShotFile = new File(projectDir, SCREENSHOT_AUTOMATIC_FILE_NAME);
-				if (!automaticScreenShotFile.exists()) {
+				if (!automaticScreenShotFile.exists() && !manualScreenshotFile.exists()) {
 					int random = new Random().nextInt(placeholderImages.length);
 					try {
 						ResourceImporter.createImageFileFromResourcesInDirectory(ProjectManager.getInstance().getApplicationContext().getResources(),
@@ -258,6 +258,7 @@ public class ProjectAndSceneScreenshotLoader {
 			}
 
 			if (manualScreenshotFile.exists() && manualScreenshotFile.length() > 0) {
+				automaticScreenShotFile.delete();
 				return manualScreenshotFile;
 			} else {
 				manualScreenshotFile.delete();

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -83,15 +83,19 @@ import org.catrobat.catroid.utils.TouchUtil;
 import org.catrobat.catroid.utils.VibrationManager;
 import org.catrobat.catroid.web.WebConnectionHolder;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import kotlinx.coroutines.GlobalScope;
 
+import static org.catrobat.catroid.common.Constants.SCREENSHOT_AUTOMATIC_FILE_NAME;
+import static org.catrobat.catroid.common.Constants.SCREENSHOT_MANUAL_FILE_NAME;
 import static org.koin.java.KoinJavaComponent.get;
 
 public class StageListener implements ApplicationListener {
@@ -588,15 +592,28 @@ public class StageListener implements ApplicationListener {
 		}
 
 		if (makeScreenshot) {
-			byte[] screenshot = ScreenUtils
-					.getFrameBufferPixels(screenshotX, screenshotY, screenshotWidth, screenshotHeight, true);
+			Scene scene = ProjectManager.getInstance().getCurrentlyEditedScene();
+			String manualScreenshotPath = scene.getDirectory()
+					+ "/" + SCREENSHOT_MANUAL_FILE_NAME;
+			File manualScreenshot = new File(manualScreenshotPath);
+			if (!manualScreenshot.exists() || Objects.equals(screenshotName,
+					SCREENSHOT_MANUAL_FILE_NAME)) {
+				byte[] screenshot = ScreenUtils
+						.getFrameBufferPixels(screenshotX, screenshotY, screenshotWidth, screenshotHeight, true);
+				screenshotSaver.saveScreenshotAndNotify(
+						screenshot,
+						screenshotName,
+						this::notifyScreenshotCallbackAndCleanup,
+						GlobalScope.INSTANCE
+				);
+			}
+			String automaticScreenShotPath = scene.getDirectory()
+					+ "/" + SCREENSHOT_AUTOMATIC_FILE_NAME;
+			File automaticScreenShot = new File(automaticScreenShotPath);
+			if (manualScreenshot.exists() && automaticScreenShot.exists()) {
+				automaticScreenShot.delete();
+			}
 			makeScreenshot = false;
-			screenshotSaver.saveScreenshotAndNotify(
-					screenshot,
-					screenshotName,
-					this::notifyScreenshotCallbackAndCleanup,
-					GlobalScope.INSTANCE
-			);
 		}
 
 		if (axesOn && !finished) {


### PR DESCRIPTION
If a manual screenshot exists for scenes or the project, the automatic screenshot is deleted and no new automatic screenshot will be created. 

https://jira.catrob.at/browse/IDE-129

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
