### PR TITLE
IDE-291 Test `FormulaEditorKeyboardTest.testConfirmButtonString` fails locally and on Jenkins

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorKeyboardTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorKeyboardTest.java
@@ -57,6 +57,7 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -188,9 +189,10 @@ public class FormulaEditorKeyboardTest {
 	}
 
 	@Test
-	public void testConfirmButtonString() {
+	public void testConfirmButtonContentDescription() {
 		onView(withId(R.id.brick_set_variable_edit_text)).perform(click());
-		onView(withId(R.id.formula_editor_keyboard_compute)).check(matches(withText(R.string.formula_editor_confirm)));
+		onView(withId(R.id.formula_editor_keyboard_confirm))
+				.check(matches(withContentDescription(R.string.formula_editor_image_button_description_confirm)));
 	}
 
 	@After


### PR DESCRIPTION
The testConfirmButtonString test is outdated and may have been overlooked during an update. Since the button under test is now an image, its text string can no longer be tested directly. Instead, the content description is now being verified, and the test has been renamed to testConfirmButtonContentDescription.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
