### PR TITLE
Add MQTT dependencies, settings UI, and test coverage (CATROID-1670, CATROID-1672)

### DIFF
--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -154,6 +154,7 @@ android {
         buildConfigField "boolean", "FEATURE_NFC_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_POCKETMUSIC_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_RASPI_ENABLED", "true"
+        buildConfigField "boolean", "FEATURE_MQTT_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_SCRATCH_CONVERTER_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_USER_REPORTERS_ENABLED", "true"
         buildConfigField "boolean", "FEATURE_MULTIPLAYER_VARIABLES_ENABLED", "true"
@@ -419,6 +420,10 @@ dependencies {
 
     implementation 'com.google.guava:guava:28.2-android'
     implementation 'com.google.code.gson:gson:2.8.7'
+
+    // MQTT
+    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
+    implementation 'org.eclipse.paho:org.eclipse.paho.android.service:1.1.1'
 
     implementation 'com.koushikdutta.async:androidasync:2.2.1'
     implementation 'com.squareup.picasso:picasso:2.71828'

--- a/catroid/build.gradle
+++ b/catroid/build.gradle
@@ -423,7 +423,6 @@ dependencies {
 
     // MQTT
     implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
-    implementation 'org.eclipse.paho:org.eclipse.paho.android.service:1.1.1'
 
     implementation 'com.koushikdutta.async:androidasync:2.2.1'
     implementation 'com.squareup.picasso:picasso:2.71828'

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsFragmentTest.java
@@ -265,7 +265,7 @@ public class SettingsFragmentTest {
 		onData(PreferenceMatchers.withTitle(R.string.preference_title_enable_mqtt_bricks))
 				.perform(click());
 
-		checkPreference(R.string.preference_title_enable_mqtt_bricks, SETTINGS_SHOW_MQTT_BRICKS);
+		checkPreference(R.string.preference_title_mqtt_enabled, SETTINGS_SHOW_MQTT_BRICKS);
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Gadgets.class})

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/activity/SettingsFragmentTest.java
@@ -85,6 +85,7 @@ import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTING
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_PHIRO_BRICKS_CHECKBOX_PREFERENCE;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_PLOT_BRICKS;
 import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_RASPI_BRICKS;
+import static org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_MQTT_BRICKS;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.AllOf.allOf;
@@ -123,7 +124,7 @@ public class SettingsFragmentTest {
 			SETTINGS_CAST_GLOBALLY_ENABLED, SETTINGS_SHOW_AI_SPEECH_RECOGNITION_SENSORS,
 			SETTINGS_SHOW_AI_SPEECH_SYNTHETIZATION_SENSORS,
 			SETTINGS_SHOW_AI_FACE_DETECTION_SENSORS, SETTINGS_SHOW_AI_POSE_DETECTION_SENSORS,
-			SETTINGS_SHOW_AI_TEXT_RECOGNITION_SENSORS));
+			SETTINGS_SHOW_AI_TEXT_RECOGNITION_SENSORS, SETTINGS_SHOW_MQTT_BRICKS));
 	private Map<String, Boolean> initialSettings = new HashMap<>();
 	private Matcher<Intent> expectedBrowserIntent;
 
@@ -256,6 +257,15 @@ public class SettingsFragmentTest {
 				.perform(click());
 
 		checkPreference(R.string.preference_title_enable_raspi_bricks, SETTINGS_SHOW_RASPI_BRICKS);
+	}
+
+	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Gadgets.class})
+	@Test
+	public void mqttSettingsTest() {
+		onData(PreferenceMatchers.withTitle(R.string.preference_title_enable_mqtt_bricks))
+				.perform(click());
+
+		checkPreference(R.string.preference_title_enable_mqtt_bricks, SETTINGS_SHOW_MQTT_BRICKS);
 	}
 
 	@Category({Cat.AppUi.class, Level.Smoke.class, Cat.Gadgets.class})

--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -263,7 +263,6 @@
         <service android:name=".transfers.MediaDownloadService" />
         <service android:name=".utils.notifications.StatusBarNotificationManager$NotificationActionService" />
         <service android:name=".cast.CastService"/>
-        <service android:name="org.eclipse.paho.android.service.MqttService" />
 
         <provider
             android:authorities="${applicationId}.fileProvider"

--- a/catroid/src/main/AndroidManifest.xml
+++ b/catroid/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Catroid: An on-device visual programming system for Android devices
-  ~ Copyright (C) 2010-2025 The Catrobat Team
+  ~ Copyright (C) 2010-2026 The Catrobat Team
   ~ (<http://developer.catrobat.org/credits>)
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -263,6 +263,7 @@
         <service android:name=".transfers.MediaDownloadService" />
         <service android:name=".utils.notifications.StatusBarNotificationManager$NotificationActionService" />
         <service android:name=".cast.CastService"/>
+        <service android:name="org.eclipse.paho.android.service.MqttService" />
 
         <provider
             android:authorities="${applicationId}.fileProvider"

--- a/catroid/src/main/java/org/catrobat/catroid/koin/CatroidKoinHelper.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/koin/CatroidKoinHelper.kt
@@ -27,6 +27,8 @@ import android.app.Application
 import com.google.android.gms.common.GoogleApiAvailability
 import com.huawei.hms.api.HuaweiApiAvailability
 import androidx.room.Room
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
 import androidx.work.WorkManager
 import org.catrobat.catroid.ProjectManager
 import org.catrobat.catroid.db.AppDatabase
@@ -50,6 +52,7 @@ import org.catrobat.catroid.ui.recyclerview.repository.FeaturedProjectsRepositor
 import org.catrobat.catroid.ui.recyclerview.repository.MqttPasswordRepository
 import org.catrobat.catroid.ui.recyclerview.repository.DefaultMqttPasswordRepository
 import org.catrobat.catroid.ui.recyclerview.repository.ProjectCategoriesRepository
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_ENCRYPTED_PREFS
 import org.catrobat.catroid.ui.recyclerview.viewmodel.MainFragmentViewModel
 import org.catrobat.catroid.utils.MobileServiceAvailability
 import org.catrobat.catroid.utils.NetworkConnectionMonitor
@@ -98,8 +101,16 @@ val repositoryModules = module {
         DefaultLocalHashVersionRepository(androidContext()) as LocalHashVersionRepository
     }
 
-    single {
-        DefaultMqttPasswordRepository(androidContext()) as MqttPasswordRepository
+    single<MqttPasswordRepository> {
+        DefaultMqttPasswordRepository(
+            EncryptedSharedPreferences.create(
+                MQTT_ENCRYPTED_PREFS,
+                MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+                androidContext(),
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+        )
     }
 
     single {

--- a/catroid/src/main/java/org/catrobat/catroid/koin/CatroidKoinHelper.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/koin/CatroidKoinHelper.kt
@@ -47,6 +47,8 @@ import org.catrobat.catroid.ui.recyclerview.repository.DefaultLocalHashVersionRe
 import org.catrobat.catroid.ui.recyclerview.repository.DefaultFeaturedProjectsRepository
 import org.catrobat.catroid.ui.recyclerview.repository.DefaultProjectCategoriesRepository
 import org.catrobat.catroid.ui.recyclerview.repository.FeaturedProjectsRepository
+import org.catrobat.catroid.ui.recyclerview.repository.MqttPasswordRepository
+import org.catrobat.catroid.ui.recyclerview.repository.DefaultMqttPasswordRepository
 import org.catrobat.catroid.ui.recyclerview.repository.ProjectCategoriesRepository
 import org.catrobat.catroid.ui.recyclerview.viewmodel.MainFragmentViewModel
 import org.catrobat.catroid.utils.MobileServiceAvailability
@@ -94,6 +96,10 @@ val viewModelModules = module {
 val repositoryModules = module {
     single {
         DefaultLocalHashVersionRepository(androidContext()) as LocalHashVersionRepository
+    }
+
+    single {
+        DefaultMqttPasswordRepository(androidContext()) as MqttPasswordRepository
     }
 
     single {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/repository/MqttPasswordRepository.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/repository/MqttPasswordRepository.kt
@@ -23,12 +23,8 @@
 
 package org.catrobat.catroid.ui.recyclerview.repository
 
-import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKeys
-import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_ENCRYPTED_PREFS
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_PASSWORD
 
 interface MqttPasswordRepository {
@@ -37,25 +33,13 @@ interface MqttPasswordRepository {
     fun clearPassword()
 }
 
-class DefaultMqttPasswordRepository(context: Context) : MqttPasswordRepository {
+class DefaultMqttPasswordRepository(private val prefs: SharedPreferences) : MqttPasswordRepository {
 
-    private val encryptedPrefs: SharedPreferences by lazy {
-        EncryptedSharedPreferences.create(
-            MQTT_ENCRYPTED_PREFS,
-            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
-            context,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
-    }
+    override fun getPassword() = prefs.getString(MQTT_PASSWORD, "").orEmpty()
 
-    override fun getPassword() = encryptedPrefs.getString(MQTT_PASSWORD, "").orEmpty()
+    override fun setPassword(password: String) =
+        prefs.edit { putString(MQTT_PASSWORD, password) }
 
-    override fun setPassword(password: String) {
-        encryptedPrefs.edit { putString(MQTT_PASSWORD, password) }
-    }
-
-    override fun clearPassword() {
-        encryptedPrefs.edit { remove(MQTT_PASSWORD) }
-    }
+    override fun clearPassword() =
+        prefs.edit { remove(MQTT_PASSWORD) }
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/repository/MqttPasswordRepository.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/repository/MqttPasswordRepository.kt
@@ -1,0 +1,61 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2026 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.ui.recyclerview.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_ENCRYPTED_PREFS
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_PASSWORD
+
+interface MqttPasswordRepository {
+    fun getPassword(): String
+    fun setPassword(password: String)
+    fun clearPassword()
+}
+
+class DefaultMqttPasswordRepository(context: Context) : MqttPasswordRepository {
+
+    private val encryptedPrefs: SharedPreferences by lazy {
+        EncryptedSharedPreferences.create(
+            MQTT_ENCRYPTED_PREFS,
+            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    override fun getPassword() = encryptedPrefs.getString(MQTT_PASSWORD, "").orEmpty()
+
+    override fun setPassword(password: String) {
+        encryptedPrefs.edit { putString(MQTT_PASSWORD, password) }
+    }
+
+    override fun clearPassword() {
+        encryptedPrefs.edit { remove(MQTT_PASSWORD) }
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/MqttSettingsFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/MqttSettingsFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2025 The Catrobat Team
+ * Copyright (C) 2010-2026 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -30,7 +30,6 @@ import android.preference.Preference
 import android.preference.PreferenceCategory
 import android.preference.PreferenceFragment
 import android.widget.Toast
-import androidx.annotation.Nullable
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import org.catrobat.catroid.R
@@ -49,7 +48,7 @@ class MqttSettingsFragment : PreferenceFragment() {
         (activity as AppCompatActivity).supportActionBar?.title = preferenceScreen.title
     }
 
-    override fun onActivityCreated(@Nullable savedInstanceState: Bundle?) {
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         SettingsFragment.setToChosenLanguage(activity)
         addPreferencesFromResource(R.xml.mqtt_preferences)
@@ -91,13 +90,16 @@ class MqttSettingsFragment : PreferenceFragment() {
     }
 
     companion object {
+        private const val MIN_PORT = 1
+        private const val MAX_PORT = 65_535
+
         @JvmField val TAG: String = MqttSettingsFragment::class.java.simpleName
 
         @VisibleForTesting
         @JvmStatic
         fun isValidPort(value: String): Boolean {
             val port = value.toIntOrNull() ?: return false
-            return port in 1..65535
+            return port in MIN_PORT..MAX_PORT
         }
     }
 }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/MqttSettingsFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/MqttSettingsFragment.kt
@@ -32,29 +32,20 @@ import android.preference.PreferenceFragment
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKeys
 import org.catrobat.catroid.R
+import org.catrobat.catroid.ui.recyclerview.repository.MqttPasswordRepository
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_CONNECTION_SETTINGS_CATEGORY
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_CLIENT_ID
-import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_ENCRYPTED_PREFS
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_HOST
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_PASSWORD
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_PORT
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_USERNAME
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_MQTT_BRICKS
+import org.koin.android.ext.android.inject
 
 class MqttSettingsFragment : PreferenceFragment() {
 
-    private val encryptedPrefs by lazy {
-        EncryptedSharedPreferences.create(
-            MQTT_ENCRYPTED_PREFS,
-            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
-            activity?.applicationContext ?: throw IllegalStateException("Fragment not attached to an activity"),
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
-    }
+    private val mqttPasswordRepository: MqttPasswordRepository by inject()
 
     override fun onResume() {
         super.onResume()
@@ -92,12 +83,9 @@ class MqttSettingsFragment : PreferenceFragment() {
 
         val passwordPreference = findPreference(MQTT_PASSWORD) as EditTextPreference
         passwordPreference.isPersistent = false
-        passwordPreference.text = encryptedPrefs.getString(MQTT_PASSWORD, "")
+        passwordPreference.text = mqttPasswordRepository.getPassword()
         passwordPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
-            with(encryptedPrefs.edit()) {
-                putString(MQTT_PASSWORD, newValue.toString())
-                apply()
-            }
+            mqttPasswordRepository.setPassword(newValue.toString())
             true
         }
     }

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/MqttSettingsFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/MqttSettingsFragment.kt
@@ -1,0 +1,103 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2025 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.ui.settingsfragments
+
+import android.os.Bundle
+import android.preference.CheckBoxPreference
+import android.preference.EditTextPreference
+import android.preference.Preference
+import android.preference.PreferenceCategory
+import android.preference.PreferenceFragment
+import android.widget.Toast
+import androidx.annotation.Nullable
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AppCompatActivity
+import org.catrobat.catroid.R
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_CONNECTION_SETTINGS_CATEGORY
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_CLIENT_ID
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_HOST
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_PASSWORD
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_PORT
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_USERNAME
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_MQTT_BRICKS
+
+class MqttSettingsFragment : PreferenceFragment() {
+
+    override fun onResume() {
+        super.onResume()
+        (activity as AppCompatActivity).supportActionBar?.title = preferenceScreen.title
+    }
+
+    override fun onActivityCreated(@Nullable savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        SettingsFragment.setToChosenLanguage(activity)
+        addPreferencesFromResource(R.xml.mqtt_preferences)
+
+        val mqttCheckBoxPreference = findPreference(SETTINGS_SHOW_MQTT_BRICKS) as CheckBoxPreference
+        val mqttConnectionSettings = findPreference(MQTT_CONNECTION_SETTINGS_CATEGORY) as PreferenceCategory
+        mqttConnectionSettings.isEnabled = mqttCheckBoxPreference.isChecked
+
+        mqttCheckBoxPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, isChecked ->
+            mqttConnectionSettings.isEnabled = isChecked as Boolean
+            true
+        }
+
+        bindSummaryToValue(findPreference(MQTT_HOST) as EditTextPreference)
+        bindSummaryToValue(findPreference(MQTT_USERNAME) as EditTextPreference)
+        bindSummaryToValue(findPreference(MQTT_CLIENT_ID) as EditTextPreference)
+
+        val portPreference = findPreference(MQTT_PORT) as EditTextPreference
+        portPreference.summary = portPreference.text
+        portPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+            if (!isValidPort(newValue.toString())) {
+                Toast.makeText(activity, R.string.preference_mqtt_port_invalid, Toast.LENGTH_SHORT).show()
+                return@OnPreferenceChangeListener false
+            }
+            portPreference.summary = newValue.toString()
+            true
+        }
+
+        val passwordPreference = findPreference(MQTT_PASSWORD) as EditTextPreference
+        passwordPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, _ -> true }
+    }
+
+    private fun bindSummaryToValue(preference: EditTextPreference) {
+        preference.summary = preference.text
+        preference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { pref, newValue ->
+            (pref as EditTextPreference).summary = newValue.toString()
+            true
+        }
+    }
+
+    companion object {
+        @JvmField val TAG: String = MqttSettingsFragment::class.java.simpleName
+
+        @VisibleForTesting
+        @JvmStatic
+        fun isValidPort(value: String): Boolean {
+            val port = value.toIntOrNull() ?: return false
+            return port in 1..65535
+        }
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/MqttSettingsFragment.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/MqttSettingsFragment.kt
@@ -32,9 +32,12 @@ import android.preference.PreferenceFragment
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
 import org.catrobat.catroid.R
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_CONNECTION_SETTINGS_CATEGORY
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_CLIENT_ID
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_ENCRYPTED_PREFS
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_HOST
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_PASSWORD
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_PORT
@@ -42,6 +45,16 @@ import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_USERNAME
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.SETTINGS_SHOW_MQTT_BRICKS
 
 class MqttSettingsFragment : PreferenceFragment() {
+
+    private val encryptedPrefs by lazy {
+        EncryptedSharedPreferences.create(
+            MQTT_ENCRYPTED_PREFS,
+            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+            activity?.applicationContext ?: throw IllegalStateException("Fragment not attached to an activity"),
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
 
     override fun onResume() {
         super.onResume()
@@ -78,7 +91,15 @@ class MqttSettingsFragment : PreferenceFragment() {
         }
 
         val passwordPreference = findPreference(MQTT_PASSWORD) as EditTextPreference
-        passwordPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, _ -> true }
+        passwordPreference.isPersistent = false
+        passwordPreference.text = encryptedPrefs.getString(MQTT_PASSWORD, "")
+        passwordPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+            with(encryptedPrefs.edit()) {
+                putString(MQTT_PASSWORD, newValue.toString())
+                apply()
+            }
+            true
+        }
     }
 
     private fun bindSummaryToValue(preference: EditTextPreference) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -131,6 +131,16 @@ public class SettingsFragment extends PreferenceFragment {
 	public static final String RASPI_PORT = "setting_raspi_port_preference";
 	public static final String RASPI_VERSION_SPINNER = "setting_raspi_version_preference";
 
+	public static final String MQTT_SCREEN_KEY = "settings_mqtt_screen";
+	public static final String SETTINGS_SHOW_MQTT_BRICKS = "setting_mqtt_bricks";
+	public static final String MQTT_CONNECTION_SETTINGS_CATEGORY = "setting_mqtt_category";
+	public static final String MQTT_HOST = "setting_mqtt_host";
+	public static final String MQTT_PORT = "setting_mqtt_port";
+	public static final String MQTT_TLS = "setting_mqtt_tls";
+	public static final String MQTT_USERNAME = "setting_mqtt_username";
+	public static final String MQTT_PASSWORD = "setting_mqtt_password";
+	public static final String MQTT_CLIENT_ID = "setting_mqtt_client_id";
+
 	public static final String SETTINGS_CRASH_REPORTS = "setting_enable_crash_reports";
 	public static final String TAG = SettingsFragment.class.getSimpleName();
 
@@ -406,6 +416,38 @@ public class SettingsFragment extends PreferenceFragment {
 
 	public static boolean isRaspiSharedPreferenceEnabled(Context context) {
 		return getBooleanSharedPreference(false, SETTINGS_SHOW_RASPI_BRICKS, context);
+	}
+
+	public static boolean isMqttSharedPreferenceEnabled(Context context) {
+		return getBooleanSharedPreference(false, SETTINGS_SHOW_MQTT_BRICKS, context);
+	}
+
+	public static String getMqttHost(Context context) {
+		return getSharedPreferences(context).getString(MQTT_HOST, "192.168.0.1");
+	}
+
+	public static int getMqttPort(Context context) {
+		try {
+			return Integer.parseInt(getSharedPreferences(context).getString(MQTT_PORT, "1883"));
+		} catch (NumberFormatException e) {
+			return 1883;
+		}
+	}
+
+	public static boolean isMqttTlsEnabled(Context context) {
+		return getBooleanSharedPreference(false, MQTT_TLS, context);
+	}
+
+	public static String getMqttUsername(Context context) {
+		return getSharedPreferences(context).getString(MQTT_USERNAME, "");
+	}
+
+	public static String getMqttPassword(Context context) {
+		return getSharedPreferences(context).getString(MQTT_PASSWORD, "");
+	}
+
+	public static String getMqttClientId(Context context) {
+		return getSharedPreferences(context).getString(MQTT_CLIENT_ID, "");
 	}
 
 	public static boolean isNfcSharedPreferenceEnabled(Context context) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -59,6 +59,8 @@ import java.util.Locale;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentActivity;
+import androidx.security.crypto.EncryptedSharedPreferences;
+import androidx.security.crypto.MasterKeys;
 
 import static org.catrobat.catroid.CatroidApplication.defaultSystemLanguage;
 import static org.catrobat.catroid.common.SharedPreferenceKeys.DEVICE_LANGUAGE;
@@ -139,6 +141,7 @@ public class SettingsFragment extends PreferenceFragment {
 	public static final String MQTT_USERNAME = "setting_mqtt_username";
 	public static final String MQTT_PASSWORD = "setting_mqtt_password";
 	public static final String MQTT_CLIENT_ID = "setting_mqtt_client_id";
+	public static final String MQTT_ENCRYPTED_PREFS = "mqtt_encrypted_prefs";
 
 	public static final String SETTINGS_CRASH_REPORTS = "setting_enable_crash_reports";
 	public static final String TAG = SettingsFragment.class.getSimpleName();
@@ -454,7 +457,18 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static String getMqttPassword(Context context) {
-		return getSharedPreferences(context).getString(MQTT_PASSWORD, "");
+		try {
+			SharedPreferences encryptedPrefs = EncryptedSharedPreferences.create(
+					MQTT_ENCRYPTED_PREFS,
+					MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+					context,
+					EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+					EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+			);
+			return encryptedPrefs.getString(MQTT_PASSWORD, "");
+		} catch (Exception e) {
+			return "";
+		}
 	}
 
 	public static String getMqttClientId(Context context) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -455,8 +455,7 @@ public class SettingsFragment extends PreferenceFragment {
 		return getSharedPreferences(context).getString(MQTT_USERNAME, "");
 	}
 
-	public static String getMqttPassword(Context context) {
-		// context parameter kept for API consistency with other getMqtt*() methods
+	public static String getMqttPassword() {
 		return inject(MqttPasswordRepository.class).getValue().getPassword();
 	}
 

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -141,6 +141,8 @@ public class SettingsFragment extends PreferenceFragment {
 	public static final String MQTT_PASSWORD = "setting_mqtt_password";
 	public static final String MQTT_CLIENT_ID = "setting_mqtt_client_id";
 
+	private static final String DEFAULT_MQTT_HOST = "192.168.0.1";
+
 	public static final String SETTINGS_CRASH_REPORTS = "setting_enable_crash_reports";
 	public static final String TAG = SettingsFragment.class.getSimpleName();
 
@@ -429,7 +431,7 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static String getMqttHost(Context context) {
-		return getSharedPreferences(context).getString(MQTT_HOST, "192.168.0.1");
+		return getSharedPreferences(context).getString(MQTT_HOST, DEFAULT_MQTT_HOST);
 	}
 
 	public static int getMqttPort(Context context) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -272,6 +272,12 @@ public class SettingsFragment extends PreferenceFragment {
 						.addToBackStack(RaspberryPiSettingsFragment.TAG)
 						.commit();
 				break;
+			case MQTT_SCREEN_KEY:
+				getFragmentManager().beginTransaction()
+						.replace(R.id.content_frame, new MqttSettingsFragment(), MqttSettingsFragment.TAG)
+						.addToBackStack(MqttSettingsFragment.TAG)
+						.commit();
+				break;
 		}
 		return super.onPreferenceTreeClick(preferenceScreen, preference);
 	}

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -125,7 +125,6 @@ public class SettingsFragment extends PreferenceFragment {
 	public static final String DRONE_ROTATION_SPEED = "setting_drone_rotation_speed";
 	public static final String DRONE_TILT_ANGLE = "setting_drone_tilt_angle";
 
-
 	public static final String RASPI_CONNECTION_SETTINGS_CATEGORY = "setting_raspi_connection_settings_category";
 	public static final String RASPI_HOST = "setting_raspi_host_preference";
 	public static final String RASPI_PORT = "setting_raspi_port_preference";
@@ -140,7 +139,6 @@ public class SettingsFragment extends PreferenceFragment {
 	public static final String MQTT_USERNAME = "setting_mqtt_username";
 	public static final String MQTT_PASSWORD = "setting_mqtt_password";
 	public static final String MQTT_CLIENT_ID = "setting_mqtt_client_id";
-
 
 	public static final String SETTINGS_CRASH_REPORTS = "setting_enable_crash_reports";
 	public static final String TAG = SettingsFragment.class.getSimpleName();
@@ -436,7 +434,7 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static String getMqttHost(Context context) {
-		return getSharedPreferences(context).getString(MQTT_HOST, "");
+		return getSharedPreferences(context).getString(MQTT_HOST, context.getString(R.string.default_mqtt_host));
 	}
 
 	public static int getMqttPort(Context context) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -59,8 +59,7 @@ import java.util.Locale;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentActivity;
-import androidx.security.crypto.EncryptedSharedPreferences;
-import androidx.security.crypto.MasterKeys;
+import org.catrobat.catroid.ui.recyclerview.repository.MqttPasswordRepository;
 
 import static org.catrobat.catroid.CatroidApplication.defaultSystemLanguage;
 import static org.catrobat.catroid.common.SharedPreferenceKeys.DEVICE_LANGUAGE;
@@ -457,18 +456,8 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static String getMqttPassword(Context context) {
-		try {
-			SharedPreferences encryptedPrefs = EncryptedSharedPreferences.create(
-					MQTT_ENCRYPTED_PREFS,
-					MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
-					context,
-					EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-					EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-			);
-			return encryptedPrefs.getString(MQTT_PASSWORD, "");
-		} catch (Exception e) {
-			return "";
-		}
+		// context parameter kept for API consistency with other getMqtt*() methods
+		return inject(MqttPasswordRepository.class).getValue().getPassword();
 	}
 
 	public static String getMqttClientId(Context context) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -141,7 +141,6 @@ public class SettingsFragment extends PreferenceFragment {
 	public static final String MQTT_PASSWORD = "setting_mqtt_password";
 	public static final String MQTT_CLIENT_ID = "setting_mqtt_client_id";
 
-	private static final String DEFAULT_MQTT_HOST = "192.168.0.1";
 
 	public static final String SETTINGS_CRASH_REPORTS = "setting_enable_crash_reports";
 	public static final String TAG = SettingsFragment.class.getSimpleName();
@@ -220,6 +219,12 @@ public class SettingsFragment extends PreferenceFragment {
 					(CheckBoxPreference) findPreference(SETTINGS_TEST_BRICKS);
 			testPreference.setEnabled(BuildConfig.DEBUG);
 			screen.removePreference(testPreference);
+		}
+
+		if (!BuildConfig.FEATURE_MQTT_ENABLED) {
+			PreferenceScreen mqttPreference = (PreferenceScreen) findPreference(MQTT_SCREEN_KEY);
+			mqttPreference.setEnabled(false);
+			screen.removePreference(mqttPreference);
 		}
 
 		setCorrectPreferenceViewForEmbroidery();
@@ -431,7 +436,7 @@ public class SettingsFragment extends PreferenceFragment {
 	}
 
 	public static String getMqttHost(Context context) {
-		return getSharedPreferences(context).getString(MQTT_HOST, DEFAULT_MQTT_HOST);
+		return getSharedPreferences(context).getString(MQTT_HOST, "");
 	}
 
 	public static int getMqttPort(Context context) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/settingsfragments/SettingsFragment.java
@@ -49,6 +49,7 @@ import org.catrobat.catroid.sync.ProjectsCategoriesSync;
 import org.catrobat.catroid.ui.MainMenuActivity;
 import org.catrobat.catroid.ui.recyclerview.dialog.AppStoreDialogFragment;
 import org.catrobat.catroid.ui.recyclerview.dialog.AppStoreDialogFragment.Companion.Extension;
+import org.catrobat.catroid.ui.recyclerview.repository.MqttPasswordRepository;
 import org.catrobat.catroid.utils.SnackbarUtil;
 
 import java.util.ArrayList;
@@ -59,7 +60,6 @@ import java.util.Locale;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentActivity;
-import org.catrobat.catroid.ui.recyclerview.repository.MqttPasswordRepository;
 
 import static org.catrobat.catroid.CatroidApplication.defaultSystemLanguage;
 import static org.catrobat.catroid.common.SharedPreferenceKeys.DEVICE_LANGUAGE;

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1531,6 +1531,23 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="error_connecting_to">Error: Could not connect to %s : %d</string>
     <!--  -->
 
+    <!-- MQTT Settings -->
+    <string formatted="false" name="preference_title_enable_mqtt_bricks">MQTT extension</string>
+    <string formatted="false" name="preference_description_mqtt_bricks">Allow the app to connect to MQTT brokers</string>
+    <string formatted="false" name="preference_title_mqtt_enabled">Enable MQTT bricks</string>
+    <string formatted="false" name="preference_description_mqtt_enabled">Enable bricks and sensors for MQTT</string>
+    <string formatted="false" name="preference_title_mqtt_category">MQTT settings</string>
+    <string formatted="false" name="preference_title_mqtt_broker_host">Broker host</string>
+    <string formatted="false" name="preference_description_mqtt_broker_host">IP address or hostname of the MQTT broker</string>
+    <string formatted="false" name="preference_title_mqtt_broker_port">Broker port</string>
+    <string formatted="false" name="preference_description_mqtt_broker_port">Port number of the MQTT broker (1–65535)</string>
+    <string formatted="false" name="preference_title_mqtt_use_tls">Use TLS</string>
+    <string formatted="false" name="preference_title_mqtt_username">Username</string>
+    <string formatted="false" name="preference_title_mqtt_password">Password</string>
+    <string formatted="false" name="preference_title_mqtt_client_id">Client ID</string>
+    <string formatted="false" name="preference_mqtt_port_invalid">Port must be a number between 1 and 65535</string>
+    <!--  -->
+
     <!-- Lego Mindstorms Strings -->
     <string formatted="false" name="nxt_brick_motor_move">Set NXT motor</string>
     <string formatted="false" name="nxt_motor_speed_to">to</string>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1546,6 +1546,7 @@ needs read and write access to it. You can always change permissions through you
     <string formatted="false" name="preference_title_mqtt_password">Password</string>
     <string formatted="false" name="preference_title_mqtt_client_id">Client ID</string>
     <string formatted="false" name="preference_mqtt_port_invalid">Port must be a number between 1 and 65535</string>
+    <string name="default_mqtt_host" translatable="false">192.168.0.1</string>
     <!--  -->
 
     <!-- Lego Mindstorms Strings -->

--- a/catroid/src/main/res/xml/mqtt_preferences.xml
+++ b/catroid/src/main/res/xml/mqtt_preferences.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Catroid: An on-device visual programming system for Android devices
+  ~ Copyright (C) 2010-2025 The Catrobat Team
+  ~ (<http://developer.catrobat.org/credits>)
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ An additional term exception under section 7 of the GNU Affero
+  ~ General Public License, version 3, is available at
+  ~ http://developer.catrobat.org/license_additional_term
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<PreferenceScreen
+    android:key="settings_mqtt_screen"
+    android:summary="@string/preference_description_mqtt_bricks"
+    android:title="@string/preference_title_enable_mqtt_bricks"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="setting_mqtt_bricks"
+        android:summary="@string/preference_description_mqtt_enabled"
+        android:title="@string/preference_title_mqtt_enabled" />
+
+    <PreferenceCategory
+        android:key="setting_mqtt_category"
+        android:title="@string/preference_title_mqtt_category">
+
+        <EditTextPreference
+            android:defaultValue="192.168.0.1"
+            android:key="setting_mqtt_host"
+            android:summary="@string/preference_description_mqtt_broker_host"
+            android:title="@string/preference_title_mqtt_broker_host" />
+
+        <EditTextPreference
+            android:defaultValue="1883"
+            android:inputType="number"
+            android:key="setting_mqtt_port"
+            android:summary="@string/preference_description_mqtt_broker_port"
+            android:title="@string/preference_title_mqtt_broker_port" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="setting_mqtt_tls"
+            android:title="@string/preference_title_mqtt_use_tls" />
+
+        <EditTextPreference
+            android:defaultValue=""
+            android:key="setting_mqtt_username"
+            android:title="@string/preference_title_mqtt_username" />
+
+        <EditTextPreference
+            android:defaultValue=""
+            android:inputType="textPassword"
+            android:key="setting_mqtt_password"
+            android:title="@string/preference_title_mqtt_password" />
+
+        <EditTextPreference
+            android:defaultValue=""
+            android:key="setting_mqtt_client_id"
+            android:title="@string/preference_title_mqtt_client_id" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/catroid/src/main/res/xml/preferences.xml
+++ b/catroid/src/main/res/xml/preferences.xml
@@ -104,6 +104,11 @@
         android:summary="@string/preference_description_raspi_bricks"
         android:title="@string/preference_title_enable_raspi_bricks" />
 
+    <PreferenceScreen
+        android:key="settings_mqtt_screen"
+        android:summary="@string/preference_description_mqtt_bricks"
+        android:title="@string/preference_title_enable_mqtt_bricks" />
+
     <Preference
         android:key="setting_enable_phiro_bricks_preference"
         android:summary="@string/preference_description_phiro_bricks"

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/DefaultMqttPasswordRepositoryTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/DefaultMqttPasswordRepositoryTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2026 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.mqtt
+
+import android.os.Build
+import android.preference.PreferenceManager
+import org.catrobat.catroid.ui.recyclerview.repository.DefaultMqttPasswordRepository
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P], instrumentedPackages = [])
+class DefaultMqttPasswordRepositoryTest {
+
+    private lateinit var repository: DefaultMqttPasswordRepository
+
+    @Before
+    fun setUp() {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.getApplication())
+        prefs.edit().clear().commit()
+        repository = DefaultMqttPasswordRepository(prefs)
+    }
+
+    @Test
+    fun testGetPasswordDefaultIsEmpty() {
+        assertEquals("", repository.getPassword())
+    }
+
+    @Test
+    fun testSetPasswordThenGetPasswordReturnsValue() {
+        repository.setPassword("secret")
+        assertEquals("secret", repository.getPassword())
+    }
+
+    @Test
+    fun testClearPasswordResetsToEmpty() {
+        repository.setPassword("secret")
+        repository.clearPassword()
+        assertEquals("", repository.getPassword())
+    }
+}

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttDependencySanityTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttDependencySanityTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2026 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.mqtt
+
+import org.eclipse.paho.client.mqttv3.MqttCallback
+import org.eclipse.paho.client.mqttv3.MqttClient
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.eclipse.paho.client.mqttv3.MqttException
+import org.eclipse.paho.client.mqttv3.MqttMessage
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class MqttDependencySanityTest {
+
+    @Test
+    fun testPahoClientClassesAreAvailable() {
+        assertNotNull(MqttClient::class.java)
+        assertNotNull(MqttConnectOptions::class.java)
+        assertNotNull(MqttMessage::class.java)
+        assertNotNull(MqttException::class.java)
+        assertNotNull(MqttCallback::class.java)
+    }
+}

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttSettingsTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttSettingsTest.kt
@@ -1,6 +1,6 @@
 /*
  * Catroid: An on-device visual programming system for Android devices
- * Copyright (C) 2010-2025 The Catrobat Team
+ * Copyright (C) 2010-2026 The Catrobat Team
  * (<http://developer.catrobat.org/credits>)
  *
  * This program is free software: you can redistribute it and/or modify

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttSettingsTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttSettingsTest.kt
@@ -25,6 +25,10 @@ package org.catrobat.catroid.test.mqtt
 
 import android.os.Build
 import android.preference.PreferenceManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.catrobat.catroid.ui.recyclerview.repository.MqttPasswordRepository
 import org.catrobat.catroid.ui.settingsfragments.MqttSettingsFragment
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment
 import org.junit.Assert.assertEquals
@@ -33,19 +37,35 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.junit.After
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.P], instrumentedPackages = [])
 class MqttSettingsTest {
 
+    private val mockMqttPasswordRepository = mockk<MqttPasswordRepository>(relaxed = true)
     private val context get() = RuntimeEnvironment.getApplication()
 
     @Before
     fun setUp() {
         PreferenceManager.getDefaultSharedPreferences(context).edit().clear().commit()
+        stopKoin()
+        startKoin {
+            modules(module {
+                single<MqttPasswordRepository> { mockMqttPasswordRepository }
+            })
+        }
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
     }
 
     // --- Default value tests ---
@@ -77,7 +97,9 @@ class MqttSettingsTest {
 
     @Test
     fun testMqttPasswordDefaultIsEmpty() {
+        every { mockMqttPasswordRepository.getPassword() } returns ""
         assertEquals("", SettingsFragment.getMqttPassword(context))
+        verify(exactly = 1) { mockMqttPasswordRepository.getPassword() }
     }
 
     @Test
@@ -124,7 +146,15 @@ class MqttSettingsTest {
 
     @Test
     fun testMqttPasswordPersistsAfterWrite() {
-        assertEquals("", SettingsFragment.getMqttPassword(context))
+        every { mockMqttPasswordRepository.getPassword() } returns "secret"
+        assertEquals("secret", SettingsFragment.getMqttPassword(context))
+        verify(exactly = 1) { mockMqttPasswordRepository.getPassword() }
+    }
+
+    @Test
+    fun testMqttPasswordSetPasswordDelegatesToRepository() {
+        mockMqttPasswordRepository.setPassword("secret")
+        verify(exactly = 1) { mockMqttPasswordRepository.setPassword("secret") }
     }
 
     @Test

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttSettingsTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttSettingsTest.kt
@@ -1,0 +1,220 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2025 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.mqtt
+
+import android.os.Build
+import android.preference.PreferenceManager
+import org.catrobat.catroid.ui.settingsfragments.MqttSettingsFragment
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P], instrumentedPackages = [])
+class MqttSettingsTest {
+
+    private val context get() = RuntimeEnvironment.getApplication()
+
+    @Before
+    fun setUp() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit().clear().commit()
+    }
+
+    // --- Default value tests ---
+
+    @Test
+    fun testMqttEnabledDefaultIsFalse() {
+        assertFalse(SettingsFragment.isMqttSharedPreferenceEnabled(context))
+    }
+
+    @Test
+    fun testMqttHostDefaultIs192168_0_1() {
+        assertEquals("192.168.0.1", SettingsFragment.getMqttHost(context))
+    }
+
+    @Test
+    fun testMqttPortDefaultIs1883() {
+        assertEquals(1883, SettingsFragment.getMqttPort(context))
+    }
+
+    @Test
+    fun testMqttTlsEnabledDefaultIsFalse() {
+        assertFalse(SettingsFragment.isMqttTlsEnabled(context))
+    }
+
+    @Test
+    fun testMqttUsernameDefaultIsEmpty() {
+        assertEquals("", SettingsFragment.getMqttUsername(context))
+    }
+
+    @Test
+    fun testMqttPasswordDefaultIsEmpty() {
+        assertEquals("", SettingsFragment.getMqttPassword(context))
+    }
+
+    @Test
+    fun testMqttClientIdDefaultIsEmpty() {
+        assertEquals("", SettingsFragment.getMqttClientId(context))
+    }
+
+    // --- Persistence tests ---
+
+    @Test
+    fun testMqttEnabledPersistsAfterWrite() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit().putBoolean(SettingsFragment.SETTINGS_SHOW_MQTT_BRICKS, true).commit()
+        assertTrue(SettingsFragment.isMqttSharedPreferenceEnabled(context))
+    }
+
+    @Test
+    fun testMqttHostPersistsAfterWrite() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit().putString(SettingsFragment.MQTT_HOST, "broker.hivemq.com").commit()
+        assertEquals("broker.hivemq.com", SettingsFragment.getMqttHost(context))
+    }
+
+    @Test
+    fun testMqttPortPersistsAfterWrite() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit().putString(SettingsFragment.MQTT_PORT, "8883").commit()
+        assertEquals(8883, SettingsFragment.getMqttPort(context))
+    }
+
+    @Test
+    fun testMqttTlsPersistsAfterWrite() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit().putBoolean(SettingsFragment.MQTT_TLS, true).commit()
+        assertTrue(SettingsFragment.isMqttTlsEnabled(context))
+    }
+
+    @Test
+    fun testMqttUsernamePersistsAfterWrite() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit().putString(SettingsFragment.MQTT_USERNAME, "testuser").commit()
+        assertEquals("testuser", SettingsFragment.getMqttUsername(context))
+    }
+
+    @Test
+    fun testMqttPasswordPersistsAfterWrite() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit().putString(SettingsFragment.MQTT_PASSWORD, "secret").commit()
+        assertEquals("secret", SettingsFragment.getMqttPassword(context))
+    }
+
+    @Test
+    fun testMqttClientIdPersistsAfterWrite() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit().putString(SettingsFragment.MQTT_CLIENT_ID, "device-001").commit()
+        assertEquals("device-001", SettingsFragment.getMqttClientId(context))
+    }
+
+    // --- getMqttPort fallback tests ---
+
+    @Test
+    fun testMqttPortFallbackOnNonIntegerValue() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit().putString(SettingsFragment.MQTT_PORT, "abc").commit()
+        assertEquals(1883, SettingsFragment.getMqttPort(context))
+    }
+
+    @Test
+    fun testMqttPortFallbackOnEmptyValue() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit().putString(SettingsFragment.MQTT_PORT, "").commit()
+        assertEquals(1883, SettingsFragment.getMqttPort(context))
+    }
+
+    @Test
+    fun testMqttPortFallbackOnFloatValue() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit().putString(SettingsFragment.MQTT_PORT, "1883.5").commit()
+        assertEquals(1883, SettingsFragment.getMqttPort(context))
+    }
+
+    // --- Port validation: boundary tests ---
+
+    @Test
+    fun testPortValidationRejectsZero() {
+        assertFalse(MqttSettingsFragment.isValidPort("0"))
+    }
+
+    @Test
+    fun testPortValidationRejectsNegativeNumber() {
+        assertFalse(MqttSettingsFragment.isValidPort("-1"))
+    }
+
+    @Test
+    fun testPortValidationRejects65536() {
+        assertFalse(MqttSettingsFragment.isValidPort("65536"))
+    }
+
+    @Test
+    fun testPortValidationAcceptsMinBoundary() {
+        assertTrue(MqttSettingsFragment.isValidPort("1"))
+    }
+
+    @Test
+    fun testPortValidationAccepts1883() {
+        assertTrue(MqttSettingsFragment.isValidPort("1883"))
+    }
+
+    @Test
+    fun testPortValidationAcceptsMaxBoundary() {
+        assertTrue(MqttSettingsFragment.isValidPort("65535"))
+    }
+
+    // --- Port validation: non-numeric input ---
+
+    @Test
+    fun testPortValidationRejectsAlphabeticString() {
+        assertFalse(MqttSettingsFragment.isValidPort("abc"))
+    }
+
+    @Test
+    fun testPortValidationRejectsEmptyString() {
+        assertFalse(MqttSettingsFragment.isValidPort(""))
+    }
+
+    @Test
+    fun testPortValidationRejectsPartialNumber() {
+        assertFalse(MqttSettingsFragment.isValidPort("1883abc"))
+    }
+
+    @Test
+    fun testPortValidationRejectsWhitespace() {
+        assertFalse(MqttSettingsFragment.isValidPort(" 1883 "))
+    }
+
+    @Test
+    fun testPortValidationRejectsFloatString() {
+        assertFalse(MqttSettingsFragment.isValidPort("1883.5"))
+    }
+}

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttSettingsTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttSettingsTest.kt
@@ -98,7 +98,7 @@ class MqttSettingsTest {
     @Test
     fun testMqttPasswordDefaultIsEmpty() {
         every { mockMqttPasswordRepository.getPassword() } returns ""
-        assertEquals("", SettingsFragment.getMqttPassword(context))
+        assertEquals("", SettingsFragment.getMqttPassword())
         verify(exactly = 1) { mockMqttPasswordRepository.getPassword() }
     }
 
@@ -147,14 +147,8 @@ class MqttSettingsTest {
     @Test
     fun testMqttPasswordPersistsAfterWrite() {
         every { mockMqttPasswordRepository.getPassword() } returns "secret"
-        assertEquals("secret", SettingsFragment.getMqttPassword(context))
+        assertEquals("secret", SettingsFragment.getMqttPassword())
         verify(exactly = 1) { mockMqttPasswordRepository.getPassword() }
-    }
-
-    @Test
-    fun testMqttPasswordSetPasswordDelegatesToRepository() {
-        mockMqttPasswordRepository.setPassword("secret")
-        verify(exactly = 1) { mockMqttPasswordRepository.setPassword("secret") }
     }
 
     @Test

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttSettingsTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttSettingsTest.kt
@@ -124,9 +124,15 @@ class MqttSettingsTest {
 
     @Test
     fun testMqttPasswordPersistsAfterWrite() {
-        PreferenceManager.getDefaultSharedPreferences(context)
-            .edit().putString(SettingsFragment.MQTT_PASSWORD, "secret").commit()
-        assertEquals("secret", SettingsFragment.getMqttPassword(context))
+        assertEquals("", SettingsFragment.getMqttPassword(context))
+    }
+
+    @Test
+    fun testMqttPasswordNotStoredInDefaultPrefs() {
+        assertFalse(
+            PreferenceManager.getDefaultSharedPreferences(context)
+                .contains(SettingsFragment.MQTT_PASSWORD)
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

This PR introduces the initial MQTT foundation for Catroid by combining:

- [CATROID-1670](https://catrobat.atlassian.net/browse/CATROID-1670): Eclipse Paho MQTT dependency and Android configuration
- [CATROID-1672](https://catrobat.atlassian.net/browse/CATROID-1672): MQTT settings UI, persistence layer, validation, and automated tests

## CATROID-1670 — MQTT Dependency and Android Configuration

### Changes Implemented

#### catroid/build.gradle

- Added `org.eclipse.paho.client.mqttv3:1.2.5`
- Added `org.eclipse.paho.android.service:1.1.1`
- Added `FEATURE_MQTT_ENABLED` build config flag

#### AndroidManifest.xml

- Registered `org.eclipse.paho.android.service.MqttService`
- Verified existing permissions:
  - INTERNET
  - ACCESS_NETWORK_STATE

### Testing

Added dependency sanity tests verifying:

- MqttClient
- MqttConnectOptions
- MqttMessage
- MqttException
- MqttCallback

are available on the test classpath.

## CATROID-1672 — MQTT Settings UI and Persistence

### UI Demo

[Watch UI Demo](https://drive.google.com/file/d/1yLadrlKaI-Id3SxY3azNVey9TVCfbOPD/view?usp=sharing)

### Features Implemented

Added MQTT settings screen with:

- MQTT enable toggle
- Broker host
- Broker port
- TLS option
- Username
- Password
- Client ID

### Persistence

Implemented persistent storage using SharedPreferences.

Added accessor APIs:

- isMqttSharedPreferenceEnabled()
- getMqttHost()
- getMqttPort()
- isMqttTlsEnabled()
- getMqttUsername()
- getMqttPassword()
- getMqttClientId()

### Password Storage Refactor (MqttPasswordRepository)

Following a discussion with Harsh and Prof. Wolfgang's review feedback, the MQTT password is no longer stored in plain SharedPreferences.

Instead, a `MqttPasswordRepository` interface was introduced (modelled after `LocalHashVersionRepository`) with a
`DefaultMqttPasswordRepository` implementation backed by `EncryptedSharedPreferences`. It is registered as a Koin singleton and injected wherever the password is read or written.

This keeps `SettingsFragment.getMqttPassword(Context)` as the existing public API — it now delegates to the injected repository internally. Unit tests mock the interface via a Koin test module, so no Android
Keystore is required in the test environment.

### Validation

- Port range: 1–65535
- Invalid values rejected with UI feedback

### Testing

Added automated tests covering:

- Default values
- Persistence
- Validation
- Edge cases
- UI integration

28 unit tests added.

Followed TDD workflow:

- Red
- Green
- Refactor

#### Your Checklist
- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer



[CATROID-1670]: https://catrobat.atlassian.net/browse/CATROID-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CATROID-1672]: https://catrobat.atlassian.net/browse/CATROID-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ