### PR TITLE
IDE-127 reduce thumbnail screenshot dimensions

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/stage/ScreenshotSaver.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/ScreenshotSaver.kt
@@ -49,6 +49,8 @@ class ScreenshotSaver(
     companion object {
         private val TAG = ScreenshotSaver::class.java.simpleName
         private const val IMAGE_QUALITY = 100
+        private const val MAX_SCREEN_SHOT_HEIGHT = 480
+        private const val MAX_SCREEN_SHOT_WIDTH = 480
         private const val NUMBER_OF_COLORS = 4
         private val VALID_FILENAME_REGEX = Regex("^[^<>:;,?\"*|/]+\$")
         private val ONLY_WHITESPACE_REGEX = Regex("\\s*")
@@ -100,11 +102,19 @@ class ScreenshotSaver(
             Bitmap.Config.ARGB_8888
         )
 
+        val aspectRatio = width / height.toDouble()
+        var newWidth = (MAX_SCREEN_SHOT_HEIGHT * aspectRatio).toInt()
+        if (newWidth > MAX_SCREEN_SHOT_WIDTH) {
+            newWidth = MAX_SCREEN_SHOT_WIDTH
+        }
+
+        val resizedBitMap = Bitmap.createScaledBitmap(fullScreenBitmap, newWidth, MAX_SCREEN_SHOT_HEIGHT, false)
+
         val imageScene = gdxFileHandler.absolute(folder + fileName)
         val streamScene = imageScene.write(false)
         try {
             File(folder + Constants.NO_MEDIA_FILE).createNewFile()
-            fullScreenBitmap.compress(Bitmap.CompressFormat.PNG, IMAGE_QUALITY, streamScene)
+            resizedBitMap.compress(Bitmap.CompressFormat.PNG, IMAGE_QUALITY, streamScene)
             streamScene.close()
 
             if (ProjectManager.getInstance().currentProject != null) {
@@ -112,7 +122,7 @@ class ScreenshotSaver(
                 val imageProject = gdxFileHandler.absolute(projectFolder + fileName)
                 val streamProject = imageProject.write(false)
                 File(projectFolder + Constants.NO_MEDIA_FILE).createNewFile()
-                fullScreenBitmap.compress(Bitmap.CompressFormat.PNG, IMAGE_QUALITY, streamProject)
+                resizedBitMap.compress(Bitmap.CompressFormat.PNG, IMAGE_QUALITY, streamProject)
                 streamProject.close()
             }
         } catch (e: IOException) {


### PR DESCRIPTION
https://jira.catrob.at/browse/IDE-127

This PR reduces the dimensions of the screenshot used for thumbnails to a maximum of 480x480 pixels by resizing the bitmap while keeping the aspect ratio of the original screenshot.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
