### PR TITLE
CATROID-1640 Reset embroidery, plot, and laser drawing state on fresh starts

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
+++ b/catroid/src/main/java/org/catrobat/catroid/content/Sprite.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2025  The Catrobat Team
+ * Copyright (C) 2010-2026 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -342,6 +342,12 @@ public class Sprite implements Nameable, Serializable {
 		}
 	}
 
+	public void resetDrawingState() {
+		penConfiguration = new PenConfiguration();
+		plot = new Plot();
+		runningStitch = new RunningStitch();
+	}
+
 	public void resetSprite() {
 		Brick.ResourcesSet resourcesSet = new Brick.ResourcesSet();
 		addRequiredResources(resourcesSet);
@@ -359,9 +365,7 @@ public class Sprite implements Nameable, Serializable {
 			look.setLookData(getLookList().get(0));
 		}
 
-		penConfiguration = new PenConfiguration();
-		plot = new Plot();
-		runningStitch = new RunningStitch();
+		resetDrawingState();
 	}
 
 	public void invalidate() {

--- a/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
+++ b/catroid/src/main/java/org/catrobat/catroid/stage/StageListener.java
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2025  The Catrobat Team
+ * Copyright (C) 2010-2026 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -460,6 +460,11 @@ public class StageListener implements ApplicationListener {
 
 		Gdx.input.setInputProcessor(stage);
 
+		// Fresh starts must drop any persisted stitch/plot state before the scene is recreated.
+		for (Sprite sprite : scene.getSpriteList()) {
+			sprite.resetDrawingState();
+		}
+
 		scene.firstStart = true;
 		create();
 	}
@@ -490,6 +495,9 @@ public class StageListener implements ApplicationListener {
 		UserDataWrapper.resetAllUserData(ProjectManager.getInstance().getCurrentProject());
 
 		for (Scene scene : ProjectManager.getInstance().getCurrentProject().getSceneList()) {
+			for (Sprite sprite : scene.getSpriteList()) {
+				sprite.resetDrawingState();
+			}
 			scene.firstStart = true;
 		}
 		reloadProject = true;

--- a/catroid/src/test/java/org/catrobat/catroid/test/stage/StageListenerDrawingStateResetTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/stage/StageListenerDrawingStateResetTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2026 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.catrobat.catroid.test.stage
+
+import android.graphics.PointF
+import org.catrobat.catroid.ProjectManager
+import org.catrobat.catroid.content.Project
+import org.catrobat.catroid.content.Scene
+import org.catrobat.catroid.content.Sprite
+import org.catrobat.catroid.embroidery.EmbroideryPatternManager
+import org.catrobat.catroid.embroidery.RunningStitchType
+import org.catrobat.catroid.stage.StageListener
+import org.catrobat.catroid.ui.dialogs.StageDialog
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.mock
+import java.lang.reflect.Field
+
+class StageListenerDrawingStateResetTest {
+
+    private val projectManagerInstanceField = ProjectManager::class.java.getDeclaredField("instance").apply {
+        isAccessible = true
+    }
+    private val previousProjectManager = projectManagerInstanceField.get(null)
+
+    @After
+    fun tearDown() {
+        projectManagerInstanceField.set(null, previousProjectManager)
+    }
+
+    @Test
+    fun testReloadProjectResetsDrawingStateForEverySprite() {
+        val sprite = Sprite("sprite")
+        val project = Project()
+        val scene = Scene("scene", project).apply {
+            addSprite(sprite)
+            firstStart = false
+        }
+        project.sceneList.add(scene)
+
+        val previousPenConfiguration = sprite.penConfiguration
+        val previousPlot = sprite.plot
+        val previousRunningStitch = sprite.runningStitch
+
+        sprite.penConfiguration.setPenDown(true)
+        sprite.penConfiguration.addQueue()
+        sprite.penConfiguration.addPosition(PointF(1f, 2f))
+
+        sprite.plot.startNewPlotLine(PointF(0f, 0f))
+        sprite.plot.resumePlot()
+        sprite.plot.startNewCutLine(PointF(1f, 1f))
+        sprite.plot.resumeCut()
+        sprite.plot.startNewEngraveLine(PointF(2f, 2f))
+        sprite.plot.resumeEngrave()
+
+        sprite.runningStitch.activateStitching(sprite, mock(RunningStitchType::class.java))
+
+        val projectManager = mock(ProjectManager::class.java).apply {
+            org.mockito.Mockito.`when`(getCurrentProject()).thenReturn(project)
+            org.mockito.Mockito.`when`(getStartScene()).thenReturn(scene)
+        }
+        projectManagerInstanceField.set(null, projectManager)
+
+        val stageListener = StageListener()
+        setField(stageListener, "scene", scene)
+        setField(stageListener, "sprites", mutableListOf<Sprite>())
+        stageListener.embroideryPatternManager = mock(EmbroideryPatternManager::class.java)
+
+        stageListener.reloadProject(mock(StageDialog::class.java))
+
+        assertNotSame(previousPenConfiguration, sprite.penConfiguration)
+        assertFalse(sprite.penConfiguration.isPenDown)
+        assertTrue(sprite.penConfiguration.positions.isEmpty)
+
+        assertNotSame(previousPlot, sprite.plot)
+        assertFalse(sprite.plot.isPlotting())
+        assertFalse(sprite.plot.isCutting())
+        assertFalse(sprite.plot.isEngraving())
+        assertTrue(sprite.plot.data().isEmpty())
+        assertTrue(sprite.plot.cutDataPointLists.isEmpty())
+        assertTrue(sprite.plot.engraveDataPointLists.isEmpty())
+
+        assertNotSame(previousRunningStitch, sprite.runningStitch)
+        assertFalse(sprite.runningStitch.isRunning)
+    }
+
+    private fun setField(target: Any, name: String, value: Any?) {
+        val field: Field = target.javaClass.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+}


### PR DESCRIPTION
### Summary
This PR fixes stale drawing/stitch runtime state being reused across fresh executions.

https://catrobat.atlassian.net/browse/CATROID-1640

If a project ended while a running stitch, plot, cut, or engrave mode was still active, the next fresh run could inherit that old state and create an unintended initial segment from the previous endpoint to the new start position.

The fix resets that runtime state when execution is supposed to start from a blank slate, while preserving the existing behavior for resume-style flows.

### Why this approach
The underlying issue was not in the stitch/plot geometry itself, but in sprite runtime state surviving longer than intended.

Sprite keeps drawing-related runtime objects such as:

- runningStitch
- plot
- penConfiguration

Those objects should be preserved for resume behavior like pause/continue and Continue scene, but they must be reset for fresh starts such as project restart and Start scene.

To keep that distinction explicit, this PR introduces a dedicated drawing-state reset helper on Sprite and uses it only on fresh-start lifecycle paths.

Changes

- Added a regression test for sprite drawing-state reset
- Added Sprite.resetDrawingState()
- Reused that helper from resetSprite()

Explicitly reset drawing state on:
- project restart
- Start scene
- Left these flows unchanged:
- stage pause / continue
- Continue scene via scene backup/restore

### Result
Fresh runs now start with clean embroidery/plot/laser state, even if no explicit stop brick was used in the previous execution.

This covers:

- embroidery running stitches
- plotting
- laser cutting
- engraving

### Testing

Verified with:

`./gradlew :catroid:testCatroidDebugUnitTest --tests org.catrobat.catroid.test.content.SpriteDrawingStat
`

Test on phone: screen recording before and after fix: https://photos.app.goo.gl/yGBKrRXvmYrQhcev6

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
