### PR TITLE
feat: implement initial MQTT settings infrastructure using TDD

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/common/SharedPreferenceKeys.java
+++ b/catroid/src/main/java/org/catrobat/catroid/common/SharedPreferenceKeys.java
@@ -67,4 +67,8 @@ public final class SharedPreferenceKeys {
 	public static final String SURVEY_URL2_HASH_KEY = "surveyUrl2Hash";
 	public static final String NEW_SPRITE_VISUAL_PLACEMENT_KEY = "newSpriteVisualPlacement";
 	public static final String SHOW_MULTIPLAYER_BLUETOOTH_DIALOG_KEY = "showMultiplayerBluetoothDialog";
+
+	public static final String MQTT_ENABLED_KEY = "setting_mqtt_enabled";
+	public static final String MQTT_BROKER_HOST_KEY = "setting_mqtt_broker_host";
+	public static final String MQTT_BROKER_PORT_KEY = "setting_mqtt_broker_port";
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -64,6 +64,9 @@ import static org.catrobat.catroid.CatroidApplication.defaultSystemLanguage;
 import static org.catrobat.catroid.common.SharedPreferenceKeys.DEVICE_LANGUAGE;
 import static org.catrobat.catroid.common.SharedPreferenceKeys.LANGUAGE_TAGS;
 import static org.catrobat.catroid.common.SharedPreferenceKeys.LANGUAGE_TAG_KEY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.MQTT_BROKER_HOST_KEY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.MQTT_BROKER_PORT_KEY;
+import static org.catrobat.catroid.common.SharedPreferenceKeys.MQTT_ENABLED_KEY;
 import static org.koin.java.KoinJavaComponent.inject;
 
 public class SettingsFragment extends PreferenceFragment {
@@ -454,6 +457,18 @@ public class SettingsFragment extends PreferenceFragment {
 
 	public static String getRaspiRevision(Context context) {
 		return getSharedPreferences(context).getString(RASPI_VERSION_SPINNER, null);
+	}
+
+	public static boolean getMqttEnabled(Context context) {
+		return getBooleanSharedPreference(false, MQTT_ENABLED_KEY, context);
+	}
+
+	public static String getMqttBrokerHost(Context context) {
+		return getSharedPreferences(context).getString(MQTT_BROKER_HOST_KEY, "");
+	}
+
+	public static int getMqttBrokerPort(Context context) {
+		return Integer.parseInt(getSharedPreferences(context).getString(MQTT_BROKER_PORT_KEY, "1883"));
 	}
 
 	public static void setLegoMindstormsNXTSensorMapping(Context context, NXTSensor.Sensor[] sensorMapping) {

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -268,6 +268,16 @@
     <string formatted="false" name="preference_raspi_port">Raspberry Pi port</string>
     <!--  -->
 
+    <!-- MQTT -->
+    <string formatted="false" name="preference_title_mqtt_settings">MQTT Settings</string>
+    <string formatted="false" name="preference_title_mqtt_enabled">Enable MQTT</string>
+    <string formatted="false" name="preference_description_mqtt_enabled">Enable or disable MQTT connection</string>
+    <string formatted="false" name="preference_title_mqtt_broker_host">MQTT Broker Host</string>
+    <string formatted="false" name="preference_description_mqtt_broker_host">MQTT broker hostname or IP address</string>
+    <string formatted="false" name="preference_title_mqtt_broker_port">MQTT Broker Port</string>
+    <string formatted="false" name="preference_description_mqtt_broker_port">MQTT broker port number</string>
+    <!--  -->
+
     <string formatted="false" name="preference_title_multiplayer_variables_enabled">Multiplayer extension</string>
     <string formatted="false" name="preference_description_multiplayer_variables_enabled">Allow the app to use
         multiplayer variables shared via Bluetooth</string>

--- a/catroid/src/main/res/xml/preferences.xml
+++ b/catroid/src/main/res/xml/preferences.xml
@@ -105,29 +105,29 @@
         android:title="@string/preference_title_enable_raspi_bricks" />
 
     <PreferenceCategory
-        android:title="MQTT Settings">
+        android:key="setting_mqtt_category"
+        android:title="@string/preference_title_mqtt_settings">
 
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="setting_mqtt_enabled"
-            android:summary="Enable or disable MQTT connection"
-            android:title="Enable MQTT" />
+            android:summary="@string/preference_description_mqtt_enabled"
+            android:title="@string/preference_title_mqtt_enabled" />
 
         <EditTextPreference
             android:defaultValue=""
             android:key="setting_mqtt_broker_host"
-            android:summary="MQTT broker hostname or IP address"
-            android:title="MQTT Broker Host" />
+            android:summary="@string/preference_description_mqtt_broker_host"
+            android:title="@string/preference_title_mqtt_broker_host" />
 
         <EditTextPreference
             android:defaultValue="1883"
             android:inputType="number"
             android:key="setting_mqtt_broker_port"
-            android:summary="MQTT broker port number"
-            android:title="MQTT Broker Port" />
+            android:summary="@string/preference_description_mqtt_broker_port"
+            android:title="@string/preference_title_mqtt_broker_port" />
 
     </PreferenceCategory>
-
 
     <Preference
         android:key="setting_enable_phiro_bricks_preference"

--- a/catroid/src/main/res/xml/preferences.xml
+++ b/catroid/src/main/res/xml/preferences.xml
@@ -104,6 +104,31 @@
         android:summary="@string/preference_description_raspi_bricks"
         android:title="@string/preference_title_enable_raspi_bricks" />
 
+    <PreferenceCategory
+        android:title="MQTT Settings">
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="setting_mqtt_enabled"
+            android:summary="Enable or disable MQTT connection"
+            android:title="Enable MQTT" />
+
+        <EditTextPreference
+            android:defaultValue=""
+            android:key="setting_mqtt_broker_host"
+            android:summary="MQTT broker hostname or IP address"
+            android:title="MQTT Broker Host" />
+
+        <EditTextPreference
+            android:defaultValue="1883"
+            android:inputType="number"
+            android:key="setting_mqtt_broker_port"
+            android:summary="MQTT broker port number"
+            android:title="MQTT Broker Port" />
+
+    </PreferenceCategory>
+
+
     <Preference
         android:key="setting_enable_phiro_bricks_preference"
         android:summary="@string/preference_description_phiro_bricks"

--- a/catroid/src/test/java/org/catrobat/catroid/test/ui/settingsfragments/MqttSettingsTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/ui/settingsfragments/MqttSettingsTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2026 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.ui.settingsfragments
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.catrobat.catroid.common.SharedPreferenceKeys.MQTT_BROKER_HOST_KEY
+import org.catrobat.catroid.common.SharedPreferenceKeys.MQTT_BROKER_PORT_KEY
+import org.catrobat.catroid.common.SharedPreferenceKeys.MQTT_ENABLED_KEY
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class MqttSettingsTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun mqttEnabledKeyFollowsNamingConvention() {
+        assertEquals("setting_mqtt_enabled", MQTT_ENABLED_KEY)
+    }
+
+    @Test
+    fun mqttBrokerHostKeyFollowsNamingConvention() {
+        assertEquals("setting_mqtt_broker_host", MQTT_BROKER_HOST_KEY)
+    }
+
+    @Test
+    fun mqttBrokerPortKeyFollowsNamingConvention() {
+        assertEquals("setting_mqtt_broker_port", MQTT_BROKER_PORT_KEY)
+    }
+
+    @Test
+    fun getMqttEnabledDefaultValueIsFalse() {
+        val result = SettingsFragment.getMqttEnabled(context)
+        assertFalse(result)
+    }
+
+    @Test
+    fun getMqttBrokerHostDefaultValueIsEmptyString() {
+        val result = SettingsFragment.getMqttBrokerHost(context)
+        assertEquals("", result)
+    }
+
+    @Test
+    fun getMqttBrokerPortDefaultValueIs1883() {
+        val result = SettingsFragment.getMqttBrokerPort(context)
+        assertEquals(1883, result)
+    }
+}


### PR DESCRIPTION
## Overview
This PR implements the initial infrastructure for MQTT settings in Catroid. The development followed a strict **Red-Green-Refactor (TDD)** approach to ensure code quality and maintainability, aligning with the GSoC 2026 MQTT IoT task requirements.

## Key Changes
- **Testing:** Created `MqttSettingsTest.kt` using Robolectric to define and verify default MQTT configuration values.
- **Data Persistence:** Added `MQTT_ENABLED_KEY`, `MQTT_BROKER_HOST_KEY`, and `MQTT_BROKER_PORT_KEY` to `SharedPreferenceKeys.java`.
- **Logic:** Implemented static helper methods in `SettingsFragment.java` for retrieving MQTT settings.
- **UI & Localization:** Integrated a new MQTT category in `preferences.xml` and moved all hardcoded strings to `strings.xml`.

## Development Cycle
- 🔴 **Red Phase:** Committed failing tests to define the required behavior.
- 🟢 **Green Phase:** Implemented the minimum logic required to pass all unit tests.
- 🔵 **Refactor Phase:** Polished the code, ensured self-documenting naming conventions, and adhered to the project's XML and Java coding standards.

## Checklist
- [x] Unit tests passed.
- [x] No hardcoded strings (all in `strings.xml`).
- [x] Code follows the existing project style (No unused imports, correct indentation).