### PR TITLE
Catroid 1661 - Fixed empty parameterized test data

### DIFF
--- a/catroid/src/androidTest/java/org/catrobat/catroid/catrobattestrunner/CatrobatTestRunner.kt
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/catrobattestrunner/CatrobatTestRunner.kt
@@ -44,6 +44,7 @@ import org.junit.runners.Parameterized
 import java.io.File
 import java.io.IOException
 import java.util.ArrayList
+import org.catrobat.catroid.test.utils.ParameterizedTestData
 
 @RunWith(Parameterized::class)
 class CatrobatTestRunner {
@@ -70,7 +71,11 @@ class CatrobatTestRunner {
         @JvmStatic
         @Parameterized.Parameters(name = "{0} - {1}")
         @Throws(IOException::class)
-        fun data(): Iterable<Array<Any>> = getCatrobatAssetsFromPath(TEST_ASSETS_ROOT)
+        fun data(): Iterable<Array<Any>> = ParameterizedTestData.requireNonEmpty(
+            getCatrobatAssetsFromPath(TEST_ASSETS_ROOT),
+            CatrobatTestRunner::class.java,
+            "Catrobat test assets from assets/catrobatTests"
+        )
 
         @Throws(IOException::class)
         private fun getCatrobatAssetsFromPath(path: String): List<Array<Any>> {

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/BricksHelpUrlTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/BricksHelpUrlTest.java
@@ -27,6 +27,7 @@ import android.util.Log;
 import org.catrobat.catroid.ProjectManager;
 import org.catrobat.catroid.content.Project;
 import org.catrobat.catroid.content.bricks.Brick;
+import org.catrobat.catroid.test.utils.ParameterizedTestData;
 import org.catrobat.catroid.ui.fragment.CategoryBricksFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -510,7 +511,10 @@ public class BricksHelpUrlTest {
 			parameters.add(new Object[] {brickClazz.getName(), brickClazz});
 		}
 
-		return parameters;
+		return ParameterizedTestData.requireNonEmpty(
+				parameters,
+				BricksHelpUrlTest.class,
+				"Brick classes discovered via DexFile");
 	}
 
 	@Parameterized.Parameter

--- a/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/ParameterizedTestData.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/test/utils/ParameterizedTestData.java
@@ -1,0 +1,19 @@
+package org.catrobat.catroid.test.utils;
+
+import java.util.Collection;
+
+public final class ParameterizedTestData {
+
+    private ParameterizedTestData() {
+    }
+
+    public static <T extends Collection<?>> T requireNonEmpty(T testData,
+            Class<?> testClass, String sourceDescription) {
+        if (testData == null || testData.isEmpty()) {
+            throw new AssertionError("No parameterized test data found for "
+                    + testClass.getName() + ". Source: " + sourceDescription);
+        }
+
+        return testData;
+    }
+}


### PR DESCRIPTION
This PR adds a reusable helper to fail parameterized tests explicitly when dynamically collected test data is empty.

Applied to:
- BricksHelpUrlTest, which discovers Brick classes via DexFile
- CatrobatTestRunner, which collects .catrobat test assets recursively

I checked the remaining @Parameterized.Parameters usages. They use explicit static test data and were intentionally left unchanged.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x ] Include the name of the Jira ticket in the PR’s title
- [x ] Include a summary of the changes plus the relevant context
- [ x] Choose the proper base branch (*develop*)
- [ x] Confirm that the changes follow the project’s coding guidelines
- [ x] Verify that the changes generate no compiler or linter warnings
- [x ] Perform a self-review of the changes
- [ x] Verify to commit no other files than the intentionally changed ones
- [x ] Include reasonable and readable tests verifying the added or changed behavior
- [x ] Confirm that new and existing unit tests pass locally
- [x ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x ] Stick to the project’s gitflow workflow
- [x ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
