### PR TITLE
IDE-59 fix toMetricUnitRepresentation

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserDefinedBrickInputTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserDefinedBrickInputTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -154,9 +154,15 @@ class DataListFragmentUserDefinedBrickInputTest(
                 ),
                 trueString
             ),
-            arrayOf("Int 1", Formula(1), "1"),
-            arrayOf("Int 1000", Formula(1_000), "1k"),
-            arrayOf("Int 1000000", Formula(1_000_000), "1M"),
+            arrayOf("Int 1", Formula(1), "1.0"),
+            arrayOf("Int 1000", Formula(1_000), "1.0k"),
+            arrayOf("Int 1000000", Formula(1_000_000), "1.0M"),
+            arrayOf("Int 2500", Formula(2_500), "2.5k"),
+            arrayOf("Int 2570", Formula(2_570), "2.57k"),
+            arrayOf("Int 2575", Formula(2_575), "2.575k"),
+            arrayOf("Int 25075", Formula(25_075), "25.075k"),
+            arrayOf("Int 1005000", Formula(1_005_000), "1.005M"),
+            arrayOf("Int 1500000", Formula(1_500_000), "1.5M"),
             arrayOf("Double 1.1", Formula(1.1), "1.1"),
             arrayOf("String hello", Formula("hello"), "hello")
         )

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserListsTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserListsTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -119,16 +119,20 @@ class DataListFragmentUserListsTest(
         fun parameters() = listOf(
             arrayOf("listOf(false)", listOf(false), listOf(falseString)),
             arrayOf("listOf(true)", listOf(true), listOf(trueString)),
-            arrayOf("listOf(1)", listOf(1), listOf("1")),
-            arrayOf("listOf(1k)", listOf(1_000), listOf("1k")),
-            arrayOf("listOf(1M)", listOf(1_000_000), listOf("1M")),
+            arrayOf("listOf(1)", listOf(1), listOf("1.0")),
+            arrayOf("listOf(1k)", listOf(1_000), listOf("1.0k")),
+            arrayOf("listOf(1M)", listOf(1_000_000), listOf("1.0M")),
             arrayOf("listOf(1.1)", listOf(1.1), listOf("1.1")),
             arrayOf("listOf(NaN)", listOf(Double.NaN), listOf("NaN")),
             arrayOf("listOf(hello)", listOf("hello"), listOf("hello")),
+            arrayOf("listOf(2.5k)", listOf(2_500), listOf("2.5k")),
+            arrayOf("listOf(2.57k)", listOf(2_570), listOf("2.57k")),
+            arrayOf("listOf(1.5M)", listOf(1_500_000), listOf("1.5M")),
+            arrayOf("listOf(1.005M)", listOf(1_005_000), listOf("1.005M")),
             arrayOf(
                 "listOf(false, true, 1, 1k, 1M, 1.1, NaN, hello)",
                 listOf(false, true, 1, 1_000, 1_000_000, 1.1, Double.NaN, "hello"),
-                listOf(falseString, trueString, "1", "1k", "1M", "1.1", "NaN", "hello")
+                listOf(falseString, trueString, "1.0", "1.0k", "1.0M", "1.1", "NaN", "hello")
             )
         )
     }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserVariablesTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserVariablesTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -112,9 +112,9 @@ class DataListFragmentUserVariablesTest(
         fun parameters() = listOf(
             arrayOf("Boolean false", false, falseString),
             arrayOf("Boolean true", true, trueString),
-            arrayOf("Int 1", 1, "1"),
-            arrayOf("Int 1k", 1_000, "1k"),
-            arrayOf("Int 1M", 1_000_000, "1M"),
+            arrayOf("Int 1", 1, "1.0"),
+            arrayOf("Int 1k", 1_000, "1.0k"),
+            arrayOf("Int 1M", 1_000_000, "1.0M"),
             arrayOf("Double 1.1", 1.1, "1.1"),
             arrayOf("Double NaN", Double.NaN, "NaN"),
             arrayOf("String hello", "hello", "hello")

--- a/catroid/src/main/java/org/catrobat/catroid/utils/NumberFormats.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/NumberFormats.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -37,7 +37,7 @@ class NumberFormats private constructor() {
 
         @Suppress("MagicNumber")
         @JvmStatic
-        fun toMetricUnitRepresentation(number: Int): String {
+        fun toMetricUnitRepresentation(number: Double): String {
             var prefix = ""
             var absoluteNumber = number
             if (number < 0) {

--- a/catroid/src/main/java/org/catrobat/catroid/utils/ShowTextUtils.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/ShowTextUtils.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -127,7 +127,7 @@ public final class ShowTextUtils {
 	public static String convertStringToMetricRepresentation(String value) {
 		String result = value;
 		try {
-			result = toMetricUnitRepresentation(Integer.parseInt(value));
+			result = toMetricUnitRepresentation(Double.parseDouble(value));
 		} catch (NumberFormatException ignored) {
 		}
 		return result;


### PR DESCRIPTION
Fixed a bug bug some values are shown in a misleading way.
https://jira.catrob.at/browse/IDE-59

Changed the datatype from Int to Double so that the actual value will be seen. Also adapted the needed test to verify this behaviour. 

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
