### PR TITLE
CATROID-1559 Fix ForVariableFromToActionTest

### DIFF
--- a/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ForVariableFromToActionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/actions/ForVariableFromToActionTest.java
@@ -23,6 +23,8 @@
 
 package org.catrobat.catroid.test.content.actions;
 
+import org.catrobat.catroid.ProjectManager;
+import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
@@ -31,6 +33,7 @@ import org.catrobat.catroid.content.bricks.ForVariableFromToBrick;
 import org.catrobat.catroid.content.eventids.EventId;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.UserVariable;
+import org.catrobat.catroid.test.MockUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,6 +56,8 @@ public class ForVariableFromToActionTest {
 		initializeStaticSingletonMethods();
 		executedLoops = new UserVariable("executedLoops", 0.0);
 		controlVariable = new UserVariable("controlVariable", 0.0);
+		Project project = new Project(MockUtil.mockContextForProject(), "testProject");
+		ProjectManager.getInstance().setCurrentProject(project);
 
 		sprite = new Sprite("sprite");
 		script = new StartScript();


### PR DESCRIPTION
The currentProject-property was not set in the setUp function, but the tests access them. This caused the NPEs when running as a seperate test. Therefore, the setup of the currentProject-property was added.

https://jira.catrob.at/browse/CATROID-1559

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
