### PR TITLE
CATROID-1594 Fix test 'testNotShowDialogOnCancelledSelection

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/ChromeCastDialogTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/ChromeCastDialogTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -30,6 +30,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.NoActivityResumedException
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.intent.Intents
@@ -138,11 +139,20 @@ class ChromeCastDialogTest {
             .perform(click())
 
         Intents.intended(expectedWebIntent)
+        pressBack()
 
+        onView(withText(R.string.cast_searching_for_cast_devices))
+            .check(doesNotExist())
+    }
+
+    @Test(expected = NoActivityResumedException::class)
+    fun testNotShowDialogOnCancelledSelectionDoublePressBackCrash() {
+        onView(withId(R.id.button_add))
+            .perform(click())
+        onView(withId(R.id.dialog_new_look_media_library))
+            .perform(click())
         pressBack()
         pressBack()
-        Espresso.closeSoftKeyboard()
-
         onView(withText(R.string.cast_searching_for_cast_devices))
             .check(doesNotExist())
     }


### PR DESCRIPTION
Will change the existing flaky test and add a new test to catch the old flaky reason. Switches double pressBack() in existing test to only one pressBack(). The new test expects the NoActivityResumedException, which happens at the second pressBack().

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
