### PR TITLE
IDE-178 Implement global clipboard

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/FormulaEditorPopupMenu.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/FormulaEditorPopupMenu.java
@@ -53,7 +53,7 @@ public class FormulaEditorPopupMenu {
 	private final View copy;
 	private final View paste;
 
-	private List<InternToken> clipboard;
+	private static List<InternToken> clipboard;
 
 	@SuppressLint("InflateParams")
 	public FormulaEditorPopupMenu(Context context, FormulaEditorEditText formulaEditorEditText) {
@@ -185,5 +185,9 @@ public class FormulaEditorPopupMenu {
 
 	public void dismiss() {
 		popupWindow.dismiss();
+	}
+
+	public static void resetClipboard() {
+		clipboard.clear();
 	}
 }


### PR DESCRIPTION
Made the clipboard variable static, so it is shared between all formulaeditor instances.
Added a test for this; Modified other tests to account for global clipboard.

[Jira Ticket](https://jira.catrob.at/browse/IDE-178)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Stick to the project’s gitflow workflow
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed
- [X] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
