### PR TITLE
IDE-73 removed bug where cameraBrick led to black screenshot

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/ScreenshotSaver.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/ScreenshotSaver.kt
@@ -60,6 +60,7 @@ class ScreenshotSaver(
         callback: ScreenshotSaverCallback,
         coroutineScope: CoroutineScope
     ) {
+
         if (data == null) {
             Log.d(TAG, "Screenshot data is null")
             callback.screenshotSaved(false)

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageActivity.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageActivity.java
@@ -33,6 +33,7 @@ import android.content.Intent;
 import android.nfc.NdefMessage;
 import android.nfc.NfcAdapter;
 import android.nfc.Tag;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -60,6 +61,7 @@ import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.content.bricks.CameraBrick;
 import org.catrobat.catroid.devices.raspberrypi.RaspberryPiService;
 import org.catrobat.catroid.io.StageAudioFocus;
 import org.catrobat.catroid.nfc.NfcHandler;
@@ -261,8 +263,17 @@ public class StageActivity extends AndroidApplication implements PermissionHandl
 		} else {
 			StageLifeCycleController.stagePause(this);
 			idlingResource.increment();
-			stageListener.requestTakingScreenshot(SCREENSHOT_AUTOMATIC_FILE_NAME,
-					success -> runOnUiThread(() -> idlingResource.decrement()));
+
+			boolean cameraInUse = false;
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+				cameraInUse =
+						ProjectManager.getInstance().getCurrentlyEditedScene().getBackgroundSprite().getAllBricks().stream().anyMatch(c -> c instanceof CameraBrick);
+			}
+			if (!cameraInUse) {
+				stageListener.requestTakingScreenshot(SCREENSHOT_AUTOMATIC_FILE_NAME,
+						success -> runOnUiThread(() -> idlingResource.decrement()));
+			}
+
 			stageDialog.show();
 		}
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -575,13 +575,12 @@ public class StageListener implements ApplicationListener {
 		if (makeScreenshot) {
 			byte[] screenshot = ScreenUtils
 					.getFrameBufferPixels(screenshotX, screenshotY, screenshotWidth, screenshotHeight, true);
-			makeScreenshot = false;
 			screenshotSaver.saveScreenshotAndNotify(
 					screenshot,
 					screenshotName,
 					this::notifyScreenshotCallbackAndCleanup,
-					GlobalScope.INSTANCE
-			);
+					GlobalScope.INSTANCE);
+			makeScreenshot = false;
 		}
 
 		if (axesOn && !finished) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/StageDialog.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dialogs/StageDialog.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.ui.dialogs;
 
 import android.app.Dialog;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.util.Log;
@@ -40,6 +41,7 @@ import org.catrobat.catroid.cast.CastManager;
 import org.catrobat.catroid.common.Constants;
 import org.catrobat.catroid.content.Scene;
 import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.bricks.CameraBrick;
 import org.catrobat.catroid.embroidery.DSTFileGenerator;
 import org.catrobat.catroid.formulaeditor.SensorHandler;
 import org.catrobat.catroid.stage.StageActivity;
@@ -199,15 +201,24 @@ public class StageDialog extends Dialog implements View.OnClickListener {
 			return;
 		}
 
-		stageListener.requestTakingScreenshot(SCREENSHOT_MANUAL_FILE_NAME,
-				success -> {
-					if (success) {
-						ToastUtil.showSuccess(stageActivity, R.string.notification_screenshot_ok);
-						ProjectManager.getInstance().changedProject(ProjectManager.getInstance().getCurrentProject().getName());
-					} else {
-						ToastUtil.showError(stageActivity, R.string.error_screenshot_failed);
-					}
-				});
+		boolean cameraInUse = false;
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			cameraInUse =
+					ProjectManager.getInstance().getCurrentlyEditedScene().getBackgroundSprite().getAllBricks().stream().anyMatch(c -> c instanceof CameraBrick);
+		}
+		if (!cameraInUse) {
+			stageListener.requestTakingScreenshot(SCREENSHOT_MANUAL_FILE_NAME,
+					success -> {
+						if (success) {
+							ToastUtil.showSuccess(stageActivity, R.string.notification_screenshot_ok);
+							ProjectManager.getInstance().changedProject(ProjectManager.getInstance().getCurrentProject().getName());
+						} else {
+							ToastUtil.showError(stageActivity, R.string.error_screenshot_failed);
+						}
+					});
+		} else {
+			ToastUtil.showError(stageActivity, R.string.error_screenshot_failed_camera_block);
+		}
 	}
 
 	private void restartProject() {

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1424,6 +1424,8 @@ needs read and write access to it. You can always change permissions through you
     <string name="error_rename_scene">Something went wrong while renaming the scene.</string>
     <string name="error_load_project">Something went wrong while loading the project.</string>
     <string name="error_screenshot_failed">Something went wrong while saving the preview image.</string>
+    <string name="error_screenshot_failed_camera_block">Screenshot not possible, when
+        camera block is used.</string>
     <string name="error_internet_connection">An unknown error occurred. Check your Internet connection.</string>
     <string name="error_project_compatibility">The project is not compatible with this version of the app.</string>
     <string name="error_outdated_version">This app version is outdated. Update now?</string>


### PR DESCRIPTION
Since the function getFrameBufferPixels led to black screenshots whenever the cameraBrick was used, i removed to possibilty to use manual screenshots of the project as a preview for the scene when the scene is using the cameraBrick and instead one of the standard preview pictures is being used. 

https://jira.catrob.at/browse/IDE-73

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
