### PR TITLE
IDE-83 Missing "Ripples" on the left side of groups of objects to move them

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/NewGroupDialogTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/NewGroupDialogTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2023 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.dialog
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.closeSoftKeyboard
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.openContextualActionModeOverflowMenu
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeTextIntoFocusedView
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Scene
+import org.catrobat.catroid.test.utils.TestUtils
+import org.catrobat.catroid.ui.ProjectActivity
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
+import org.hamcrest.Matchers.allOf
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.java.KoinJavaComponent
+
+@RunWith(AndroidJUnit4::class)
+class NewGroupDialogTest {
+
+    private lateinit var project: Project
+    private lateinit var scene: Scene
+    private val projectManager: ProjectManager by KoinJavaComponent.inject(ProjectManager::class.java)
+
+    @Rule
+    @JvmField
+    var baseActivityTestRule = FragmentActivityTestRule(
+        ProjectActivity::class.java, ProjectActivity.EXTRA_FRAGMENT_POSITION,
+        ProjectActivity.FRAGMENT_SPRITES
+    )
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        project = Project(ApplicationProvider.getApplicationContext(), NewGroupDialogTest::class.java.simpleName)
+
+        projectManager.currentProject = project
+        projectManager.currentlyEditedScene = project.defaultScene
+
+        scene = project.defaultScene
+        baseActivityTestRule.launchActivity()
+    }
+
+    @After
+    fun tearDown() {
+        baseActivityTestRule.finishActivity()
+        TestUtils.deleteProjects(NewGroupDialogTest::class.java.simpleName)
+    }
+
+    @Test
+    fun testIfNewGroupDialogIsDisplayed() {
+        openContextualActionModeOverflowMenu()
+        onView(withText(R.string.new_group)).perform(click())
+
+        onView(withText(R.string.new_group)).inRoot(isDialog()).check(matches(isDisplayed()))
+
+        onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testNewGroupDialogCreatesNewGroupWithDefaultGroupName() {
+        openContextualActionModeOverflowMenu()
+        onView(withText(R.string.new_group)).perform(click())
+
+        onView(withText(R.string.new_group)).inRoot(isDialog()).check(matches(isDisplayed()))
+
+        closeSoftKeyboard()
+
+        onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+            .inRoot(isDialog())
+            .perform(click())
+
+        onView(withText(R.string.default_group_name)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testNewGroupDialogCreatesNewGroupWithCustomGroupName() {
+        val customGroupName = "TestGroup123"
+        openContextualActionModeOverflowMenu()
+        onView(withText(R.string.new_group)).perform(click())
+
+        onView(withText(R.string.new_group)).inRoot(isDialog()).check(matches(isDisplayed()))
+
+        onView(withText(R.string.default_group_name))
+            .inRoot(isDialog())
+            .perform(typeTextIntoFocusedView(customGroupName))
+
+        closeSoftKeyboard()
+
+        onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+            .inRoot(isDialog())
+            .perform(click())
+
+        onView(withText(customGroupName)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testNewGroupDialogCancelButton() {
+        openContextualActionModeOverflowMenu()
+        onView(withText(R.string.new_group)).perform(click())
+
+        onView(withText(R.string.new_group)).inRoot(isDialog()).check(matches(isDisplayed()))
+
+        closeSoftKeyboard()
+
+        onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        onView(allOf(withId(android.R.id.button2), withText(R.string.cancel)))
+            .inRoot(isDialog())
+            .perform(click())
+
+        onView(withText(R.string.default_group_name)).check(doesNotExist())
+    }
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CopySpriteTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CopySpriteTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -152,6 +152,7 @@ class CopySpriteTest {
         val standaloneSprite = Sprite(spriteList[2])
         val groupSprite = GroupSprite(spriteList[0])
         val sprite: Sprite = GroupItemSprite(spriteList[1])
+        groupSprite.addToChildrenSpriteList(sprite as GroupItemSprite)
         project.defaultScene.addSprite(standaloneSprite)
         project.defaultScene.addSprite(groupSprite)
         project.defaultScene.addSprite(sprite)

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/GroupSpriteMoveTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/GroupSpriteMoveTest.kt
@@ -1,0 +1,322 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2023 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment
+
+import android.view.View
+import android.view.ViewConfiguration
+import androidx.annotation.NonNull
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.GeneralLocation
+import androidx.test.espresso.action.MotionEvents
+import androidx.test.espresso.action.Press
+import androidx.test.espresso.matcher.ViewMatchers.withSubstring
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.content.GroupItemSprite
+import org.catrobat.catroid.content.GroupSprite
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Scene
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.test.utils.TestUtils
+import org.catrobat.catroid.ui.ProjectActivity
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
+import org.hamcrest.Matcher
+import org.hamcrest.core.IsAnything
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.java.KoinJavaComponent.inject
+
+@RunWith(AndroidJUnit4::class)
+class GroupSpriteMoveTest {
+
+    private lateinit var project: Project
+    private lateinit var scene: Scene
+    private val projectManager: ProjectManager by inject(ProjectManager::class.java)
+
+    private val oneBlock: Float = 150f
+
+    private lateinit var groupSprite1: GroupSprite
+    private lateinit var groupSprite2: GroupSprite
+    private lateinit var groupSprite3: GroupSprite
+    private lateinit var groupSprite4: GroupSprite
+    private lateinit var groupSprite5: GroupSprite
+
+    private lateinit var groupItemSprite1: GroupItemSprite
+    private lateinit var groupItemSprite2: GroupItemSprite
+    private lateinit var groupItemSprite3: GroupItemSprite
+    private lateinit var groupItemSprite4: GroupItemSprite
+    private lateinit var groupItemSprite5: GroupItemSprite
+    private lateinit var groupItemSprite6: GroupItemSprite
+    private lateinit var groupItemSprite7: GroupItemSprite
+    private lateinit var groupItemSprite8: GroupItemSprite
+    private lateinit var groupItemSprite9: GroupItemSprite
+    private lateinit var groupItemSprite10: GroupItemSprite
+
+    private lateinit var basicList: List<Sprite>
+
+    @Rule
+    @JvmField
+    var baseActivityTestRule = FragmentActivityTestRule(
+        ProjectActivity::class.java, ProjectActivity.EXTRA_FRAGMENT_POSITION,
+        ProjectActivity.FRAGMENT_SPRITES
+    )
+
+    @Before
+    fun setUp() {
+        project = Project(
+            ApplicationProvider.getApplicationContext(),
+            GroupSpriteMoveTest::class.java.simpleName
+        )
+
+        projectManager.currentProject = project
+        projectManager.currentlyEditedScene = project.defaultScene
+
+        scene = project.defaultScene
+
+        groupSprite1 = GroupSprite("group sprite (1)")
+        groupItemSprite1 = GroupItemSprite("child (1)")
+        groupItemSprite2 = GroupItemSprite("child (2)")
+        groupSprite1.addToChildrenSpriteList(groupItemSprite1)
+        groupSprite1.addToChildrenSpriteList(groupItemSprite2)
+
+        groupSprite2 = GroupSprite("group sprite (2)")
+        groupItemSprite3 = GroupItemSprite("child (3)")
+        groupItemSprite4 = GroupItemSprite("child (4)")
+        groupSprite2.addToChildrenSpriteList(groupItemSprite3)
+        groupSprite2.addToChildrenSpriteList(groupItemSprite4)
+
+        groupSprite3 = GroupSprite("group sprite (3)")
+        groupItemSprite5 = GroupItemSprite("child (5)")
+        groupItemSprite6 = GroupItemSprite("child (6)")
+        groupSprite3.addToChildrenSpriteList(groupItemSprite5)
+        groupSprite3.addToChildrenSpriteList(groupItemSprite6)
+
+        groupSprite4 = GroupSprite("group sprite (4)")
+        groupItemSprite7 = GroupItemSprite("child (7)")
+        groupItemSprite8 = GroupItemSprite("child (8)")
+        groupSprite4.addToChildrenSpriteList(groupItemSprite7)
+        groupSprite4.addToChildrenSpriteList(groupItemSprite8)
+
+        groupSprite5 = GroupSprite("group sprite (5)")
+        groupItemSprite9 = GroupItemSprite("child (9)")
+        groupItemSprite10 = GroupItemSprite("child (10)")
+        groupSprite5.addToChildrenSpriteList(groupItemSprite9)
+        groupSprite5.addToChildrenSpriteList(groupItemSprite10)
+
+        basicList = listOf(
+            groupSprite1, groupItemSprite1, groupItemSprite2,
+            groupSprite2, groupItemSprite3, groupItemSprite4,
+            groupSprite3, groupItemSprite5, groupItemSprite6,
+            groupSprite4, groupItemSprite7, groupItemSprite8,
+            groupSprite5, groupItemSprite9, groupItemSprite10
+        )
+
+        scene.addSprite(groupSprite1)
+        scene.addSprite(groupItemSprite1)
+        scene.addSprite(groupItemSprite2)
+        scene.addSprite(groupSprite2)
+        scene.addSprite(groupItemSprite3)
+        scene.addSprite(groupItemSprite4)
+        scene.addSprite(groupSprite3)
+        scene.addSprite(groupItemSprite5)
+        scene.addSprite(groupItemSprite6)
+        scene.addSprite(groupSprite4)
+        scene.addSprite(groupItemSprite7)
+        scene.addSprite(groupItemSprite8)
+        scene.addSprite(groupSprite5)
+        scene.addSprite(groupItemSprite9)
+        scene.addSprite(groupItemSprite10)
+
+        baseActivityTestRule.launchActivity()
+    }
+
+    @After
+    fun tearDown() {
+        baseActivityTestRule.finishActivity()
+        TestUtils.deleteProjects(GroupSpriteMoveTest::class.java.simpleName)
+    }
+
+    private fun checkList(checkList: List<Sprite>) {
+        val list = project.defaultScene.spriteList
+
+        for ((index, item) in list.withIndex()) {
+            if (index == 0) {
+                continue
+            }
+            val checkItem = checkList[index - 1]
+            Assert.assertEquals(item, checkItem)
+        }
+    }
+
+    @Test
+    fun testDragAndDropUp() {
+        checkList(basicList)
+        onView(withSubstring("group sprite (4)")).perform(DragAndDrop(oneBlock))
+        checkList(
+            listOf(
+                groupSprite1, groupItemSprite1, groupItemSprite2,
+                groupSprite2, groupItemSprite3, groupItemSprite4,
+                groupSprite4, groupItemSprite7, groupItemSprite8,
+                groupSprite3, groupItemSprite5, groupItemSprite6,
+                groupSprite5, groupItemSprite9, groupItemSprite10
+            )
+        )
+        onView(withSubstring("group sprite (5)")).perform(DragAndDrop(oneBlock))
+        checkList(
+            listOf(
+                groupSprite1, groupItemSprite1, groupItemSprite2,
+                groupSprite2, groupItemSprite3, groupItemSprite4,
+                groupSprite4, groupItemSprite7, groupItemSprite8,
+                groupSprite5, groupItemSprite9, groupItemSprite10,
+                groupSprite3, groupItemSprite5, groupItemSprite6
+            )
+        )
+        onView(withSubstring("group sprite (2)")).perform(DragAndDrop(oneBlock))
+        checkList(
+            listOf(
+                groupSprite2, groupItemSprite3, groupItemSprite4,
+                groupSprite1, groupItemSprite1, groupItemSprite2,
+                groupSprite4, groupItemSprite7, groupItemSprite8,
+                groupSprite5, groupItemSprite9, groupItemSprite10,
+                groupSprite3, groupItemSprite5, groupItemSprite6
+            )
+        )
+        onView(withSubstring("group sprite (3)")).perform(DragAndDrop(oneBlock))
+        checkList(
+            listOf(
+                groupSprite2, groupItemSprite3, groupItemSprite4,
+                groupSprite1, groupItemSprite1, groupItemSprite2,
+                groupSprite4, groupItemSprite7, groupItemSprite8,
+                groupSprite3, groupItemSprite5, groupItemSprite6,
+                groupSprite5, groupItemSprite9, groupItemSprite10
+            )
+        )
+    }
+
+    @Test
+    fun testDragAndDropDown() {
+        checkList(basicList)
+        onView(withSubstring("group sprite (1)")).perform(DragAndDrop(-oneBlock))
+        checkList(
+            listOf(
+                groupSprite2, groupItemSprite3, groupItemSprite4,
+                groupSprite1, groupItemSprite1, groupItemSprite2,
+                groupSprite3, groupItemSprite5, groupItemSprite6,
+                groupSprite4, groupItemSprite7, groupItemSprite8,
+                groupSprite5, groupItemSprite9, groupItemSprite10
+            )
+        )
+        onView(withSubstring("group sprite (4)")).perform(DragAndDrop(-oneBlock))
+        checkList(
+            listOf(
+                groupSprite2, groupItemSprite3, groupItemSprite4,
+                groupSprite1, groupItemSprite1, groupItemSprite2,
+                groupSprite3, groupItemSprite5, groupItemSprite6,
+                groupSprite5, groupItemSprite9, groupItemSprite10,
+                groupSprite4, groupItemSprite7, groupItemSprite8
+            )
+        )
+        onView(withSubstring("group sprite (3)")).perform(DragAndDrop(-oneBlock))
+        checkList(
+            listOf(
+                groupSprite2, groupItemSprite3, groupItemSprite4,
+                groupSprite1, groupItemSprite1, groupItemSprite2,
+                groupSprite5, groupItemSprite9, groupItemSprite10,
+                groupSprite3, groupItemSprite5, groupItemSprite6,
+                groupSprite4, groupItemSprite7, groupItemSprite8
+            )
+        )
+        onView(withSubstring("group sprite (1)")).perform(DragAndDrop(-oneBlock))
+        checkList(
+            listOf(
+                groupSprite2, groupItemSprite3, groupItemSprite4,
+                groupSprite5, groupItemSprite9, groupItemSprite10,
+                groupSprite1, groupItemSprite1, groupItemSprite2,
+                groupSprite3, groupItemSprite5, groupItemSprite6,
+                groupSprite4, groupItemSprite7, groupItemSprite8
+            )
+        )
+    }
+}
+
+class DragAndDrop(private val offset: Float) : ViewAction {
+    @NonNull
+    private fun anyView(): Matcher<View> = IsAnything()
+
+    override fun getConstraints(): Matcher<View> = anyView()
+
+    override fun getDescription(): String = "DragAndDrop"
+
+    override fun perform(uiController: UiController, view: View) {
+        val recyclerView: AppCompatTextView = view as AppCompatTextView
+
+        uiController.loopMainThreadUntilIdle()
+
+        val sourceViewCenter = GeneralLocation.VISIBLE_CENTER.calculateCoordinates(recyclerView)
+        val targetViewCenter = sourceViewCenter.clone()
+        targetViewCenter[1] = targetViewCenter[1] - offset
+        val fingerPrecision = Press.FINGER.describePrecision()
+        val downEvent = MotionEvents.sendDown(uiController, sourceViewCenter, fingerPrecision).down
+        try {
+            val longPressTimeout = (ViewConfiguration.getLongPressTimeout() * 2f).toLong()
+            uiController.loopMainThreadForAtLeast(longPressTimeout)
+
+            uiController.loopMainThreadUntilIdle()
+
+            val steps = interpolate(sourceViewCenter, targetViewCenter)
+
+            for (element in steps) {
+                if (!MotionEvents.sendMovement(uiController, downEvent, element)) {
+                    MotionEvents.sendCancel(uiController, downEvent)
+                }
+            }
+
+            if (!MotionEvents.sendUp(uiController, downEvent, targetViewCenter)) {
+                MotionEvents.sendCancel(uiController, downEvent)
+            }
+        } finally {
+            downEvent.recycle()
+        }
+    }
+
+    private val swipeEventCount = 5
+
+    private fun interpolate(start: FloatArray, end: FloatArray): Array<FloatArray> {
+        val res = Array(swipeEventCount) { FloatArray(2) }
+
+        for (i in 1..swipeEventCount) {
+            res[i - 1][0] = start[0] + (end[0] - start[0]) * i / swipeEventCount
+            res[i - 1][1] = start[1] + (end[1] - start[1]) * i / swipeEventCount
+        }
+        return res
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/content/GroupSprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/GroupSprite.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -28,11 +28,13 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.common.LookData;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class GroupSprite extends Sprite {
 
 	private static final long serialVersionUID = 1L;
+	private ArrayList<GroupItemSprite> childrenSpriteList = new ArrayList<>();
 
 	private transient boolean collapsed = true;
 
@@ -44,20 +46,10 @@ public class GroupSprite extends Sprite {
 		super(name);
 	}
 
-	public List<GroupItemSprite> getGroupItems() {
-		List<Sprite> allSprites = ProjectManager.getInstance().getCurrentlyPlayingScene().getSpriteList();
-		List<GroupItemSprite> groupItems = new ArrayList<>();
-
-		int position = allSprites.indexOf(this);
-
-		for (Sprite sprite : allSprites.subList(position + 1, allSprites.size())) {
-			if (sprite instanceof GroupItemSprite) {
-				groupItems.add((GroupItemSprite) sprite);
-			} else {
-				break;
-			}
-		}
-		return groupItems;
+	public List<GroupItemSprite> getReversedGroupItems() {
+		List<GroupItemSprite> reversedGroupItemSpriteList = new ArrayList<>(childrenSpriteList);
+		Collections.reverse(reversedGroupItemSpriteList);
+		return reversedGroupItemSpriteList;
 	}
 
 	public boolean isCollapsed() {
@@ -66,13 +58,9 @@ public class GroupSprite extends Sprite {
 
 	public void setCollapsed(boolean collapsed) {
 		this.collapsed = collapsed;
-		for (GroupItemSprite item : getGroupItems()) {
+		for (GroupItemSprite item : childrenSpriteList) {
 			item.setCollapsed(collapsed);
 		}
-	}
-
-	public int getNumberOfItems() {
-		return getGroupItems().size();
 	}
 
 	public static List<Sprite> getSpritesFromGroupWithGroupName(String groupName, List<Sprite> sprites) {
@@ -93,6 +81,22 @@ public class GroupSprite extends Sprite {
 			}
 		}
 		return result;
+	}
+
+	public void addToChildrenSpriteList(GroupItemSprite child) {
+		childrenSpriteList.add(child);
+	}
+
+	public void removeFromChildrenSpriteList(GroupItemSprite child) {
+		childrenSpriteList.remove(child);
+	}
+
+	public int getNumberOfChildren() {
+		return childrenSpriteList.size();
+	}
+
+	public List<GroupItemSprite> getChildrenSpriteList() {
+		return childrenSpriteList;
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -117,6 +117,7 @@ public class Sprite implements Nameable, Serializable {
 	private transient boolean isGliding = false;
 	private transient float glidingVelocityX = 0f;
 	private transient float glidingVelocityY = 0f;
+	private transient GroupSprite parent = null;
 
 	public Sprite() {
 	}
@@ -409,6 +410,7 @@ public class Sprite implements Nameable, Serializable {
 		Sprite convertedSprite;
 
 		if (convertToSprite) {
+			parent.removeFromChildrenSpriteList((GroupItemSprite) this);
 			convertedSprite = new Sprite(name);
 		} else if (convertToGroupItemSprite) {
 			convertedSprite = new GroupItemSprite(name);
@@ -431,6 +433,11 @@ public class Sprite implements Nameable, Serializable {
 		convertedSprite.userVariables = userVariables;
 		convertedSprite.userLists = userLists;
 		convertedSprite.userDefinedBrickList = userDefinedBrickList;
+
+		if (convertedSprite instanceof GroupItemSprite) {
+			parent.addToChildrenSpriteList((GroupItemSprite) convertedSprite);
+			convertedSprite.parent = parent;
+		}
 
 		return convertedSprite;
 	}
@@ -828,5 +835,11 @@ public class Sprite implements Nameable, Serializable {
 	}
 	public float getGlidingVelocityY() {
 		return glidingVelocityY;
+	}
+	public GroupSprite getParent() {
+		return parent;
+	}
+	public void setParent(GroupSprite parentGroup) {
+		parent = parentGroup;
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/MultiViewSpriteAdapter.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/MultiViewSpriteAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -158,36 +158,41 @@ public class MultiViewSpriteAdapter extends SpriteAdapter {
 			return true;
 		}
 
-		Sprite fromItem = items.get(sourcePosition);
-		Sprite toItem = items.get(targetPosition);
+		Sprite sourceItem = items.get(sourcePosition);
+		Sprite targetItem = items.get(targetPosition);
 
-		if (fromItem instanceof GroupSprite) {
-			return true;
+		if (sourceItem instanceof GroupSprite && targetItem instanceof GroupSprite) {
+			return super.onItemMove(sourcePosition, targetPosition);
 		}
 
-		if (toItem instanceof GroupSprite) {
-			GroupSprite groupItem = (GroupSprite) toItem;
-			if (targetPosition > sourcePosition) {
-				targetPosition += groupItem.getNumberOfItems();
-				fromItem.setConvertToGroupItemSprite(true);
-			} else {
-				fromItem.setConvertToSprite(true);
+		if (sourceItem instanceof GroupSprite) {
+			return super.onItemMove(sourcePosition, targetPosition);
+		}
+
+		if (targetItem instanceof GroupSprite) {
+			GroupSprite groupItem = (GroupSprite) targetItem;
+			targetPosition += groupItem.getNumberOfChildren();
+			if (sourcePosition > targetPosition) {
+				targetPosition = sourcePosition;
 			}
+			sourceItem.setConvertToGroupItemSprite(true);
+			sourceItem.setParent((GroupSprite) targetItem);
 			return super.onItemMove(sourcePosition, targetPosition);
 		}
 
-		if (!(fromItem instanceof GroupItemSprite) && toItem instanceof GroupItemSprite) {
-			fromItem.setConvertToGroupItemSprite(true);
+		if (!(sourceItem instanceof GroupItemSprite) && targetItem instanceof GroupItemSprite) {
+			sourceItem.setConvertToGroupItemSprite(true);
+			sourceItem.setParent(targetItem.getParent());
 			return super.onItemMove(sourcePosition, targetPosition);
 		}
 
-		if (fromItem instanceof GroupItemSprite && !(toItem instanceof GroupItemSprite)) {
-			fromItem.setConvertToSprite(true);
+		if (sourceItem instanceof GroupItemSprite && !(targetItem instanceof GroupItemSprite)) {
+			sourceItem.setConvertToSprite(true);
 			return super.onItemMove(sourcePosition, targetPosition);
 		}
 
-		fromItem.setConvertToGroupItemSprite(false);
-		fromItem.setConvertToSprite(false);
+		sourceItem.setConvertToGroupItemSprite(false);
+		sourceItem.setConvertToSprite(false);
 		return super.onItemMove(sourcePosition, targetPosition);
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SpriteListFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/SpriteListFragment.kt
@@ -36,6 +36,7 @@ import androidx.annotation.PluralsRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.SCROLL_STATE_IDLE
 import org.catrobat.catroid.ProjectManager
 import org.catrobat.catroid.R
 import org.catrobat.catroid.common.Constants
@@ -97,7 +98,9 @@ class SpriteListFragment : RecyclerViewFragment<Sprite?>() {
                             item.isCollapsed = item.isCollapsed
                         }
                     }
-                    adapter.notifyDataSetChanged()
+                    if (!recyclerView.isComputingLayout && recyclerView.scrollState == SCROLL_STATE_IDLE) {
+                        adapter.notifyDataSetChanged()
+                    }
                 }
             }
         }
@@ -233,7 +236,7 @@ class SpriteListFragment : RecyclerViewFragment<Sprite?>() {
         setShowProgressBar(true)
         for (item in selectedItems) {
             if (item is GroupSprite) {
-                for (sprite in item.groupItems) {
+                for (sprite in item.childrenSpriteList) {
                     sprite.setConvertToSprite(true)
                     val convertedSprite = spriteController.convert(sprite)
                     adapter.items[adapter.items.indexOf(sprite)] = convertedSprite

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/viewholder/CheckableViewHolder.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/viewholder/CheckableViewHolder.java
@@ -26,6 +26,7 @@ package org.catrobat.catroid.ui.recyclerview.viewholder;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.ImageButton;
+import android.widget.ImageView;
 
 import org.catrobat.catroid.R;
 
@@ -33,10 +34,12 @@ public class CheckableViewHolder extends ViewHolder {
 
 	public CheckBox checkBox;
 	public ImageButton settings;
+	public ImageView ripples;
 
 	public CheckableViewHolder(View itemView) {
 		super(itemView);
 		checkBox = itemView.findViewById(R.id.checkbox);
 		settings = itemView.findViewById(R.id.settings_button);
+		ripples = itemView.findViewById(R.id.ic_ripples);
 	}
 }

--- a/catroid/src/main/res/layout/view_holder_sprite_group.xml
+++ b/catroid/src/main/res/layout/view_holder_sprite_group.xml
@@ -50,6 +50,14 @@
         tools:ignore="UseCompoundDrawables">
 
         <ImageView
+            android:id="@+id/ic_ripples"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_ripples"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="@dimen/img_margin"/>
+
+        <ImageView
             android:id="@+id/image_view"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
- Add "ripples" on left side of groups in XML
- Implement logic for correct drag and drop behaviour
- Add tests to verify drag and drop behaviour for groups of objects
- Add espresso tests for new group creation
https://jira.catrob.at/browse/IDE-83

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
