### PR TITLE
CATROID-1613 Fix ColorDetection ignoring z-index

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/sensing/ColorAtXYDetection.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/ColorAtXYDetection.kt
@@ -186,10 +186,10 @@ class ColorAtXYDetection(
     }
 
     private fun rgbaColorToRGBHexString(color: Color): String =
-        COLOR_HEX_PREFIX + color.toString().substring(RGBA_START_INDEX, RGBA_END_INDEX)
+        COLOR_HEX_PREFIX + color.toString().substring(RGBA_START_INDEX, RGBA_END_INDEX).uppercase()
 
     private fun argbColorToRGBHexString(color: Color): String =
-        COLOR_HEX_PREFIX + color.toString().substring(ARGB_START_INDEX, ARGB_END_INDEX)
+        COLOR_HEX_PREFIX + color.toString().substring(ARGB_START_INDEX, ARGB_END_INDEX).uppercase()
 
     private fun convertStageToBitmapCoordinate(
         position: Int,

--- a/catroid/src/main/java/org/catrobat/catroid/sensing/ColorDetection.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/sensing/ColorDetection.kt
@@ -85,7 +85,8 @@ abstract class ColorDetection(
     }
 
     private fun drawSprites(lookList: List<Look>, batch: SpriteBatch) {
-        lookList.forEach { it.draw(batch, 1f) }
+        val sortedLookList = lookList.sortedBy { it.zIndex }
+        sortedLookList.forEach { it.draw(batch, 1f) }
     }
 
     protected fun createViewport(


### PR DESCRIPTION
Jira ticket: https://catrobat.atlassian.net/browse/CATROID-1613

Description:

- Fixed ColorDetection ignoring z-index of sprites when creating an image
- Fixed ColorAtXYDetection returning lowercase HEX value of the color

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ x ] Include the name of the Jira ticket in the PR’s title
- [ x ] Include a summary of the changes plus the relevant context
- [ x ] Choose the proper base branch (*develop*)
- [ x ] Confirm that the changes follow the project’s coding guidelines
- [ x ] Verify that the changes generate no compiler or linter warnings
- [ x ] Perform a self-review of the changes
- [ x ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ x ] Confirm that new and existing unit tests pass locally
- [ x ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [ x ] Stick to the project’s gitflow workflow
- [ x ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
