### PR TITLE
IDE-183 Fix testComputeDialogValue

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/FormulaEditorComputeDialogComputationResultTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/FormulaEditorComputeDialogComputationResultTest.kt
@@ -817,7 +817,7 @@ class FormulaEditorComputeDialogComputationResultTest(
                     falseString
                 ),
                 arrayOf(
-                    "Function COLOR_EQUALS_COLOR",
+                    "Function COLOR_EQUALS_COLOR True",
                     getFormula(
                         Pair(FUNCTION, COLOR_EQUALS_COLOR.name), Pair(STRING, "#FFFFFF"),
                         Pair(STRING, "#FFFFFF"), Pair(NUMBER, 1)
@@ -826,7 +826,7 @@ class FormulaEditorComputeDialogComputationResultTest(
                     trueString
                 ),
                 arrayOf(
-                    "Function COLOR_EQUALS_COLOR",
+                    "Function COLOR_EQUALS_COLOR False",
                     getFormula(
                         Pair(FUNCTION, COLOR_EQUALS_COLOR.name), Pair(STRING, "#FFFFFF"),
                         Pair(STRING, "#000000"), Pair(NUMBER, 1)

--- a/catroid/src/main/java/org/catrobat/catroid/utils/TextBlockUtil.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/TextBlockUtil.kt
@@ -25,15 +25,18 @@ package org.catrobat.catroid.utils
 import android.graphics.Point
 import android.graphics.Rect
 import com.google.mlkit.nl.languageid.LanguageIdentification
+import com.google.mlkit.nl.languageid.LanguageIdentifier
 import com.google.mlkit.vision.text.Text
 import com.huawei.hms.mlsdk.langdetect.MLLangDetectorFactory
 import com.huawei.hms.mlsdk.langdetect.local.MLLocalLangDetector
 import com.huawei.hms.mlsdk.langdetect.local.MLLocalLangDetectorSetting
 import com.huawei.hms.mlsdk.text.MLText
+import org.catrobat.catroid.CatroidApplication
 import org.catrobat.catroid.ProjectManager
 import org.catrobat.catroid.camera.VisualDetectionHandler.coordinatesFromRelativePosition
 import org.catrobat.catroid.common.ScreenValues.currentScreenResolution
 import org.catrobat.catroid.stage.StageActivity
+import org.koin.java.KoinJavaComponent.get
 import kotlin.math.roundToInt
 
 object TextBlockUtil {
@@ -44,12 +47,25 @@ object TextBlockUtil {
     private var imageWidth = 0
     private var imageHeight = 0
     private const val MAX_TEXT_SIZE = 100
-    private var languageIdentifierGoogle = LanguageIdentification.getClient()
-    private var languageDetectorFactoryHuawei: MLLangDetectorFactory = MLLangDetectorFactory.getInstance()
-    var languageDetectorSettingHuawei: MLLocalLangDetectorSetting = MLLocalLangDetectorSetting.Factory()
-        .setTrustedThreshold(TRUSTED_THRESHOLD)
-        .create()
-    var languageIdentifierHuawei: MLLocalLangDetector = languageDetectorFactoryHuawei.getLocalLangDetector(languageDetectorSettingHuawei)
+    private var languageIdentifierGoogle: LanguageIdentifier? = null
+    private var languageIdentifierHuawei: MLLocalLangDetector? = null
+
+    init {
+        val context = CatroidApplication.getAppContext()
+        val mobileServiceAvailability = get(MobileServiceAvailability::class.java)
+        if (mobileServiceAvailability.isGmsAvailable(context)) {
+            languageIdentifierGoogle = LanguageIdentification.getClient()
+        } else if (mobileServiceAvailability.isHmsAvailable(context)) {
+            val languageDetectorFactoryHuawei: MLLangDetectorFactory =
+                MLLangDetectorFactory.getInstance()
+            val languageDetectorSettingHuawei: MLLocalLangDetectorSetting =
+                MLLocalLangDetectorSetting.Factory()
+                    .setTrustedThreshold(TRUSTED_THRESHOLD)
+                    .create()
+            languageIdentifierHuawei =
+                languageDetectorFactoryHuawei.getLocalLangDetector(languageDetectorSettingHuawei)
+        }
+    }
 
     fun setTextBlocksGoogle(text: List<Text.TextBlock>, width: Int, height: Int) {
         imageWidth = width
@@ -61,9 +77,10 @@ object TextBlockUtil {
         text.forEachIndexed { index, textBlock ->
             textBlock.text.let { textBlocks.add(index, it) }
             textBlock.boundingBox?.let { textBlockBoundingBoxes.add(index, it) }
-            languageIdentifierGoogle.identifyLanguage(textBlock.text).addOnSuccessListener { languageCode ->
-                textBlockLanguages[index] = languageCode
-            }
+            languageIdentifierGoogle?.identifyLanguage(textBlock.text)
+                ?.addOnSuccessListener { languageCode ->
+                    textBlockLanguages[index] = languageCode
+                }
         }
     }
 
@@ -77,8 +94,9 @@ object TextBlockUtil {
         text.forEachIndexed { index, textBlock ->
             textBlock.stringValue?.let { textBlocks.add(index, it) }
             textBlock.border?.let { textBlockBoundingBoxes.add(index, it) }
-            val firstBestDetectTask = languageIdentifierHuawei.firstBestDetect(textBlock.stringValue)
-            firstBestDetectTask.addOnSuccessListener { languageCode ->
+            val firstBestDetectTask =
+                languageIdentifierHuawei?.firstBestDetect(textBlock.stringValue)
+            firstBestDetectTask?.addOnSuccessListener { languageCode ->
                 textBlockLanguages[index] = languageCode
             }
         }


### PR DESCRIPTION
Fix testComputeDialogValue by moving the initialization code to the init block in TextBlockUtil.kt and distinguishing between HMS and GMS.
[https://catrobat.atlassian.net/browse/IDE-183](https://catrobat.atlassian.net/browse/IDE-183)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
