### PR TITLE
CATROID-1655 Add update smoke CI workflow

### DIFF
--- a/.github/workflows/update_smoke.yml
+++ b/.github/workflows/update_smoke.yml
@@ -1,0 +1,134 @@
+name: Catroid Update Smoke Test
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+  push:
+    branches:
+      - develop
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+  workflow_dispatch:
+    inputs:
+      BASE_REF:
+        description: "Play Store baseline branch or commit to install before updating"
+        required: false
+        type: string
+        default: "main"
+
+env:
+  BASELINE_JAVA_VERSION: 21
+  PR_JAVA_VERSION: 21
+  PACKAGE_NAME: org.catrobat.catroid
+  BASELINE_REF: ${{ github.event.inputs.BASE_REF || 'main' }}
+
+concurrency:
+  group: update-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-smoke:
+    name: Update Smoke Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          path: pr
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout baseline
+        uses: actions/checkout@v4
+        with:
+          path: baseline
+          ref: ${{ env.BASELINE_REF }}
+
+      - name: Resolve baseline commit
+        id: baseline-ref
+        working-directory: baseline
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup baseline JDK ${{ env.BASELINE_JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: ${{ env.BASELINE_JAVA_VERSION }}
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Restore baseline APK cache
+        id: baseline-cache
+        uses: actions/cache@v4
+        with:
+          path: baseline-apk
+          key: update-smoke-baseline-${{ steps.baseline-ref.outputs.sha }}-${{ hashFiles('baseline/**/*.gradle*', 'baseline/gradle/**') }}
+          restore-keys: |
+            update-smoke-baseline-${{ steps.baseline-ref.outputs.sha }}-
+
+      - name: Build baseline APK
+        if: steps.baseline-cache.outputs.cache-hit != 'true'
+        working-directory: baseline
+        run: |
+          ./gradlew :catroid:copyAndroidNatives :catroid:assembleCatroidRelease --stacktrace
+
+          mkdir -p ../baseline-apk
+          baseline_apk="$(find catroid/build/outputs/apk/catroid/release -name '*.apk' -print -quit)"
+          test -n "$baseline_apk"
+          cp "$baseline_apk" ../baseline-apk/catroid-update-baseline.apk
+          cp catroid/build/outputs/apk/catroid/release/output-metadata.json ../baseline-apk/output-metadata.json
+
+      - name: Resolve PR version code
+        id: pr-version
+        run: |
+          baseline_version_code="$(python3 -c 'import json; print(json.load(open("baseline-apk/output-metadata.json", encoding="utf-8"))["elements"][0]["versionCode"])')"
+          echo "version-code=$((baseline_version_code + 1))" >> "$GITHUB_OUTPUT"
+
+      - name: Setup PR JDK ${{ env.PR_JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: ${{ env.PR_JAVA_VERSION }}
+
+      - name: Build PR APK
+        working-directory: pr
+        run: |
+          ./gradlew :catroid:copyAndroidNatives :catroid:assembleCatroidUpdateTest \
+            -PversionCodeOverride=${{ steps.pr-version.outputs.version-code }} \
+            --stacktrace
+
+          pr_apk="$(find catroid/build/outputs/apk/catroid/updateTest -name '*.apk' -print -quit)"
+          test -n "$pr_apk"
+          echo "$pr_apk" > ../pr-apk-path.txt
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run update smoke test
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          arch: x86_64
+          force-avd-creation: true
+          emulator-boot-timeout: 900
+          emulator-options: >
+            -no-window
+            -no-boot-anim
+          script: |
+            bash pr/automationScripts/update-smoke/run-update-smoke.sh "$(pwd)/baseline-apk/catroid-update-baseline.apk" "$(pwd)/pr/$(cat pr-apk-path.txt)" "${{ env.PACKAGE_NAME }}"
+
+      - name: Upload update smoke artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: update-smoke-artifacts
+          path: pr/build/update-smoke/**

--- a/automationScripts/update-smoke/README.md
+++ b/automationScripts/update-smoke/README.md
@@ -1,0 +1,49 @@
+# Catroid Update Smoke Test
+
+This smoke test exercises the update path users take from the currently deployed
+Play Store branch to the APK under test.
+
+The workflow builds a release-style baseline APK from `main`, and a
+release-style `updateTest` APK for the PR with the same package
+name and a higher version code. Both APKs are built locally and signed with the
+same debug key so Android accepts the in-place update. The `updateTest` build
+type is not suitable for updating over an APK actually downloaded from Google
+Play, because Play-signed and debug-signed APKs cannot update each other.
+
+## Local Run
+
+Build or provide two APKs with the same package name, where the second APK has a
+higher version code:
+
+```sh
+ADB=/path/to/adb \
+automationScripts/update-smoke/run-update-smoke.sh \
+  /path/to/baseline.apk \
+  /path/to/pr.apk \
+  org.catrobat.catroid
+```
+
+The emulator must allow `adb root`, because the test seeds private app storage
+under `/data/data/org.catrobat.catroid` before launching the updated APK.
+
+## Seeded Fixtures
+
+The script seeds:
+
+- `Pong Starter` as a known-good project.
+- `UpdateSmokeBrokenProject` with malformed `code.xml` and a corrupt thumbnail.
+- `fixtures/legacy-room-v2-app-database.sql`, a Room schema version 2 database
+  fixture whose `project_response` table intentionally lacks the version 3
+  `private` column.
+
+## Environment Variables
+
+- `ADB`: path to `adb`; defaults to `adb`.
+- `UPDATE_SMOKE_ARTIFACT_DIR`: directory for logcat/UI artifacts.
+- `UPDATE_SMOKE_GOOD_PROJECT_ARCHIVE`: override the good `.catrobat` fixture.
+- `UPDATE_SMOKE_GOOD_PROJECT_NAME`: expected display name for the good project.
+- `UPDATE_SMOKE_BROKEN_PROJECT_NAME`: expected display name for the broken project.
+- `UPDATE_SMOKE_LEGACY_DB_SQL`: override the legacy Room SQL fixture.
+- `UPDATE_SMOKE_SEED_LEGACY_DB`: set to `false` to skip DB seeding.
+- `UPDATE_SMOKE_STRICT_UI`: defaults to `true`; set to `false` for local
+  debugging when UI matching should not fail the run.

--- a/automationScripts/update-smoke/fixtures/legacy-room-v2-app-database.sql
+++ b/automationScripts/update-smoke/fixtures/legacy-room-v2-app-database.sql
@@ -1,0 +1,10 @@
+-- Legacy Catroid Room app_database fixture for update smoke tests.
+-- Represents schema version 2 with identity hash c60ebf67428479ff4619d56d1eb30d08.
+-- The project_response table intentionally lacks the version 3 private column.
+PRAGMA journal_mode=DELETE;
+PRAGMA user_version=2;
+CREATE TABLE IF NOT EXISTS `featured_project` (`id` TEXT NOT NULL, `project_id` TEXT NOT NULL, `project_url` TEXT NOT NULL, `name` TEXT NOT NULL, `author` TEXT NOT NULL, `featured_image` TEXT NOT NULL, PRIMARY KEY(`id`));
+CREATE TABLE IF NOT EXISTS `project_category` (`type` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`type`));
+CREATE TABLE IF NOT EXISTS `project_response` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `author` TEXT NOT NULL, `description` TEXT NOT NULL, `version` TEXT NOT NULL, `views` INTEGER NOT NULL, `download` INTEGER NOT NULL, `flavor` TEXT NOT NULL, `tags` TEXT NOT NULL, `uploaded` INTEGER NOT NULL, `uploadedString` TEXT NOT NULL, `screenshotLarge` TEXT NOT NULL, `screenshotSmall` TEXT NOT NULL, `projectUrl` TEXT NOT NULL, `downloadUrl` TEXT NOT NULL, `fileSize` REAL NOT NULL, `categoryType` TEXT NOT NULL, PRIMARY KEY(`id`, `categoryType`));
+CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY, identity_hash TEXT);
+INSERT OR REPLACE INTO room_master_table (id, identity_hash) VALUES(42, 'c60ebf67428479ff4619d56d1eb30d08');

--- a/automationScripts/update-smoke/run-update-smoke.sh
+++ b/automationScripts/update-smoke/run-update-smoke.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export MSYS2_ARG_CONV_EXCL='*'
+export MSYS_NO_PATHCONV=1
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  echo "Usage: $0 <baseline-apk> <pr-apk> [package-name]" >&2
+  exit 2
+fi
+
+BASELINE_APK="$1"
+PR_APK="$2"
+PACKAGE_NAME="${3:-org.catrobat.catroid}"
+ADB="${ADB:-adb}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ARTIFACT_DIR="${UPDATE_SMOKE_ARTIFACT_DIR:-$REPO_ROOT/build/update-smoke}"
+LEGACY_DB_SQL="${UPDATE_SMOKE_LEGACY_DB_SQL:-$SCRIPT_DIR/fixtures/legacy-room-v2-app-database.sql}"
+GOOD_PROJECT_ARCHIVE="${UPDATE_SMOKE_GOOD_PROJECT_ARCHIVE:-$REPO_ROOT/catroid/src/androidTest/assets/Pong_Starter.catrobat}"
+GOOD_PROJECT_NAME="${UPDATE_SMOKE_GOOD_PROJECT_NAME:-Pong Starter}"
+BROKEN_PROJECT_NAME="${UPDATE_SMOKE_BROKEN_PROJECT_NAME:-UpdateSmokeBrokenProject}"
+STRICT_UI="${UPDATE_SMOKE_STRICT_UI:-true}"
+SEED_LEGACY_DB="${UPDATE_SMOKE_SEED_LEGACY_DB:-true}"
+
+APP_ROOT="/data/data/$PACKAGE_NAME"
+APP_FILES="$APP_ROOT/files"
+APP_DATABASES="$APP_ROOT/databases"
+APP_DATABASE="$APP_DATABASES/app_database"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+
+mkdir -p "$ARTIFACT_DIR"
+
+log() {
+  echo "[update-smoke] $*"
+}
+
+capture_logcat() {
+  local name="$1"
+  "$ADB" logcat -d > "$ARTIFACT_DIR/$name-logcat.txt" || true
+}
+
+capture_failure_artifacts() {
+  local exit_code="$1"
+  if [ "$exit_code" -ne 0 ]; then
+    log "Capturing failure artifacts after exit code $exit_code"
+    capture_logcat "failure"
+    "$ADB" shell uiautomator dump /sdcard/update-smoke-failure-window.xml \
+      > "$ARTIFACT_DIR/failure-uiautomator.txt" 2>&1 || true
+    "$ADB" pull /sdcard/update-smoke-failure-window.xml "$ARTIFACT_DIR/failure-window.xml" \
+      > "$ARTIFACT_DIR/failure-adb-pull-window.txt" 2>&1 || true
+  fi
+}
+
+finish() {
+  local exit_code="$?"
+  capture_failure_artifacts "$exit_code"
+  cleanup
+  exit "$exit_code"
+}
+
+trap finish EXIT
+
+assert_no_crash() {
+  local name="$1"
+  capture_logcat "$name"
+
+  if grep -E "FATAL EXCEPTION|ANR in $PACKAGE_NAME|Process: $PACKAGE_NAME|BaseExceptionHandler: uncaughtException|Process $PACKAGE_NAME .*has died|SIG: 9" "$ARTIFACT_DIR/$name-logcat.txt"; then
+    log "Crash or ANR found in $name logcat"
+    exit 1
+  fi
+}
+
+prepare_seed_data() {
+  local seed_root="$TMP_DIR/app-files"
+  mkdir -p "$seed_root/$GOOD_PROJECT_NAME"
+  unzip -q "$GOOD_PROJECT_ARCHIVE" -d "$seed_root/$GOOD_PROJECT_NAME"
+
+  mkdir -p "$seed_root/$BROKEN_PROJECT_NAME/images"
+  mkdir -p "$seed_root/$BROKEN_PROJECT_NAME/sounds"
+  touch "$seed_root/$BROKEN_PROJECT_NAME/.nomedia"
+  touch "$seed_root/$BROKEN_PROJECT_NAME/images/.nomedia"
+  touch "$seed_root/$BROKEN_PROJECT_NAME/sounds/.nomedia"
+
+  cat > "$seed_root/$BROKEN_PROJECT_NAME/code.xml" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<program>
+  <header>
+    <programName>$BROKEN_PROJECT_NAME</programName>
+  </header>
+  <broken>
+EOF
+
+  printf '%s\n' 'not a png file' > "$seed_root/$BROKEN_PROJECT_NAME/automatic_screenshot.png"
+
+  echo "$seed_root"
+}
+
+enable_adb_root() {
+  "$ADB" wait-for-device
+  "$ADB" root > "$ARTIFACT_DIR/adb-root.txt" 2>&1 || true
+  "$ADB" wait-for-device
+}
+
+seed_private_storage() {
+  local seed_root="$1"
+  local seed_archive="$TMP_DIR/update-smoke-fixtures.tar.gz"
+  local seed_archive_for_adb
+  local device_seed_archive="/data/local/tmp/update-smoke-fixtures.tar.gz"
+  local app_uid
+
+  app_uid="$("$ADB" shell "stat -c %u '$APP_ROOT'" | tr -d '\r')"
+
+  tar -czf "$seed_archive" -C "$seed_root" .
+  seed_archive_for_adb="$seed_archive"
+  if command -v cygpath >/dev/null 2>&1; then
+    seed_archive_for_adb="$(cygpath -w "$seed_archive")"
+  fi
+  "$ADB" push "$seed_archive_for_adb" "$device_seed_archive" > "$ARTIFACT_DIR/adb-push-fixtures.txt"
+  "$ADB" shell "rm -rf '$APP_FILES' && mkdir -p '$APP_FILES'"
+  "$ADB" shell "tar -xzf '$device_seed_archive' -C '$APP_FILES'"
+  "$ADB" shell "rm -f '$device_seed_archive'"
+  "$ADB" shell "chown -R $app_uid:$app_uid '$APP_FILES'"
+  "$ADB" shell "restorecon -R '$APP_ROOT'" > "$ARTIFACT_DIR/restorecon.txt" 2>&1 || true
+}
+
+seed_legacy_room_database() {
+  local sql_file="$TMP_DIR/update-smoke-legacy-db.sql"
+  local sql_file_for_adb
+  local device_sql_file="/data/local/tmp/update-smoke-legacy-db.sql"
+  local app_uid
+
+  [ "$SEED_LEGACY_DB" = "true" ] || return 0
+
+  app_uid="$("$ADB" shell "stat -c %u '$APP_ROOT'" | tr -d '\r')"
+
+  cp "$LEGACY_DB_SQL" "$sql_file"
+
+  sql_file_for_adb="$sql_file"
+  if command -v cygpath >/dev/null 2>&1; then
+    sql_file_for_adb="$(cygpath -w "$sql_file")"
+  fi
+
+  "$ADB" push "$sql_file_for_adb" "$device_sql_file" > "$ARTIFACT_DIR/adb-push-legacy-db-sql.txt"
+  "$ADB" shell "rm -rf '$APP_DATABASES' && mkdir -p '$APP_DATABASES'"
+  "$ADB" shell "sqlite3 '$APP_DATABASE' < '$device_sql_file'" > "$ARTIFACT_DIR/sqlite-seed-legacy-db.txt" 2>&1
+  "$ADB" shell "rm -f '$device_sql_file'"
+  "$ADB" shell "chown -R $app_uid:$app_uid '$APP_DATABASES'"
+  "$ADB" shell "restorecon -R '$APP_DATABASES'" > "$ARTIFACT_DIR/restorecon-db.txt" 2>&1 || true
+}
+
+launch_app() {
+  "$ADB" shell monkey -p "$PACKAGE_NAME" -c android.intent.category.LAUNCHER 1 \
+    > "$ARTIFACT_DIR/monkey-launch.txt"
+}
+
+wait_for_process() {
+  local timeout_seconds="$1"
+  local elapsed=0
+
+  while [ "$elapsed" -lt "$timeout_seconds" ]; do
+    if "$ADB" shell pidof "$PACKAGE_NAME" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  log "Package $PACKAGE_NAME is not running after $timeout_seconds seconds"
+  capture_logcat "missing-process"
+  exit 1
+}
+
+dump_window() {
+  local name="$1"
+
+  "$ADB" shell uiautomator dump /sdcard/update-smoke-window.xml \
+    > "$ARTIFACT_DIR/$name-uiautomator.txt" 2>&1 || true
+  "$ADB" pull /sdcard/update-smoke-window.xml "$ARTIFACT_DIR/$name-window.xml" \
+    > "$ARTIFACT_DIR/$name-adb-pull-window.txt" 2>&1 || true
+}
+
+tap_first_matching_node() {
+  local pattern="$1"
+  local label="$2"
+  local xml_file="$ARTIFACT_DIR/tap-window.xml"
+  local node
+  local bounds
+  local x1
+  local y1
+  local x2
+  local y2
+  local x
+  local y
+
+  "$ADB" shell uiautomator dump /sdcard/update-smoke-window.xml >/dev/null 2>&1 || return 1
+  "$ADB" pull /sdcard/update-smoke-window.xml "$xml_file" >/dev/null 2>&1 || return 1
+
+  node="$(tr '<' '\n' < "$xml_file" | grep -E "$pattern" | head -n 1 || true)"
+  [ -n "$node" ] || return 1
+
+  bounds="$(printf '%s\n' "$node" | sed -n 's/.*bounds="\[\([0-9]\+\),\([0-9]\+\)\]\[\([0-9]\+\),\([0-9]\+\)\]".*/\1 \2 \3 \4/p')"
+  [ -n "$bounds" ] || return 1
+
+  read -r x1 y1 x2 y2 <<< "$bounds"
+  x=$(((x1 + x2) / 2))
+  y=$(((y1 + y2) / 2))
+
+  log "Tapping $label at $x,$y"
+  "$ADB" shell input tap "$x" "$y"
+}
+
+accept_first_run_dialog_if_present() {
+  sleep 2
+  tap_first_matching_node 'text="ACCEPT"' "first-run accept button" || true
+}
+
+open_project_list_if_needed() {
+  if tap_first_matching_node 'text="Projects"' "projects list"; then
+    sleep 3
+  fi
+}
+
+hide_hints_dialog_if_present() {
+  sleep 2
+  tap_first_matching_node 'text="HIDE"' "hide hints button" || true
+}
+
+run_optional_ui_smoke() {
+  accept_first_run_dialog_if_present
+  dump_window "after-launch"
+
+  open_project_list_if_needed
+
+  if ! tap_first_matching_node "text=\"$GOOD_PROJECT_NAME\"" "$GOOD_PROJECT_NAME project"; then
+    log "Good project node was not found in the UI dump"
+    [ "$STRICT_UI" = "true" ] && exit 1
+    return 0
+  fi
+
+  sleep 5
+  hide_hints_dialog_if_present
+  assert_no_crash "after-good-project-tap"
+
+  if tap_first_matching_node 'resource-id="org\.catrobat\.catroid:id/button_play"' "play button"; then
+    sleep 10
+    assert_no_crash "after-good-project-play"
+    "$ADB" shell input keyevent KEYCODE_BACK || true
+    sleep 2
+  else
+    log "Play button node was not found after opening the good project"
+    [ "$STRICT_UI" = "true" ] && exit 1
+  fi
+
+  "$ADB" shell am force-stop "$PACKAGE_NAME"
+  "$ADB" logcat -c
+  launch_app
+  sleep 5
+  open_project_list_if_needed || true
+
+  if tap_first_matching_node "text=\"$BROKEN_PROJECT_NAME\"" "$BROKEN_PROJECT_NAME project"; then
+    sleep 10
+    assert_no_crash "after-broken-project-tap"
+  else
+    log "Broken project node was not found in the UI dump"
+    [ "$STRICT_UI" = "true" ] && exit 1
+  fi
+}
+
+log "Preparing direct private-storage project fixtures"
+SEED_ROOT="$(prepare_seed_data)"
+
+log "Starting rootable emulator adb session"
+enable_adb_root
+"$ADB" logcat -c
+
+log "Installing baseline APK without launching it"
+"$ADB" install "$BASELINE_APK" > "$ARTIFACT_DIR/install-baseline.txt"
+if "$ADB" shell pidof "$PACKAGE_NAME" >/dev/null 2>&1; then
+  log "Baseline app is already running before the update"
+  exit 1
+fi
+
+log "Pushing fixtures into $APP_FILES"
+seed_private_storage "$SEED_ROOT"
+log "Seeding legacy Room app_database"
+seed_legacy_room_database
+
+log "Installing PR APK as an in-place update"
+"$ADB" install -r "$PR_APK" > "$ARTIFACT_DIR/install-pr.txt"
+
+log "Launching updated app"
+"$ADB" logcat -c
+launch_app
+wait_for_process 30
+sleep 15
+assert_no_crash "after-launch"
+
+log "Running optional UI smoke interactions"
+run_optional_ui_smoke
+
+log "Update smoke test completed"

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -102,7 +102,9 @@ ext.copyGoogleServicesFile = { flavorName, flavorId ->
     }
 }
 
-def defaultVersionCode = 102
+def defaultVersionCode = rootProject.hasProperty('versionCodeOverride')
+        ? rootProject.property('versionCodeOverride').toInteger()
+        : 102
 def defaultVersionName = "1.4.1"
 
 android {
@@ -238,6 +240,14 @@ android {
         signedRelease {
             initWith buildTypes.release
             signingConfig = signingConfigs.signedRelease
+        }
+
+        updateTest {
+            initWith buildTypes.release
+            matchingFallbacks = ['release']
+            // Both update smoke APKs are built locally, so they share the debug signing key.
+            signingConfig = signingConfigs.debug
+            enableAndroidTestCoverage = false
         }
     }
 


### PR DESCRIPTION
This PR adds a GitHub Actions update smoke test to catch regressions that only appear when users update an existing Catroid installation.

https://catrobat.atlassian.net/browse/CATROID-1655

## What this tests

This workflow simulates the real Play Store update path:

1. Build or restore a release-style baseline APK from the currently deployed Play Store branch (`main`).
2. Build a release-like `updateTest` APK for the PR with the same package name and `baselineVersionCode + 1`.
3. Install the baseline APK without launching it.
4. Seed private app storage directly with legacy/update fixtures.
5. Update in place to the PR APK.
6. Launch the updated app and perform a small UI smoke flow.

Both APKs are built locally and signed with the same debug key. This is intentional for CI; the test does not update over an actually Play-signed APK.

## CI Cost And Caching

The baseline APK cache is keyed by the resolved Play Store baseline commit SHA plus Gradle/build-file hash. As long as the deployed baseline branch does not move, later PRs can reuse the baseline APK instead of rebuilding it.

The workflow ignores docs/Markdown-only changes, uses a concurrency group to cancel stale runs, and has a 35-minute timeout.

## Fixtures

The test seeds:

- `Pong Starter` as a known-good project.
- `UpdateSmokeBrokenProject` with malformed `code.xml` and a corrupt thumbnail.
- `automationScripts/update-smoke/fixtures/legacy-room-v2-app-database.sql`, a Room v2 database fixture with `user_version=2`, identity hash `c60ebf...`, and a `project_response` table missing the v3 `private` column.

## Diagnostics

On failure, the script captures logcat and a UIAutomator window dump. CI uploads these artifacts via `actions/upload-artifact`.

**Verification result:**

- [x] Fixed branch #5203 + smoke test: passed end-to-end.
It launched, accepted first-run dialog, opened Pong Starter, played it, relaunched, tapped UpdateSmokeBrokenProject, and completed.

- [x] Ran the smoke test against PR 5202 as an example PR without the release crash fix.
The test failed at launch with the expected Room integrity failure:
`IllegalStateException: Pre-packaged database has an invalid schema: project_response`
This confirms the workflow catches the legacy update crash scenario before the fix is merged.
Log shows: Room cannot verify the data integrity... `Expected identity hash: 2d6dd..., found: c60e...`

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
