### PR TITLE
IDE-278 Pocketcode application crashes when you add new object which …

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/ImageEditingTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utiltests/ImageEditingTest.java
@@ -215,4 +215,35 @@ public class ImageEditingTest {
 		double sampleSizeHeight = ((double) originalBackgroundImageDimensions[1]) / ((double) newHeight);
 		return (1d / Math.max(sampleSizeWidth, sampleSizeHeight));
 	}
+	@Test
+	public void testScaleThumbnailForImageEdgeCase() throws Exception {
+		int originalWidth = 2;
+		int originalHeight = 302;
+
+		Bitmap originalBitmap = Bitmap.createBitmap(originalWidth, originalHeight, Bitmap.Config.RGB_565);
+
+		File testImageFile = new File(FlavoredConstants.DEFAULT_ROOT_DIRECTORY, "test_thumbnail.png");
+		FileOutputStream fos = new FileOutputStream(testImageFile);
+		BufferedOutputStream bos = new BufferedOutputStream(fos, 8192);
+		originalBitmap.compress(CompressFormat.PNG, 100, bos);
+		bos.flush();
+		bos.close();
+
+		int targetWidth = 150;  // THUMBNAIL_WIDTH
+		int targetHeight = 150; // THUMBNAIL_HEIGHT
+
+		Bitmap scaledBitmap = ImageEditing.getScaledBitmapFromPath(
+				testImageFile.getAbsolutePath(),
+				targetWidth,
+				targetHeight,
+				ImageEditing.ResizeType.STAY_IN_RECTANGLE_WITH_SAME_ASPECT_RATIO,
+				true
+		);
+
+		int expectedWidth = 1;
+		int expectedHeight = 150;
+
+		assertEquals("Scaled width should be " + expectedWidth, expectedWidth, scaledBitmap.getWidth());
+		assertEquals("Scaled height should be " + expectedHeight, expectedHeight, scaledBitmap.getHeight());
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/utils/ImageEditing.java
+++ b/catroid/src/main/java/org/catrobat/catroid/utils/ImageEditing.java
@@ -76,12 +76,10 @@ public final class ImageEditing {
 		int[] imageDimensions = getImageDimensions(imagePath);
 		int originalWidth = imageDimensions[0];
 		int originalHeight = imageDimensions[1];
-
 		int[] scaledImageDimensions = getScaledImageDimensions(originalWidth, originalHeight, outputRectangleWidth,
 				outputRectangleHeight, resizeType, justScaleDown);
 		int newWidth = scaledImageDimensions[0];
 		int newHeight = scaledImageDimensions[1];
-
 		int loadingSampleSize = calculateInSampleSize(originalWidth, originalHeight, outputRectangleWidth,
 				outputRectangleHeight);
 
@@ -107,7 +105,7 @@ public final class ImageEditing {
 	}
 
 	private static int[] getScaledImageDimensions(int originalWidth, int originalHeight, int outputRectangleWidth, int
-			outputRectangleHeight,
+					outputRectangleHeight,
 			ResizeType resizeType, boolean justScaleDown) {
 		int newWidth = originalWidth;
 		int newHeight = originalHeight;
@@ -130,8 +128,8 @@ public final class ImageEditing {
 			}
 		}
 		int[] scaledImageDimensions = new int[2];
-		scaledImageDimensions[0] = newWidth;
-		scaledImageDimensions[1] = newHeight;
+		scaledImageDimensions[0] = Math.max(newWidth, 1);
+		scaledImageDimensions[1] = Math.max(newHeight, 1);
 		return scaledImageDimensions;
 	}
 


### PR DESCRIPTION
…has a big width/ height difference

When you add a new object in your Pocketcode project that has a very large height/width difference (over 1:150), the scaling algorithm calculates a width or height of 0, which causes the application to crash. 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
