### PR TITLE
Fix IDE 324 : ClassCastException in DataListFragment and stabilize UI tests

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUndoTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUndoTest.kt
@@ -335,7 +335,11 @@ class FormulaEditorUndoTest {
             .check(matches(isDisplayed()))
 
         assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME), userVariable)
-        assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value, NEW_VARIABLE_VALUE)
+        assertEquals(
+            (ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value as Number).toDouble(),
+            NEW_VARIABLE_VALUE.toDouble(),
+            0.001
+        )
 
         onView(withId(R.id.menu_undo))
             .perform(click())
@@ -343,7 +347,11 @@ class FormulaEditorUndoTest {
             .check(doesNotExist())
 
         assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME), userVariable)
-        assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value, VARIABLE_VALUE)
+        assertEquals(
+            (ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value as Number).toDouble(),
+            VARIABLE_VALUE.toDouble(),
+            0.001
+        )
     }
 
     @Category(Cat.AppUi::class, Level.Smoke::class)

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUndoTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorUndoTest.kt
@@ -276,8 +276,8 @@ class FormulaEditorUndoTest {
 
         assertNotNull(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME))
 
-        assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME), userVariable)
-        assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value, VARIABLE_VALUE)
+        assertEquals(userVariable, ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME))
+        assertEquals(VARIABLE_VALUE, ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value)
     }
 
     @Category(Cat.AppUi::class, Level.Smoke::class)
@@ -295,8 +295,8 @@ class FormulaEditorUndoTest {
 
         assertNull(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME))
         assertNotNull(ProjectManager.getInstance().currentProject.getUserVariable(NEW_VARIABLE_NAME))
-        assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(NEW_VARIABLE_NAME), userVariable)
-        assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(NEW_VARIABLE_NAME).value, VARIABLE_VALUE)
+        assertEquals(userVariable, ProjectManager.getInstance().currentProject.getUserVariable(NEW_VARIABLE_NAME))
+        assertEquals(VARIABLE_VALUE, ProjectManager.getInstance().currentProject.getUserVariable(NEW_VARIABLE_NAME).value)
 
         onView(withId(R.id.menu_undo))
             .perform(click())
@@ -306,8 +306,8 @@ class FormulaEditorUndoTest {
 
         assertNull(ProjectManager.getInstance().currentProject.getUserVariable(NEW_VARIABLE_NAME))
         assertNotNull(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME))
-        assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME), userVariable)
-        assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value, VARIABLE_VALUE)
+        assertEquals(userVariable, ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME))
+        assertEquals(VARIABLE_VALUE, ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value)
     }
 
     @Category(Cat.AppUi::class, Level.Smoke::class)
@@ -334,10 +334,10 @@ class FormulaEditorUndoTest {
         onView(withId(R.id.menu_undo))
             .check(matches(isDisplayed()))
 
-        assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME), userVariable)
+        assertEquals(userVariable, ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME))
         assertEquals(
-            (ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value as Number).toDouble(),
             NEW_VARIABLE_VALUE.toDouble(),
+            (ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value as Number).toDouble(),
             0.001
         )
 
@@ -346,10 +346,10 @@ class FormulaEditorUndoTest {
         onView(withId(R.id.menu_undo))
             .check(doesNotExist())
 
-        assertEquals(ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME), userVariable)
+        assertEquals(userVariable, ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME))
         assertEquals(
-            (ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value as Number).toDouble(),
             VARIABLE_VALUE.toDouble(),
+            (ProjectManager.getInstance().currentProject.getUserVariable(VARIABLE_NAME).value as Number).toDouble(),
             0.001
         )
     }

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/UserDataItemRVInteractionWrapper.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/utils/UserDataItemRVInteractionWrapper.java
@@ -60,6 +60,7 @@ public abstract class UserDataItemRVInteractionWrapper<T extends UserDataItemRVI
 		onChildView(R.id.settings_button)
 				.perform(click());
 		onView(withText(R.string.rename))
+				.inRoot(androidx.test.espresso.matcher.RootMatchers.isPlatformPopup())
 				.perform(click());
 		onView(withId(R.id.input_edit_text))
 				.perform(replaceText(newName), closeSoftKeyboard());
@@ -71,6 +72,7 @@ public abstract class UserDataItemRVInteractionWrapper<T extends UserDataItemRVI
 		onChildView(R.id.settings_button)
 				.perform(click());
 		onView(withText(R.string.edit))
+				.inRoot(androidx.test.espresso.matcher.RootMatchers.isPlatformPopup())
 				.perform(click());
 		onView(withId(R.id.input_edit_text))
 				.perform(replaceText(newValue), closeSoftKeyboard());

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
@@ -66,9 +66,9 @@ import org.catrobat.catroid.utils.ToastUtil
 import org.catrobat.catroid.utils.UserDataUtil.renameUserData
 import java.util.Collections
 
-class DataListFragment<T : UserData<String>> : Fragment(),
+class DataListFragment : Fragment(),
     ActionMode.Callback, RVAdapter.SelectionListener,
-    RVAdapter.OnItemClickListener<T> {
+    RVAdapter.OnItemClickListener<UserData<*>> {
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(NONE, DELETE)
     internal annotation class ActionModeType
@@ -478,7 +478,7 @@ class DataListFragment<T : UserData<String>> : Fragment(),
         }
     }
 
-    private fun showEditDialog(selectedItems: List<T>) {
+    private fun showEditDialog(selectedItems: List<UserData<*>>) {
         val item = selectedItems[0]
         val builder = TextInputDialog.Builder(requireContext())
 
@@ -492,7 +492,7 @@ class DataListFragment<T : UserData<String>> : Fragment(),
             .show()
     }
 
-    private fun editItem(item: T, value: String?) {
+    private fun editItem(item: UserData<*>, value: String?) {
         val trimmedValue = value?.trim()
         if (item is UserVariable) {
             val parsedValue: Any? = try {
@@ -500,10 +500,7 @@ class DataListFragment<T : UserData<String>> : Fragment(),
             } catch (e: NumberFormatException) {
                 trimmedValue
             }
-            @Suppress("UNCHECKED_CAST")
-            (item as UserVariable).value = parsedValue
-        } else {
-            updateUserVariableValue(trimmedValue, item)
+            item.value = parsedValue
         }
         adapter?.updateDataSet()
         finishActionMode()
@@ -515,7 +512,7 @@ class DataListFragment<T : UserData<String>> : Fragment(),
         }
     }
 
-    override fun onItemClick(item: T, selectionManager: MultiSelectionManager?) {
+    override fun onItemClick(item: UserData<*>, selectionManager: MultiSelectionManager?) {
         if (actionModeType == NONE) {
             val formulaEditorFragment =
                 fragmentManager?.findFragmentByTag(FormulaEditorFragment.FORMULA_EDITOR_FRAGMENT_TAG) as FormulaEditorFragment?
@@ -524,7 +521,7 @@ class DataListFragment<T : UserData<String>> : Fragment(),
         }
     }
 
-    override fun onItemLongClick(item: T, holder: CheckableViewHolder) {
+    override fun onItemLongClick(item: UserData<*>, holder: CheckableViewHolder) {
         onItemClick(item, null)
     }
 
@@ -550,13 +547,9 @@ class DataListFragment<T : UserData<String>> : Fragment(),
             )
         }
 
-        @JvmStatic
-        fun <T> updateUserVariableValue(value: T?, item: UserData<T>) {
-            item.value = value
-        }
     }
 
-    override fun onSettingsClick(item: T, view: View?) {
+    override fun onSettingsClick(item: UserData<*>, view: View?) {
         if (item is UserDefinedBrickInput) {
             return
         }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
@@ -61,6 +61,7 @@ import org.catrobat.catroid.ui.recyclerview.dialog.TextInputDialog
 import org.catrobat.catroid.ui.recyclerview.dialog.textwatcher.DuplicateInputTextWatcher
 import org.catrobat.catroid.ui.recyclerview.viewholder.CheckableViewHolder
 import org.catrobat.catroid.userbrick.UserDefinedBrickInput
+import org.catrobat.catroid.utils.ShowTextUtils
 import org.catrobat.catroid.utils.ToastUtil
 import org.catrobat.catroid.utils.UserDataUtil.renameUserData
 import java.util.Collections
@@ -482,26 +483,27 @@ class DataListFragment<T : UserData<String>> : Fragment(),
         val builder = TextInputDialog.Builder(requireContext())
 
         builder.setHint(getString(R.string.data_value))
-            .setText((item as UserData<*>).value?.toString() ?: "")
+            .setText(ShowTextUtils.convertObjectToString(item.value))
             .setPositiveButton(getString(R.string.save)) { _: DialogInterface?, textInput: String? ->
                 editItem(item, textInput)
             }
-        builder.setTitle(getString(R.string.edit) + " " + item.name)
+        builder.setTitle(getString(R.string.edit_data_dialog_title, item.name))
             .setNegativeButton(R.string.cancel, null)
             .show()
     }
 
     private fun editItem(item: T, value: String?) {
+        val trimmedValue = value?.trim()
         if (item is UserVariable) {
             val parsedValue: Any? = try {
-                value?.toDouble()
+                trimmedValue?.toDouble()
             } catch (e: NumberFormatException) {
-                value
+                trimmedValue
             }
             @Suppress("UNCHECKED_CAST")
             (item as UserVariable).value = parsedValue
         } else {
-            updateUserVariableValue(value, item)
+            updateUserVariableValue(trimmedValue, item)
         }
         adapter?.updateDataSet()
         finishActionMode()

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
@@ -494,7 +494,11 @@ class DataListFragment : Fragment(),
 
     private fun rawValueToString(value: Any?): String {
         return when (value) {
-            is Boolean -> value.toString()
+            is Boolean -> if (value) {
+                getString(R.string.formula_editor_function_true)
+            } else {
+                getString(R.string.formula_editor_function_false)
+            }
             is Double -> trimTrailingCharacters(value.toString())
             else -> value?.toString().orEmpty()
         }
@@ -503,9 +507,13 @@ class DataListFragment : Fragment(),
     private fun editItem(item: UserData<*>, value: String?) {
         val trimmedValue = value?.trim()
         if (item is UserVariable) {
+            val localizedTrue = getString(R.string.formula_editor_function_true)
+            val localizedFalse = getString(R.string.formula_editor_function_false)
             val parsedValue: Any? = when {
-                trimmedValue.equals("true", ignoreCase = true) -> true
-                trimmedValue.equals("false", ignoreCase = true) -> false
+                trimmedValue.equals("true", ignoreCase = true) ||
+                    trimmedValue.equals(localizedTrue, ignoreCase = true) -> true
+                trimmedValue.equals("false", ignoreCase = true) ||
+                    trimmedValue.equals(localizedFalse, ignoreCase = true) -> false
                 else -> try {
                     trimmedValue?.toDouble()
                 } catch (_: NumberFormatException) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
@@ -509,7 +509,7 @@ class DataListFragment : Fragment(),
                 else -> try {
                     trimmedValue?.toDouble()
                 } catch (_: NumberFormatException) {
-                    trimmedValue
+                    value
                 }
             }
             item.value = parsedValue

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
@@ -482,17 +482,27 @@ class DataListFragment<T : UserData<String>> : Fragment(),
         val builder = TextInputDialog.Builder(requireContext())
 
         builder.setHint(getString(R.string.data_value))
-            .setText(item.value.toString())
+            .setText((item as UserData<*>).value?.toString() ?: "")
             .setPositiveButton(getString(R.string.save)) { _: DialogInterface?, textInput: String? ->
                 editItem(item, textInput)
             }
-        builder.setTitle("Edit " + item.name)
+        builder.setTitle(getString(R.string.edit) + " " + item.name)
             .setNegativeButton(R.string.cancel, null)
             .show()
     }
 
     private fun editItem(item: T, value: String?) {
-        updateUserVariableValue(value, item)
+        if (item is UserVariable) {
+            val parsedValue: Any? = try {
+                value?.toDouble()
+            } catch (e: NumberFormatException) {
+                value
+            }
+            @Suppress("UNCHECKED_CAST")
+            (item as UserVariable).value = parsedValue
+        } else {
+            updateUserVariableValue(value, item)
+        }
         adapter?.updateDataSet()
         finishActionMode()
     }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/DataListFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2025 The Catrobat Team
+ * Copyright (C) 2010-2026 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -61,7 +61,7 @@ import org.catrobat.catroid.ui.recyclerview.dialog.TextInputDialog
 import org.catrobat.catroid.ui.recyclerview.dialog.textwatcher.DuplicateInputTextWatcher
 import org.catrobat.catroid.ui.recyclerview.viewholder.CheckableViewHolder
 import org.catrobat.catroid.userbrick.UserDefinedBrickInput
-import org.catrobat.catroid.utils.ShowTextUtils
+import org.catrobat.catroid.utils.NumberFormats.Companion.trimTrailingCharacters
 import org.catrobat.catroid.utils.ToastUtil
 import org.catrobat.catroid.utils.UserDataUtil.renameUserData
 import java.util.Collections
@@ -483,7 +483,7 @@ class DataListFragment : Fragment(),
         val builder = TextInputDialog.Builder(requireContext())
 
         builder.setHint(getString(R.string.data_value))
-            .setText(ShowTextUtils.convertObjectToString(item.value))
+            .setText(rawValueToString(item.value))
             .setPositiveButton(getString(R.string.save)) { _: DialogInterface?, textInput: String? ->
                 editItem(item, textInput)
             }
@@ -492,13 +492,25 @@ class DataListFragment : Fragment(),
             .show()
     }
 
+    private fun rawValueToString(value: Any?): String {
+        return when (value) {
+            is Boolean -> value.toString()
+            is Double -> trimTrailingCharacters(value.toString())
+            else -> value?.toString().orEmpty()
+        }
+    }
+
     private fun editItem(item: UserData<*>, value: String?) {
         val trimmedValue = value?.trim()
         if (item is UserVariable) {
-            val parsedValue: Any? = try {
-                trimmedValue?.toDouble()
-            } catch (e: NumberFormatException) {
-                trimmedValue
+            val parsedValue: Any? = when {
+                trimmedValue.equals("true", ignoreCase = true) -> true
+                trimmedValue.equals("false", ignoreCase = true) -> false
+                else -> try {
+                    trimmedValue?.toDouble()
+                } catch (_: NumberFormatException) {
+                    trimmedValue
+                }
             }
             item.value = parsedValue
         }

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -2296,6 +2296,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="no_internet_connection">No internet connection. Make sure Wi-Fi or mobile
     data is turned on.</string>
     <string formatted="false" name="edit">Edit</string>
+    <string name="edit_data_dialog_title">Edit %s</string>
     <string formatted="false" name="data_value">Value</string>
     <string formatted="false" name="category_recently_used">Recently used</string>
     <string formatted="false" name="new_sprite_dialog_place_visually">Place visually</string>

--- a/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickVariableUpdateTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/content/bricks/CompositeBrickVariableUpdateTest.java
@@ -115,13 +115,13 @@ public class CompositeBrickVariableUpdateTest {
 
 	@Test
 	public void testEditVariable() {
-		DataListFragment.updateUserVariableValue(NEW_VARIABLE_VALUE, userVariable);
+		userVariable.setValue(NEW_VARIABLE_VALUE);
 		assertEquals(NEW_VARIABLE_VALUE, userVariable.getValue());
 	}
 
 	@Test
 	public void testEditVariableSameValue() {
-		DataListFragment.updateUserVariableValue(VARIABLE_VALUE, userVariable);
+		userVariable.setValue(VARIABLE_VALUE);
 		assertEquals(VARIABLE_VALUE, userVariable.getValue());
 	}
 


### PR DESCRIPTION
JIRA TICKET - https://catrobat.atlassian.net/browse/IDE-324
**Description:**
This pull request addresses a `ClassCastException` in `DataListFragment` and resolves test regressions within the `FormulaEditorUndoTest`. Additionally, it stabilizes UI interactions for Espresso tests involving platform popups. 

Note: This pull request is a continuation of (https://github.com/Catrobat/Catroid/pull/5171)

### **Detailed Changes**

**1. Fixed `ClassCastException` in `DataListFragment.kt`**
* **Issue:** The variable editing logic in `DataListFragment` had a type-safety issue when trying to update user variables, which could lead to a `ClassCastException` or incorrect data types being saved.
* **Solution:** Added an explicit check for `UserVariable` types in `editItem`. It now intelligently tries to parse the input value as a `Double` first (for numeric variables) and falls back to a `String` if it's not a number. This ensures the underlying data model remains consistent.

**2. Resolved `FormulaEditorUndoTest` Regressions**
* **Issue:** The Espresso tests for Formula Editor undo were failing due to inconsistent UI states and strict equality checks on floating-point numbers.
* **Solution:** Added `closeSoftKeyboard()` calls to prevent the soft keyboard from obstructing the view during automated tests. Updated numeric assertions to use a delta comparison (`assertEquals(expected, actual, 0.001)`), making the tests more robust against minor precision differences in floating-point math.

**3. Stabilized UI Test Interactions**
* **Issue:** Espresso sometimes failed to find "Rename" or "Edit" buttons because they are located within platform popups (context menus).
* **Solution:** Modified `UserDataItemRVInteractionWrapper.java` to explicitly search for these buttons within the platform popup root (`isPlatformPopup()`). This prevents common "No Matching View" errors in UI tests.

**Files Modified:**
* `DataListFragment.kt`: Updated `editField` and `editItem` logic.
* `FormulaEditorUndoTest.java`: Improved test stability and assertions.
* `UserDataItemRVInteractionWrapper.java`: Fixed popup menu interaction logic.

### **Checklist for this pull request**
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer