### PR TITLE
IDE-69 End of enclosing bricks (loops, conditionals etc) can't be moved

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/dragndrop/BrickListView.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dragndrop/BrickListView.kt
@@ -39,6 +39,8 @@ import android.widget.ListAdapter
 import android.widget.ListView
 import androidx.annotation.VisibleForTesting
 import org.catrobat.catroid.content.bricks.Brick
+import org.catrobat.catroid.content.bricks.CompositeBrick
+import org.catrobat.catroid.content.bricks.EndBrick
 import java.util.ArrayList
 
 private const val SMOOTH_SCROLL_BY = 15
@@ -104,11 +106,15 @@ class BrickListView : ListView {
         cancelMove()
         val flatList: MutableList<Brick> = ArrayList()
         brickToMove?.addToFlatList(flatList)
-        if (brickToMove !== flatList[0]) {
+        if (brickToMove?.parent is CompositeBrick && brickToMove is EndBrick) {
+            this.brickToMove = brickToMove
+            flatList.clear()
+        } else if (brickToMove !== flatList[0]) {
             return
+        } else {
+            this.brickToMove = flatList[0]
+            flatList.removeAt(0)
         }
-        this.brickToMove = flatList[0]
-        flatList.removeAt(0)
 
         upperScrollBound = height / UPPER_SCROLL_BOUND_DIVISOR
         lowerScrollBound = height / LOWER_SCROLL_BOUND_DIVISOR

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/BrickAdapter.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/adapter/BrickAdapter.kt
@@ -34,7 +34,9 @@ import androidx.annotation.IntDef
 import org.catrobat.catroid.content.Script
 import org.catrobat.catroid.content.Sprite
 import org.catrobat.catroid.content.bricks.Brick
+import org.catrobat.catroid.content.bricks.CompositeBrick
 import org.catrobat.catroid.content.bricks.EmptyEventBrick
+import org.catrobat.catroid.content.bricks.EndBrick
 import org.catrobat.catroid.content.bricks.FormulaBrick
 import org.catrobat.catroid.content.bricks.ListSelectorBrick
 import org.catrobat.catroid.content.bricks.ScriptBrick
@@ -365,11 +367,111 @@ class BrickAdapter(private val sprite: Sprite) :
         if (source !is ScriptBrick && targetPosition == 0) {
             return false
         }
-        if (source.allParts.contains(items[targetPosition])) {
+        if (source !is EndBrick && source.allParts.contains(items[targetPosition])) {
             return false
         }
         Collections.swap(items, sourcePosition, targetPosition)
         return true
+    }
+
+    private fun getParentBrickInDragAndDropList(
+        brickAboveTarget: Brick,
+        enclosureBrick: Brick
+    ): Pair<Brick, Int>? {
+
+        if (brickAboveTarget == enclosureBrick) {
+            return brickAboveTarget to 0
+        }
+
+        var brickInEnclosure = brickAboveTarget
+        while (brickInEnclosure.parent !== null &&
+            brickInEnclosure.parent !in enclosureBrick.allParts &&
+            brickInEnclosure !in enclosureBrick.dragAndDropTargetList
+        ) {
+
+            brickInEnclosure = brickInEnclosure.parent
+        }
+
+        if (brickInEnclosure.parent !== enclosureBrick &&
+            brickInEnclosure !in enclosureBrick.dragAndDropTargetList
+        ) {
+            return null
+        }
+
+        return brickInEnclosure to
+            enclosureBrick.dragAndDropTargetList.indexOf(brickInEnclosure) + 1
+    }
+
+    private fun moveEndIntoExtendedSection(
+        position: Int,
+        endBrick: Brick,
+        brickAboveTargetPosition: Brick
+    ): Boolean {
+        var tmpParent = brickAboveTargetPosition
+        val firstPart = endBrick.parent
+        while (tmpParent.parent != null) {
+            if (tmpParent is CompositeBrick) {
+                moveItemTo(position, firstPart)
+                return true
+            }
+            tmpParent = tmpParent.parent
+            if (tmpParent !is CompositeBrick || tmpParent == firstPart.parent) {
+                break
+            }
+        }
+        return false
+    }
+
+    private fun moveEndTo(position: Int, endBrick: Brick, brickAboveTargetPosition: Brick) {
+        if (endBrick.script !== brickAboveTargetPosition.script) {
+            return
+        }
+
+        var startBrick = endBrick.parent
+        var enclosure = (startBrick as CompositeBrick).nestedBricks
+        if (startBrick.hasSecondaryList()) {
+            enclosure = startBrick.secondaryNestedBricks
+            startBrick = startBrick.allParts[1]
+        }
+
+        val (parentOfBrickAboveTargetPosition, destinationPosition) =
+            getParentBrickInDragAndDropList(brickAboveTargetPosition, startBrick)
+                ?: null to 0
+
+        val indexStartBrick = getPosition(startBrick)
+        if (getPosition(brickAboveTargetPosition) + 1 < indexStartBrick) {
+            return
+        }
+
+        if (parentOfBrickAboveTargetPosition == null) {
+            if (moveEndIntoExtendedSection(position, endBrick, brickAboveTargetPosition)) {
+                return
+            }
+
+            var (outsideParent, outPosition) =
+                getParentBrickInDragAndDropList(
+                    brickAboveTargetPosition,
+                    endBrick.parent.parent
+                )
+                    ?: return
+            outsideParent = outsideParent.parent
+
+            val startIndex =
+                outsideParent.dragAndDropTargetList.indexOf(endBrick.parent) + 1
+            for (i in startIndex until outPosition) {
+                val brick = outsideParent.dragAndDropTargetList.removeAt(startIndex)
+                brick.parent = startBrick
+                enclosure.add(brick)
+            }
+        } else {
+            val parentOfCompBrick = endBrick.parent.parent
+            val positionInList = parentOfCompBrick.dragAndDropTargetList.indexOf(endBrick) + 1
+            for (index in (destinationPosition until enclosure.size).withIndex()) {
+                val brick = enclosure.removeAt(destinationPosition)
+                brick.parent = parentOfCompBrick
+                parentOfCompBrick.dragAndDropTargetList.add(positionInList + index.value, brick)
+            }
+        }
     }
 
     override fun moveItemTo(position: Int, itemToMove: Brick?) {
@@ -377,6 +479,8 @@ class BrickAdapter(private val sprite: Sprite) :
 
         if (itemToMove is ScriptBrick) {
             moveScript(itemToMove, brickAboveTargetPosition)
+        } else if (itemToMove is EndBrick) {
+            moveEndTo(position, itemToMove, brickAboveTargetPosition)
         } else {
             for (script in scripts) {
                 script.removeBrick(itemToMove)

--- a/catroid/src/test/java/org/catrobat/catroid/test/ui/brickadapter/EndBrickDragAndDropTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/ui/brickadapter/EndBrickDragAndDropTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2023 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.ui.brickadapter
+
+import org.catrobat.catroid.content.Script
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.content.StartScript
+import org.catrobat.catroid.content.bricks.ChangeSizeByNBrick
+import org.catrobat.catroid.content.bricks.ForeverBrick
+import org.catrobat.catroid.content.bricks.IfLogicBeginBrick
+import org.catrobat.catroid.content.bricks.SetXBrick
+import org.catrobat.catroid.ui.recyclerview.adapter.BrickAdapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+@RunWith(JUnit4::class)
+class EndBrickDragAndDropTest {
+    lateinit var adapter: BrickAdapter
+    lateinit var script: Script
+    var ifLogicBeginBrick = IfLogicBeginBrick()
+    var changeSizeByNBrick = ChangeSizeByNBrick()
+    var setXBrick = SetXBrick()
+    lateinit var sprite: Sprite
+
+    @Before
+    fun setUp() {
+        script = StartScript()
+
+        val scripts: MutableList<Script> = ArrayList()
+        scripts.add(script)
+
+        sprite = mock(Sprite::class.java)
+        `when`(sprite.scriptList).thenReturn(scripts)
+    }
+
+    @Test
+    fun testDragDownEndBrick() {
+        script.addBrick(ifLogicBeginBrick)
+        script.addBrick(changeSizeByNBrick)
+        script.addBrick(setXBrick)
+        adapter = BrickAdapter(sprite)
+
+        val endBrick = adapter.items[3]
+
+        assertTrue(adapter.onItemMove(3, 4))
+        assertTrue(adapter.onItemMove(4, 5))
+
+        adapter.moveItemTo(5, endBrick)
+
+        assertTrue(ifLogicBeginBrick.secondaryNestedBricks.contains(changeSizeByNBrick))
+        assertTrue(ifLogicBeginBrick.secondaryNestedBricks.contains(setXBrick))
+        assertFalse(script.brickList.contains(changeSizeByNBrick))
+        assertFalse(script.brickList.contains(setXBrick))
+    }
+
+    @Test
+    fun testDragUpEndBrick() {
+        ifLogicBeginBrick.addBrickToElseBranch(changeSizeByNBrick)
+        ifLogicBeginBrick.addBrickToElseBranch(setXBrick)
+        script.addBrick(ifLogicBeginBrick)
+        adapter = BrickAdapter(sprite)
+        val endBrick = adapter.items[5]
+
+        assertTrue(adapter.onItemMove(5, 4))
+        assertTrue(adapter.onItemMove(4, 3))
+
+        adapter.moveItemTo(3, endBrick)
+
+        assertTrue(script.brickList.contains(changeSizeByNBrick))
+        assertTrue(script.brickList.contains(setXBrick))
+        assertFalse(ifLogicBeginBrick.secondaryNestedBricks.contains(changeSizeByNBrick))
+        assertFalse(ifLogicBeginBrick.secondaryNestedBricks.contains(setXBrick))
+    }
+
+    @Test
+    fun testDragDownIntoAnotherEnclosure() {
+        ifLogicBeginBrick.addBrickToElseBranch(changeSizeByNBrick)
+        ifLogicBeginBrick.addBrickToElseBranch(setXBrick)
+        script.addBrick(ifLogicBeginBrick)
+        val foreverBrick = ForeverBrick()
+        script.addBrick(foreverBrick)
+        adapter = BrickAdapter(sprite)
+        val endBrick = adapter.items[5]
+
+        assertTrue(adapter.onItemMove(5, 6))
+
+        adapter.moveItemTo(6, endBrick)
+
+        assertTrue(foreverBrick.dragAndDropTargetList.contains(ifLogicBeginBrick))
+        assertEquals(changeSizeByNBrick, adapter.items[4])
+        assertEquals(setXBrick, adapter.items[5])
+    }
+}


### PR DESCRIPTION
Some code parts have been reused from https://github.com/Catrobat/Catroid/pull/4707
- Add possibility to drag and drop EndBricks
- Implement logic for drag up and drag down operations
- Add unit tests to verify correct behaviour of adapter.moveItemTo() method

https://jira.catrob.at/browse/IDE-69

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
