### PR TITLE
IDE-130 Fix spriteEqualBackgroundTest

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/SpriteTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/content/sprite/SpriteTest.java
@@ -39,15 +39,21 @@ import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.test.utils.TestUtils;
 import org.catrobat.catroid.utils.ShowTextUtils.AndroidStringProvider;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Locale;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
+
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.updateLocale;
 
 @RunWith(AndroidJUnit4.class)
 public class SpriteTest {
@@ -60,6 +66,7 @@ public class SpriteTest {
 
 	private Project project;
 	private Sprite sprite;
+	private Locale locale;
 
 	private AndroidStringProvider androidStringProvider =
 			new AndroidStringProvider(ApplicationProvider.getApplicationContext());
@@ -76,6 +83,13 @@ public class SpriteTest {
 		project.addUserVariable(globalVariable);
 
 		ProjectManager.getInstance().setCurrentProject(project);
+		locale = ApplicationProvider.getApplicationContext()
+				.getResources().getConfiguration().locale;
+	}
+
+	@After
+	public void tearDown() {
+		updateLocale(ApplicationProvider.getApplicationContext(), locale);
 	}
 
 	@Test
@@ -113,5 +127,14 @@ public class SpriteTest {
 
 		userVariable = sprite2.getUserVariable(variableName);
 		assertTrue(userVariable.getVisible());
+	}
+
+	@Test
+	public void spriteEqualBackgroundTest() {
+		sprite.setName("Hintergrund");
+		updateLocale(ApplicationProvider.getApplicationContext(), new Locale("de"));
+		project.checkIfSpriteNameEqualBackground(ApplicationProvider.getApplicationContext());
+		Assert.assertNotEquals(sprite.getName(), "Hintergrund");
+		Assert.assertEquals(sprite.getName(), "Hintergrund (1)");
 	}
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSpriteTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RenameSpriteTest.kt
@@ -47,7 +47,6 @@ import org.catrobat.catroid.testsuites.annotations.Level.Smoke
 import org.catrobat.catroid.ui.ProjectActivity
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.setLanguageSharedPreference
 import org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper
-import org.catrobat.catroid.uiespresso.ui.fragment.rvutils.RecyclerViewInteractionWrapper.onRecyclerView
 import org.catrobat.catroid.uiespresso.util.UiTestUtils
 import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
 import org.hamcrest.Matchers.allOf
@@ -215,58 +214,6 @@ class RenameSpriteTest {
             .check(matches(isDisplayed()))
         onView(withText(spriteToRename))
             .check(doesNotExist())
-    }
-
-    @Test
-    fun spriteEqualBackgroundTest() {
-        UiTestUtils.openActionBarMenu()
-        onView(withText(R.string.rename)).perform(click())
-        onRecyclerView().atPosition(0)
-            .check(matches(not(isDisplayed())))
-        onRecyclerView().atPosition(2)
-            .perform(click())
-        onView(withText(R.string.rename_sprite_dialog))
-            .inRoot(isDialog())
-            .check(matches(isDisplayed()))
-        val backgroundString = "Background"
-        onView(allOf(withText(secondSpriteName), isDisplayed()))
-            .perform(replaceText(backgroundString))
-        closeSoftKeyboard()
-        onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
-            .check(matches(not(isEnabled())))
-    }
-
-    // This test only works when the OS language of the emulator or device is set to English.
-    // Somehow the project gets created in the OS language whilst menus are translated according
-    // to setLanguageSharedPreference(...). This test is used to test functionality after switching
-    // language, this means if OS language is not set to english it probably wont work.
-    @Test
-    fun spriteEqualsBackgroundNameAfterLanguageChangeTest() {
-        baseActivityTestRule.finishActivity()
-        setLanguageSharedPreference(ApplicationProvider.getApplicationContext(), "en-GB")
-        baseActivityTestRule.launchActivity()
-
-        UiTestUtils.openActionBarMenu()
-        onView(withText(R.string.rename)).perform(click())
-        onRecyclerView().atPosition(0)
-            .check(matches(not(isDisplayed())))
-        onRecyclerView().atPosition(2)
-            .perform(click())
-        onView(withText(R.string.rename_sprite_dialog))
-            .inRoot(isDialog())
-            .check(matches(isDisplayed()))
-        val backgroundString = "Hintergrund"
-        onView(allOf(withText(secondSpriteName), isDisplayed()))
-            .perform(replaceText(backgroundString))
-        closeSoftKeyboard()
-        onView(allOf(withId(android.R.id.button1), withText(R.string.ok)))
-            .perform(click())
-
-        baseActivityTestRule.finishActivity()
-        setLanguageSharedPreference(ApplicationProvider.getApplicationContext(), "de")
-        baseActivityTestRule.launchActivity()
-        onView(withText("$backgroundString (1)"))
-            .check(matches(isDisplayed()))
     }
 
     private fun createProject(projectName: String) {

--- a/catroid/src/main/java/org/catrobat/catroid/content/Project.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Project.java
@@ -22,7 +22,6 @@
  */
 package org.catrobat.catroid.content;
 
-import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
 
@@ -537,15 +536,15 @@ public class Project implements Serializable {
 		return spriteNames;
 	}
 
-	public void checkIfSpriteNameEqualBackground(Activity activity) {
+	public void checkIfSpriteNameEqualBackground(Context context) {
 		List<Sprite> spriteList =
 				new ArrayList<>(this.getSpriteListWithClones());
 		List<String> spriteNames = getSpriteNames(spriteList);
 		for (int sprite = 1; sprite < spriteList.size(); ++sprite) {
-			if (spriteList.get(sprite).getName().matches("[\\s]*" + activity.getString(R.string.background)
+			if (spriteList.get(sprite).getName().matches("[\\s]*" + context.getString(R.string.background)
 					+ "[\\s]*")) {
 				UniqueNameProvider name = new UniqueNameProvider();
-				String newSpriteName = name.getUniqueName(activity.getString(R.string.background), spriteNames);
+				String newSpriteName = name.getUniqueName(context.getString(R.string.background), spriteNames);
 				spriteList.get(sprite).setName(newSpriteName);
 				return;
 			}


### PR DESCRIPTION
https://jira.catrob.at/browse/IDE-130
Remove `spriteEqualBackgroundTest` as an uiespresso test, instead implement as an Unit Test. In `checkIfSpriteNameEqualBackground` use Context instead of Activity. This allows calling the necessary function -> `checkIfSpriteNameEqualBackground(Context context)` from the new test. Furthermore it is a cleaner solution to use the context instead of activity. 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
