### PR TITLE
DEVOPS-843 remove Pantroid directory to avoid too long file name errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -215,6 +215,7 @@ pipeline {
                                         }
                                     }
 
+                                    sh 'rm -rf Paintroid'
                                     // Build the flavors so that they can be installed next independently of older versions.
                                     sh "./gradlew ${webTestUrlParameter()} -Pindependent='#$env.BUILD_NUMBER $env.BRANCH_NAME' assembleCatroidDebug ${allFlavoursParameters()}"
 


### PR DESCRIPTION
Solution for https://catrobat.atlassian.net/browse/DEVOPS-843. Issue with renameApks method which adds given suffixes to .apk files. The issue is that when Build with Pantroid step is executed, it creates pantroid apk and "pantroid" directory is never deleted in case Build with Pantroid step is not executed again. This means that the suffix is continuously added to the pantroid apk and leads to issues such as File name too long as can be seen here 

`[2025-02-14T17:36:43.557Z] + mv ./Paintroid/app/build/outputs/apk/debug/paintroid-debug-develop-263-develop-264-develop-265-develop-267-develop-268-develop-269-develop-270-develop-272-develop-274-develop-275-develop-276-develop-277-develop-278-develop-279-develop-280-develop-281-develop-282-develop-284-develop-285.apk ./Paintroid/app/build/outputs/apk/debug/paintroid-debug-develop-263-develop-264-develop-265-develop-267-develop-268-develop-269-develop-270-develop-272-develop-274-develop-275-develop-276-develop-277-develop-278-develop-279-develop-280-develop-281-develop-282-develop-284-develop-285-develop-369.apk

[2025-02-14T17:36:43.557Z] mv: failed to access './Paintroid/app/build/outputs/apk/debug/paintroid-debug-develop-263-develop-264-develop-265-develop-267-develop-268-develop-269-develop-270-develop-272-develop-274-develop-275-develop-276-develop-277-develop-278-develop-279-develop-280-develop-281-develop-282-develop-284-develop-285-develop-369.apk': File name too long
`