### PR TITLE
IDE-318 Fix reflection helper null handling on Java 22

### DIFF
--- a/catroid/src/test/java/org/catrobat/catroid/test/utils/Reflection.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/utils/Reflection.java
@@ -24,6 +24,7 @@ package org.catrobat.catroid.test.utils;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 public final class Reflection {
 	private Reflection() {
@@ -167,6 +168,9 @@ public final class Reflection {
 	public static Object invokeMethod(Class<?> clazz, Object object, String methodName, ParameterList parameterList) throws Exception {
 		Method method = clazz.getDeclaredMethod(methodName, parameterList.types);
 		method.setAccessible(true);
+		if (object == null && !Modifier.isStatic(method.getModifiers())) {
+			throw new NullPointerException("Object is null");
+		}
 		return method.invoke(object, parameterList.values);
 	}
 }


### PR DESCRIPTION
## Summary

This PR fixes a unit test failure caused by changed reflection behavior on Java 22.

The shared test helper `Reflection.invokeMethod(Class<?>, Object, String, ParameterList)` now explicitly throws `NullPointerException` when it is asked to invoke a non-static method on a `null` receiver.

https://catrobat.atlassian.net/browse/IDE-318

Note: This PR is conceptually independent from #5170 but they currently affect the same test pipeline. Removing the obsolete Scratch Converter tests does not fix the separate Java 22 reflection failure, and #5168 does not remove the obsolete Scratch Converter tests. So each PR is reviewable on its own, but CI may stay red until both are merged.

## Background

In the current CI setup, the reflection-based unit test `ReflectionExceptionsTest.testInvokeMethodWithNullObject3` no longer behaves as expected on Java 22.

Previously, this test expected a `NullPointerException` when invoking an instance method with a `null` target through the helper. On Java 22, the reflective call path wraps that situation differently, which makes the test fail even though the underlying problem is still a null receiver.

## Change

Instead of relying on JDK-version-specific reflection internals, the helper now performs this check itself before calling `Method.invoke(...)`:

- if the target object is `null`
- and the reflected method is not static

then it throws `NullPointerException` directly.

This makes the helper behavior stable and keeps the existing test expectation meaningful across Java versions.

## Verification

The existing regression test `ReflectionExceptionsTest.testInvokeMethodWithNullObject3` failed before this change on Java 22 and passes again after the helper-side null check was added.

Verified locally with:

`bash`
`./gradlew -PenableCoverage jacocoTestCatroidDebugUnitTestReport --full-stacktrace --no-daemon`

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
