### PR TITLE
Remove Multidex usages

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -126,7 +126,6 @@ android {
         versionName defaultVersionName
         println "VersionCode is $versionCode"
         println "VersionName is $versionName"
-        multiDexEnabled true
         manifestPlaceholders += [appName: manifestAppName,
                                  appIcon: manifestAppIcon,
                                  intentFilterScheme: "https",
@@ -388,7 +387,6 @@ dependencies {
     implementation 'androidx.browser:browser:1.2.0'
 
     implementation "androidx.test.espresso:espresso-idling-resource:$espressoVersion"
-    implementation 'androidx.multidex:multidex:2.0.1'
 
     implementation ('com.opencsv:opencsv:5.0') {
         exclude group: 'org.apache.commons', module: 'commons-text'
@@ -500,7 +498,6 @@ dependencies {
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0'
 
     testImplementation 'org.robolectric:robolectric:4.7.3'
-    testImplementation 'org.robolectric:shadows-multidex:4.7.3'
 
     testImplementation 'org.reflections:reflections:0.9.11'
     testImplementation 'org.json:json:20190722'

--- a/catroid/src/main/java/org/catrobat/catroid/CatroidApplication.java
+++ b/catroid/src/main/java/org/catrobat/catroid/CatroidApplication.java
@@ -40,8 +40,6 @@ import org.catrobat.catroid.utils.Utils;
 
 import java.util.Locale;
 
-import androidx.multidex.MultiDex;
-
 public class CatroidApplication extends Application {
 
 	private static final String TAG = CatroidApplication.class.getSimpleName();
@@ -87,12 +85,6 @@ public class CatroidApplication extends Application {
 
 		String apiKey = AGConnectServicesConfig.fromContext(this).getString("client/api_key");
 		MLApplication.getInstance().setApiKey(apiKey);
-	}
-
-	@Override
-	protected void attachBaseContext(Context base) {
-		super.attachBaseContext(base);
-		MultiDex.install(this);
 	}
 
 	public synchronized Tracker getDefaultTracker() {


### PR DESCRIPTION
Since the min SDK is 28, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l

### Your checklist for this pull request

Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer