### PR TITLE
CATROID-1564 Increase version of the crowdin GitHub action

### DIFF
--- a/.github/workflows/sync_crowdin.yml
+++ b/.github/workflows/sync_crowdin.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: crowdin/github-action@1.0.10
+      - uses: crowdin/github-action@v1.7.1
         with:
           upload_sources: true
           upload_translations: false


### PR DESCRIPTION
https://jira.catrob.at/browse/CATROID-1564

The GitHub-action used to create PRs containing translations from crowdin fails. For Paintroid this issue was solved by increasing the version of the GitHub-action. This PR does the same for Catroid.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
