### PR TITLE
IDE-197 Correct grammar for German in copy_brick and copy_script

### DIFF
--- a/catroid/src/main/res/values-de/strings.xml
+++ b/catroid/src/main/res/values-de/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2023 The Catrobat Team
+  ~ Copyright (C) 2010-2024 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -683,8 +683,8 @@
     <string name="brick_context_dialog_move_script">Skript bewegen</string>
     <string name="brick_context_dialog_move_definition">Verschiebe diese Definition</string>
     <string name="brick_context_dialog_delete_brick">Baustein löschen</string>
-    <string name="brick_context_dialog_copy_brick">Baustein kopiert</string>
-    <string name="brick_context_dialog_copy_script">Skript kopiert</string>
+    <string name="brick_context_dialog_copy_brick">Baustein kopieren</string>
+    <string name="brick_context_dialog_copy_script">Skript kopieren</string>
     <string name="brick_context_dialog_formula_edit_brick">Formel bearbeiten</string>
     <string name="brick_context_dialog_delete_script">Skript löschen</string>
     <string name="brick_context_dialog_delete_definition">Lösche diese Definition</string>


### PR DESCRIPTION
I have corrected grammar errors in the following two strings with name:

- brick_context_dialog_copy_brick
- brick_context_dialog_copy_script

The original meaning of the old German translation in English was 'Block copied' and 'Script copied', rather than 'Copy block' and 'Copy script' respectively.

https://catrobat.atlassian.net/browse/IDE-197


![Frame 5](https://github.com/Catrobat/Catroid/assets/96479341/e593e680-4590-4cee-b176-6d2d84cef2cc)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
