### PR TITLE
CATROID-1607: Crash when using Arduino sensors

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorBluetoothConnectionTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorBluetoothConnectionTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2024 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.formulaeditor
+
+import android.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.catrobat.catroid.R
+import org.catrobat.catroid.content.bricks.ChangeSizeByNBrick
+import org.catrobat.catroid.testsuites.annotations.Cat.AppUi
+import org.catrobat.catroid.testsuites.annotations.Level.Smoke
+import org.catrobat.catroid.ui.SpriteActivity
+import org.catrobat.catroid.ui.recyclerview.viewholder.ViewHolder
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment
+import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper
+import org.catrobat.catroid.uiespresso.util.UiTestUtils.Companion.createProjectAndGetStartScript
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FormulaEditorBluetoothConnectionTest {
+
+    @Rule
+    @JvmField
+    val baseActivityTestRule = FragmentActivityTestRule(
+        SpriteActivity::class.java, SpriteActivity.EXTRA_FRAGMENT_POSITION,
+        SpriteActivity.FRAGMENT_SCRIPTS
+    )
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        val script = createProjectAndGetStartScript("FormulaEditorBluetoothConnectionTest")
+        script.addBrick(ChangeSizeByNBrick(0.0))
+
+        val sharedPreferences = PreferenceManager
+            .getDefaultSharedPreferences(ApplicationProvider.getApplicationContext())
+
+        sharedPreferences.edit()
+            .putBoolean(SettingsFragment.SETTINGS_SHOW_ARDUINO_BRICKS, true)
+            .commit()
+
+        baseActivityTestRule.launchActivity()
+        Espresso.onView(withId(R.id.brick_change_size_by_edit_text))
+            .perform(ViewActions.click())
+        FormulaEditorWrapper.onFormulaEditor()
+            .performOpenCategory(FormulaEditorWrapper.Category.DEVICE)
+    }
+
+    @Category(AppUi::class, Smoke::class)
+    @Test
+    fun arduinoDoesNotCrashTest() {
+        Espresso.onView(withId(R.id.recycler_view))
+            .perform(RecyclerViewActions.actionOnItemAtPosition<ViewHolder>(0, ViewActions.click()))
+        Espresso.onView(FormulaEditorWrapper.Control.COMPUTE)
+            .perform(ViewActions.click())
+    }
+}

--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
         android:smallScreens="true"
         android:xlargeScreens="false" />
 
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" /><uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission

--- a/catroid/src/main/java/org/catrobat/catroid/bluetooth/BluetoothDeviceServiceImpl.java
+++ b/catroid/src/main/java/org/catrobat/catroid/bluetooth/BluetoothDeviceServiceImpl.java
@@ -25,14 +25,19 @@ package org.catrobat.catroid.bluetooth;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.util.Log;
 
+import org.catrobat.catroid.R;
 import org.catrobat.catroid.bluetooth.base.BluetoothDevice;
 import org.catrobat.catroid.bluetooth.base.BluetoothDeviceService;
 import org.catrobat.catroid.devices.mindstorms.MindstormsException;
+import org.catrobat.catroid.utils.ToastUtil;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import androidx.annotation.RequiresApi;
 
 public class BluetoothDeviceServiceImpl implements BluetoothDeviceService {
 
@@ -49,10 +54,17 @@ public class BluetoothDeviceServiceImpl implements BluetoothDeviceService {
 			return ConnectDeviceResult.ALREADY_CONNECTED;
 		}
 
-		Intent intent = createStartIntent(deviceToConnect, activity);
-		activity.startActivityForResult(intent, requestCode);
-
-		return ConnectDeviceResult.CONNECTION_REQUESTED;
+		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+			Intent intent = createStartIntent(deviceToConnect, activity);
+			activity.startActivityForResult(intent, requestCode);
+			return ConnectDeviceResult.CONNECTION_REQUESTED;
+		} else {
+			ToastUtil.showError(
+					activity.getApplicationContext(),
+					R.string.notification_blueth_err_api_lvl
+			);
+			return ConnectDeviceResult.CANNOT_CONNECT;
+		}
 	}
 
 	@Override
@@ -63,10 +75,14 @@ public class BluetoothDeviceServiceImpl implements BluetoothDeviceService {
 			return ConnectDeviceResult.ALREADY_CONNECTED;
 		}
 
-		Intent intent = createStartIntent(deviceToConnect, context);
-		context.startActivity(intent);
-
-		return ConnectDeviceResult.CONNECTION_REQUESTED;
+		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+			Intent intent = createStartIntent(deviceToConnect, context);
+			context.startActivity(intent);
+			return ConnectDeviceResult.CONNECTION_REQUESTED;
+		} else {
+			ToastUtil.showError(context, R.string.notification_blueth_err_api_lvl);
+			return ConnectDeviceResult.CANNOT_CONNECT;
+		}
 	}
 
 	private synchronized boolean isDeviceConnectedAndAlive(Class<? extends BluetoothDevice> deviceToConnect) {
@@ -110,6 +126,7 @@ public class BluetoothDeviceServiceImpl implements BluetoothDeviceService {
 		return null;
 	}
 
+	@RequiresApi(api = Build.VERSION_CODES.S)
 	protected Intent createStartIntent(Class<? extends BluetoothDevice> deviceToConnect,
 			Context context) {
 		Intent intent = new Intent(context, ConnectBluetoothDeviceActivity.class);

--- a/catroid/src/main/java/org/catrobat/catroid/bluetooth/BluetoothManager.java
+++ b/catroid/src/main/java/org/catrobat/catroid/bluetooth/BluetoothManager.java
@@ -25,6 +25,12 @@ package org.catrobat.catroid.bluetooth;
 import android.app.Activity;
 import android.bluetooth.BluetoothAdapter;
 import android.content.Intent;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+import androidx.annotation.RequiresPermission;
+
+import static android.Manifest.permission.BLUETOOTH_CONNECT;
 
 public class BluetoothManager {
 
@@ -40,6 +46,8 @@ public class BluetoothManager {
 		this.activity = activity;
 	}
 
+	@RequiresApi(api = Build.VERSION_CODES.S)
+	@RequiresPermission(BLUETOOTH_CONNECT)
 	public int activateBluetooth() {
 		if (bluetoothAdapter == null) {
 			bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();

--- a/catroid/src/main/java/org/catrobat/catroid/bluetooth/base/BluetoothDeviceService.java
+++ b/catroid/src/main/java/org/catrobat/catroid/bluetooth/base/BluetoothDeviceService.java
@@ -33,7 +33,8 @@ public interface BluetoothDeviceService extends CatroidService, StageResourceInt
 
 	enum ConnectDeviceResult {
 		ALREADY_CONNECTED,
-		CONNECTION_REQUESTED
+		CONNECTION_REQUESTED,
+		CANNOT_CONNECT
 	}
 
 	ConnectDeviceResult connectDevice(Class<? extends BluetoothDevice> deviceType,

--- a/catroid/src/main/java/org/catrobat/catroid/devices/multiplayer/Multiplayer.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/multiplayer/Multiplayer.kt
@@ -82,7 +82,8 @@ class Multiplayer : MultiplayerInterface {
 
         closeStreams()
 
-        if (acceptThread?.isAlive == true) {
+        val hasCorrectApiVersion = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S
+        if (acceptThread?.isAlive == true && hasCorrectApiVersion) {
             acceptThread?.cancel()
             acceptThread?.interrupt()
         }

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1464,6 +1464,8 @@ needs read and write access to it. You can always change permissions through you
 
     <!-- Bluetooth Connection Strings -->
     <string formatted="false" name="notification_blueth_err">Can\'t enable Bluetooth, please try turning it off and on again.</string>
+    <string formatted="false" name="notification_blueth_err_api_lvl">Can\'t enable
+        Bluetooth, requires Android 12</string>
     <string formatted="false" name="title_paired_devices">Paired devices</string>
     <string formatted="false" name="title_other_devices">Available devices</string>
     <string formatted="false" name="bluetooth_connection_title">Bluetooth connection</string>


### PR DESCRIPTION
Fixed arduino sensors by adding required permission checks. From this ticket onward, only API level 31 can use bluetooth.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
