### PR TITLE
IDE-232 Fix Instance creation error in BackpackListManager

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/controller/BackpackListManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/controller/BackpackListManager.java
@@ -83,7 +83,8 @@ public final class BackpackListManager {
 	}
 
 	private void createDirectory(File directory) {
-		if (!directory.mkdir()) {
+		directory.mkdir();
+		if (!directory.exists()) {
 			throw new RuntimeException("Could not create directory: " + directory.getAbsolutePath());
 		}
 	}


### PR DESCRIPTION
Fix Instance creation error by checking if directory exists after mkdir and not relying on mkdir return value.
https://catrobat.atlassian.net/browse/IDE-232

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
