### PR TITLE
IDE-322 Show app version in About dialog

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/AboutDialogTest.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/dialog/AboutDialogTest.kt
@@ -103,8 +103,22 @@ class AboutDialogTest {
         Espresso.onView(ViewMatchers.withText(R.string.dialog_about_catrobat_link_text))
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
 
+        val versionCode =
+            if (BuildConfig.FLAVOR == "pocketCodeBeta") "-${BuildConfig.VERSION_CODE}" else ""
+        val expectedVersionName = baseActivityTestRule.activity.getString(R.string.app_name) +
+            versionCode + " " +
+            baseActivityTestRule.activity.getString(R.string.dialog_about_version) + " " +
+            baseActivityTestRule.activity.getString(R.string.android_version_prefix) +
+            Utils.getVersionName(ApplicationProvider.getApplicationContext())
+        val expectedCatrobatVersionName =
+            baseActivityTestRule.activity.getString(R.string.dialog_about_catrobat_language_version) +
+                ": " + Constants.CURRENT_CATROBAT_LANGUAGE_VERSION
+
+        Espresso.onView(ViewMatchers.withId(R.id.dialog_about_text_view_version_name))
+            .check(ViewAssertions.matches(ViewMatchers.withText(expectedVersionName)))
+
         Espresso.onView(ViewMatchers.withId(R.id.dialog_about_text_view_catrobat_version_name))
-            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+            .check(ViewAssertions.matches(ViewMatchers.withText(expectedCatrobatVersionName)))
 
         Assert.assertNotNull(Utils.getVersionName(ApplicationProvider.getApplicationContext()))
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/AboutDialogFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/dialog/AboutDialogFragment.kt
@@ -70,7 +70,7 @@ class AboutDialogFragment : DialogFragment() {
             Html.fromHtml(aboutCatrobatUrl)
         }
 
-        val aboutVersionNameTextView = binding.dialogAboutTextViewCatrobatVersionName
+        val aboutVersionNameTextView = binding.dialogAboutTextViewVersionName
         val versionCode =
             if (BuildConfig.FLAVOR == "pocketCodeBeta") "-" + BuildConfig.VERSION_CODE else ""
         val versionName =


### PR DESCRIPTION
### Summary
This PR fixes the About dialog so the app version is displayed correctly again.

https://catrobat.atlassian.net/browse/IDE-322

### Root Cause
The app version text was assigned to the Catrobat language version TextView, and was then overwritten by the language version text. Because of that, the app version was not visible in the dialog.

### Commit Structure

#### Commit 1

Adds a regression test for the About dialog.

The test now verifies:

- the app version is shown in dialog_about_text_view_version_name
- the Catrobat language version is shown in dialog_about_text_view_catrobat_version_name

This commit was executed against the buggy implementation first and fails red, confirming the test detects the issue.

#### Commit 2
Applies the actual fix.

The About dialog now writes the app version to the correct TextView, so both pieces of version information are displayed as intended.

### Verification
#### Focused Espresso verification was run in test-first order:

- run test on commit 1 only: fails red
- apply commit 2
- run the same test again: passes green

#### Executed test:
`org.catrobat.catroid.uiespresso.ui.dialog.AboutDialogTest`

#### Screenshot:
<img height="500" alt="about-dialog-ide-322" src="https://github.com/user-attachments/assets/6a6f810a-3a20-4501-a455-d706cb86f3e9" />

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks that previously passed have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
