### PR TITLE
IDE-310 fixing selectFragmentToDeleteTest()

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DeleteSoundTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/DeleteSoundTest.java
@@ -156,7 +156,12 @@ public class DeleteSoundTest {
 
 	@Category({Cat.AppUi.class, Level.Smoke.class})
 	@Test
-	public void selectFragmentToDeleteTest() {
+	public void selectFragmentToDeleteTest() throws IOException {
+		// Two sounds are required -> otherwise, the selection checkbox does not appear
+		ActionUtils.addSound(projectManager, "testSound1");
+		ActionUtils.addSound(projectManager, toBeDeletedSoundName);
+		baseActivityTestRule.launchActivity();
+
 		openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getInstrumentation().getTargetContext());
 		onView(withText(R.string.delete)).perform(click());
 


### PR DESCRIPTION
Launching the activity aswell as adding at least 2 sounds was missing to pass the test.

The Test DeleteSoundTest.selectFragmentToDeleteTest() failed locally. The issue was, that launching the activity aswell as adding at least 2 sounds was missing. It is important to add at least 2 sounds because otherwise there is no selection checkbox and the test fails.
(https://catrobat.atlassian.net/browse/IDE-310)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
