### PR TITLE
CATROID-1622 Improve script block scrolling

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/ui/dragndrop/BrickListView.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/dragndrop/BrickListView.kt
@@ -48,8 +48,8 @@ private const val ANIMATION_DURATION = 250
 private const val TRANSLUCENT_BLACK_ALPHA = 128
 private const val OBJECT_ANIMATOR_VALUE = 255
 private const val ANIMATION_REPEAT_COUNT = 5
-private const val UPPER_SCROLL_BOUND_DIVISOR = 8
-private const val LOWER_SCROLL_BOUND_DIVISOR = 48
+private const val UPPER_SCROLL_BOUND_MULTIPLIER = 0.05
+private const val LOWER_SCROLL_BOUND_MULTIPLIER = 0.85
 private const val Y_TRANSLATION_CONSTANT = 10
 
 class BrickListView : ListView {
@@ -65,6 +65,8 @@ class BrickListView : ListView {
     private var invalidateHoveringItem = false
     private var brickAdapterInterface: BrickAdapterInterface? = null
     private val translucentBlack = Color.argb(TRANSLUCENT_BLACK_ALPHA, 0, 0, 0)
+    private var scrollRunnable: Runnable? = null
+    private var isScrollRunnableRunning = false
 
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attributes: AttributeSet?) : super(context, attributes)
@@ -73,6 +75,18 @@ class BrickListView : ListView {
         attributes,
         defStyle
     )
+
+    init {
+        scrollRunnable = Runnable {
+            when {
+                downY > lowerScrollBound -> smoothScrollBy(SMOOTH_SCROLL_BY, 0)
+                downY < upperScrollBound -> smoothScrollBy(-SMOOTH_SCROLL_BY, 0)
+            }
+
+            swapListItems()
+            postDelayed(scrollRunnable, 16)
+        }
+    }
 
     val brickPositionsToHighlight: MutableList<Int> = ArrayList()
 
@@ -116,8 +130,8 @@ class BrickListView : ListView {
             flatList.removeAt(0)
         }
 
-        upperScrollBound = height / UPPER_SCROLL_BOUND_DIVISOR
-        lowerScrollBound = height / LOWER_SCROLL_BOUND_DIVISOR
+        upperScrollBound = (height * UPPER_SCROLL_BOUND_MULTIPLIER).toInt()
+        lowerScrollBound = (height * LOWER_SCROLL_BOUND_MULTIPLIER).toInt()
         currentPositionOfHoveringBrick = brickAdapterInterface!!.getPosition(this.brickToMove)
         invalidateHoveringItem = true
 
@@ -130,6 +144,8 @@ class BrickListView : ListView {
     }
 
     fun stopMoving() {
+        removeCallbacks(scrollRunnable)
+        isScrollRunnableRunning = false
         brickAdapterInterface?.moveItemTo(currentPositionOfHoveringBrick, brickToMove)
         cancelMove()
     }
@@ -160,7 +176,10 @@ class BrickListView : ListView {
                 hoveringDrawable?.bounds = viewBounds
                 invalidate()
                 swapListItems()
-                scrollWhileDragging()
+                if (!isScrollRunnableRunning) {
+                    post(scrollRunnable)
+                    isScrollRunnableRunning = true
+                }
             }
             MotionEvent.ACTION_POINTER_UP -> {
                 val pointerIndex =
@@ -265,14 +284,6 @@ class BrickListView : ListView {
             override fun onAnimationCancel(animation: Animator) = Unit
             override fun onAnimationRepeat(animation: Animator) = Unit
         })
-    }
-
-    private fun scrollWhileDragging() {
-        if (downY > lowerScrollBound) {
-            smoothScrollBy(SMOOTH_SCROLL_BY, 0)
-        } else if (downY < upperScrollBound) {
-            smoothScrollBy(-SMOOTH_SCROLL_BY, 0)
-        }
     }
 
     private fun getChildAtVisiblePosition(positionInAdapter: Int): View? =


### PR DESCRIPTION
https://catrobat.atlassian.net/browse/CATROID-1622

- Script block scrolling now works as user would expect (No more weird jittering around)
- Once user reaches top/bottom edge of the screen, the scrolling begins
- Scrolling ends, once user goes away from the edges

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
