### PR TITLE
DETEKT remove wildcard import warnings

### DIFF
--- a/catroid/config/detekt.yml
+++ b/catroid/config/detekt.yml
@@ -246,7 +246,7 @@ formatting:
     active: true
     autoCorrect: true
   NoWildcardImports:
-    active: true
+    active: false
     autoCorrect: true
   PackageName:
     active: true
@@ -558,6 +558,5 @@ style:
   VarCouldBeVal:
     active: true
   WildcardImport:
-    active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    excludeImports: 'java.util.*,kotlinx.android.synthetic.*'
+    active: false
+


### PR DESCRIPTION
We have some files where the imports make up over 100 lines. Many of them from the same source file.
We should improve this.

The benefits of wildcard imports are:
- easier refactoring (changes less code)
- less lines of code
- less effort for programmers
- lessens the need for IDE help to be able to work with the code (auto-imports, folding away imports)

The only drawback is the possibility of class name conflicts
- this is really rare
- this is caught by the compiler

Hence, allowing wildcard imports would be a net positive.

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [-] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [-] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [-] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
