### PR TITLE
IDE-257 Formula Editor - missing a "Confirm" button

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorKeyboardTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorKeyboardTest.java
@@ -187,6 +187,12 @@ public class FormulaEditorKeyboardTest {
 		onView(withId(R.id.brick_set_variable_edit_text)).check(matches(withText("'#0074CD' ")));
 	}
 
+	@Test
+	public void testConfirmButtonString() {
+		onView(withId(R.id.brick_set_variable_edit_text)).perform(click());
+		onView(withId(R.id.formula_editor_keyboard_compute)).check(matches(withText(R.string.formula_editor_confirm)));
+	}
+
 	@After
 	public void tearDown() throws IOException {
 		baseActivityTestRule.finishActivity();

--- a/catroid/src/main/res/layout/formula_editor_keyboard.xml
+++ b/catroid/src/main/res/layout/formula_editor_keyboard.xml
@@ -248,6 +248,6 @@
             style="@style/FormulaEditorComputeButton"
             android:layout_marginBottom="@dimen/key_margin"
             android:layout_span="2"
-            android:text="@string/formula_editor_compute" />
+            android:text="@string/formula_editor_confirm" />
     </TableRow>
 </TableLayout>

--- a/catroid/src/main/res/values-af/strings.xml
+++ b/catroid/src/main/res/values-af/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-ar/strings.xml
+++ b/catroid/src/main/res/values-ar/strings.xml
@@ -1912,7 +1912,7 @@
     <string formatted="false" name="formula_editor_object_background_name">إسم خلفية الشاشة</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">عدد الخلفيات</string>
     <string formatted="false" name="formula_editor_object_distance_to">المسافة إلى</string>
-    <string formatted="false" name="formula_editor_compute">النتيجة</string>
+    <string formatted="false" name="formula_editor_confirm">النتيجة</string>
     <string formatted="false" name="formula_editor_object">الكائن</string>
     <string formatted="false" name="formula_editor_functions">الدوال</string>
     <string formatted="false" name="formula_editor_logic">المنطق</string>

--- a/catroid/src/main/res/values-az/strings.xml
+++ b/catroid/src/main/res/values-az/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-bg/strings.xml
+++ b/catroid/src/main/res/values-bg/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-bn/strings.xml
+++ b/catroid/src/main/res/values-bn/strings.xml
@@ -1706,7 +1706,7 @@
     <string formatted="false" name="formula_editor_object_background_name">ব্যাকগ্রাউন্ড নাম</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">পটভূমি সংখ্যা</string>
     <string formatted="false" name="formula_editor_object_distance_to">স্পর্শ অবস্থান থেকে দূরত্ব</string>
-    <string formatted="false" name="formula_editor_compute">গণনা করা</string>
+    <string formatted="false" name="formula_editor_confirm">গণনা করা</string>
     <string formatted="false" name="formula_editor_object">বিশিষ্টতাসমূহ</string>
     <string formatted="false" name="formula_editor_functions">ক্রিয়াকলাপ</string>
     <string formatted="false" name="formula_editor_logic">যুক্তিবিদ্যা</string>

--- a/catroid/src/main/res/values-bs/strings.xml
+++ b/catroid/src/main/res/values-bs/strings.xml
@@ -1771,7 +1771,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">naziv pozadine</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">udaljenost od pozicije dodira</string>
-    <string formatted="false" name="formula_editor_compute">Izračunaj</string>
+    <string formatted="false" name="formula_editor_confirm">Izračunaj</string>
     <string formatted="false" name="formula_editor_object">Objekat</string>
     <string formatted="false" name="formula_editor_functions">Funkcije</string>
     <string formatted="false" name="formula_editor_logic">Logika</string>

--- a/catroid/src/main/res/values-ca/strings.xml
+++ b/catroid/src/main/res/values-ca/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-chr/strings.xml
+++ b/catroid/src/main/res/values-chr/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-cs/strings.xml
+++ b/catroid/src/main/res/values-cs/strings.xml
@@ -1832,7 +1832,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">název_pozadí</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">vzdálenost k</string>
-    <string formatted="false" name="formula_editor_compute">Výpočetní výkon</string>
+    <string formatted="false" name="formula_editor_confirm">Výpočetní výkon</string>
     <string formatted="false" name="formula_editor_object">Objekt</string>
     <string formatted="false" name="formula_editor_functions">Funkce</string>
     <string formatted="false" name="formula_editor_logic">Logika</string>

--- a/catroid/src/main/res/values-da/strings.xml
+++ b/catroid/src/main/res/values-da/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Udfør</string>
+    <string formatted="false" name="formula_editor_confirm">Udfør</string>
     <string formatted="false" name="formula_editor_object">Objekt</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logik</string>

--- a/catroid/src/main/res/values-de/strings.xml
+++ b/catroid/src/main/res/values-de/strings.xml
@@ -1709,7 +1709,7 @@
     <string formatted="false" name="formula_editor_object_background_name">Hintergrundname</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">Anzahl der Hintergründe</string>
     <string formatted="false" name="formula_editor_object_distance_to">Entfernung zu</string>
-    <string formatted="false" name="formula_editor_compute">Berechnen</string>
+    <string formatted="false" name="formula_editor_confirm">Berechnen</string>
     <string formatted="false" name="formula_editor_object">Eigenschaften</string>
     <string formatted="false" name="formula_editor_functions">Funktionen</string>
     <string formatted="false" name="formula_editor_logic">Logik</string>

--- a/catroid/src/main/res/values-el/strings.xml
+++ b/catroid/src/main/res/values-el/strings.xml
@@ -1742,7 +1742,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Αντικείμενο</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-en-rAU/strings.xml
+++ b/catroid/src/main/res/values-en-rAU/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-en-rCA/strings.xml
+++ b/catroid/src/main/res/values-en-rCA/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-en-rGB/strings.xml
+++ b/catroid/src/main/res/values-en-rGB/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Object</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-es/strings.xml
+++ b/catroid/src/main/res/values-es/strings.xml
@@ -1730,7 +1730,7 @@ necesita acceso de lectura y escritura a ella. Siempre puedes cambiar los permis
     <string formatted="false" name="formula_editor_object_background_name">nombre_fondo</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">número de fondos</string>
     <string formatted="false" name="formula_editor_object_distance_to">distancia a</string>
-    <string formatted="false" name="formula_editor_compute">Calcular</string>
+    <string formatted="false" name="formula_editor_confirm">Calcular</string>
     <string formatted="false" name="formula_editor_object">Objeto</string>
     <string formatted="false" name="formula_editor_functions">Funciones</string>
     <string formatted="false" name="formula_editor_logic">Lógica</string>

--- a/catroid/src/main/res/values-eu-rES/strings.xml
+++ b/catroid/src/main/res/values-eu-rES/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-fa-rIR/strings.xml
+++ b/catroid/src/main/res/values-fa-rIR/strings.xml
@@ -1727,7 +1727,7 @@
     <string formatted="false" name="formula_editor_object_background_name">نام پس زمینه</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">تعداد پس زمینه</string>
     <string formatted="false" name="formula_editor_object_distance_to">فاصله تا موقعیت لمس</string>
-    <string formatted="false" name="formula_editor_compute">محاسبه</string>
+    <string formatted="false" name="formula_editor_confirm">محاسبه</string>
     <string formatted="false" name="formula_editor_object">شی</string>
     <string formatted="false" name="formula_editor_functions">توابع</string>
     <string formatted="false" name="formula_editor_logic">منطق</string>

--- a/catroid/src/main/res/values-fa/strings.xml
+++ b/catroid/src/main/res/values-fa/strings.xml
@@ -1669,7 +1669,7 @@
     <string formatted="false" name="formula_editor_object_background_name">نام پس زمینه</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">تعداد پس زمینه ها</string>
     <string formatted="false" name="formula_editor_object_distance_to">فاصله تا موقعیت لمس</string>
-    <string formatted="false" name="formula_editor_compute">محاسبه کن</string>
+    <string formatted="false" name="formula_editor_confirm">محاسبه کن</string>
     <string formatted="false" name="formula_editor_object">خواص</string>
     <string formatted="false" name="formula_editor_functions">توابع </string>
     <string formatted="false" name="formula_editor_logic">منطق</string>

--- a/catroid/src/main/res/values-fi/strings.xml
+++ b/catroid/src/main/res/values-fi/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-fr/strings.xml
+++ b/catroid/src/main/res/values-fr/strings.xml
@@ -1739,7 +1739,7 @@ doit avoir accès en lecture et en écriture à la mémoire locale. Vous pouvez 
     <string formatted="false" name="formula_editor_object_background_name">nom de l\'arrière-plan</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">nombre de fonds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance à la position tactile</string>
-    <string formatted="false" name="formula_editor_compute">Calculer</string>
+    <string formatted="false" name="formula_editor_confirm">Calculer</string>
     <string formatted="false" name="formula_editor_object">Objet</string>
     <string formatted="false" name="formula_editor_functions">Fonctions</string>
     <string formatted="false" name="formula_editor_logic">Logique</string>

--- a/catroid/src/main/res/values-gl/strings.xml
+++ b/catroid/src/main/res/values-gl/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Obxecto</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-gu/strings.xml
+++ b/catroid/src/main/res/values-gu/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-ha/strings.xml
+++ b/catroid/src/main/res/values-ha/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-hi/strings.xml
+++ b/catroid/src/main/res/values-hi/strings.xml
@@ -1743,7 +1743,7 @@
     <string formatted="false" name="formula_editor_object_background_name">पृष्ठभूमि का नाम</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">पृष्ठभूमि की संख्या</string>
     <string formatted="false" name="formula_editor_object_distance_to">स्पर्श करने की स्थिति की दूरी</string>
-    <string formatted="false" name="formula_editor_compute">गणना करें</string>
+    <string formatted="false" name="formula_editor_confirm">गणना करें</string>
     <string formatted="false" name="formula_editor_object">वस्तु</string>
     <string formatted="false" name="formula_editor_functions">कार्यों</string>
     <string formatted="false" name="formula_editor_logic">तर्क</string>

--- a/catroid/src/main/res/values-hr/strings.xml
+++ b/catroid/src/main/res/values-hr/strings.xml
@@ -1785,7 +1785,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">ime pozadine</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Izračunati</string>
+    <string formatted="false" name="formula_editor_confirm">Izračunati</string>
     <string formatted="false" name="formula_editor_object">Objekt</string>
     <string formatted="false" name="formula_editor_functions">Funkcije</string>
     <string formatted="false" name="formula_editor_logic">Logika</string>

--- a/catroid/src/main/res/values-hu/strings.xml
+++ b/catroid/src/main/res/values-hu/strings.xml
@@ -1745,7 +1745,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Kiszámítás</string>
+    <string formatted="false" name="formula_editor_confirm">Kiszámítás</string>
     <string formatted="false" name="formula_editor_object">Objektum</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logika</string>

--- a/catroid/src/main/res/values-ig/strings.xml
+++ b/catroid/src/main/res/values-ig/strings.xml
@@ -1701,7 +1701,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Compute</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-in/strings.xml
+++ b/catroid/src/main/res/values-in/strings.xml
@@ -1696,7 +1696,7 @@ membutuhkan akses baca dan tulis untuk itu. Anda selalu dapat mengubah izin mela
     <string formatted="false" name="formula_editor_object_background_name">layarbelakang nama</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">jumlah latar belakang</string>
     <string formatted="false" name="formula_editor_object_distance_to">jarak untuk menyentuh posisi</string>
-    <string formatted="false" name="formula_editor_compute">Menghitung</string>
+    <string formatted="false" name="formula_editor_confirm">Menghitung</string>
     <string formatted="false" name="formula_editor_object">Objek</string>
     <string formatted="false" name="formula_editor_functions">Fungsi</string>
     <string formatted="false" name="formula_editor_logic">Logika</string>

--- a/catroid/src/main/res/values-it/strings.xml
+++ b/catroid/src/main/res/values-it/strings.xml
@@ -1742,7 +1742,7 @@ con tolleranza %        </string>
     <string formatted="false" name="formula_editor_object_background_name">nome_sfondo</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">numero di sfondi</string>
     <string formatted="false" name="formula_editor_object_distance_to">distanza a</string>
-    <string formatted="false" name="formula_editor_compute">Calcola</string>
+    <string formatted="false" name="formula_editor_confirm">Calcola</string>
     <string formatted="false" name="formula_editor_object">Oggetto</string>
     <string formatted="false" name="formula_editor_functions">Funzioni</string>
     <string formatted="false" name="formula_editor_logic">Logica</string>

--- a/catroid/src/main/res/values-iw/strings.xml
+++ b/catroid/src/main/res/values-iw/strings.xml
@@ -1839,7 +1839,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">אובייקט</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-ja/strings.xml
+++ b/catroid/src/main/res/values-ja/strings.xml
@@ -1685,7 +1685,7 @@
     <string formatted="false" name="formula_editor_object_background_name">背景名</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">バックグラウンド数</string>
     <string formatted="false" name="formula_editor_object_distance_to">距離</string>
-    <string formatted="false" name="formula_editor_compute">計算</string>
+    <string formatted="false" name="formula_editor_confirm">計算</string>
     <string formatted="false" name="formula_editor_object">オブジェクト</string>
     <string formatted="false" name="formula_editor_functions">関数</string>
     <string formatted="false" name="formula_editor_logic">論理</string>

--- a/catroid/src/main/res/values-ka/strings.xml
+++ b/catroid/src/main/res/values-ka/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-kab/strings.xml
+++ b/catroid/src/main/res/values-kab/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-kk/strings.xml
+++ b/catroid/src/main/res/values-kk/strings.xml
@@ -1719,7 +1719,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-kn/strings.xml
+++ b/catroid/src/main/res/values-kn/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-ko/strings.xml
+++ b/catroid/src/main/res/values-ko/strings.xml
@@ -1669,7 +1669,7 @@
     <string formatted="false" name="formula_editor_object_background_name">배경 이름</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">배경 수</string>
     <string formatted="false" name="formula_editor_object_distance_to">거리</string>
-    <string formatted="false" name="formula_editor_compute">연산결과 미리보기</string>
+    <string formatted="false" name="formula_editor_confirm">연산결과 미리보기</string>
     <string formatted="false" name="formula_editor_object">오브젝트</string>
     <string formatted="false" name="formula_editor_functions">함수</string>
     <string formatted="false" name="formula_editor_logic">논리 연산</string>

--- a/catroid/src/main/res/values-lt/strings.xml
+++ b/catroid/src/main/res/values-lt/strings.xml
@@ -1839,7 +1839,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-mk/strings.xml
+++ b/catroid/src/main/res/values-mk/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-ml-rIN/strings.xml
+++ b/catroid/src/main/res/values-ml-rIN/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-ml/strings.xml
+++ b/catroid/src/main/res/values-ml/strings.xml
@@ -1714,7 +1714,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_number" tools:ignore="UnusedResources">background number</string>
     <string formatted="false" name="formula_editor_object_background_name" tools:ignore="UnusedResources">background name</string>
     <string formatted="false" name="formula_editor_object_distance_to" tools:ignore="UnusedResources">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-ms/strings.xml
+++ b/catroid/src/main/res/values-ms/strings.xml
@@ -1701,7 +1701,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-nl/strings.xml
+++ b/catroid/src/main/res/values-nl/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Berekenen</string>
+    <string formatted="false" name="formula_editor_confirm">Berekenen</string>
     <string formatted="false" name="formula_editor_object">Object</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logica</string>

--- a/catroid/src/main/res/values-no/strings.xml
+++ b/catroid/src/main/res/values-no/strings.xml
@@ -1736,7 +1736,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">bakgrunns_navn</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">avstand til</string>
-    <string formatted="false" name="formula_editor_compute">Beregn</string>
+    <string formatted="false" name="formula_editor_confirm">Beregn</string>
     <string formatted="false" name="formula_editor_object">Objekt</string>
     <string formatted="false" name="formula_editor_functions">Funksjoner</string>
     <string formatted="false" name="formula_editor_logic">Logikk</string>

--- a/catroid/src/main/res/values-pa-rIN/strings.xml
+++ b/catroid/src/main/res/values-pa-rIN/strings.xml
@@ -1745,7 +1745,7 @@
     <string formatted="false" name="formula_editor_object_background_name">ਪਿਛੋਕੜ ਦਾ ਨਾਮ</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">ਪਿਛੋਕੜ ਦੀ ਗਿਣਤੀ</string>
     <string formatted="false" name="formula_editor_object_distance_to">ਸਥਿਤੀ ਨੂੰ ਛੂਹਣ ਲਈ ਦੂਰੀ</string>
-    <string formatted="false" name="formula_editor_compute">ਗਣਨਾ</string>
+    <string formatted="false" name="formula_editor_confirm">ਗਣਨਾ</string>
     <string formatted="false" name="formula_editor_object">ਗੁਣ</string>
     <string formatted="false" name="formula_editor_functions">ਕਾਰਜ</string>
     <string formatted="false" name="formula_editor_logic">ਤਰਕ</string>

--- a/catroid/src/main/res/values-pl/strings.xml
+++ b/catroid/src/main/res/values-pl/strings.xml
@@ -1795,7 +1795,7 @@ Jeśli jednak nie chcesz tego robić, możesz skorzystać z naszych bezpłatnych
     <string formatted="false" name="formula_editor_object_background_name">nazwa_tła</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">liczba teł</string>
     <string formatted="false" name="formula_editor_object_distance_to">odległość do</string>
-    <string formatted="false" name="formula_editor_compute">Oblicz</string>
+    <string formatted="false" name="formula_editor_confirm">Oblicz</string>
     <string formatted="false" name="formula_editor_object">Właściwości</string>
     <string formatted="false" name="formula_editor_functions">Funkcje</string>
     <string formatted="false" name="formula_editor_logic">Logika</string>

--- a/catroid/src/main/res/values-ps/strings.xml
+++ b/catroid/src/main/res/values-ps/strings.xml
@@ -1741,7 +1741,7 @@
     <string formatted="false" name="formula_editor_object_background_name">د شاليد نوم</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">د شالید شمیر</string>
     <string formatted="false" name="formula_editor_object_distance_to">د تماس موقعیت ته واټن</string>
-    <string formatted="false" name="formula_editor_compute">محاسبه</string>
+    <string formatted="false" name="formula_editor_confirm">محاسبه</string>
     <string formatted="false" name="formula_editor_object">ملکیتونه</string>
     <string formatted="false" name="formula_editor_functions">افعال</string>
     <string formatted="false" name="formula_editor_logic">منطق</string>

--- a/catroid/src/main/res/values-pt-rBR/strings.xml
+++ b/catroid/src/main/res/values-pt-rBR/strings.xml
@@ -1739,7 +1739,7 @@ precisa de acesso de leitura e escrita a ele. Você sempre pode alterar as permi
     <string formatted="false" name="formula_editor_object_background_name">nome do fundo</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">número de fundos</string>
     <string formatted="false" name="formula_editor_object_distance_to">distância de posição tocada</string>
-    <string formatted="false" name="formula_editor_compute">Calcular</string>
+    <string formatted="false" name="formula_editor_confirm">Calcular</string>
     <string formatted="false" name="formula_editor_object">Propriedades</string>
     <string formatted="false" name="formula_editor_functions">Funções</string>
     <string formatted="false" name="formula_editor_logic">Lógica</string>

--- a/catroid/src/main/res/values-pt/strings.xml
+++ b/catroid/src/main/res/values-pt/strings.xml
@@ -1743,7 +1743,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">nome_fundo</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distância para</string>
-    <string formatted="false" name="formula_editor_compute">Calcular</string>
+    <string formatted="false" name="formula_editor_confirm">Calcular</string>
     <string formatted="false" name="formula_editor_object">Objeto</string>
     <string formatted="false" name="formula_editor_functions">Funções</string>
     <string formatted="false" name="formula_editor_logic">Lógica</string>

--- a/catroid/src/main/res/values-ro/strings.xml
+++ b/catroid/src/main/res/values-ro/strings.xml
@@ -1793,7 +1793,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Calculă</string>
+    <string formatted="false" name="formula_editor_confirm">Calculă</string>
     <string formatted="false" name="formula_editor_object">obiect</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logică</string>

--- a/catroid/src/main/res/values-ru/strings.xml
+++ b/catroid/src/main/res/values-ru/strings.xml
@@ -1836,7 +1836,7 @@
     <string formatted="false" name="formula_editor_object_background_name">название фона</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">количество фонов</string>
     <string formatted="false" name="formula_editor_object_distance_to">расстояние до точки касания</string>
-    <string formatted="false" name="formula_editor_compute">Вычислить</string>
+    <string formatted="false" name="formula_editor_confirm">Вычислить</string>
     <string formatted="false" name="formula_editor_object">Свойства</string>
     <string formatted="false" name="formula_editor_functions">Функции</string>
     <string formatted="false" name="formula_editor_logic">Логика</string>

--- a/catroid/src/main/res/values-sd/strings.xml
+++ b/catroid/src/main/res/values-sd/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">آبجيڪٽ</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-si/strings.xml
+++ b/catroid/src/main/res/values-si/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-sk/strings.xml
+++ b/catroid/src/main/res/values-sk/strings.xml
@@ -1832,7 +1832,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-sl/strings.xml
+++ b/catroid/src/main/res/values-sl/strings.xml
@@ -1839,7 +1839,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Izračuni</string>
+    <string formatted="false" name="formula_editor_confirm">Izračuni</string>
     <string formatted="false" name="formula_editor_object">Objekt</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logika</string>

--- a/catroid/src/main/res/values-sq/strings.xml
+++ b/catroid/src/main/res/values-sq/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-sr-rCS/strings.xml
+++ b/catroid/src/main/res/values-sr-rCS/strings.xml
@@ -1793,7 +1793,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">ime pozadine</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Računaj</string>
+    <string formatted="false" name="formula_editor_confirm">Računaj</string>
     <string formatted="false" name="formula_editor_object">Svojstva</string>
     <string formatted="false" name="formula_editor_functions">Funkcije</string>
     <string formatted="false" name="formula_editor_logic">Logika</string>

--- a/catroid/src/main/res/values-sr-rSP/strings.xml
+++ b/catroid/src/main/res/values-sr-rSP/strings.xml
@@ -1777,7 +1777,7 @@
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-sr/strings.xml
+++ b/catroid/src/main/res/values-sr/strings.xml
@@ -1778,7 +1778,7 @@
     <string formatted="false" name="formula_editor_object_background_number">background number</string>
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-sv/strings.xml
+++ b/catroid/src/main/res/values-sv/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background_name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">avstånd till</string>
-    <string formatted="false" name="formula_editor_compute">Beräkna</string>
+    <string formatted="false" name="formula_editor_confirm">Beräkna</string>
     <string formatted="false" name="formula_editor_object">Objekt</string>
     <string formatted="false" name="formula_editor_functions">Funktioner</string>
     <string formatted="false" name="formula_editor_logic">Logik</string>

--- a/catroid/src/main/res/values-sw/strings.xml
+++ b/catroid/src/main/res/values-sw/strings.xml
@@ -1736,7 +1736,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">jina_la_mandharinyuma</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">umbali wa</string>
-    <string formatted="false" name="formula_editor_compute">kokotoa</string>
+    <string formatted="false" name="formula_editor_confirm">kokotoa</string>
     <string formatted="false" name="formula_editor_object">Kipengee</string>
     <string formatted="false" name="formula_editor_functions">Kazi</string>
     <string formatted="false" name="formula_editor_logic">Mantiki</string>

--- a/catroid/src/main/res/values-ta/strings.xml
+++ b/catroid/src/main/res/values-ta/strings.xml
@@ -1725,7 +1725,7 @@
     <string formatted="false" name="formula_editor_object_background_name">பின்னணி பெயர்</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">தொடுவதற்கான தூரம்</string>
-    <string formatted="false" name="formula_editor_compute">கம்ப்யூட்</string>
+    <string formatted="false" name="formula_editor_confirm">கம்ப்யூட்</string>
     <string formatted="false" name="formula_editor_object">பொருள்</string>
     <string formatted="false" name="formula_editor_functions">பணிகள்</string>
     <string formatted="false" name="formula_editor_logic">தர்க்கம்</string>

--- a/catroid/src/main/res/values-te/strings.xml
+++ b/catroid/src/main/res/values-te/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-th/strings.xml
+++ b/catroid/src/main/res/values-th/strings.xml
@@ -1677,7 +1677,7 @@
     <string formatted="false" name="formula_editor_object_background_name">ชื่อพื้นหลัง</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">จำนวนพื้นหลัง</string>
     <string formatted="false" name="formula_editor_object_distance_to">ระยะทางไปยังตำแหน่งที่สัมผัส</string>
-    <string formatted="false" name="formula_editor_compute">คำนวณ</string>
+    <string formatted="false" name="formula_editor_confirm">คำนวณ</string>
     <string formatted="false" name="formula_editor_object">วัตถุ</string>
     <string formatted="false" name="formula_editor_functions">ฟังก์ชัน</string>
     <string formatted="false" name="formula_editor_logic">ตรรกะ</string>

--- a/catroid/src/main/res/values-tl/strings.xml
+++ b/catroid/src/main/res/values-tl/strings.xml
@@ -1745,7 +1745,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-tr/strings.xml
+++ b/catroid/src/main/res/values-tr/strings.xml
@@ -1698,7 +1698,7 @@ Lütfen projeyi yeniden adlandırın.</string>
     <string formatted="false" name="formula_editor_object_background_name">arka plan adı</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">arka plan sayısı</string>
     <string formatted="false" name="formula_editor_object_distance_to">dokunma pozisyonuna olan mesafe</string>
-    <string formatted="false" name="formula_editor_compute">Hesapla</string>
+    <string formatted="false" name="formula_editor_confirm">Hesapla</string>
     <string formatted="false" name="formula_editor_object">Nesne</string>
     <string formatted="false" name="formula_editor_functions">Fonksiyonlar</string>
     <string formatted="false" name="formula_editor_logic">Mantık</string>

--- a/catroid/src/main/res/values-tw/strings.xml
+++ b/catroid/src/main/res/values-tw/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-uk/strings.xml
+++ b/catroid/src/main/res/values-uk/strings.xml
@@ -1835,7 +1835,7 @@
     <string formatted="false" name="formula_editor_object_background_name">назва фона</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">кількість фонів</string>
     <string formatted="false" name="formula_editor_object_distance_to">відстань до позиції дотику</string>
-    <string formatted="false" name="formula_editor_compute">Обчислити</string>
+    <string formatted="false" name="formula_editor_confirm">Обчислити</string>
     <string formatted="false" name="formula_editor_object">Властивості</string>
     <string formatted="false" name="formula_editor_functions">Функції</string>
     <string formatted="false" name="formula_editor_logic">Логіка</string>

--- a/catroid/src/main/res/values-ur/strings.xml
+++ b/catroid/src/main/res/values-ur/strings.xml
@@ -1714,7 +1714,7 @@
     <string formatted="false" name="formula_editor_object_background_name">پس منظر کے نام</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">پس منظر کی تعداد</string>
     <string formatted="false" name="formula_editor_object_distance_to">پوزیشن کو چھونے کے لئے فاصلہ</string>
-    <string formatted="false" name="formula_editor_compute">شمار</string>
+    <string formatted="false" name="formula_editor_confirm">شمار</string>
     <string formatted="false" name="formula_editor_object">آبجیکٹ</string>
     <string formatted="false" name="formula_editor_functions">افعال</string>
     <string formatted="false" name="formula_editor_logic">منطق</string>

--- a/catroid/src/main/res/values-uz/strings.xml
+++ b/catroid/src/main/res/values-uz/strings.xml
@@ -1747,7 +1747,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-vi/strings.xml
+++ b/catroid/src/main/res/values-vi/strings.xml
@@ -1701,7 +1701,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Tính toán</string>
+    <string formatted="false" name="formula_editor_confirm">Tính toán</string>
     <string formatted="false" name="formula_editor_object">Đối tượng</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-yo-rNG/strings.xml
+++ b/catroid/src/main/res/values-yo-rNG/strings.xml
@@ -1701,7 +1701,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values-zh-rCN/strings.xml
+++ b/catroid/src/main/res/values-zh-rCN/strings.xml
@@ -1676,7 +1676,7 @@ dash(-), 下划线 (_), 和 句号(.).</string>
     <string formatted="false" name="formula_editor_object_background_name">背景名称</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">背景数</string>
     <string formatted="false" name="formula_editor_object_distance_to">到目标的距离</string>
-    <string formatted="false" name="formula_editor_compute">计算</string>
+    <string formatted="false" name="formula_editor_confirm">计算</string>
     <string formatted="false" name="formula_editor_object">对象</string>
     <string formatted="false" name="formula_editor_functions">函数</string>
     <string formatted="false" name="formula_editor_logic">逻辑</string>

--- a/catroid/src/main/res/values-zh-rTW/strings.xml
+++ b/catroid/src/main/res/values-zh-rTW/strings.xml
@@ -1698,7 +1698,7 @@
     <string formatted="false" name="formula_editor_object_background_name">背景名稱</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">背景數量</string>
     <string formatted="false" name="formula_editor_object_distance_to">到觸摸位置的距離</string>
-    <string formatted="false" name="formula_editor_compute">計算</string>
+    <string formatted="false" name="formula_editor_confirm">計算</string>
     <string formatted="false" name="formula_editor_object">物件</string>
     <string formatted="false" name="formula_editor_functions">職能</string>
     <string formatted="false" name="formula_editor_logic">邏輯</string>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1955,7 +1955,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Confirm</string>
+    <string formatted="false" name="formula_editor_confirm">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1955,7 +1955,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="formula_editor_object_background_name">background name</string>
     <string formatted="false" name="formula_editor_object_number_of_backgrounds">number of backgrounds</string>
     <string formatted="false" name="formula_editor_object_distance_to">distance to touch position</string>
-    <string formatted="false" name="formula_editor_compute">Compute</string>
+    <string formatted="false" name="formula_editor_compute">Confirm</string>
     <string formatted="false" name="formula_editor_object">Properties</string>
     <string formatted="false" name="formula_editor_functions">Functions</string>
     <string formatted="false" name="formula_editor_logic">Logic</string>


### PR DESCRIPTION
Change the “Compute” button into a “Confirm” button

- change @string/formula_editor_compute to @string/formula_editor_confirm
- change all formula editor strings  “Compute” to “Confirm” (english strings only)

https://catrobat.atlassian.net/browse/IDE-257

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
