### PR TITLE
CATROID-1593 Fix error 'Could not launch activity' in Espresso tests

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -387,6 +387,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.browser:browser:1.2.0'
 
+    implementation "org.mockito:mockito-core:$mockitoVersion"
     implementation "androidx.test.espresso:espresso-idling-resource:$espressoVersion"
     implementation 'androidx.multidex:multidex:2.0.1'
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ConnectBluetoothDeviceActivityTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ConnectBluetoothDeviceActivityTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -33,8 +33,8 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.catrobat.catroid.ui.ConnectBluetoothDeviceTestActivity
 import org.catrobat.catroid.R
-import org.catrobat.catroid.bluetooth.ConnectBluetoothDeviceActivity
 import org.catrobat.catroid.bluetooth.ConnectBluetoothDeviceActivity.DEVICE_TO_CONNECT
 import org.catrobat.catroid.bluetooth.base.BluetoothDevice.MULTIPLAYER
 import org.catrobat.catroid.common.SharedPreferenceKeys.SHOW_MULTIPLAYER_BLUETOOTH_DIALOG_KEY
@@ -118,10 +118,5 @@ class ConnectBluetoothDeviceActivityTest {
             .check(matches(withDrawable(R.drawable.ic_search)))
             .perform(click())
             .check(matches(withDrawable(R.drawable.ic_close)))
-    }
-
-    class ConnectBluetoothDeviceTestActivity : ConnectBluetoothDeviceActivity() {
-        override fun initBluetooth() = Unit
-        override fun doDiscovery() = Unit
     }
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectUploadDialogTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/ProjectUploadDialogTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2023 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -48,8 +48,7 @@ import org.catrobat.catroid.content.Scene
 import org.catrobat.catroid.io.asynctask.saveProjectSerial
 import org.catrobat.catroid.ui.NUMBER_OF_UPLOADED_PROJECTS
 import org.catrobat.catroid.ui.PROJECT_DIR
-import org.catrobat.catroid.ui.ProjectUploadActivity
-import org.catrobat.catroid.ui.controller.ProjectUploadController
+import org.catrobat.catroid.ui.ProjectUploadTestActivity
 import org.catrobat.catroid.uiespresso.util.UiTestUtils
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityTestRule
 import org.junit.Assert.assertFalse
@@ -58,7 +57,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -236,18 +234,5 @@ class ProjectUploadDialogTest {
     private fun isKeyboardVisible(): Boolean {
         val checkKeyboardCommand = "dumpsys input_method | grep mInputShown"
         return UiDevice.getInstance(getInstrumentation()).executeShellCommand(checkKeyboardCommand).contains("mInputShown=true")
-    }
-
-    class ProjectUploadTestActivity : ProjectUploadActivity() {
-        override fun createProjectUploadController(): ProjectUploadController? {
-            projectUploadController = spy(ProjectUploadController(this))
-            return projectUploadController
-        }
-
-        override fun verifyUserIdentity() {
-            onTokenCheckComplete(true, false)
-        }
-
-        fun projectUploadController(): ProjectUploadController? = projectUploadController
     }
 }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/ReplaceApiKeyDialogTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/ReplaceApiKeyDialogTest.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -40,7 +40,7 @@ import org.catrobat.catroid.content.Script;
 import org.catrobat.catroid.content.Sprite;
 import org.catrobat.catroid.content.StartScript;
 import org.catrobat.catroid.content.bricks.BackgroundRequestBrick;
-import org.catrobat.catroid.uiespresso.ui.activity.ProjectUploadDialogTest;
+import org.catrobat.catroid.ui.ProjectUploadTestActivity;
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityTestRule;
 import org.junit.After;
 import org.junit.Before;
@@ -68,8 +68,8 @@ public class ReplaceApiKeyDialogTest {
 	private static final String TAG = ReplaceApiKeyDialogTest.class.getSimpleName();
 
 	@Rule
-	public BaseActivityTestRule<ProjectUploadDialogTest.ProjectUploadTestActivity> activityTestRule =
-			new BaseActivityTestRule<>(ProjectUploadDialogTest.ProjectUploadTestActivity.class, false, false);
+	public BaseActivityTestRule<ProjectUploadTestActivity> activityTestRule =
+			new BaseActivityTestRule<>(ProjectUploadTestActivity.class, false, false);
 
 	private int bufferedPrivacyPolicyPreferenceSetting;
 

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/ReuploadProjectDialogTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/ReuploadProjectDialogTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2022 The Catrobat Team
+ * Copyright (C) 2010-2024 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -39,7 +39,7 @@ import org.catrobat.catroid.formulaeditor.UserVariable
 import org.catrobat.catroid.io.XstreamSerializer
 import org.catrobat.catroid.io.asynctask.saveProjectSerial
 import org.catrobat.catroid.ui.PROJECT_DIR
-import org.catrobat.catroid.uiespresso.ui.activity.ProjectUploadDialogTest.ProjectUploadTestActivity
+import org.catrobat.catroid.ui.ProjectUploadTestActivity
 import org.catrobat.catroid.uiespresso.util.rules.BaseActivityTestRule
 import org.junit.After
 import org.junit.Rule

--- a/catroid/src/debug/AndroidManifest.xml
+++ b/catroid/src/debug/AndroidManifest.xml
@@ -91,6 +91,11 @@
         tools:replace="android:label,android:allowBackup,android:name"
         android:usesCleartextTraffic="true">
 
+    <activity
+        android:name=".ui.ConnectBluetoothDeviceTestActivity" />
+
+    <activity
+        android:name=".ui.ProjectUploadTestActivity" />
 <!--
         <activity
             android:name=".ui.SettingsActivity"

--- a/catroid/src/debug/java/org/catrobat/catroid/ui/ConnectBluetoothDeviceTestActivity.kt
+++ b/catroid/src/debug/java/org/catrobat/catroid/ui/ConnectBluetoothDeviceTestActivity.kt
@@ -1,0 +1,30 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2024 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.ui
+
+import org.catrobat.catroid.bluetooth.ConnectBluetoothDeviceActivity
+
+class ConnectBluetoothDeviceTestActivity : ConnectBluetoothDeviceActivity() {
+    override fun initBluetooth() = Unit
+    override fun doDiscovery() = Unit
+}

--- a/catroid/src/debug/java/org/catrobat/catroid/ui/ProjectUploadTestActivity.kt
+++ b/catroid/src/debug/java/org/catrobat/catroid/ui/ProjectUploadTestActivity.kt
@@ -1,0 +1,40 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2024 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.ui
+
+import org.catrobat.catroid.ui.controller.ProjectUploadController
+import org.mockito.Mockito.spy
+
+class ProjectUploadTestActivity : ProjectUploadActivity() {
+    override fun createProjectUploadController(): ProjectUploadController? {
+        projectUploadController = spy(ProjectUploadController(this))
+        return projectUploadController
+    }
+
+    override fun verifyUserIdentity() {
+        onTokenCheckComplete(true, false)
+    }
+
+    fun projectUploadController(): ProjectUploadController? = projectUploadController
+}

--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -79,9 +79,10 @@
 
     <uses-feature
         android:glEsVersion="0x00020000"
-        android:required="true" /><uses-feature
-    android:name="android.hardware.camera"
-    android:required="false" />
+        android:required="true" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 
     <application
         android:name=".CatroidApplication"


### PR DESCRIPTION
Android OS can only start activities if they are listed in the app's Manifest. Activities created for testing purposes were therefore moved into the debug source set and listed in the corresponding debug Manifest. When the app us built for testing those activities will be available but not when the app is built for release.

https://catrobat.atlassian.net/browse/CATROID-1593

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
