### PR TITLE
IDE-219 Icons for all options in the overflow menu

### DIFF
--- a/catroid/src/main/res/drawable/ic_2d.xml
+++ b/catroid/src/main/res/drawable/ic_2d.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
+  ~ Copyright (C) 2010-2024 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -21,26 +20,16 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<menu
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <item
-        android:id="@+id/unpack"
-        android:title="@string/unpack"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_placeholder"/>
-
-    <item
-        android:id="@+id/delete"
-        android:title="@string/delete"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_delete"/>
-
-    <item
-        android:id="@+id/show_details"
-        android:title="@string/show_details"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_info"/>
-
-</menu>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="56dp"
+    android:height="24dp"
+    android:viewportWidth="56"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h56v24h-56z"/>
+    <path
+        android:pathData="M22.5,15L27,15v-1.5L24,13.5v-1h2q0.425,0 0.713,-0.288T27,11.5L27,10q0,-0.425 -0.288,-0.712T26,9L22.5,9v1.5h3v1h-2q-0.425,0 -0.712,0.288T22.5,12.5zM29,15h4q0.425,0 0.713,-0.288T34,14v-4q0,-0.425 -0.288,-0.712T33,9h-4zM30.5,13.5v-3h2v3zM21,21q-0.825,0 -1.412,-0.587T19,19L19,5q0,-0.825 0.588,-1.412T21,3h14q0.825,0 1.413,0.588T37,5v14q0,0.825 -0.587,1.413T35,21zM21,19h14L35,5L21,5zM21,5v14z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+</vector>

--- a/catroid/src/main/res/drawable/ic_add_photo_alternative.xml
+++ b/catroid/src/main/res/drawable/ic_add_photo_alternative.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
+  ~ Copyright (C) 2010-2024 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -21,26 +20,16 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<menu
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <item
-        android:id="@+id/unpack"
-        android:title="@string/unpack"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_placeholder"/>
-
-    <item
-        android:id="@+id/delete"
-        android:title="@string/delete"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_delete"/>
-
-    <item
-        android:id="@+id/show_details"
-        android:title="@string/show_details"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_info"/>
-
-</menu>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="56"
+    android:width="56dp">
+    <group>
+        <clip-path
+            android:pathData="M0,0h56v24h-56z"/>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M34,20L20,20L20,6h9L29,4L20,4c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2v-9h-2v9zM26.21,16.83l-1.96,-2.36L21.5,18h11l-3.54,-4.71zM36,4L36,1h-2v3h-3c0.01,0.01 0,2 0,2h3v2.99c0.01,0.01 2,0 2,0L36,6h3L39,4h-3z"/>
+    </group>
+</vector>

--- a/catroid/src/main/res/drawable/ic_info.xml
+++ b/catroid/src/main/res/drawable/ic_info.xml
@@ -1,6 +1,6 @@
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
+  ~ Copyright (C) 2010-2021 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify

--- a/catroid/src/main/res/drawable/ic_join.xml
+++ b/catroid/src/main/res/drawable/ic_join.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
   ~ Copyright (C) 2010-2022 The Catrobat Team
@@ -21,26 +20,16 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<menu
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <item
-        android:id="@+id/unpack"
-        android:title="@string/unpack"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_placeholder"/>
-
-    <item
-        android:id="@+id/delete"
-        android:title="@string/delete"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_delete"/>
-
-    <item
-        android:id="@+id/show_details"
-        android:title="@string/show_details"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_info"/>
-
-</menu>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="56dp"
+    android:height="24dp"
+    android:viewportWidth="56"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h56v24h-56z"/>
+    <path
+        android:pathData="M32,17q2.075,0 3.538,-1.463T37,12t-1.463,-3.537T32,7q-0.675,0 -1.312,0.175t-1.188,0.5q0.725,0.9 1.113,2T31,12t-0.387,2.325t-1.113,2q0.55,0.325 1.188,0.5T32,17m-4,-2q0.475,-0.625 0.738,-1.388T29,12t-0.262,-1.612T28,9q-0.475,0.625 -0.737,1.388T27,12t0.263,1.613T28,15m-4,2q0.675,0 1.313,-0.175t1.187,-0.5q-0.725,-0.9 -1.112,-2T25,12t0.388,-2.325t1.112,-2q-0.55,-0.325 -1.187,-0.5T24,7Q21.925,7 20.463,8.463T19,12t1.463,3.538T24,17m0,2q-2.925,0 -4.962,-2.037T17,12t2.038,-4.962T24,5q1.125,0 2.138,0.325T28,6.25q0.85,-0.6 1.863,-0.925T32,5q2.925,0 4.963,2.038T39,12t-2.037,4.963T32,19q-1.125,0 -2.137,-0.325T28,17.75q-0.85,0.6 -1.862,0.925T24,19"
+        android:fillColor="#FFFFFF"/>
+  </group>
+</vector>

--- a/catroid/src/main/res/drawable/ic_visibility.xml
+++ b/catroid/src/main/res/drawable/ic_visibility.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2022 The Catrobat Team
+  ~ Copyright (C) 2010-2024 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -21,26 +20,17 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<menu
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <item
-        android:id="@+id/unpack"
-        android:title="@string/unpack"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_placeholder"/>
-
-    <item
-        android:id="@+id/delete"
-        android:title="@string/delete"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_delete"/>
-
-    <item
-        android:id="@+id/show_details"
-        android:title="@string/show_details"
-        app:showAsAction="never"
-        android:icon="@drawable/ic_info"/>
-
-</menu>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="56dp"
+    android:height="24dp"
+    android:viewportWidth="56"
+    android:viewportHeight="24">
+    <group>
+        <clip-path
+            android:pathData="M0,0h56v24h-56z"/>
+        <path
+            android:pathData="M28,6.5c3.79,0 7.17,2.13 8.82,5.5C35.17,15.37 31.79,17.5 28,17.5s-7.17,-2.13 -8.82,-5.5C20.83,8.63 24.21,6.5 28,6.5m0,-2C23,4.5 18.73,7.61 17,12 18.73,16.39 23,19.5 28,19.5s9.27,-3.11 11,-7.5C37.27,7.61 33,4.5 28,4.5zM28,9.5c1.38,0 2.5,1.12 2.5,2.5S29.38,14.5 28,14.5s-2.5,-1.12 -2.5,-2.5S26.62,9.5 28,9.5m0,-2c-2.48,0 -4.5,2.02 -4.5,4.5S25.52,16.5 28,16.5s4.5,-2.02 4.5,-4.5S30.48,7.5 28,7.5z"
+            android:fillColor="@android:color/white"/>
+    </group>
+</vector>

--- a/catroid/src/main/res/menu/menu_project_activity.xml
+++ b/catroid/src/main/res/menu/menu_project_activity.xml
@@ -56,17 +56,17 @@
         android:id="@+id/new_group"
         android:title="@string/new_group"
         app:showAsAction="never"
-        android:icon="@drawable/ic_placeholder"/>
+        android:icon="@drawable/ic_join"/>
     <item
         android:id="@+id/new_scene"
         android:title="@string/new_scene"
         app:showAsAction="never"
-        android:icon="@drawable/ic_placeholder" />
+        android:icon="@drawable/ic_add_photo_alternative" />
     <item
         android:id="@+id/show_details"
         android:title="@string/show_details"
         app:showAsAction="never"
-        android:icon="@drawable/ic_placeholder" />
+        android:icon="@drawable/ic_info" />
     <item
         android:id="@+id/project_options"
         android:title="@string/project_options"

--- a/catroid/src/main/res/menu/menu_projects_activity.xml
+++ b/catroid/src/main/res/menu/menu_projects_activity.xml
@@ -50,7 +50,7 @@
         android:id="@+id/show_details"
         android:title="@string/show_details"
         app:showAsAction="never"
-        android:icon="@drawable/ic_placeholder"/>
+        android:icon="@drawable/ic_info"/>
     <item
         android:id="@+id/cast_button"
         android:title="@string/cast_button_menu_item_title"

--- a/catroid/src/main/res/menu/menu_script_activity.xml
+++ b/catroid/src/main/res/menu/menu_script_activity.xml
@@ -56,13 +56,13 @@
     <item
         android:id="@+id/show_details"
         android:title="@string/show_details"
-        android:icon="@drawable/ic_placeholder"
+        android:icon="@drawable/ic_info"
         app:showAsAction="never" />
     <item
         android:id="@+id/comment_in_out"
         android:title="@string/comment_in_out"
         android:visible="false"
-        android:icon="@drawable/ic_placeholder"
+        android:icon="@drawable/ic_visibility"
         app:showAsAction="never" />
     <item
         android:id="@+id/find"
@@ -72,7 +72,7 @@
     <item
          android:id="@+id/catblocks"
          android:title="@string/catblocks"
-         android:icon="@drawable/ic_placeholder"
+         android:icon="@drawable/ic_2d"
          app:showAsAction="never"
          />
     <item android:id="@+id/catblocks_reorder_scripts"


### PR DESCRIPTION
Added new icons for info, 2d, visibility, join and add-photo-alternative and added to overflow menus.

https://catrobat.atlassian.net/browse/IDE-219

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
