### PR TITLE
CATROID-812 Refactor FormulaEditorFragment

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/stage/SearchParameterTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/stage/SearchParameterTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ShowTextColorSizeAlignmentBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/ShowTextColorSizeAlignmentBrickTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -119,9 +119,7 @@ public class ShowTextColorSizeAlignmentBrickTest {
 	}
 
 	@Test
-	public void testPickColorInFormulaFragment() {
-		onView(withId(R.id.brick_show_variable_color_size_edit_relative_size))
-				.perform(click());
+	public void testPickColorInSpriteFragment() {
 		onView(withId(R.id.brick_show_variable_color_size_edit_color))
 				.perform(click());
 		onView(withText(R.string.brick_context_dialog_pick_color))

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/VisualPlacementBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/app/VisualPlacementBrickTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -86,7 +86,8 @@ public class VisualPlacementBrickTest {
 				{"GlideToBrick", R.string.brick_glide, new GlideToBrick()},
 				{"PlaceAtBrick", R.string.brick_place_at, new PlaceAtBrick()},
 				{"ShowTextBrick", R.string.brick_show_variable, new ShowTextBrick()},
-				{"ShowTextColorSizeAlignment", R.string.brick_show_variable_size, new ShowTextColorSizeAlignmentBrick(0, 0, 100, "#FFFF00")}
+				{"ShowTextColorSizeAlignment", R.string.brick_show_variable_size,
+						new ShowTextColorSizeAlignmentBrick(0, 0, 100, "#FFFF00")}
 		});
 	}
 
@@ -141,6 +142,44 @@ public class VisualPlacementBrickTest {
 	}
 
 	@Test
+	public void testIsVisualPlacementShownInSpriteFragmentForEditTextY() {
+		onBrickAtPosition(1).checkShowsText(brickString);
+		onView(withId(brick.getYEditTextId())).perform(click());
+		onView(withText(R.string.brick_option_place_visually)).check(matches(isDisplayed()));
+	}
+
+	@Test
+	public void testDialogIsShownForVisualPlacementBricksOnEditTextX() {
+		onBrickAtPosition(brickPosition).checkShowsText(brickString);
+		openFormulaEditorActivityFromEditTextX();
+		onFormulaEditor().check(matches(isDisplayed()));
+	}
+
+	@Test
+	public void testVisualPlacementActivityReturnsCorrectlyToScriptFragment() {
+		openVisualPlacementActivityFromEditTextX();
+		intended(hasComponent(VisualPlacementActivity.class.getName()));
+		pressBack();
+
+		isBackInScriptFragment();
+	}
+
+	@Test
+	public void testFormulaEditorActivityReturnsCorrectlyToScriptFragment() {
+		openFormulaEditorActivityFromEditTextX();
+		onFormulaEditor().check(matches(isDisplayed()));
+		pressBack();
+
+		isBackInScriptFragment();
+	}
+
+	@Test
+	public void testIsVisualPlacementActivityShownInSpriteFragment() {
+		openVisualPlacementActivityFromEditTextX();
+		intended(hasComponent(VisualPlacementActivity.class.getName()));
+	}
+
+	@Test
 	public void testIsVisualPlacementShownForEditTextX() {
 		onBrickAtPosition(1).checkShowsText(brickString);
 		isPlaceVisuallyEditFormulaChooserShownWithTapOnEditText(brick.getXEditTextId());
@@ -160,15 +199,8 @@ public class VisualPlacementBrickTest {
 	}
 
 	@Test
-	public void testVisualPlacementAfterFormulaNotANumber() {
-		openFormulaEditorFragmentFromEditTextX();
-		onFormulaEditor().performEnterFormula("1+2");
-		isFormulaEditorShownImmediatelyWithTapOnEditText(brick.getYEditTextId());
-	}
-
-	@Test
 	public void testVisualPlacementAfterNumberEntered() {
-		openFormulaEditorFragmentFromEditTextX();
+		openFormulaEditorActivityFromEditTextX();
 		onFormulaEditor()
 				.performEnterNumber(42);
 		pressBack();
@@ -182,50 +214,8 @@ public class VisualPlacementBrickTest {
 	}
 
 	@Test
-	public void testIsVisualPlacementShownInFormulaFragmentForEditTextX() {
-		onBrickAtPosition(brickPosition).checkShowsText(brickString);
-		openFormulaEditorFragmentFromEditTextX();
-		isPlaceVisuallyEditFormulaChooserShownWithTapOnEditText(brick.getXEditTextId());
-	}
-
-	@Test
-	public void testIsVisualPlacementShownInFormulaFragmentForEditTextY() {
-		onBrickAtPosition(1).checkShowsText(brickString);
-		openFormulaEditorFragmentFromEditTextX();
-		isPlaceVisuallyEditFormulaChooserShownWithTapOnEditText(brick.getYEditTextId());
-	}
-
-	@Test
-	public void testIsVisualPlacementActivityShownInFormulaFragment() {
-		openFormulaEditorFragmentFromEditTextX();
-		openVisualPlacementActivityFromEditTextX();
-		intended(hasComponent(VisualPlacementActivity.class.getName()));
-	}
-
-	@Test
-	public void testVisualPlacementInFormulaFragmentAfterFormulaNotANumber() {
-		openFormulaEditorFragmentFromEditTextX();
-		enterFormulaInFormulaEditor("1+2");
-		isFormulaEditorShownImmediatelyWithTapOnEditText(brick.getXEditTextId());
-		isFormulaEditorShownImmediatelyWithTapOnEditText(brick.getYEditTextId());
-	}
-
-	@Test
-	public void testDoesFormulaFragmentReturnCorrectlyAfterVisualPlacement() {
-		openFormulaEditorFragmentFromEditTextX();
-		openVisualPlacementActivityFromEditTextX();
-		intended(hasComponent(VisualPlacementActivity.class.getName()));
-		pressBack();
-		onFormulaEditor()
-				.check(matches(isDisplayed()));
-		pressBack();
-		isBackInScriptFragment();
-	}
-
-	@Test
 	public void testNoRecursiveOpeningOfFormulaEditors() {
-		openFormulaEditorFragmentFromEditTextX();
-		openFormulaEditorFragmentFromEditTextX();
+		openFormulaEditorActivityFromEditTextX();
 		pressBack();
 		isBackInScriptFragment();
 	}
@@ -238,14 +228,7 @@ public class VisualPlacementBrickTest {
 	}
 
 	private void isBackInScriptFragment() {
-		onBrickAtPosition(brickPosition)
-				.check(matches(isDisplayed()));
-	}
-
-	private void enterFormulaInFormulaEditor(String formula) {
-		onFormulaEditor()
-				.performEnterFormula(formula);
-		pressBack();
+		onBrickAtPosition(brickPosition).check(matches(isDisplayed()));
 	}
 
 	private void openVisualPlacementActivityFromEditTextX() {
@@ -255,7 +238,7 @@ public class VisualPlacementBrickTest {
 				.perform(click());
 	}
 
-	private void openFormulaEditorFragmentFromEditTextX() {
+	private void openFormulaEditorActivityFromEditTextX() {
 		onView(withId(brick.getXEditTextId()))
 				.perform(click());
 		onView(withText(R.string.brick_context_dialog_formula_edit_brick))

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -105,15 +105,20 @@ public class FormulaEditorFragmentTest {
 	public void testFailParse() {
 		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
 				.perform(click());
+		onView(withText(R.string.formula_editor_title))
+				.check(matches(isDisplayed()));
 		onFormulaEditor()
 				.performEnterFormula("3+");
 		pressBack();
 		UiTestUtils.onToast(withText(R.string.formula_editor_parse_fail))
 				.check(matches(isDisplayed()));
-		onView(withText(R.string.formula_editor_title))
-				.check(matches(isDisplayed()));
+		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
+				.check(matches(withText("1 ")));
+
+		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
+				.perform(click());
 		onFormulaEditor()
-				.performBackspace();
+				.performEnterFormula("3");
 		pressBack();
 		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText("3 ")));

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUndoTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUndoTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUserDefinedBrickTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUserDefinedBrickTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserDefinedBrickInputTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DataListFragmentUserDefinedBrickInputTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RemoveTabsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/RemoveTabsTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2023 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -77,7 +77,6 @@ public class RemoveTabsTest {
 	public void testRemoveTabsInFormulaEditorFragmentTest() {
 		assertTabLayoutIsShown(FRAGMENT_SCRIPTS);
 		onView(withId(R.id.brick_set_variable_edit_text)).perform(click());
-		assertTabLayoutIsNotShown();
 		pressBack();
 		assertTabLayoutIsShown(FRAGMENT_SCRIPTS);
 	}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/UndoTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/UndoTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/tabs/SpriteActivityTabsTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/tabs/SpriteActivityTabsTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -47,7 +47,6 @@ import static org.catrobat.catroid.ui.SpriteActivity.FRAGMENT_LOOKS;
 import static org.catrobat.catroid.ui.SpriteActivity.FRAGMENT_SCRIPTS;
 import static org.catrobat.catroid.ui.SpriteActivity.FRAGMENT_SOUNDS;
 import static org.catrobat.catroid.uiespresso.util.actions.TabActionsKt.selectTabAtPosition;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -98,9 +97,10 @@ public class SpriteActivityTabsTest {
 		onView(withId(R.id.formula_editor_keyboard_data)).perform(click());
 		openActionBarOverflowOrOptionsMenu(baseActivityTestRule.getActivity());
 		onView(withText(R.string.delete)).perform(click());
-		assertTabLayoutIsNotShown();
 		pressBack();
-		assertTabLayoutIsNotShown();
+		pressBack();
+		pressBack();
+		assertTabLayoutIsShown();
 	}
 
 	private void assertFragmentIsShown(String tag) {
@@ -114,8 +114,8 @@ public class SpriteActivityTabsTest {
 		assertTrue(fragment.isVisible());
 	}
 
-	private void assertTabLayoutIsNotShown() {
+	private void assertTabLayoutIsShown() {
 		onIdle();
-		assertNull(baseActivityTestRule.getActivity().findViewById(tab_layout));
+		assertNotNull(baseActivityTestRule.getActivity().findViewById(tab_layout));
 	}
 }

--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -186,8 +186,13 @@
                 android:resource="@xml/searchable"/>
         </activity>
 
+         <activity
+             android:name=".ui.SignInActivity"
+             android:screenOrientation="portrait"
+             android:windowSoftInputMode="adjustNothing" />
+
         <activity
-            android:name=".ui.SignInActivity"
+            android:name=".ui.FormulaEditorActivity"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustNothing" />
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/BrickBaseType.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/BrickBaseType.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -48,9 +48,10 @@ public abstract class BrickBaseType implements Brick {
 	private static final long serialVersionUID = 1L;
 
 	public transient View view;
+
 	private transient CheckBox checkbox;
 
-	protected transient Brick parent;
+	protected Brick parent;
 
 	protected boolean commentedOut;
 

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorMoveForwardBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/PhiroMotorMoveForwardBrick.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -23,6 +23,7 @@
 package org.catrobat.catroid.content.bricks;
 
 import android.content.Context;
+import android.content.Intent;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
@@ -33,10 +34,20 @@ import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.actions.ScriptSequenceAction;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.FormulaElement;
+import org.catrobat.catroid.formulaeditor.InternFormula;
+import org.catrobat.catroid.ui.FormulaEditorActivity;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.ui.UiUtils;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import org.catrobat.catroid.ui.fragment.SingleSeekBar;
 
+import java.util.HashMap;
+
+import androidx.appcompat.app.AppCompatActivity;
 import kotlin.Unit;
+
+import static org.catrobat.catroid.ui.SpriteActivity.EXTRA_BRICK_HASH;
+import static org.catrobat.catroid.ui.SpriteActivity.REQUEST_CODE_EDIT_FORMULA;
 
 public class PhiroMotorMoveForwardBrick extends FormulaBrick {
 
@@ -93,10 +104,33 @@ public class PhiroMotorMoveForwardBrick extends FormulaBrick {
 	@Override
 	public void showFormulaEditorToEditFormula(View view) {
 		if (isSpeedOnlyANumber()) {
-			FormulaEditorFragment.showCustomFragment(view.getContext(), this, BrickField.PHIRO_SPEED);
+			showCustomFragment(view.getContext(), this, BrickField.PHIRO_SPEED);
 		} else {
 			super.showFormulaEditorToEditFormula(view);
 		}
+	}
+
+	private void showCustomFragment(Context context, FormulaBrick formulaBrick, Brick.FormulaField formulaField) {
+		Intent intent = new Intent(context, FormulaEditorActivity.class);
+		intent.putExtra(FormulaEditorFragment.SHOW_CUSTOM_VIEW, true);
+		intent.putExtra(FormulaEditorFragment.FORMULA_BRICK_BUNDLE_ARGUMENT, formulaBrick);
+		intent.putExtra(FormulaEditorFragment.FORMULA_FIELD_BUNDLE_ARGUMENT, formulaField);
+		intent.putExtra(FormulaEditorFragment.BRICK_FIELD_TO_TEXT_VIEW_ID_MAP, new HashMap<>(brickFieldToTextViewIdMap));
+		intent.putExtra(FormulaEditorFragment.FORMULA_MAP_BUNDLE_ARGUMENT, formulaMap);
+
+		Brick.FormulaField currentFormulaField = (Brick.FormulaField) intent
+				.getSerializableExtra(FormulaEditorFragment.FORMULA_FIELD_BUNDLE_ARGUMENT);
+
+		Formula currentFormula = formulaBrick.getFormulaWithBrickField(currentFormulaField);
+		InternFormula internFormula = currentFormula.internFormula;
+		intent.putExtra(FormulaEditorFragment.CURRENT_BRICK_INTERN_FORMULA, internFormula);
+		intent.putExtra(EXTRA_BRICK_HASH, hashCode());
+
+		AppCompatActivity activity = UiUtils.getActivityFromView(view);
+		if (!(activity instanceof SpriteActivity)) {
+			return;
+		}
+		activity.startActivityForResult(intent, REQUEST_CODE_EDIT_FORMULA);
 	}
 
 	private boolean isSpeedOnlyANumber() {

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextColorSizeAlignmentBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/ShowTextColorSizeAlignmentBrick.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -66,7 +66,7 @@ public class ShowTextColorSizeAlignmentBrick extends UserVariableBrickWithVisual
 
 	public int alignmentSelection = ALIGNMENT_STYLE_CENTERED;
 
-	private final transient ShowFormulaEditorStrategy showFormulaEditorStrategy;
+	private transient ShowFormulaEditorStrategy showFormulaEditorStrategy;
 
 	public ShowTextColorSizeAlignmentBrick() {
 		addAllowedBrickField(BrickField.X_POSITION, R.id.brick_show_variable_color_size_edit_text_x);
@@ -97,6 +97,9 @@ public class ShowTextColorSizeAlignmentBrick extends UserVariableBrickWithVisual
 	public void showFormulaEditorToEditFormula(View view) {
 		if (view.getId() == R.id.brick_show_variable_color_size_edit_color && isValidColorString(getColor())) {
 			ShowFormulaEditorStrategy.Callback callback = new ShowTextColorSizeAlignmentBrickCallback(view);
+			if (showFormulaEditorStrategy == null) {
+				showFormulaEditorStrategy = new ShowColorPickerFormulaEditorStrategy();
+			}
 			showFormulaEditorStrategy.showFormulaEditorToEditFormula(view, callback);
 		} else {
 			superShowFormulaEditor(view);

--- a/catroid/src/main/java/org/catrobat/catroid/content/bricks/VisualPlacementBrick.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/bricks/VisualPlacementBrick.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -84,7 +84,8 @@ public abstract class VisualPlacementBrick extends FormulaBrick {
 					placeVisually(getXBrickField(), getYBrickField());
 					break;
 				case 1:
-					if (currentFragment instanceof ScriptFragment) {
+					if (currentFragment instanceof ScriptFragment
+							|| currentFragment instanceof FormulaEditorFragment) {
 						super.showFormulaEditorToEditFormula(view);
 					}
 					break;

--- a/catroid/src/main/java/org/catrobat/catroid/content/strategy/ShowColorPickerFormulaEditorStrategy.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/strategy/ShowColorPickerFormulaEditorStrategy.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -65,7 +65,7 @@ public class ShowColorPickerFormulaEditorStrategy implements ShowFormulaEditorSt
 			callback.showFormulaEditor(view);
 		}
 
-		return currentFragment instanceof ScriptFragment || currentFragment instanceof FormulaEditorFragment;
+		return currentFragment instanceof ScriptFragment;
 	}
 
 	private void showSelectEditDialog(View view, Callback callback) {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/Formula.java
@@ -40,8 +40,7 @@ public class Formula implements Serializable {
 	private static final long serialVersionUID = 1L;
 	private static final String ERROR_STRING = "ERROR";
 	private FormulaElement formulaTree;
-
-	private transient InternFormula internFormula = null;
+	public transient InternFormula internFormula = null;
 
 	private boolean sceneFirstStart = false;
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -27,13 +27,14 @@ import android.util.Log;
 
 import org.catrobat.catroid.R;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
 import androidx.annotation.VisibleForTesting;
 
-public class InternFormula {
+public class InternFormula implements Serializable {
 	private static final String TAG = InternFormula.class.getSimpleName();
 
 	public enum CursorTokenPosition {
@@ -49,7 +50,9 @@ public class InternFormula {
 	}
 
 	@VisibleForTesting
-	public ExternInternRepresentationMapping externInternRepresentationMapping;
+	/* Property needs to be transient to be able to pass the internFormula via an intent
+	   whe starting the FormulaEditorActivity */
+	public transient ExternInternRepresentationMapping externInternRepresentationMapping;
 
 	private List<InternToken> internTokenFormulaList;
 	private String externFormulaString;

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaTokenSelection.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormulaTokenSelection.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -24,7 +24,9 @@ package org.catrobat.catroid.formulaeditor;
 
 import org.catrobat.catroid.formulaeditor.InternFormula.TokenSelectionType;
 
-public class InternFormulaTokenSelection {
+import java.io.Serializable;
+
+public class InternFormulaTokenSelection implements Serializable {
 
 	private int internTokenSelectionStart;
 	private int internTokenSelectionEnd;

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternToken.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -26,9 +26,10 @@ import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.sensing.CollisionDetection;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class InternToken {
+public class InternToken implements Serializable {
 
 	private String tokenStringValue = "";
 	private InternTokenType internTokenType;

--- a/catroid/src/main/java/org/catrobat/catroid/io/XstreamSerializer.java
+++ b/catroid/src/main/java/org/catrobat/catroid/io/XstreamSerializer.java
@@ -807,7 +807,6 @@ public final class XstreamSerializer {
 					String previousXml = Files.asCharSource(currentCodeFile, Charsets.UTF_8).read();
 
 					if (previousXml.equals(currentXml)) {
-						Log.d(TAG, "Project version is the same. Do not update " + currentCodeFile.getName());
 						return false;
 					} else {
 						String languageRegex = "<catrobatLanguageVersion>.*</catrobatLanguageVersion>";

--- a/catroid/src/main/java/org/catrobat/catroid/ui/FormulaEditorActivity.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/FormulaEditorActivity.kt
@@ -1,0 +1,340 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2024 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.ui
+
+import android.content.DialogInterface
+import android.content.Intent
+import android.os.Bundle
+import android.preference.PreferenceManager
+import android.view.Menu
+import android.view.View
+import android.widget.CheckBox
+import android.widget.CompoundButton
+import android.widget.RadioButton
+import androidx.fragment.app.Fragment
+import com.google.android.material.textfield.TextInputEditText
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.R
+import org.catrobat.catroid.common.SharedPreferenceKeys
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.databinding.ActivityRecyclerBinding
+import org.catrobat.catroid.formulaeditor.UserData
+import org.catrobat.catroid.formulaeditor.UserList
+import org.catrobat.catroid.formulaeditor.UserVariable
+import org.catrobat.catroid.io.asynctask.ProjectSaver
+import org.catrobat.catroid.ui.SpriteActivity.EXTRA_BRICK_HASH
+import org.catrobat.catroid.ui.fragment.AddBrickFragment
+import org.catrobat.catroid.ui.fragment.BrickCategoryFragment
+import org.catrobat.catroid.ui.fragment.FormulaEditorFragment
+import org.catrobat.catroid.ui.recyclerview.dialog.TextInputDialog
+import org.catrobat.catroid.ui.recyclerview.dialog.textwatcher.DuplicateInputTextWatcher
+import org.catrobat.catroid.ui.recyclerview.fragment.DataListFragment
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment
+import org.catrobat.catroid.utils.SnackbarUtil
+
+class FormulaEditorActivity : BaseActivity() {
+
+    private lateinit var binding: ActivityRecyclerBinding
+    private lateinit var projectManager: ProjectManager
+    private lateinit var currentProject: Project
+    private lateinit var currentSprite: Sprite
+    private lateinit var generatedVariableName: String
+
+    private var setUndoMenuItemVisibility: Boolean = false
+    private var formulaHasChanged: Boolean = false
+    private var userVariableChanged: Boolean = false
+    private var editedFormulaName: String = ""
+
+    companion object {
+        const val FORMULA_HAS_CHANGED = "formulaHasChanged"
+        const val FORMULA_MAP = "formulaMap"
+        const val SET_UNDO_MENU_ITEM_VISIBILITY = "setUndoMenuItemVisibility"
+        const val BRICK_HASH_DEFAULT_VALUE = -1
+
+        val TAG: String = FormulaEditorFragment::class.java.simpleName
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (isFinishing) {
+            return
+        }
+
+        projectManager = ProjectManager.getInstance()
+        currentProject = projectManager.currentProject
+
+        binding = ActivityRecyclerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        setSupportActionBar(binding.toolbar.toolbar)
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        loadFragment()
+    }
+
+    private fun loadFragment() {
+        val fragment = FormulaEditorFragment()
+        fragment.arguments = makeBundleForFormulaEditorFragment()
+
+        supportFragmentManager
+            .beginTransaction()
+            .replace(R.id.fragment_container, fragment, FormulaEditorFragment.TAG)
+            .commit()
+
+        BottomBar.hideBottomBar(this)
+    }
+
+    private fun makeBundleForFormulaEditorFragment(): Bundle {
+        val bundle = Bundle()
+
+        bundle.putSerializable(
+            FormulaEditorFragment.SHOW_CUSTOM_VIEW,
+            intent.getSerializableExtra(FormulaEditorFragment.SHOW_CUSTOM_VIEW)
+        )
+        bundle.putSerializable(
+            FormulaEditorFragment.FORMULA_BRICK_BUNDLE_ARGUMENT,
+            intent.getSerializableExtra(FormulaEditorFragment.FORMULA_BRICK_BUNDLE_ARGUMENT)
+        )
+        bundle.putSerializable(
+            FormulaEditorFragment.FORMULA_FIELD_BUNDLE_ARGUMENT,
+            intent.getSerializableExtra(FormulaEditorFragment.FORMULA_FIELD_BUNDLE_ARGUMENT)
+        )
+        bundle.putSerializable(
+            FormulaEditorFragment.BRICK_FIELD_TO_TEXT_VIEW_ID_MAP,
+            intent.getSerializableExtra(FormulaEditorFragment.BRICK_FIELD_TO_TEXT_VIEW_ID_MAP)
+        )
+        bundle.putSerializable(
+            FormulaEditorFragment.CURRENT_BRICK_INTERN_FORMULA,
+            intent.getSerializableExtra(FormulaEditorFragment.CURRENT_BRICK_INTERN_FORMULA)
+        )
+        bundle.putSerializable(
+            FormulaEditorFragment.FORMULA_MAP_BUNDLE_ARGUMENT,
+            intent.getSerializableExtra(FormulaEditorFragment.FORMULA_MAP_BUNDLE_ARGUMENT)
+        )
+        bundle.putInt(
+            EXTRA_BRICK_HASH,
+            intent.getIntExtra(EXTRA_BRICK_HASH, BRICK_HASH_DEFAULT_VALUE)
+        )
+
+        return bundle
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_script_activity, menu)
+        optionsMenu = menu
+        return super.onCreateOptionsMenu(menu)
+    }
+
+    override fun onBackPressed() {
+        saveProject()
+
+        val fragment = getCurrentFragment()
+
+        if (fragment is FormulaEditorFragment) {
+            fragment.exitFormulaEditorFragment()
+            if (formulaHasChanged || userVariableChanged || setUndoMenuItemVisibility) {
+                setResult(RESULT_OK, makeIntentForResult(fragment))
+            }
+            finish()
+        } else if (supportFragmentManager.backStackEntryCount > 0) {
+            if (fragment is BrickCategoryFragment) {
+                SnackbarUtil.showHintSnackbar(this, R.string.hint_scripts)
+            }
+            if (fragment is AddBrickFragment) {
+                SnackbarUtil.showHintSnackbar(this, R.string.hint_category)
+            }
+            supportFragmentManager.popBackStack()
+            return
+        }
+
+        finish()
+    }
+
+    private fun makeIntentForResult(fragment: FormulaEditorFragment): Intent {
+        val extras = Bundle()
+
+        extras.putInt(
+            EXTRA_BRICK_HASH,
+            intent.getIntExtra(EXTRA_BRICK_HASH, BRICK_HASH_DEFAULT_VALUE)
+        )
+        extras.putBoolean(FORMULA_HAS_CHANGED, formulaHasChanged)
+
+        val showUndoMenuItemVisibility =
+            if (userVariableChanged) true else setUndoMenuItemVisibility
+        extras.putBoolean(SET_UNDO_MENU_ITEM_VISIBILITY, showUndoMenuItemVisibility)
+
+        extras.putSerializable(FORMULA_MAP, fragment.formulaBrick.formulaMap)
+
+        return Intent().putExtras(extras)
+    }
+
+    private fun saveProject() {
+        currentProject = ProjectManager.getInstance().currentProject
+        val projectSaver = ProjectSaver(currentProject, applicationContext)
+        projectSaver.saveProjectAsync()
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun handleAddButton(vie: View?) {
+        if (getCurrentFragment() is DataListFragment) {
+            handleAddUserDataButton()
+            return
+        }
+    }
+
+    private fun handleAddUserDataButton() {
+        val view = View.inflate(this, R.layout.dialog_new_user_data, null)
+
+        val makeListCheckBox = view.findViewById<CheckBox>(R.id.make_list)
+        makeListCheckBox.visibility = View.VISIBLE
+
+        val multiplayerRadioButton = view.findViewById<RadioButton>(R.id.multiplayer)
+        if (SettingsFragment.isMultiplayerVariablesPreferenceEnabled(applicationContext)) {
+            multiplayerRadioButton.visibility = View.VISIBLE
+            multiplayerRadioButton.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
+                makeListCheckBox.isEnabled = !isChecked
+            }
+        }
+
+        val addToProjectUserDataRadioButton = view.findViewById<RadioButton>(R.id.global)
+
+        val variables: MutableList<UserData<*>?> = ArrayList()
+
+        val projectManager = ProjectManager.getInstance()
+        currentSprite = projectManager.currentSprite
+        currentProject = projectManager.currentProject
+
+        variables.addAll(currentProject.userVariables)
+        variables.addAll(currentProject.multiplayerVariables)
+        variables.addAll(currentSprite.userVariables)
+
+        val lists: MutableList<UserData<*>?> = ArrayList()
+        lists.addAll(currentProject.userLists)
+        lists.addAll(currentSprite.userLists)
+
+        val textWatcher: DuplicateInputTextWatcher<UserData<*>?> =
+            DuplicateInputTextWatcher<UserData<*>?>(variables)
+
+        val builder = TextInputDialog.Builder(this)
+
+        val uniqueVariableNameProvider =
+            builder.createUniqueNameProvider(R.string.default_variable_name)
+
+        val uniqueListNameProvider = builder.createUniqueNameProvider(R.string.default_list_name)
+        generatedVariableName = uniqueVariableNameProvider.getUniqueName(
+            getString(R.string.default_variable_name),
+            null
+        )
+
+        builder.setTextWatcher(textWatcher)
+            .setText(generatedVariableName)
+            .setPositiveButton(
+                getString(R.string.ok)
+            ) { _: DialogInterface?, textInput: String? ->
+                val addToProjectUserData = addToProjectUserDataRadioButton.isChecked
+                val addToMultiplayerData = multiplayerRadioButton.isChecked
+                PreferenceManager.getDefaultSharedPreferences(this).edit()
+                    .putBoolean(
+                        SharedPreferenceKeys.INDEXING_VARIABLE_PREFERENCE_KEY,
+                        false
+                    ).apply()
+                if (makeListCheckBox.isChecked) {
+                    val userList = UserList(textInput)
+                    if (addToProjectUserData) {
+                        currentProject.addUserList(userList)
+                    } else {
+                        currentSprite.addUserList(userList)
+                    }
+                } else {
+                    val userVariable = UserVariable(textInput)
+                    if (addToMultiplayerData) {
+                        currentProject.addMultiplayerVariable(userVariable)
+                    } else if (addToProjectUserData) {
+                        currentProject.addUserVariable(userVariable)
+                    } else {
+                        currentSprite.addUserVariable(userVariable)
+                    }
+                }
+                if (getCurrentFragment() is DataListFragment) {
+                    (getCurrentFragment() as DataListFragment?)!!.notifyDataSetChanged()
+                    (getCurrentFragment() as DataListFragment?)!!.indexAndSort()
+                }
+            }
+
+        val alertDialog = builder.setTitle(R.string.formula_editor_variable_dialog_title)
+            .setView(view)
+            .setNegativeButton(getString(R.string.cancel), null)
+            .create()
+
+        makeListCheckBox.setOnCheckedChangeListener { _: CompoundButton?, checked: Boolean ->
+            val textInputEditText =
+                alertDialog.findViewById<TextInputEditText>(R.id.input_edit_text)
+            val currentName = textInputEditText!!.text.toString()
+            if (checked) {
+                alertDialog.setTitle(getString(R.string.formula_editor_list_dialog_title))
+                textWatcher.setOriginalScope(lists)
+                if (currentName == generatedVariableName) {
+                    generatedVariableName = uniqueListNameProvider.getUniqueName(
+                        getString(R.string.default_list_name),
+                        null
+                    )
+                    textInputEditText.setText(generatedVariableName)
+                }
+            } else {
+                alertDialog.setTitle(getString(R.string.formula_editor_variable_dialog_title))
+                textWatcher.setOriginalScope(variables)
+                if (currentName == generatedVariableName) {
+                    generatedVariableName = uniqueVariableNameProvider.getUniqueName(
+                        getString(R.string.default_variable_name),
+                        null
+                    )
+                    textInputEditText.setText(generatedVariableName)
+                }
+            }
+            multiplayerRadioButton.isEnabled = !checked
+        }
+        alertDialog.show()
+    }
+
+    private fun getCurrentFragment(): Fragment? =
+        supportFragmentManager.findFragmentById(R.id.fragment_container)
+
+    fun setUndoMenuItemVisibility(value: Boolean) {
+        setUndoMenuItemVisibility = value
+    }
+
+    fun setFormulaHasChanged(value: Boolean) {
+        formulaHasChanged = value
+    }
+
+    fun setUserVariableHasChanged(value: Boolean) {
+        userVariableChanged = value
+    }
+
+    fun setEditedFormulaName(name: String) {
+        editedFormulaName = name
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SingleSeekBar.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/SingleSeekBar.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2023 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -24,6 +24,7 @@
 package org.catrobat.catroid.ui.fragment;
 
 import android.content.Context;
+import android.content.Intent;
 import android.view.View;
 import android.widget.SeekBar;
 import android.widget.TextView;
@@ -32,6 +33,10 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.FormulaBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
+import org.catrobat.catroid.formulaeditor.InternFormula;
+import org.catrobat.catroid.ui.FormulaEditorActivity;
+
+import java.util.HashMap;
 
 public class SingleSeekBar {
 
@@ -56,7 +61,7 @@ public class SingleSeekBar {
 		seekBarTitle.setText(seekBarTitleId);
 
 		valueTextView = view.findViewById(R.id.single_seekbar_value);
-		valueTextView.setOnClickListener(view1 -> FormulaEditorFragment.showFragment(context, formulaBrick, brickField));
+		valueTextView.setOnClickListener(view1 -> showFormulaEditorToEditFormula(context, formulaBrick, brickField));
 
 		SeekBar seekBar = view.findViewById(R.id.single_seekbar_seekbar);
 		String currentStringValue = formulaBrick.getFormulaWithBrickField(brickField).getTrimmedFormulaString(context);
@@ -79,5 +84,19 @@ public class SingleSeekBar {
 		});
 
 		return view;
+	}
+
+	public static void showFormulaEditorToEditFormula(Context context, FormulaBrick formulaBrick, Brick.FormulaField brickField) {
+		Intent intent = new Intent(context, FormulaEditorActivity.class);
+		intent.putExtra(FormulaEditorFragment.SHOW_CUSTOM_VIEW, false);
+		intent.putExtra(FormulaEditorFragment.FORMULA_BRICK_BUNDLE_ARGUMENT, formulaBrick);
+		intent.putExtra(FormulaEditorFragment.FORMULA_FIELD_BUNDLE_ARGUMENT, brickField);
+		intent.putExtra(FormulaEditorFragment.BRICK_FIELD_TO_TEXT_VIEW_ID_MAP, new HashMap<>(formulaBrick.brickFieldToTextViewIdMap));
+
+		Formula currentFormula = formulaBrick.getFormulaWithBrickField(brickField);
+		InternFormula internFormula = currentFormula.internFormula;
+		intent.putExtra(FormulaEditorFragment.CURRENT_BRICK_INTERN_FORMULA, internFormula);
+
+		context.startActivity(intent);
 	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
@@ -52,6 +52,7 @@ import org.catrobat.catroid.formulaeditor.UserData
 import org.catrobat.catroid.formulaeditor.UserList
 import org.catrobat.catroid.formulaeditor.UserVariable
 import org.catrobat.catroid.ui.BottomBar
+import org.catrobat.catroid.ui.FormulaEditorActivity
 import org.catrobat.catroid.ui.UiUtils
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment
 import org.catrobat.catroid.ui.recyclerview.adapter.DataListAdapter
@@ -482,6 +483,7 @@ class DataListFragment : Fragment(),
         updateUserVariableValue(value, item)
         adapter?.updateDataSet()
         finishActionMode()
+        (activity as? FormulaEditorActivity)?.setUserVariableHasChanged(true)
     }
 
     override fun onSelectionChanged(selectedItemCnt: Int) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -984,7 +984,7 @@ public class ScriptFragment extends ListFragment implements
 		refreshFragmentAfterUndo();
 	}
 
-	private void saveVariables() {
+	public void saveVariables() {
 		ProjectManager projectManager = ProjectManager.getInstance();
 		Sprite currentSprite = projectManager.getCurrentSprite();
 		Project project = projectManager.getCurrentProject();

--- a/catroid/src/main/java/org/catrobat/catroid/userbrick/UserDefinedBrickData.java
+++ b/catroid/src/main/java/org/catrobat/catroid/userbrick/UserDefinedBrickData.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -23,7 +23,9 @@
 
 package org.catrobat.catroid.userbrick;
 
-public abstract class UserDefinedBrickData {
+import java.io.Serializable;
+
+public abstract class UserDefinedBrickData implements Serializable {
 	public enum UserDefinedBrickDataType {
 		INPUT,
 		LABEL

--- a/catroid/src/main/java/org/catrobat/catroid/userbrick/UserDefinedBrickInput.java
+++ b/catroid/src/main/java/org/catrobat/catroid/userbrick/UserDefinedBrickInput.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -39,7 +39,7 @@ public class UserDefinedBrickInput extends UserDefinedBrickData implements Seria
 
 	@XStreamAlias("input")
 	private InputFormulaField name;
-	private transient Formula value;
+	public Formula value;
 	private int initialIndex = -1;
 
 	public UserDefinedBrickInput(String input) {


### PR DESCRIPTION
Refactor the FormulaEditorFragment such that it is started from its own FormulaEditorActivity and not from the SpriteActivity.
https://jira.catrob.at/browse/CATROID-812

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
