### PR TITLE
IDE-323CI : fix artifact naming conflicts in reusable workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,7 +160,7 @@ jobs:
     uses: ./.github/workflows/emulated_tests.yml
     with:
       gradle-test-config: org.catrobat.catroid.testsuites.LocalHeadlessTestSuite
-      calling-job: ${{github.job}}
+      calling-job: instrumented-unit-tests
 
   testrunner-tests:
     needs: repo-check
@@ -168,7 +168,7 @@ jobs:
     uses: ./.github/workflows/emulated_tests.yml
     with:
       gradle-test-config: org.catrobat.catroid.catrobattestrunner.CatrobatTestRunner
-      calling-job: ${{github.job}}
+      calling-job: testrunner-tests
 
   quarantined-tests:
     needs: repo-check
@@ -176,7 +176,7 @@ jobs:
     uses: ./.github/workflows/emulated_tests.yml
     with:
       gradle-test-config: org.catrobat.catroid.testsuites.UiEspressoQuarantineTestSuite
-      calling-job: ${{github.job}}
+      calling-job: quarantined-tests
 
   rtl-tests:
     needs: repo-check
@@ -184,4 +184,4 @@ jobs:
     uses: ./.github/workflows/emulated_tests.yml
     with:
       gradle-test-config: org.catrobat.catroid.testsuites.UiEspressoRtlTestSuite
-      calling-job: ${{github.job}}
+      calling-job: rtl-tests

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -27,4 +27,4 @@ jobs:
     uses: ./.github/workflows/emulated_tests.yml
     with:
       gradle-test-config: org.catrobat.catroid.testsuites.UiEspressoPullRequestTriggerSuite
-      calling-job: ${{github.job}}
+      calling-job: ui-tests


### PR DESCRIPTION
### Description

**Jira Ticket:** [IDE-323](https://catrobat.atlassian.net/browse/IDE-323)

This PR resolves a critical CI pipeline failure where parallel emulator jobs (e.g., `test-reports`, `coverage-report`) were triggering `(409) Conflict: an artifact with this name already exists` errors. This issue was introduced following the migration to `actions/upload-artifact@v4`, which requires unique artifact names within a single workflow run.

By replacing the dynamic `${{ github.job }}` reference—which resolved to the same internal ID within the reusable `emulated_tests.yml`—with unique string literals passed as inputs for each job (e.g., `instrumented-unit-tests`, `rtl-tests`), I have ensured that artifacts are correctly uploaded to distinct folders. This satisfies the acceptance criteria of ensuring the CI pipeline completes without 409 errors and that artifacts are easily identifiable in the GitHub Actions summary.


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

[IDE-323]: https://catrobat.atlassian.net/browse/IDE-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ