### PR TITLE
CATROID-1599 Fix test 'testContinueSoundDoesNotStartFromBeginning'

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/SceneTransitionWithSoundBrickStageTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/content/brick/stage/SceneTransitionWithSoundBrickStageTest.java
@@ -114,9 +114,10 @@ public class SceneTransitionWithSoundBrickStageTest {
 	public void testContinueSoundDoesNotStartFromBeginning() {
 		secondScript.addBrick(new SceneTransitionBrick(firstSceneName));
 		runProject(lastBrickFirstScript);
-		MediaPlayer mediaPlayer = getMediaplayer();
-		assertTrue(mediaPlayer.isPlaying());
-		assertTrue(mediaPlayer.getCurrentPosition() > 50);
+		assertTrue(getMediaplayer().isPlaying());
+		int oldCurrentPosition = getMediaplayer().getCurrentPosition();
+		runProject(lastBrickSecondScript);
+		assertTrue(getMediaplayer().getCurrentPosition() >= oldCurrentPosition);
 	}
 
 	private void runProject(ScriptEvaluationGateBrick scriptBrick) {
@@ -147,7 +148,7 @@ public class SceneTransitionWithSoundBrickStageTest {
 		soundInfo.setName("testSound");
 		soundBrick.setSound(soundInfo);
 		script.addBrick(soundBrick);
-		script.addBrick(new WaitBrick(500));
+		script.addBrick(new WaitBrick(1000));
 		script.addBrick(new SceneTransitionBrick(secondScene.getName()));
 		projectManager.getCurrentSprite().getSoundList().add(soundInfo);
 


### PR DESCRIPTION
Will change the existing flaky test. Instead of checking if some specific time of the Sound passed, it checks if after the transition the currentTime is bigger or equal then it was before the transition. The wait brick is bigger then before so the sound can start play.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
