### PR TITLE
Add MqttManager for broker connection lifecycle (CATROID-1671)

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientFactory.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientFactory.kt
@@ -1,0 +1,33 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2026 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.devices.mqtt
+
+fun interface MqttClientFactory {
+    fun create(brokerUrl: String, clientId: String): MqttClientInterface
+}
+
+object DefaultMqttClientFactory : MqttClientFactory {
+    override fun create(brokerUrl: String, clientId: String): MqttClientInterface =
+        PahoMqttClient(brokerUrl, clientId)
+}

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientFactory.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientFactory.kt
@@ -27,7 +27,4 @@ fun interface MqttClientFactory {
     fun create(brokerUrl: String, clientId: String): MqttClientInterface
 }
 
-object DefaultMqttClientFactory : MqttClientFactory {
-    override fun create(brokerUrl: String, clientId: String): MqttClientInterface =
-        PahoMqttClient(brokerUrl, clientId)
-}
+val DefaultMqttClientFactory = MqttClientFactory { brokerUrl, clientId -> PahoMqttClient(brokerUrl, clientId) }

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientInterface.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientInterface.kt
@@ -1,0 +1,35 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2026 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.devices.mqtt
+
+import org.eclipse.paho.client.mqttv3.MqttCallback
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+
+interface MqttClientInterface {
+    val isConnected: Boolean
+    fun connect(options: MqttConnectOptions)
+    fun disconnect()
+    fun close()
+    fun setCallback(callback: MqttCallback)
+}

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttConnectionConfig.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttConnectionConfig.kt
@@ -1,0 +1,47 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2026 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.devices.mqtt
+
+import android.content.Context
+import org.catrobat.catroid.ui.settingsfragments.SettingsFragment
+
+data class MqttConnectionConfig(
+    val host: String,
+    val port: Int,
+    val clientId: String,
+    val username: String,
+    val password: String,
+    val useTls: Boolean
+) {
+    companion object {
+        fun fromContext(context: Context) = MqttConnectionConfig(
+            host = SettingsFragment.getMqttHost(context),
+            port = SettingsFragment.getMqttPort(context),
+            clientId = SettingsFragment.getMqttClientId(context),
+            username = SettingsFragment.getMqttUsername(context),
+            password = SettingsFragment.getMqttPassword(),
+            useTls = SettingsFragment.isMqttTlsEnabled(context)
+        )
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttManager.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttManager.kt
@@ -32,7 +32,10 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions
 import org.eclipse.paho.client.mqttv3.MqttException
 import org.eclipse.paho.client.mqttv3.MqttMessage
 
-class MqttManager(private var mqttClient: MqttClientInterface? = null) {
+class MqttManager(private val clientFactory: MqttClientFactory = DefaultMqttClientFactory) {
+
+    @Volatile
+    private var mqttClient: MqttClientInterface? = null
 
     val isConnected: Boolean
         get() = mqttClient?.isConnected == true
@@ -49,16 +52,25 @@ class MqttManager(private var mqttClient: MqttClientInterface? = null) {
 
     fun connectFromContext(context: Context) = connect(MqttConnectionConfig.fromContext(context))
 
-    fun connect(config: MqttConnectionConfig): Boolean {
+    fun connect(config: MqttConnectionConfig): Boolean = synchronized(this) {
         if (isConnected) return true
         if (config.host.isBlank()) {
             Log.e(TAG, "Cannot connect: host is blank")
             return false
         }
+        val currentClient = mqttClient
+        if (currentClient != null && !currentClient.isConnected) {
+            try {
+                currentClient.close()
+            } catch (e: MqttException) {
+                Log.e(TAG, "Failed to close stale client before reconnect", e)
+            }
+            mqttClient = null
+        }
         return try {
             val brokerUrl = buildServerUri(config.host, config.port, config.useTls)
             val resolvedClientId = config.clientId.ifEmpty { MqttClient.generateClientId() }
-            val client = mqttClient ?: PahoMqttClient(brokerUrl, resolvedClientId).also { mqttClient = it }
+            val client = mqttClient ?: clientFactory.create(brokerUrl, resolvedClientId).also { mqttClient = it }
             client.setCallback(callback)
             client.connect(buildConnectOptions(config.username, config.password))
             val connected = client.isConnected
@@ -77,15 +89,17 @@ class MqttManager(private var mqttClient: MqttClientInterface? = null) {
     }
 
     fun disconnect() {
-        if (!isConnected) return
-        try {
-            mqttClient?.disconnect()
-            mqttClient?.close()
-            Log.d(TAG, "Disconnected and closed client")
-        } catch (e: MqttException) {
-            Log.e(TAG, "Error during disconnect", e)
-        } finally {
-            mqttClient = null
+        synchronized(this) {
+            if (mqttClient == null) return
+            try {
+                mqttClient?.disconnect()
+                mqttClient?.close()
+                Log.d(TAG, "Disconnected and closed client")
+            } catch (e: MqttException) {
+                Log.e(TAG, "Error during disconnect", e)
+            } finally {
+                mqttClient = null
+            }
         }
     }
 

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttManager.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttManager.kt
@@ -1,0 +1,115 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2026 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.devices.mqtt
+
+import android.content.Context
+import android.util.Log
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken
+import org.eclipse.paho.client.mqttv3.MqttCallback
+import org.eclipse.paho.client.mqttv3.MqttClient
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.eclipse.paho.client.mqttv3.MqttException
+import org.eclipse.paho.client.mqttv3.MqttMessage
+
+class MqttManager(private var mqttClient: MqttClientInterface? = null) {
+
+    val isConnected: Boolean
+        get() = mqttClient?.isConnected == true
+
+    companion object {
+        private val TAG = MqttManager::class.simpleName
+        private const val TCP_SCHEME = "tcp"
+        private const val SSL_SCHEME = "ssl"
+        private const val CONNECTION_TIMEOUT = 5
+
+        @JvmStatic
+        val instance: MqttManager by lazy { MqttManager() }
+    }
+
+    fun connectFromContext(context: Context) = connect(MqttConnectionConfig.fromContext(context))
+
+    fun connect(config: MqttConnectionConfig): Boolean {
+        if (isConnected) return true
+        if (config.host.isBlank()) {
+            Log.e(TAG, "Cannot connect: host is blank")
+            return false
+        }
+        return try {
+            val brokerUrl = buildServerUri(config.host, config.port, config.useTls)
+            val resolvedClientId = config.clientId.ifEmpty { MqttClient.generateClientId() }
+            val client = mqttClient ?: PahoMqttClient(brokerUrl, resolvedClientId).also { mqttClient = it }
+            client.setCallback(callback)
+            client.connect(buildConnectOptions(config.username, config.password))
+            val connected = client.isConnected
+            Log.d(TAG, "Connect result for clientId=$resolvedClientId at $brokerUrl: connected=$connected")
+            connected
+        } catch (e: MqttException) {
+            Log.e(TAG, "Failed to connect to ${config.host}:${config.port}", e)
+            try {
+                mqttClient?.close()
+            } catch (closeEx: MqttException) {
+                Log.e(TAG, "Failed to close client after connect error", closeEx)
+            }
+            mqttClient = null
+            false
+        }
+    }
+
+    fun disconnect() {
+        if (!isConnected) return
+        try {
+            mqttClient?.disconnect()
+            mqttClient?.close()
+            Log.d(TAG, "Disconnected and closed client")
+        } catch (e: MqttException) {
+            Log.e(TAG, "Error during disconnect", e)
+        } finally {
+            mqttClient = null
+        }
+    }
+
+    internal fun buildServerUri(host: String, port: Int, useTls: Boolean): String {
+        val scheme = if (useTls) SSL_SCHEME else TCP_SCHEME
+        return "$scheme://$host:$port"
+    }
+
+    internal fun buildConnectOptions(username: String, password: String) = MqttConnectOptions().apply {
+        isCleanSession = true
+        connectionTimeout = CONNECTION_TIMEOUT
+        if (username.isNotBlank()) {
+            this.userName = username
+            this.password = password.toCharArray()
+        }
+    }
+
+    private val callback = object : MqttCallback {
+        override fun connectionLost(cause: Throwable?) {
+            Log.e(TAG, "Connection lost: ${cause?.message}")
+        }
+        // Message handling is implemented in a later ticket.
+        override fun messageArrived(topic: String, message: MqttMessage) = Unit
+        // Delivery tokens are not used until publish is implemented in a later ticket.
+        override fun deliveryComplete(token: IMqttDeliveryToken?) = Unit
+    }
+}

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/PahoMqttClient.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/PahoMqttClient.kt
@@ -1,0 +1,38 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2026 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.devices.mqtt
+
+import org.eclipse.paho.client.mqttv3.MqttCallback
+import org.eclipse.paho.client.mqttv3.MqttClient
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
+
+class PahoMqttClient(brokerUrl: String, clientId: String) : MqttClientInterface {
+    private val client = MqttClient(brokerUrl, clientId, MemoryPersistence())
+    override val isConnected get() = client.isConnected
+    override fun connect(options: MqttConnectOptions) = client.connect(options)
+    override fun disconnect() = client.disconnect()
+    override fun close() = client.close()
+    override fun setCallback(callback: MqttCallback) = client.setCallback(callback)
+}

--- a/catroid/src/main/java/org/catrobat/catroid/koin/CatroidKoinHelper.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/koin/CatroidKoinHelper.kt
@@ -51,6 +51,9 @@ import org.catrobat.catroid.ui.recyclerview.repository.DefaultProjectCategoriesR
 import org.catrobat.catroid.ui.recyclerview.repository.FeaturedProjectsRepository
 import org.catrobat.catroid.ui.recyclerview.repository.MqttPasswordRepository
 import org.catrobat.catroid.ui.recyclerview.repository.DefaultMqttPasswordRepository
+import org.catrobat.catroid.devices.mqtt.MqttClientFactory
+import org.catrobat.catroid.devices.mqtt.DefaultMqttClientFactory
+import org.catrobat.catroid.devices.mqtt.MqttManager
 import org.catrobat.catroid.ui.recyclerview.repository.ProjectCategoriesRepository
 import org.catrobat.catroid.ui.settingsfragments.SettingsFragment.MQTT_ENCRYPTED_PREFS
 import org.catrobat.catroid.ui.recyclerview.viewmodel.MainFragmentViewModel
@@ -78,6 +81,9 @@ val componentsModules = module(createdAtStart = true, override = false) {
     factory { HuaweiApiAvailability.getInstance() }
     factory { GoogleApiAvailability.getInstance() }
     factory { MobileServiceAvailability(get(), get()) }
+
+    single<MqttClientFactory> { DefaultMqttClientFactory }
+    single { MqttManager(get()) }
 
     single { BackpackListManager.getInstance() }
     single {

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttManagerTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttManagerTest.kt
@@ -23,6 +23,7 @@
 
 package org.catrobat.catroid.test.mqtt
 
+import org.catrobat.catroid.devices.mqtt.MqttClientFactory
 import org.catrobat.catroid.devices.mqtt.MqttClientInterface
 import org.catrobat.catroid.devices.mqtt.MqttConnectionConfig
 import org.catrobat.catroid.devices.mqtt.MqttManager
@@ -39,12 +40,14 @@ import org.junit.Test
 class MqttManagerTest {
 
     private lateinit var fakeClient: FakeMqttClient
+    private lateinit var fakeFactory: FakeMqttClientFactory
     private lateinit var manager: MqttManager
 
     @Before
     fun setUp() {
         fakeClient = FakeMqttClient()
-        manager = MqttManager(fakeClient)
+        fakeFactory = FakeMqttClientFactory(fakeClient)
+        manager = MqttManager(fakeFactory)
     }
 
     private val defaultConfig = MqttConnectionConfig("localhost", 1883, "client-1", "", "", false)
@@ -105,14 +108,15 @@ class MqttManagerTest {
 
     @Test
     fun testConnectWhenAlreadyConnectedDoesNotReconnect() {
-        fakeClient.connected = true
+        manager.connect(defaultConfig)
+        fakeClient.connectCalled = false
         manager.connect(defaultConfig)
         assertFalse(fakeClient.connectCalled)
     }
 
     @Test
     fun testConnectWhenAlreadyConnectedReturnsTrue() {
-        fakeClient.connected = true
+        manager.connect(defaultConfig)
         assertTrue(manager.connect(defaultConfig))
     }
 
@@ -131,6 +135,24 @@ class MqttManagerTest {
     fun testConnectSucceedsWithEmptyClientId() {
         manager.connect(MqttConnectionConfig("localhost", 1883, "", "", "", false))
         assertTrue(fakeClient.connectCalled)
+    }
+
+    @Test
+    fun testConnectClosesStaleClientBeforeReconnecting() {
+        manager.connect(defaultConfig)
+        fakeClient.connected = false
+        fakeFactory.createCalled = false
+        manager.connect(defaultConfig)
+        assertTrue(fakeClient.closeCalled)
+        assertTrue(fakeFactory.createCalled)
+    }
+
+    @Test
+    fun testConnectDoesNotCloseAlreadyConnectedClient() {
+        manager.connect(defaultConfig)
+        fakeClient.closeCalled = false
+        manager.connect(defaultConfig)
+        assertFalse(fakeClient.closeCalled)
     }
 
     // --- URI building ---
@@ -190,39 +212,58 @@ class MqttManagerTest {
 
     @Test
     fun testDisconnectCallsClientDisconnect() {
-        fakeClient.connected = true
+        manager.connect(defaultConfig)
         manager.disconnect()
         assertTrue(fakeClient.disconnectCalled)
     }
 
     @Test
     fun testDisconnectCallsClientClose() {
-        fakeClient.connected = true
+        manager.connect(defaultConfig)
         manager.disconnect()
         assertTrue(fakeClient.closeCalled)
     }
 
     @Test
-    fun testDisconnectWhenNotConnectedDoesNotCallClient() {
-        fakeClient.connected = false
+    fun testDisconnectWhenNoClientDoesNotCallClient() {
+        manager = MqttManager(FakeMqttClientFactory(fakeClient))
         manager.disconnect()
         assertFalse(fakeClient.disconnectCalled)
         assertFalse(fakeClient.closeCalled)
     }
 
     @Test
+    fun testDisconnectCleansUpDroppedConnection() {
+        manager.connect(defaultConfig)
+        fakeClient.connected = false
+        manager.disconnect()
+        assertTrue(fakeClient.disconnectCalled)
+        assertTrue(fakeClient.closeCalled)
+    }
+
+    @Test
     fun testIsNotConnectedAfterDisconnect() {
-        fakeClient.connected = true
+        manager.connect(defaultConfig)
         manager.disconnect()
         assertFalse(manager.isConnected)
     }
 
     @Test
     fun testDisconnectTwiceDoesNotCrash() {
-        fakeClient.connected = true
+        manager.connect(defaultConfig)
         manager.disconnect()
         manager.disconnect()
         // no exception = pass
+    }
+
+    // --- FakeMqttClientFactory ---
+
+    private class FakeMqttClientFactory(private val client: FakeMqttClient) : MqttClientFactory {
+        var createCalled = false
+        override fun create(brokerUrl: String, clientId: String): FakeMqttClient {
+            createCalled = true
+            return client
+        }
     }
 
     // --- FakeMqttClient ---

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttManagerTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttManagerTest.kt
@@ -1,0 +1,261 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2026 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.mqtt
+
+import org.catrobat.catroid.devices.mqtt.MqttClientInterface
+import org.catrobat.catroid.devices.mqtt.MqttConnectionConfig
+import org.catrobat.catroid.devices.mqtt.MqttManager
+import org.eclipse.paho.client.mqttv3.MqttCallback
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class MqttManagerTest {
+
+    private lateinit var fakeClient: FakeMqttClient
+    private lateinit var manager: MqttManager
+
+    @Before
+    fun setUp() {
+        fakeClient = FakeMqttClient()
+        manager = MqttManager(fakeClient)
+    }
+
+    private val defaultConfig = MqttConnectionConfig("localhost", 1883, "client-1", "", "", false)
+
+    // --- Singleton ---
+
+    @Test
+    fun testMqttManagerInstanceIsNotNull() {
+        assertNotNull(MqttManager.instance)
+    }
+
+    @Test
+    fun testMqttManagerIsSingleton() {
+        assertSame(MqttManager.instance, MqttManager.instance)
+    }
+
+    // --- Initial state ---
+
+    @Test
+    fun testIsNotConnectedInitially() {
+        fakeClient.connected = false
+        assertFalse(manager.isConnected)
+    }
+
+    // --- connect() ---
+
+    @Test
+    fun testConnectReturnsTrueOnSuccess() {
+        assertTrue(manager.connect(defaultConfig))
+        assertTrue(fakeClient.connectCalled)
+    }
+
+    @Test
+    fun testConnectSetsCallbackOnClient() {
+        manager.connect(defaultConfig)
+        assertTrue(fakeClient.callbackSet)
+    }
+
+    @Test
+    fun testConnectReturnsFalseWhenClientThrows() {
+        fakeClient.throwOnConnect = true
+        assertFalse(manager.connect(defaultConfig))
+    }
+
+    @Test
+    fun testIsNotConnectedAfterConnectFailure() {
+        fakeClient.throwOnConnect = true
+        manager.connect(defaultConfig)
+        assertFalse(manager.isConnected)
+    }
+
+    @Test
+    fun testCloseIsCalledOnClientWhenConnectThrows() {
+        fakeClient.throwOnConnect = true
+        manager.connect(defaultConfig)
+        assertTrue(fakeClient.closeCalled)
+    }
+
+    @Test
+    fun testConnectWhenAlreadyConnectedDoesNotReconnect() {
+        fakeClient.connected = true
+        manager.connect(defaultConfig)
+        assertFalse(fakeClient.connectCalled)
+    }
+
+    @Test
+    fun testConnectWhenAlreadyConnectedReturnsTrue() {
+        fakeClient.connected = true
+        assertTrue(manager.connect(defaultConfig))
+    }
+
+    @Test
+    fun testConnectWithBlankHostReturnsFalse() {
+        assertFalse(manager.connect(MqttConnectionConfig("   ", 1883, "client-1", "", "", false)))
+    }
+
+    @Test
+    fun testConnectWithBlankHostDoesNotCallClient() {
+        manager.connect(MqttConnectionConfig("   ", 1883, "client-1", "", "", false))
+        assertFalse(fakeClient.connectCalled)
+    }
+
+    @Test
+    fun testConnectSucceedsWithEmptyClientId() {
+        manager.connect(MqttConnectionConfig("localhost", 1883, "", "", "", false))
+        assertTrue(fakeClient.connectCalled)
+    }
+
+    // --- URI building ---
+
+    @Test
+    fun testBuildServerUriWithoutTlsUsesTcpScheme() {
+        assertTrue(manager.buildServerUri("localhost", 1883, false).startsWith("tcp://"))
+    }
+
+    @Test
+    fun testBuildServerUriWithTlsUsesSslScheme() {
+        assertTrue(manager.buildServerUri("localhost", 8883, true).startsWith("ssl://"))
+    }
+
+    @Test
+    fun testBuildServerUriTcpFullUri() {
+        assertEquals("tcp://broker.test.com:1883", manager.buildServerUri("broker.test.com", 1883, false))
+    }
+
+    @Test
+    fun testBuildServerUriSslFullUri() {
+        assertEquals("ssl://broker.test.com:8883", manager.buildServerUri("broker.test.com", 8883, true))
+    }
+
+    // --- ConnectOptions building ---
+
+    @Test
+    fun testBuildConnectOptionsUsesCleanSession() {
+        assertTrue(manager.buildConnectOptions("", "").isCleanSession)
+    }
+
+    @Test
+    fun testBuildConnectOptionsSetsUsernameAndPasswordWhenProvided() {
+        val options = manager.buildConnectOptions("user", "pass")
+        assertEquals("user", options.userName)
+        assertEquals("pass", String(options.password ?: charArrayOf()))
+    }
+
+    @Test
+    fun testBuildConnectOptionsDoesNotSetUsernameWhenEmpty() {
+        assertEquals(null, manager.buildConnectOptions("", "").userName)
+    }
+
+    @Test
+    fun testBuildConnectOptionsUsernameOnlyWithEmptyPasswordStillSets() {
+        val options = manager.buildConnectOptions("user", "")
+        assertEquals("user", options.userName)
+        assertEquals("", String(options.password ?: charArrayOf()))
+    }
+
+    @Test
+    fun testBuildConnectOptionsDoesNotSetUsernameWhenBlank() {
+        assertEquals(null, manager.buildConnectOptions("   ", "").userName)
+    }
+
+    // --- disconnect() ---
+
+    @Test
+    fun testDisconnectCallsClientDisconnect() {
+        fakeClient.connected = true
+        manager.disconnect()
+        assertTrue(fakeClient.disconnectCalled)
+    }
+
+    @Test
+    fun testDisconnectCallsClientClose() {
+        fakeClient.connected = true
+        manager.disconnect()
+        assertTrue(fakeClient.closeCalled)
+    }
+
+    @Test
+    fun testDisconnectWhenNotConnectedDoesNotCallClient() {
+        fakeClient.connected = false
+        manager.disconnect()
+        assertFalse(fakeClient.disconnectCalled)
+        assertFalse(fakeClient.closeCalled)
+    }
+
+    @Test
+    fun testIsNotConnectedAfterDisconnect() {
+        fakeClient.connected = true
+        manager.disconnect()
+        assertFalse(manager.isConnected)
+    }
+
+    @Test
+    fun testDisconnectTwiceDoesNotCrash() {
+        fakeClient.connected = true
+        manager.disconnect()
+        manager.disconnect()
+        // no exception = pass
+    }
+
+    // --- FakeMqttClient ---
+
+    private inner class FakeMqttClient : MqttClientInterface {
+        var connected = false
+        var connectCalled = false
+        var disconnectCalled = false
+        var closeCalled = false
+        var callbackSet = false
+        var throwOnConnect = false
+        var lastConnectOptions: MqttConnectOptions? = null
+
+        override val isConnected get() = connected
+
+        override fun connect(options: MqttConnectOptions) {
+            if (throwOnConnect) throw org.eclipse.paho.client.mqttv3.MqttException(0)
+            connectCalled = true
+            connected = true
+            lastConnectOptions = options
+        }
+
+        override fun disconnect() {
+            disconnectCalled = true
+            connected = false
+        }
+
+        override fun close() {
+            closeCalled = true
+        }
+
+        override fun setCallback(callback: MqttCallback) {
+            callbackSet = true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements the centralized MQTT Manager for Catroid, responsible for the full connection lifecycle of an MQTT broker client:

- [CATROID-1671](https://catrobat.atlassian.net/browse/CATROID-1671): MqttManager - connect, disconnect, state tracking, and failure handling

This ticket is scoped to **connection management only**. Message publishing, subscriptions, and MQTT bricks are deferred to separate tickets.

---

## CATROID-1671: MqttManager for Broker Connection Lifecycle

### Changes Implemented

#### `org.catrobat.catroid.devices.mqtt`

- **`MqttClientInterface`** Abstracts the Paho client behind an interface, decoupling `MqttManager` from the third-party library and enabling pure JVM unit tests without an Android runtime or real network.

- **`PahoMqttClient`** Thin adapter wrapping `org.eclipse.paho.client.mqttv3.MqttClient` behind `MqttClientInterface`. Used in production.

- **`MqttClientFactory`** Fun interface for creating `MqttClientInterface` instances. `DefaultMqttClientFactory` is the production implementation that creates `PahoMqttClient`. Registered as a Koin `single` in `CatroidKoinHelper` and injected into `MqttManager`. Tests use `FakeMqttClientFactory` so no real Paho clients are created during unit tests.

- **`MqttConnectionConfig`** Data class grouping all six broker parameters (host, port, clientId, username, password, TLS flag). Includes a `fromContext()` factory that reads values from `SettingsFragment`. Keeps `connect()` to a single overload with one parameter.

- **`MqttManager`** Core manager class, registered as a Koin `single`:
  - Singleton via `by lazy`, following the same pattern as `RaspberryPiService`
  - `@Volatile` on `mqttClient` with `synchronized(this)` on `connect()` and `disconnect()` to handle concurrent access from background threads, UI thread, and Paho callbacks safely
  - `connect(config)` is idempotent if already connected, validates host, and auto-generates client ID if blank. If a stale disconnected client exists (e.g. after settings change), it is closed and nulled before a fresh one is created via the factory so updated broker URL or clientId are always picked up
  - `connectFromContext(context)` is a convenience entry point that reads config from `SettingsFragment`
  - `disconnect()` guards on `mqttClient == null` rather than `isConnected`, matching the `RaspberryPiService` pattern. This ensures cleanup runs even on dropped connections where the client exists but `isConnected` is false
  - `isConnected` exposes queryable connection state backed by the client
  - `buildServerUri()` produces a `tcp://` or `ssl://` URI based on the TLS flag
  - `buildConnectOptions()` configures clean session, connection timeout, and applies credentials when a username is provided
  - On connect failure, the client is closed and nulled so no stale reference is kept

### Testing

Added `MqttManagerTest` with 30 unit tests using `FakeMqttClient` and `FakeMqttClientFactory` as hand-written test doubles with no Mockito and no emulator needed:

- Singleton is non-null and returns the same object on repeated access
- `isConnected` is false before any call
- `connect()` returns true on success, calls the client, and sets the callback
- `connect()` returns false without crashing when `MqttException` is thrown, and calls `close()` for cleanup
- Already connected returns true without reconnecting; blank host returns false without touching the client; empty client ID auto-generates one
- Stale disconnected client is closed and a fresh one is created via the factory on reconnect; a live client is not closed
- `tcp://` vs `ssl://` scheme selection and full URI format verified
- `isCleanSession` is always true; credentials are set when username is provided, password can be empty
- `disconnect()` calls both `disconnect()` and `close()` on the client, cleans up dropped connections, skips safely when no client exists, and is safe to call twice

---

#### Your Checklist
- [x] Include the name of the Jira ticket in the PR's title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project's coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits' message style matches the [project's guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project's gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

[CATROID-1671]: https://catrobat.atlassian.net/browse/CATROID-1671
