### PR TITLE
IDE-54 Input field hidden behind keyboard, cannot be scrolled up

### DIFF
--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
+  ~ Copyright (C) 2010-2023 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -135,7 +135,7 @@
         <activity
             android:name=".ui.ProjectUploadActivity"
             android:screenOrientation="portrait"
-            android:windowSoftInputMode="adjustNothing"/>
+            android:windowSoftInputMode="adjustResize"/>
 
         <activity
             android:name=".stage.StageActivity"

--- a/catroid/src/main/res/layout/activity_upload.xml
+++ b/catroid/src/main/res/layout/activity_upload.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
+  ~ Copyright (C) 2010-2023 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -22,7 +22,6 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -33,6 +32,10 @@
 
     <include layout="@layout/progress_bar" />
 
+    <ScrollView
+        android:id="@+id/upload_scroll_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
     <LinearLayout
         android:id="@+id/upload_layout"
         android:layout_width="match_parent"
@@ -40,6 +43,7 @@
         android:paddingTop="@dimen/dialog_content_area_padding_top"
         android:paddingStart="@dimen/dialog_content_area_padding"
         android:paddingEnd="@dimen/dialog_content_area_padding"
+        android:paddingBottom="@dimen/padding_for_scrolling"
         android:orientation="vertical">
 
         <ImageView
@@ -136,4 +140,5 @@
     </LinearLayout>
 
     </LinearLayout>
+    </ScrollView>
 </LinearLayout>

--- a/catroid/src/main/res/values/dimens.xml
+++ b/catroid/src/main/res/values/dimens.xml
@@ -82,6 +82,9 @@
     <dimen name="sprite_group_item_view_holder_padding">40dp</dimen>
     <dimen name="checkbox_margin">16dp</dimen>
 
+    <!-- Padding -->
+    <dimen name="padding_for_scrolling">150dp</dimen>
+
     <!-- Activity -->
     <dimen name="activity_text_view_margin_large" >35dp</dimen >
 


### PR DESCRIPTION
make linear layout in upload view scrollable, so that the input field is no longer hidden behind the keyboard.
Additionally the user doesn't have to scroll down manually when typing.

https://catrobat.atlassian.net/browse/IDE-54

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
