### PR TITLE
 IDE-143 fix testUploadControllerGetsCalled 

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectUploadDialogTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectUploadDialogTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -60,6 +60,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
@@ -96,26 +97,26 @@ class ProjectUploadDialogTest {
 
     @Test
     fun testUploadControllerGetsCalled() {
+
+        Looper.prepare()
+
         sharedPreferences.edit()
             .putInt(NUMBER_OF_UPLOADED_PROJECTS, 1)
             .commit()
 
         onView(withText(R.string.next))
             .perform(click())
-        getInstrumentation().waitForIdleSync()
 
-        onView(withText(R.string.next))
-            .perform(click())
-        getInstrumentation().waitForIdleSync()
-
-        onView(withText(R.string.next))
+        onView(withText(R.string.done))
             .perform(click())
 
         val projectUploadController = activityTestRule.activity.projectUploadController()
 
-        Looper.prepare()
-        verify(projectUploadController)?.startUpload(projectName, "", "", project)
+        Thread.sleep(100)
         Looper.myLooper()?.quit()
+
+        verify(projectUploadController)?.startUpload(projectName, "", "", project)
+        Mockito.verifyNoMoreInteractions();
     }
 
     @Test

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectUploadDialogTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectUploadDialogTest.kt
@@ -97,26 +97,20 @@ class ProjectUploadDialogTest {
 
     @Test
     fun testUploadControllerGetsCalled() {
-
-        Looper.prepare()
-
         sharedPreferences.edit()
             .putInt(NUMBER_OF_UPLOADED_PROJECTS, 1)
             .commit()
 
-        onView(withText(R.string.next))
-            .perform(click())
-
-        onView(withText(R.string.done))
-            .perform(click())
-
+        onView(withText(R.string.next)).perform(click())
+        getInstrumentation().waitForIdleSync()
+        onView(withText(R.string.next)).perform(click())
+        getInstrumentation().waitForIdleSync()
+        onView(withId(android.R.id.button1)).perform(click())
         val projectUploadController = activityTestRule.activity.projectUploadController()
 
-        Thread.sleep(100)
         Looper.myLooper()?.quit()
-
-        verify(projectUploadController)?.startUpload(projectName, "", "", project)
-        Mockito.verifyNoMoreInteractions();
+        verify(projectUploadController!!).startUpload(projectName, "", "", project)
+        Mockito.verifyNoMoreInteractions(projectUploadController)
     }
 
     @Test

--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/ProjectUploadController.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/ProjectUploadController.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -56,7 +56,7 @@ open class ProjectUploadController(private val projectUploadInterface: ProjectUp
         }
     }
 
-    fun startUpload(
+    open fun startUpload(
         projectName: String,
         projectDescription: String,
         projectNotesAndCredits: String?,


### PR DESCRIPTION
fix testUploadControllerGetsCalled

This TC was broken by another unrelated TC: testUploadControllerGetsCalled
We fixed this TC and now testUploadControllerGetsCalled is working.

https://jira.catrob.at/browse/IDE-143

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Stick to the project’s gitflow workflow
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed
- [X] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
