### PR TITLE
Implement MQTT Message Publishing in MqttManager (CATROID-1673)

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientInterface.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientInterface.kt
@@ -25,6 +25,7 @@ package org.catrobat.catroid.devices.mqtt
 
 import org.eclipse.paho.client.mqttv3.MqttCallback
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.eclipse.paho.client.mqttv3.MqttMessage
 
 interface MqttClientInterface {
     val isConnected: Boolean
@@ -32,4 +33,5 @@ interface MqttClientInterface {
     fun disconnect()
     fun close()
     fun setCallback(callback: MqttCallback)
+    fun publish(topic: String, message: MqttMessage)
 }

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttManager.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttManager.kt
@@ -88,6 +88,36 @@ class MqttManager(private val clientFactory: MqttClientFactory = DefaultMqttClie
         }
     }
 
+    fun publishFromContext(context: Context, topic: String, payload: String, qos: Int = 0, retained: Boolean = false) =
+        publish(MqttConnectionConfig.fromContext(context), topic, payload, qos, retained)
+
+    fun publish(config: MqttConnectionConfig, topic: String, payload: String, qos: Int = 0, retained: Boolean = false): Boolean {
+        if (topic.isBlank()) {
+            Log.e(TAG, "Cannot publish: topic is blank")
+            return false
+        }
+        if (topic.contains('#') || topic.contains('+')) {
+            Log.e(TAG, "Cannot publish: topic contains wildcard characters")
+            return false
+        }
+        if (qos !in 0..2) {
+            Log.e(TAG, "Cannot publish: invalid QoS value $qos")
+            return false
+        }
+        if (!isConnected && !connect(config)) {
+            Log.e(TAG, "Cannot publish: connection failed")
+            return false
+        }
+        val client = mqttClient ?: return false
+        return try {
+            client.publish(topic, buildMessage(payload, qos, retained))
+            true
+        } catch (e: MqttException) {
+            Log.e(TAG, "Failed to publish to '$topic'", e)
+            false
+        }
+    }
+
     fun disconnect() {
         synchronized(this) {
             if (mqttClient == null) return
@@ -117,13 +147,16 @@ class MqttManager(private val clientFactory: MqttClientFactory = DefaultMqttClie
         }
     }
 
+    internal fun buildMessage(payload: String, qos: Int, retained: Boolean) = MqttMessage(payload.toByteArray()).apply {
+        this.qos = qos
+        isRetained = retained
+    }
+
     private val callback = object : MqttCallback {
         override fun connectionLost(cause: Throwable?) {
-            Log.e(TAG, "Connection lost: ${cause?.message}")
+            Log.e(TAG, "Connection lost", cause)
         }
-        // Message handling is implemented in a later ticket.
         override fun messageArrived(topic: String, message: MqttMessage) = Unit
-        // Delivery tokens are not used until publish is implemented in a later ticket.
         override fun deliveryComplete(token: IMqttDeliveryToken?) = Unit
     }
 }

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/PahoMqttClient.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/PahoMqttClient.kt
@@ -26,6 +26,7 @@ package org.catrobat.catroid.devices.mqtt
 import org.eclipse.paho.client.mqttv3.MqttCallback
 import org.eclipse.paho.client.mqttv3.MqttClient
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
 
 class PahoMqttClient(brokerUrl: String, clientId: String) : MqttClientInterface {
@@ -35,4 +36,5 @@ class PahoMqttClient(brokerUrl: String, clientId: String) : MqttClientInterface 
     override fun disconnect() = client.disconnect()
     override fun close() = client.close()
     override fun setCallback(callback: MqttCallback) = client.setCallback(callback)
+    override fun publish(topic: String, message: MqttMessage) = client.publish(topic, message)
 }

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttManagerTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttManagerTest.kt
@@ -29,6 +29,7 @@ import org.catrobat.catroid.devices.mqtt.MqttConnectionConfig
 import org.catrobat.catroid.devices.mqtt.MqttManager
 import org.eclipse.paho.client.mqttv3.MqttCallback
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -256,6 +257,168 @@ class MqttManagerTest {
         // no exception = pass
     }
 
+    // --- publish() ---
+
+    @Test
+    fun testPublishReturnsTrueWhenConnectedAndTopicValid() {
+        fakeClient.connected = true
+        assertTrue(manager.publish(defaultConfig, "home/temp", "22"))
+    }
+
+    @Test
+    fun testPublishCallsClientPublish() {
+        fakeClient.connected = true
+        manager.publish(defaultConfig, "home/temp", "22")
+        assertTrue(fakeClient.publishCalled)
+    }
+
+    @Test
+    fun testPublishSendsCorrectTopicAndPayload() {
+        fakeClient.connected = true
+        manager.publish(defaultConfig, "home/temp", "42")
+        assertEquals("home/temp", fakeClient.lastTopic)
+        assertEquals("42", fakeClient.lastPayload)
+    }
+
+    @Test
+    fun testPublishSetsQosAndRetained() {
+        fakeClient.connected = true
+        manager.publish(defaultConfig, "home/temp", "on", qos = 2, retained = true)
+        assertEquals(2, fakeClient.lastQos)
+        assertTrue(fakeClient.lastRetained)
+    }
+
+    @Test
+    fun testPublishTriggersLazyConnectWhenDisconnected() {
+        fakeClient.connected = false
+        manager.publish(defaultConfig, "home/temp", "22")
+        assertTrue(fakeClient.connectCalled)
+    }
+
+    @Test
+    fun testPublishReturnsTrueAfterLazyConnect() {
+        fakeClient.connected = false
+        assertTrue(manager.publish(defaultConfig, "home/temp", "22"))
+    }
+
+    @Test
+    fun testPublishReturnsFalseWhenLazyConnectFails() {
+        fakeClient.connected = false
+        fakeClient.throwOnConnect = true
+        assertFalse(manager.publish(defaultConfig, "home/temp", "22"))
+    }
+
+    @Test
+    fun testPublishReturnsFalseForBlankTopic() {
+        fakeClient.connected = true
+        assertFalse(manager.publish(defaultConfig, "   ", "22"))
+    }
+
+    @Test
+    fun testPublishDoesNotCallClientForBlankTopic() {
+        fakeClient.connected = true
+        manager.publish(defaultConfig, "   ", "22")
+        assertFalse(fakeClient.publishCalled)
+    }
+
+    @Test
+    fun testPublishReturnsFalseForTopicWithHashWildcard() {
+        fakeClient.connected = true
+        assertFalse(manager.publish(defaultConfig, "home/#", "22"))
+    }
+
+    @Test
+    fun testPublishReturnsFalseForTopicWithPlusWildcard() {
+        fakeClient.connected = true
+        assertFalse(manager.publish(defaultConfig, "home/+/temp", "22"))
+    }
+
+    @Test
+    fun testPublishReturnsFalseForInvalidQos() {
+        fakeClient.connected = true
+        assertFalse(manager.publish(defaultConfig, "home/temp", "22", qos = 3))
+    }
+
+    @Test
+    fun testPublishReturnsFalseWhenClientThrows() {
+        fakeClient.connected = true
+        fakeClient.throwOnPublish = true
+        assertFalse(manager.publish(defaultConfig, "home/temp", "22"))
+    }
+
+    @Test
+    fun testPublishDoesNotCrashWhenClientThrows() {
+        fakeClient.connected = true
+        fakeClient.throwOnPublish = true
+        manager.publish(defaultConfig, "home/temp", "22")
+        // no exception = pass
+    }
+
+    @Test
+    fun testPublishWithEmptyPayloadReturnsTrue() {
+        fakeClient.connected = true
+        assertTrue(manager.publish(defaultConfig, "home/temp", ""))
+    }
+
+    @Test
+    fun testPublishWithQosZeroReturnsTrue() {
+        fakeClient.connected = true
+        assertTrue(manager.publish(defaultConfig, "home/temp", "22", qos = 0))
+    }
+
+    @Test
+    fun testPublishWithQosOneReturnsTrue() {
+        fakeClient.connected = true
+        assertTrue(manager.publish(defaultConfig, "home/temp", "22", qos = 1))
+    }
+
+    @Test
+    fun testPublishWithQosTwoReturnsTrue() {
+        fakeClient.connected = true
+        assertTrue(manager.publish(defaultConfig, "home/temp", "22", qos = 2))
+    }
+
+    @Test
+    fun testPublishWithRetainedFalseSetsRetainedFalse() {
+        fakeClient.connected = true
+        manager.publish(defaultConfig, "home/temp", "22", retained = false)
+        assertFalse(fakeClient.lastRetained)
+    }
+
+    @Test
+    fun testPublishWhenAlreadyConnectedDoesNotReconnect() {
+        manager.connect(defaultConfig)
+        fakeClient.connectCalled = false
+        manager.publish(defaultConfig, "home/temp", "22")
+        assertFalse(fakeClient.connectCalled)
+    }
+
+    @Test
+    fun testPublishDoesNotCallClientWhenLazyConnectFails() {
+        fakeClient.connected = false
+        fakeClient.throwOnConnect = true
+        manager.publish(defaultConfig, "home/temp", "22")
+        assertFalse(fakeClient.publishCalled)
+    }
+
+    // --- buildMessage() ---
+
+    @Test
+    fun testBuildMessageSetsPayload() {
+        val msg = manager.buildMessage("hello", 1, false)
+        assertEquals("hello", String(msg.payload))
+    }
+
+    @Test
+    fun testBuildMessageSetsQos() {
+        assertEquals(1, manager.buildMessage("hello", 1, false).qos)
+    }
+
+    @Test
+    fun testBuildMessageSetsRetained() {
+        assertTrue(manager.buildMessage("hello", 0, true).isRetained)
+    }
+
     // --- FakeMqttClientFactory ---
 
     private class FakeMqttClientFactory(private val client: FakeMqttClient) : MqttClientFactory {
@@ -275,6 +438,12 @@ class MqttManagerTest {
         var closeCalled = false
         var callbackSet = false
         var throwOnConnect = false
+        var throwOnPublish = false
+        var publishCalled = false
+        var lastTopic: String? = null
+        var lastPayload: String? = null
+        var lastQos: Int = -1
+        var lastRetained: Boolean = false
         var lastConnectOptions: MqttConnectOptions? = null
 
         override val isConnected get() = connected
@@ -297,6 +466,15 @@ class MqttManagerTest {
 
         override fun setCallback(callback: MqttCallback) {
             callbackSet = true
+        }
+
+        override fun publish(topic: String, message: MqttMessage) {
+            if (throwOnPublish) throw org.eclipse.paho.client.mqttv3.MqttException(0)
+            publishCalled = true
+            lastTopic = topic
+            lastPayload = String(message.payload)
+            lastQos = message.qos
+            lastRetained = message.isRetained
         }
     }
 }


### PR DESCRIPTION
## Summary

Extends `MqttManager` to support publishing MQTT messages to a broker using Eclipse Paho.

This PR previously carried the dependency and settings groundwork (CATROID-1670, CATROID-1672) and the connection lifecycle (CATROID-1671) as extra commits, because none of them were on `develop` yet. All three have since been merged ([#5220](https://github.com/Catrobat/Catroid/pull/5220), [#5222](https://github.com/Catrobat/Catroid/pull/5222)), so the branch has been rebased onto `develop` and those commits removed. What remains is a single commit containing only the publish work.

## CATROID-1673 — Publish implementation

### Changes

- Added `publish(topic, message)` to `MqttClientInterface` and implemented it in `PahoMqttClient`
- `MqttManager.publish()` validates the topic (rejects blank, rejects the `#` and `+` wildcards, which are only legal in subscriptions) and the QoS range (0–2)
- Lazy-connects before publishing when no connection is active
- `publishFromContext()` convenience wrapper for the brick layer
- No forced unwraps; failures are logged and returned as `false` rather than thrown
- `connectionLost` now passes the `Throwable` to `Log.e` so the stacktrace is kept

### Tests

24 new tests covering publish and message building:

- Successful publish, and that the correct topic and payload reach the client
- QoS 0, 1 and 2 accepted; out-of-range QoS rejected
- Retained flag set both ways
- Blank topic rejected, and the client is not called
- Wildcard topics rejected (`#` and `+`)
- Lazy connect succeeds before publishing
- No reconnect when a connection already exists
- No publish when the lazy connect fails
- Client exception returns `false` without crashing
- `buildMessage()` sets payload, QoS and retained correctly

Two existing tests were updated in this rebase. `MqttManager` now takes an `MqttClientFactory` rather than a client instance, following the change made during the CATROID-1671 review, so tests that assumed an injected client had to connect first. Without that, `testPublishWhenAlreadyConnectedDoesNotReconnect` failed and `testSubscribeAfterDisconnectSucceedsAgain` did not compile.

Full suite: 4709 tests, 0 failures.

## Acceptance criteria

- [x] `publish()` API added to `MqttManager`
- [x] `publish()` added to `MqttClientInterface` and `PahoMqttClient`
- [x] Messages published successfully to a connected broker
- [x] Lazy connection established automatically if none exists
- [x] Configurable QoS and retained flag
- [x] Failures logged without crashing
- [x] Unit tests covering the success paths, the validation rejections and the failure modes
- [x] All existing and new tests pass

## Your Checklist

- [x] Include the name of the Jira ticket in the PR's title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project's coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits' message style matches the [project's guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project's gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
