### PR TITLE
IDE-21

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentTest.java
@@ -176,17 +176,13 @@ public class FormulaEditorFragmentTest {
 	public void testScrolling() {
 		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
 				.perform(click());
-		//onFormulaEditor().performEnterString("test".repeat(150));
-		onFormulaEditor().performEnterString(
-				"testtttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt"
-						+
-						"ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt"
-						+
-						"ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt");
+		onView(withId(R.id.formula_editor_brick_space)).check(matches(isDisplayed()));
 
-		onFormulaEditor().perform(swipeUp());
+		onFormulaEditor().performEnterString("test".repeat(150));
+		onView(withId(R.id.formula_editor_brick_and_formula)).perform(swipeUp());
 		onView(withId(R.id.formula_editor_brick_space)).check(matches(not(isDisplayed())));
-		onFormulaEditor().perform(swipeDown());
+
+		onView(withId(R.id.formula_editor_brick_and_formula)).perform(swipeDown());
 		onView(withId(R.id.formula_editor_brick_space)).check(matches(isDisplayed()));
 	}
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorFragmentTest.java
@@ -26,7 +26,9 @@ import org.catrobat.catroid.R;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
+import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.content.bricks.SetVariableBrick;
+import org.catrobat.catroid.content.bricks.ShowTextBrick;
 import org.catrobat.catroid.formulaeditor.Formula;
 import org.catrobat.catroid.formulaeditor.UserVariable;
 import org.catrobat.catroid.rules.FlakyTestRule;
@@ -48,10 +50,14 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
 import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+import static org.hamcrest.Matchers.not;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.swipeDown;
+import static androidx.test.espresso.action.ViewActions.swipeUp;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -163,6 +169,25 @@ public class FormulaEditorFragmentTest {
 		pressBack();
 		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
 				.check(matches(withText("12 ")));
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class})
+	@Test
+	public void testScrolling() {
+		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text))
+				.perform(click());
+		//onFormulaEditor().performEnterString("test".repeat(150));
+		onFormulaEditor().performEnterString(
+				"testtttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt"
+						+
+						"ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt"
+						+
+						"ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt");
+
+		onFormulaEditor().perform(swipeUp());
+		onView(withId(R.id.formula_editor_brick_space)).check(matches(not(isDisplayed())));
+		onFormulaEditor().perform(swipeDown());
+		onView(withId(R.id.formula_editor_brick_space)).check(matches(isDisplayed()));
 	}
 
 	@After

--- a/catroid/src/main/res/layout/fragment_formula_editor.xml
+++ b/catroid/src/main/res/layout/fragment_formula_editor.xml
@@ -26,55 +26,65 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:theme="@android:style/Theme.Light" >
-
+    
     <LinearLayout
         android:id="@+id/formula_editor_brick_and_formula"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_weight="1"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:scrollbarStyle="insideInset"
+        android:scrollbars="vertical">
 
-        <LinearLayout
-            android:id="@+id/formula_editor_brick_space"
+        <ScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="@dimen/brick_space_padding_formular_editor"
-            android:paddingBottom="@dimen/brick_space_padding_formular_editor"
-            android:background="@color/toolbar_background"
-            android:orientation="vertical"/>
+            android:layout_height="wrap_content">
 
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/solid_white" >
-
-            <org.catrobat.catroid.formulaeditor.FormulaEditorEditText
-                android:id="@+id/formula_editor_edit_field"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="30dp"
-                android:layout_marginTop="5dp"
-                android:layout_marginStart="5dp"
-                android:layout_marginBottom="5dp"
-                android:background="@color/solid_white"
-                android:hint="@string/formula_nothing_selected"
-                android:inputType="textMultiLine"
-                android:lineSpacingExtra="5dp"
-                android:maxLines="20"
-                android:scrollbarStyle="insideInset"
-                android:scrollbars="vertical"
-                android:textColor="@color/solid_black"
-                android:textSize="?attr/x_large" />
-        </FrameLayout>
+                android:orientation="vertical">
 
+                <LinearLayout
+                    android:id="@+id/formula_editor_brick_space"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="@dimen/brick_space_padding_formular_editor"
+                    android:paddingBottom="@dimen/brick_space_padding_formular_editor"
+                    android:background="@color/toolbar_background"
+                    android:orientation="vertical" />
+
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/solid_white">
+
+                    <org.catrobat.catroid.formulaeditor.FormulaEditorEditText
+                        android:id="@+id/formula_editor_edit_field"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="30dp"
+                        android:layout_marginTop="5dp"
+                        android:layout_marginStart="5dp"
+                        android:layout_marginBottom="5dp"
+                        android:background="@color/solid_white"
+                        android:hint="@string/formula_nothing_selected"
+                        android:inputType="textMultiLine"
+                        android:lineSpacingExtra="5dp"
+                        android:maxLines="20"
+                        android:textColor="@color/solid_black"
+                        android:textSize="?attr/x_large" />
+                </FrameLayout>
+            </LinearLayout>
+        </ScrollView>
     </LinearLayout>
 
     <include
         android:id="@+id/formula_editor_keyboardview"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_weight="1"
+        layout="@layout/formula_editor_keyboard"
         android:layout_gravity="bottom"
-        layout="@layout/formula_editor_keyboard" />
+        android:layout_weight="1" />
 
 </LinearLayout>


### PR DESCRIPTION
IDE-21
While scrolling text field in formula editor the brick sticks to the text field (scrolls together with text). 
The testScrolling tests if the brick stays visible by scrolling a very long text.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
