### PR TITLE
IDE-117 Open Color Picker when clicking on Color Square

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
@@ -374,13 +374,16 @@ public class FormulaEditorEditText extends EditText implements OnTouchListener {
 				Rect rect = span.getLastDrawRect();
 
 				if (rect != null && rect.contains(x, y)) {
-					internFormula.selectWholeFormula();
 					formulaEditorFragment.showColorPickerDialog(view);
 					return true;
 				}
 			}
 		}
 		return gestureDetector.onTouchEvent(motion);
+	}
+
+	public void setSelectedColorValue() {
+		internFormula.selectWholeFormula();
 	}
 
 	@Override

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
@@ -26,6 +26,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.Rect;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.style.BackgroundColorSpan;
@@ -35,7 +36,6 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnTouchListener;
 import android.widget.EditText;
-
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.formulaeditor.InternFormula.TokenSelectionType;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -357,14 +357,30 @@ public class FormulaEditorEditText extends EditText implements OnTouchListener {
 		if (absoluteCursorPosition > length()) {
 			absoluteCursorPosition = length();
 		}
-
 		highlightSelection();
-
 		return newExternFormulaString;
 	}
 
 	@Override
 	public boolean onTouch(View view, MotionEvent motion) {
+		if (motion.getAction() == MotionEvent.ACTION_UP) {
+			Spannable spannable = (Spannable) getText();
+			int x = (int) (motion.getX() - getTotalPaddingLeft() + getScrollX());
+			int y = (int) (motion.getY() - getTotalPaddingTop()  + getScrollY());
+
+			VisualizeColorImageSpan[] spans = spannable.getSpans(0, spannable.length(),
+					VisualizeColorImageSpan.class);
+			for (VisualizeColorImageSpan span : spans) {
+				Rect rect = span.getLastDrawRect();
+
+				if (rect != null && rect.contains(x, y)) {
+					formulaEditorFragment.showColorPickerDialog(view);
+					// something like formulaEditorFragment.openColorPicker(span.colorValue);
+
+					return true;
+				}
+			}
+		}
 		return gestureDetector.onTouchEvent(motion);
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
@@ -43,6 +43,8 @@ import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
 import java.util.List;
 import java.util.Map;
 
+import static org.catrobat.catroid.formulaeditor.InternFormula.TokenSelectionType.USER_SELECTION;
+
 @SuppressLint("AppCompatCustomView")
 public class FormulaEditorEditText extends EditText implements OnTouchListener {
 
@@ -370,10 +372,13 @@ public class FormulaEditorEditText extends EditText implements OnTouchListener {
 
 			VisualizeColorImageSpan[] spans = spannable.getSpans(0, spannable.length(),
 					VisualizeColorImageSpan.class);
-			for (VisualizeColorImageSpan span : spans) {
-				Rect rect = span.getLastDrawRect();
+			for (int i = 0; i < spans.length; i++) {
+				Rect rect = spans[i].getDrawRect();
 
 				if (rect != null && rect.contains(x, y)) {
+					internFormula.internFormulaTokenSelection = new InternFormulaTokenSelection(
+							USER_SELECTION, i, i);
+
 					formulaEditorFragment.showColorPickerDialog(view);
 					return true;
 				}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
@@ -36,6 +36,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnTouchListener;
 import android.widget.EditText;
+
 import org.catrobat.catroid.content.bricks.Brick;
 import org.catrobat.catroid.formulaeditor.InternFormula.TokenSelectionType;
 import org.catrobat.catroid.ui.fragment.FormulaEditorFragment;
@@ -368,7 +369,7 @@ public class FormulaEditorEditText extends EditText implements OnTouchListener {
 		if (motion.getAction() == MotionEvent.ACTION_UP) {
 			Spannable spannable = (Spannable) getText();
 			int x = (int) (motion.getX() - getTotalPaddingLeft() + getScrollX());
-			int y = (int) (motion.getY() - getTotalPaddingTop()  + getScrollY());
+			int y = (int) (motion.getY() - getTotalPaddingTop() + getScrollY());
 
 			VisualizeColorImageSpan[] spans = spannable.getSpans(0, spannable.length(),
 					VisualizeColorImageSpan.class);

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
@@ -374,9 +374,8 @@ public class FormulaEditorEditText extends EditText implements OnTouchListener {
 				Rect rect = span.getLastDrawRect();
 
 				if (rect != null && rect.contains(x, y)) {
+					internFormula.selectWholeFormula();
 					formulaEditorFragment.showColorPickerDialog(view);
-					// something like formulaEditorFragment.openColorPicker(span.colorValue);
-
 					return true;
 				}
 			}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
@@ -1190,4 +1190,8 @@ public class InternFormula {
 	public List<InternToken> getInternTokenFormulaList() {
 		return internTokenFormulaList;
 	}
+
+	public int getCursorPositionInternTokenIndex() {
+		return cursorPositionInternTokenIndex;
+	}
 }

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/VisualizeColorString.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/VisualizeColorString.kt
@@ -81,12 +81,12 @@ class VisualizeColorImageSpan(
     drawable: RoundedBitmapDrawable,
     val colorValue: Int,
 ) : ImageSpan(drawable, ALIGN_BOTTOM) {
-    var lastDrawRect: android.graphics.Rect? = null
+    var drawRect: android.graphics.Rect? = null
     override fun draw(
         canvas: Canvas, text: CharSequence,
         start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {
         super.draw(canvas, text, start, end, x, top, y, bottom, paint)
-        lastDrawRect = android.graphics.Rect(
+        drawRect = android.graphics.Rect(
             x.toInt(),
             top,
             (x + drawable.bounds.width()).toInt(),

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/VisualizeColorString.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/VisualizeColorString.kt
@@ -25,6 +25,8 @@ package org.catrobat.catroid.formulaeditor
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
 import android.text.style.ImageSpan
 import androidx.core.graphics.drawable.RoundedBitmapDrawable
 import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory
@@ -77,5 +79,18 @@ class VisualizeColorString(
 
 class VisualizeColorImageSpan(
     drawable: RoundedBitmapDrawable,
-    val colorValue: Int
-) : ImageSpan(drawable, ALIGN_BOTTOM)
+    val colorValue: Int,
+) : ImageSpan(drawable, ALIGN_BOTTOM) {
+    var lastDrawRect: android.graphics.Rect? = null
+    override fun draw(
+        canvas: Canvas, text: CharSequence,
+        start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {
+        super.draw(canvas, text, start, end, x, top, y, bottom, paint)
+        lastDrawRect = android.graphics.Rect(
+            x.toInt(),
+            top,
+            (x + drawable.bounds.width()).toInt(),
+            bottom
+        )
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/VisualizeColorString.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/VisualizeColorString.kt
@@ -79,12 +79,22 @@ class VisualizeColorString(
 
 class VisualizeColorImageSpan(
     drawable: RoundedBitmapDrawable,
-    val colorValue: Int,
+    val colorValue: Int
 ) : ImageSpan(drawable, ALIGN_BOTTOM) {
+
     var drawRect: android.graphics.Rect? = null
+
     override fun draw(
-        canvas: Canvas, text: CharSequence,
-        start: Int, end: Int, x: Float, top: Int, y: Int, bottom: Int, paint: Paint) {
+        canvas: Canvas,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        x: Float,
+        top: Int,
+        y: Int,
+        bottom: Int,
+        paint: Paint
+    ) {
         super.draw(canvas, text, start, end, x, top, y, bottom, paint)
         drawRect = android.graphics.Rect(
             x.toInt(),

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -459,7 +459,6 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 
 			@Override
 			public void setValue(int value) {
-				formulaEditorEditText.setSelectedColorValue();
 				addString(String.format("#%06X", (0xFFFFFF & value)));
 			}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -443,7 +443,7 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		dialog.show(fragmentManager, null);
 	}
 
-	private void showColorPickerDialog(View view) {
+	public void showColorPickerDialog(View view) {
 		AppCompatActivity activity = UiUtils.getActivityFromView(view);
 		if (activity == null) {
 			return;

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -459,6 +459,7 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 
 			@Override
 			public void setValue(int value) {
+				formulaEditorEditText.setSelectedColorValue();
 				addString(String.format("#%06X", (0xFFFFFF & value)));
 			}
 


### PR DESCRIPTION
Made color square next to the color formula clickable. A color in the formula editor edit field can now be changed by click on color square next to the formula. 
Color formula and color square are implemented as SpannableStringBuilder (build on IDE-116).

https://catrobat.atlassian.net/browse/IDE-117

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
