### PR TITLE
IDE-210 Improve workflow when packing scripts

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/ScriptFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/ScriptFragmentTest.java
@@ -51,6 +51,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static junit.framework.TestCase.assertTrue;
 
 import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.catrobat.catroid.uiespresso.util.UiTestUtils.openActionBarMenu;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
@@ -64,6 +65,7 @@ import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -236,6 +238,13 @@ public class ScriptFragmentTest {
 				.onCheckBox().check(matches(allOf(not(isChecked()), isEnabled())));
 		onBrickAtPosition(5)
 				.onCheckBox().check(matches(allOf(not(isChecked()), isEnabled())));
+	}
+	@Test
+	public void testAddToBackpackWithEmptyBrickSelection() {
+		openActionBarMenu();
+		onView(withText("Backpack")).perform(click());
+		onView(withId(R.id.confirm)).perform(click());
+		UiTestUtils.onToast(withText(R.string.brick_selection_empty)).check(matches(isDisplayed()));
 	}
 
 	private void createProject() {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java
@@ -853,9 +853,13 @@ public class ScriptFragment extends ListFragment implements
 				.setTextWatcher(duplicateInputTextwatcher)
 				.setPositiveButton(getString(R.string.ok), (TextInputDialog.OnClickListener) (dialog, textInput) -> pack(textInput, selectedBricks));
 
-		builder.setTitle(R.string.new_group)
-				.setNegativeButton(R.string.cancel, null)
-				.show();
+		if (selectedBricks.isEmpty()) {
+			ToastUtil.showError(getActivity(), R.string.brick_selection_empty);
+		} else {
+			builder.setTitle(R.string.new_group)
+					.setNegativeButton(R.string.cancel, null)
+					.show();
+		}
 	}
 
 	public void pack(String name, List<Brick> selectedBricks) {

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -497,6 +497,7 @@
     <!-- Action Toasts -->
     <!-- Backpack -->
     <string formatted="false" name="backpack_empty">Backpack empty. Nothing to unpack.</string>
+    <string formatted="false" name="brick_selection_empty">Selection for packing is empty.</string>
     <plurals name="packed_scenes">
         <item quantity="one">Backpacked %d scene.</item>
         <item quantity="other">Backpacked %d scenes.</item>


### PR DESCRIPTION
When the script packing selection for a backpack is empty and the checkmark is pressed, a toast message with following text is displayed: "Selection for packing is empty".
https://catrobat.atlassian.net/browse/IDE-210 


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
