### PR TITLE
Fix title inconsistency in ProjectListActivity

### DIFF
--- a/.run/Instrumented Unit Tests.run.xml
+++ b/.run/Instrumented Unit Tests.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Instrumented Unit Tests" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests">
-    <module name="Catroid.catroid.androidTest" />
+    <option name="ANDROID_TEST_RUN_CONFIGURATION_SCHEMA_VERSION" value="0" />
     <option name="TESTING_TYPE" value="2" />
     <option name="METHOD_NAME" value="" />
     <option name="CLASS_NAME" value="org.catrobat.catroid.testsuites.LocalHeadlessTestSuite" />
@@ -8,12 +8,8 @@
     <option name="TEST_NAME_REGEX" value="" />
     <option name="INSTRUMENTATION_RUNNER_CLASS" value="" />
     <option name="EXTRA_OPTIONS" value="" />
-    <option name="RETENTION_ENABLED" value="No" />
-    <option name="RETENTION_MAX_SNAPSHOTS" value="2" />
-    <option name="RETENTION_COMPRESS_SNAPSHOTS" value="false" />
     <option name="CLEAR_LOGCAT" value="false" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
-    <option name="INSPECTION_WITHOUT_ACTIVITY_RESTART" value="false" />
     <option name="TARGET_SELECTION_MODE" value="DEVICE_AND_SNAPSHOT_COMBO_BOX" />
     <option name="SELECTED_CLOUD_MATRIX_CONFIGURATION_ID" value="-1" />
     <option name="SELECTED_CLOUD_MATRIX_PROJECT_ID" value="" />
@@ -24,6 +20,8 @@
       <option name="WORKING_DIR" value="" />
       <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
       <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
     </Auto>
     <Hybrid>
       <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
@@ -31,14 +29,21 @@
       <option name="WORKING_DIR" value="" />
       <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
       <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
     </Hybrid>
-    <Java />
+    <Java>
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
+    </Java>
     <Native>
       <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
       <option name="SHOW_STATIC_VARS" value="true" />
       <option name="WORKING_DIR" value="" />
       <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
       <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+      <option name="ATTACH_ON_WAIT_FOR_DEBUGGER" value="false" />
+      <option name="DEBUG_SANDBOX_SDK" value="false" />
     </Native>
     <Profilers>
       <option name="ADVANCED_PROFILING_ENABLED" value="false" />
@@ -47,10 +52,7 @@
       <option name="STARTUP_CPU_PROFILING_CONFIGURATION_NAME" value="Java/Kotlin Method Sample (legacy)" />
       <option name="STARTUP_NATIVE_MEMORY_PROFILING_ENABLED" value="false" />
       <option name="NATIVE_MEMORY_SAMPLE_RATE_BYTES" value="2048" />
-      <option name="PROFILING_MODE" value="NOT_SET" />
     </Profilers>
-    <method v="2">
-      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
-    </method>
+    <method v="2" />
   </configuration>
 </component>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Catrobat** is a visual programming language and a set of creativity tools for smartphones. 
 Catrobat projects can be created using Catrobat's Android apps available on [Google Play](https://play.google.com/store/apps/developer?id=Catrobat) and iPhone apps available on [Apple's app store](https://apps.apple.com/us/developer/international-catrobat-association-verein-zur-foerderung/id1117935891).
 
-For more information oriented towards developers, check out our [developers page](https://developer.catrobat.org/).
+For more information aimed at developers, please visit our [developers page](https://developer.catrobat.org/).
 
 # Issues #
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Catroid #
 
-**Catroid** is a visual coding IDE and interpreter for Android for the Catrobat programming language.
+**Catroid** is a visual coding IDE and interpreter for Android for the Catrobat programming language.This Project is actively developed and welcomes contributions from new open-source contributors.
 
 **Catrobat** is a visual programming language and a set of creativity tools for smartphones. 
 Catrobat projects can be created using Catrobat's Android apps available on [Google Play](https://play.google.com/store/apps/developer?id=Catrobat) and iPhone apps available on [Apple's app store](https://apps.apple.com/us/developer/international-catrobat-association-verein-zur-foerderung/id1117935891).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Catroid #
 
-**Catroid** is a visual coding IDE and interpreter for Android for the Catrobat programming language.This Project is actively developed and welcomes contributions from new open-source contributors.
+**Catroid** is a visual coding IDE and interpreter for Android for the Catrobat programming language. This Project is actively developed and welcomes contributions from new open-source contributors.
 
 **Catrobat** is a visual programming language and a set of creativity tools for smartphones. 
 Catrobat projects can be created using Catrobat's Android apps available on [Google Play](https://play.google.com/store/apps/developer?id=Catrobat) and iPhone apps available on [Apple's app store](https://apps.apple.com/us/developer/international-catrobat-association-verein-zur-foerderung/id1117935891).

--- a/catroid/src/main/java/org/catrobat/catroid/ui/ProjectListActivity.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/ProjectListActivity.kt
@@ -76,6 +76,11 @@ class ProjectListActivity : BaseCastActivity() {
         return super.onCreateOptionsMenu(menu)
     }
 
+    override fun onResume() {
+        super.onResume()
+        supportActionBar?.setTitle(R.string.project_list_title)
+    }
+
     override fun onBackPressed() {
         if (supportFragmentManager.backStackEntryCount > 0) {
             supportFragmentManager.popBackStack()


### PR DESCRIPTION
Fixes CATROID-1338

This PR fixes the title inconsistency in ProjectListActivity.
When navigating back from Project Options, the title is now correctly reset to the project list title.

Testing:
- Built and ran the project in Android Studio.
- Verified the title is correct after navigating back to the Project List screen.
