### PR TITLE
DEVOPS-701 Update Catroid Docker image to Java11 and include targetSD…

### DIFF
--- a/docker/Dockerfile.jenkins
+++ b/docker/Dockerfile.jenkins
@@ -1,13 +1,14 @@
-FROM debian:buster
+FROM debian:bullseye
 # Android Dependencies
 # --------------------
 # Adapt the paramters below to change the dependencies.
 #
-# Android SDK 26.1.1
-ARG ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
-# No Android NDK needed
-ARG ANDROID_NDK_URL
-ARG SDKMANAGER_PACKAGES="build-tools;30.0.3 emulator platform-tools platforms;android-28 system-images;android-28;default;x86_64"
+ARG ANDROID_API_LEVEL=28
+ARG ANDROID_BUILD_TOOLS_LEVEL=30.0.3
+ARG ANDROID_NDK_VERSION=21.1.6352462
+ARG ANDROID_CLI_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip"
+ARG SDKMANAGER_PACKAGES="build-tools;${ANDROID_BUILD_TOOLS_LEVEL} platforms;android-$ANDROID_API_LEVEL cmake;3.6.4111459 system-images;android-$ANDROID_API_LEVEL;default;x86_64"
+
 # Arguments, Environment
 # ----------------------
 #
@@ -23,7 +24,8 @@ ENV ANDROID_SDK_ROOT=$USER_HOME/android/sdk
 ENV ANDROID_AVD_HOME=$USER_HOME/avds
 # Deprecated: Still used by gradle, once gradle respects ANDROID_SDK_ROOT, this can be removed
 ENV ANDROID_HOME=$ANDROID_SDK_ROOT
-ARG _SDKMANAGER=$ANDROID_SDK_ROOT/tools/bin/sdkmanager
+ENV PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin
+ARG _SDKMANAGER=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
 # System Packages
 # ---------------
 #
@@ -31,26 +33,27 @@ ARG _SDKMANAGER=$ANDROID_SDK_ROOT/tools/bin/sdkmanager
 # x11-commons/x11-utils/libpulse0 needed to start emulator
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
-#        openjdk-8-jdk \
+        openjdk-11-jdk \
         unzip \
         openssh-client \
-         x11-common \
-         x11-utils \
-         libpulse0 \
-         libxcursor-dev \
-         libnss3-dev \
-         libasound2 \
-         wget \
-         gnupg \
-         software-properties-common \
+        x11-common \
+        x11-utils \
+        libpulse0 \
+        libxcursor-dev \
+        libnss3-dev \
+        libasound2 \
+        wget \
+        gnupg \
+        software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 # Install Fastlane
 RUN wget --no-check-certificate -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
 RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
 
-RUN apt-get update && apt-get install -y adoptopenjdk-8-hotspot
+RUN apt-get update
 RUN apt-get install -y python2
 RUN apt-get install -y --no-install-recommends \
+        openjdk-11-jdk-headless \
         rubygems \
         ruby-dev \
         g++ \
@@ -58,13 +61,8 @@ RUN apt-get install -y --no-install-recommends \
         less \
         git \
     && rm -rf /var/lib/apt/lists/* \
-    #&& gem update --system \
     && gem install rake \
     && gem install fastlane -NV
-    #&& apt-get purge -y --auto-remove \
-    #    ruby-dev \
-    #    g++ \
-    #    make
 # User Management
 # ---------------
 #
@@ -82,10 +80,13 @@ RUN mkdir -p $ANDROID_AVD_HOME
 # Android SDK
 # ------------------
 #
-RUN curl $ANDROID_SDK_URL --output /tmp/android_sdk.zip \
+ARG _CMD_LINE=$ANDROID_SDK_ROOT/cmdline-tools
+RUN curl $ANDROID_CLI_TOOLS_URL --output /tmp/android_sdk.zip \
     && mkdir -p $ANDROID_SDK_ROOT \
     && unzip -d $ANDROID_SDK_ROOT /tmp/android_sdk.zip \
-    && rm /tmp/android_sdk.zip
+    && rm /tmp/android_sdk.zip \
+                && mkdir -p $_CMD_LINE/latest \
+                && mv $_CMD_LINE/bin $_CMD_LINE/lib $_CMD_LINE/source.properties $_CMD_LINE/latest/
 # Android NDK
 # ----------------
 #
@@ -108,4 +109,6 @@ RUN if [ ! -z "$SDKMANAGER_PACKAGES" ]; then yes | $_SDKMANAGER $SDKMANAGER_PACK
 #       JAVA_TOOL_OPTIONS and the command line parameters.
 #       We still use it here to ensure that these settings
 #       are respected, no matter what is configured elsewhere.
-ENV _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+ENV _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions"
+# Accept SDK licenses
+RUN yes | $_SDKMANAGER --licenses


### PR DESCRIPTION
Catroid image Java11, targetSDK 11, 13 and Debian 11, for Q2 IDE and Stage release
[DEVOPS-701](https://jira.catrob.at/browse/DEVOPS-701)
[IDE-168](https://jira.catrob.at/browse/IDE-168)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
