### PR TITLE
CATROID-1481 Fix bug in 'Single tap at' brick

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/actions/TapAtAction.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/content/actions/TapAtAction.kt
@@ -49,7 +49,9 @@ class TapAtAction : TemporalAction() {
     override fun begin() {
         super.begin()
         try {
-            touchCoords = Vector2(startX.interpretFloat(scope), startY.interpretFloat(scope))
+            touchCoords = Vector2(
+                startX.interpretFloat(scope), startY.interpretFloat(scope) + 1f
+            )
             if (changeX != null && changeY != null) {
                 dragCoords = Vector2(
                     changeX?.interpretFloat(scope) ?: 0f,
@@ -71,7 +73,11 @@ class TapAtAction : TemporalAction() {
                 stage.stageToScreenCoordinates(dragCoords)
             }
             stage.stageToScreenCoordinates(touchCoords)
-            stage.touchDown(touchCoords.x.toInt(), touchCoords.y.toInt(), pointer, 0)
+            stage.touchDown(
+                Math.round(touchCoords.x),
+                Math.round(touchCoords.y),
+                pointer, 0
+            )
         } else {
             duration = 0f
         }


### PR DESCRIPTION
https://catrobat.atlassian.net/browse/CATROID-1481
When brick coordinates added and read with e.g. 'Show variable' brick at runtime, then the x and y coordinate had one value less than previously assigned.
This is a bug in the libgdx library. In our version of libgdx the `Camera.unproject()` method, with which we come from the screen coordinates back to the stage coordinates, calculates y like that: `y = Gdx.graphics.getHeight() - y - 1;`. The -1 is unnecessary and in the `Camera.project()` function, it is not added to the worldcoordinates. However in the new version of libgdx, y is calculated like that: `y = Gdx.graphics.getHeight() - screenCoords.y - viewportY;`, which would be correct. In this bug fix I just added +1 to the y coordinate when touch is applied. Furthermore I applied `Math.round()` for both x and y, in order to fix rounding errors.



### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
