### PR TITLE
IDE-285: Changed the upload failed message for clarity to users.

### DIFF
--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -2219,8 +2219,8 @@ needs read and write access to it. You can always change permissions through you
     <!-- Upload progress dialog -->
     <string formatted="false" name="progress_upload_dialog_message">Your project gets uploaded to the app\’s sharing site where others
         can use and download it. You can also download your project as a standalone app.</string>
-    <string formatted="false" name="progress_upload_dialog_failed">Upload failed. Please check your internet connection and try
-        again!</string>
+    <string formatted="false" name="progress_upload_dialog_failed">Upload failed. The upload
+        feature is currently unavailable. Please try again later.</string>
     <string formatted="false" name="progress_upload_dialog_show_program">Show project</string>
     <!--  -->
 


### PR DESCRIPTION
At present, when I attempt to upload my project, I receive an error message stating, "Upload failed. Please check your internet connection." This message is misleading and has caused me to waste time. I have revised the message to clearly inform users that the upload feature is currently unavailable.

This issue has personally consumed a significant amount of my time, as I repeatedly checked my internet connection.


- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [ ] Stick to the project’s gitflow workflow
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
