### PR TITLE
Implement MQTT Topic Subscription in MqttManager (CATROID-1674)

### DIFF
--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientInterface.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientInterface.kt
@@ -25,6 +25,7 @@ package org.catrobat.catroid.devices.mqtt
 
 import org.eclipse.paho.client.mqttv3.MqttCallback
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.eclipse.paho.client.mqttv3.MqttMessage
 
 interface MqttClientInterface {
     val isConnected: Boolean
@@ -32,4 +33,5 @@ interface MqttClientInterface {
     fun disconnect()
     fun close()
     fun setCallback(callback: MqttCallback)
+    fun publish(topic: String, message: MqttMessage)
 }

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientInterface.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttClientInterface.kt
@@ -34,4 +34,6 @@ interface MqttClientInterface {
     fun close()
     fun setCallback(callback: MqttCallback)
     fun publish(topic: String, message: MqttMessage)
+    fun subscribe(topic: String, qos: Int)
+    fun unsubscribe(topic: String)
 }

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttManager.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttManager.kt
@@ -40,6 +40,9 @@ class MqttManager(private val clientFactory: MqttClientFactory = DefaultMqttClie
     val isConnected: Boolean
         get() = mqttClient?.isConnected == true
 
+    private val subscriptions = mutableMapOf<String, Int>()
+    internal val activeSubscriptions: Set<String> get() = subscriptions.keys.toSet()
+
     companion object {
         private val TAG = MqttManager::class.simpleName
         private const val TCP_SCHEME = "tcp"
@@ -111,9 +114,71 @@ class MqttManager(private val clientFactory: MqttClientFactory = DefaultMqttClie
         val client = mqttClient ?: return false
         return try {
             client.publish(topic, buildMessage(payload, qos, retained))
+            Log.d(TAG, "Published message to '$topic'")
             true
         } catch (e: MqttException) {
             Log.e(TAG, "Failed to publish to '$topic'", e)
+            false
+        }
+    }
+
+    fun subscribeFromContext(context: Context, topic: String, qos: Int = 0) =
+        subscribe(MqttConnectionConfig.fromContext(context), topic, qos)
+
+    fun subscribe(config: MqttConnectionConfig, topic: String, qos: Int = 0): Boolean {
+        if (topic.isBlank()) {
+            Log.e(TAG, "Cannot subscribe: topic is blank")
+            return false
+        }
+        if (qos !in 0..2) {
+            Log.e(TAG, "Cannot subscribe: invalid QoS value $qos")
+            return false
+        }
+        val existingQos = subscriptions[topic]
+        if (existingQos != null) {
+            Log.d(TAG, "Already subscribed to '$topic' with QoS $existingQos, ignoring duplicate")
+            return true
+        }
+        // Wildcards (#, +) are valid for MQTT subscriptions unlike publish.
+        if (!isConnected && !connect(config)) {
+            Log.e(TAG, "Cannot subscribe: connection failed")
+            return false
+        }
+        val client = mqttClient ?: run {
+            Log.e(TAG, "Cannot subscribe: client is null")
+            return false
+        }
+        return try {
+            client.subscribe(topic, qos)
+            subscriptions[topic] = qos
+            Log.d(TAG, "Subscribed to '$topic' with QoS $qos")
+            true
+        } catch (e: MqttException) {
+            Log.e(TAG, "Failed to subscribe to '$topic'", e)
+            false
+        }
+    }
+
+    fun unsubscribe(topic: String): Boolean {
+        if (topic.isBlank()) {
+            Log.e(TAG, "Cannot unsubscribe: topic is blank")
+            return false
+        }
+        if (!subscriptions.containsKey(topic)) {
+            Log.d(TAG, "Not subscribed to '$topic', ignoring")
+            return true
+        }
+        val client = mqttClient ?: run {
+            Log.e(TAG, "Cannot unsubscribe: client is null")
+            return false
+        }
+        return try {
+            client.unsubscribe(topic)
+            val qos = subscriptions.remove(topic)
+            Log.d(TAG, "Unsubscribed from '$topic' (was QoS $qos)")
+            true
+        } catch (e: MqttException) {
+            Log.e(TAG, "Failed to unsubscribe from '$topic'", e)
             false
         }
     }
@@ -128,6 +193,7 @@ class MqttManager(private val clientFactory: MqttClientFactory = DefaultMqttClie
             } catch (e: MqttException) {
                 Log.e(TAG, "Error during disconnect", e)
             } finally {
+                subscriptions.clear()
                 mqttClient = null
             }
         }

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttManager.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/MqttManager.kt
@@ -88,6 +88,36 @@ class MqttManager(private val clientFactory: MqttClientFactory = DefaultMqttClie
         }
     }
 
+    fun publishFromContext(context: Context, topic: String, payload: String, qos: Int = 0, retained: Boolean = false) =
+        publish(MqttConnectionConfig.fromContext(context), topic, payload, qos, retained)
+
+    fun publish(config: MqttConnectionConfig, topic: String, payload: String, qos: Int = 0, retained: Boolean = false): Boolean {
+        if (topic.isBlank()) {
+            Log.e(TAG, "Cannot publish: topic is blank")
+            return false
+        }
+        if (topic.contains('#') || topic.contains('+')) {
+            Log.e(TAG, "Cannot publish: topic contains wildcard characters")
+            return false
+        }
+        if (qos !in 0..2) {
+            Log.e(TAG, "Cannot publish: invalid QoS value $qos")
+            return false
+        }
+        if (!isConnected && !connect(config)) {
+            Log.e(TAG, "Cannot publish: connection failed")
+            return false
+        }
+        val client = mqttClient ?: return false
+        return try {
+            client.publish(topic, buildMessage(payload, qos, retained))
+            true
+        } catch (e: MqttException) {
+            Log.e(TAG, "Failed to publish to '$topic'", e)
+            false
+        }
+    }
+
     fun disconnect() {
         synchronized(this) {
             if (mqttClient == null) return
@@ -117,13 +147,16 @@ class MqttManager(private val clientFactory: MqttClientFactory = DefaultMqttClie
         }
     }
 
+    internal fun buildMessage(payload: String, qos: Int, retained: Boolean) = MqttMessage(payload.toByteArray()).apply {
+        this.qos = qos
+        isRetained = retained
+    }
+
     private val callback = object : MqttCallback {
         override fun connectionLost(cause: Throwable?) {
-            Log.e(TAG, "Connection lost: ${cause?.message}")
+            Log.e(TAG, "Connection lost", cause)
         }
-        // Message handling is implemented in a later ticket.
         override fun messageArrived(topic: String, message: MqttMessage) = Unit
-        // Delivery tokens are not used until publish is implemented in a later ticket.
         override fun deliveryComplete(token: IMqttDeliveryToken?) = Unit
     }
 }

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/PahoMqttClient.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/PahoMqttClient.kt
@@ -37,4 +37,6 @@ class PahoMqttClient(brokerUrl: String, clientId: String) : MqttClientInterface 
     override fun close() = client.close()
     override fun setCallback(callback: MqttCallback) = client.setCallback(callback)
     override fun publish(topic: String, message: MqttMessage) = client.publish(topic, message)
+    override fun subscribe(topic: String, qos: Int) = client.subscribe(topic, qos)
+    override fun unsubscribe(topic: String) = client.unsubscribe(topic)
 }

--- a/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/PahoMqttClient.kt
+++ b/catroid/src/main/java/org/catrobat/catroid/devices/mqtt/PahoMqttClient.kt
@@ -26,6 +26,7 @@ package org.catrobat.catroid.devices.mqtt
 import org.eclipse.paho.client.mqttv3.MqttCallback
 import org.eclipse.paho.client.mqttv3.MqttClient
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
 
 class PahoMqttClient(brokerUrl: String, clientId: String) : MqttClientInterface {
@@ -35,4 +36,5 @@ class PahoMqttClient(brokerUrl: String, clientId: String) : MqttClientInterface 
     override fun disconnect() = client.disconnect()
     override fun close() = client.close()
     override fun setCallback(callback: MqttCallback) = client.setCallback(callback)
+    override fun publish(topic: String, message: MqttMessage) = client.publish(topic, message)
 }

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttManagerTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttManagerTest.kt
@@ -401,6 +401,224 @@ class MqttManagerTest {
         assertFalse(fakeClient.publishCalled)
     }
 
+    // --- subscribe() ---
+
+    @Test
+    fun testSubscribeReturnsTrueWhenConnectedAndTopicValid() {
+        fakeClient.connected = true
+        assertTrue(manager.subscribe(defaultConfig, "home/temp"))
+    }
+
+    @Test
+    fun testSubscribeCallsClientSubscribe() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp")
+        assertTrue(fakeClient.subscribeCalled)
+    }
+
+    @Test
+    fun testSubscribeSendsCorrectTopicAndQos() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp", qos = 1)
+        assertEquals("home/temp", fakeClient.lastSubscribedTopic)
+        assertEquals(1, fakeClient.lastSubscribedQos)
+    }
+
+    @Test
+    fun testSubscribeAcceptsWildcardHashTopic() {
+        fakeClient.connected = true
+        assertTrue(manager.subscribe(defaultConfig, "home/#"))
+    }
+
+    @Test
+    fun testSubscribeAcceptsWildcardPlusTopic() {
+        fakeClient.connected = true
+        assertTrue(manager.subscribe(defaultConfig, "home/+/temp"))
+    }
+
+    @Test
+    fun testSubscribeReturnsFalseForBlankTopic() {
+        fakeClient.connected = true
+        assertFalse(manager.subscribe(defaultConfig, "   "))
+    }
+
+    @Test
+    fun testSubscribeDoesNotCallClientForBlankTopic() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "   ")
+        assertFalse(fakeClient.subscribeCalled)
+    }
+
+    @Test
+    fun testSubscribeReturnsFalseForInvalidQos() {
+        fakeClient.connected = true
+        assertFalse(manager.subscribe(defaultConfig, "home/temp", qos = 3))
+    }
+
+    @Test
+    fun testDuplicateSubscribeReturnsTrueWithoutCallingClientAgain() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp")
+        fakeClient.subscribeCalled = false
+        assertTrue(manager.subscribe(defaultConfig, "home/temp"))
+        assertFalse(fakeClient.subscribeCalled)
+    }
+
+    @Test
+    fun testSubscribeTriggersLazyConnectWhenDisconnected() {
+        fakeClient.connected = false
+        manager.subscribe(defaultConfig, "home/temp")
+        assertTrue(fakeClient.connectCalled)
+    }
+
+    @Test
+    fun testSubscribeReturnsFalseWhenLazyConnectFails() {
+        fakeClient.connected = false
+        fakeClient.throwOnConnect = true
+        assertFalse(manager.subscribe(defaultConfig, "home/temp"))
+    }
+
+    @Test
+    fun testSubscribeDoesNotCallClientWhenLazyConnectFails() {
+        fakeClient.connected = false
+        fakeClient.throwOnConnect = true
+        manager.subscribe(defaultConfig, "home/temp")
+        assertFalse(fakeClient.subscribeCalled)
+    }
+
+    @Test
+    fun testSubscribeReturnsFalseWhenClientThrows() {
+        fakeClient.connected = true
+        fakeClient.throwOnSubscribe = true
+        assertFalse(manager.subscribe(defaultConfig, "home/temp"))
+    }
+
+    @Test
+    fun testSubscribeDoesNotCrashWhenClientThrows() {
+        fakeClient.connected = true
+        fakeClient.throwOnSubscribe = true
+        manager.subscribe(defaultConfig, "home/temp")
+        // no exception = pass
+    }
+
+    @Test
+    fun testSubscribeWithQosZeroReturnsTrue() {
+        fakeClient.connected = true
+        assertTrue(manager.subscribe(defaultConfig, "home/temp", qos = 0))
+    }
+
+    @Test
+    fun testSubscribeWithQosTwoReturnsTrue() {
+        fakeClient.connected = true
+        assertTrue(manager.subscribe(defaultConfig, "home/temp", qos = 2))
+    }
+
+    // --- unsubscribe() ---
+
+    @Test
+    fun testUnsubscribeReturnsTrueAfterSubscribe() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp")
+        assertTrue(manager.unsubscribe("home/temp"))
+    }
+
+    @Test
+    fun testUnsubscribeCallsClientUnsubscribe() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp")
+        manager.unsubscribe("home/temp")
+        assertTrue(fakeClient.unsubscribeCalled)
+    }
+
+    @Test
+    fun testUnsubscribeSendsCorrectTopic() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp")
+        manager.unsubscribe("home/temp")
+        assertEquals("home/temp", fakeClient.lastUnsubscribedTopic)
+    }
+
+    @Test
+    fun testUnsubscribeWhenNotSubscribedReturnsTrueWithoutCallingClient() {
+        fakeClient.connected = true
+        assertTrue(manager.unsubscribe("home/temp"))
+        assertFalse(fakeClient.unsubscribeCalled)
+    }
+
+    @Test
+    fun testUnsubscribeRemovesTopicFromActiveSubscriptions() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp")
+        manager.unsubscribe("home/temp")
+        assertFalse(manager.activeSubscriptions.contains("home/temp"))
+    }
+
+    @Test
+    fun testUnsubscribeReturnsFalseForBlankTopic() {
+        assertFalse(manager.unsubscribe("   "))
+    }
+
+    @Test
+    fun testUnsubscribeDoesNotCallClientForBlankTopic() {
+        manager.unsubscribe("   ")
+        assertFalse(fakeClient.unsubscribeCalled)
+    }
+
+    @Test
+    fun testUnsubscribeReturnsFalseWhenClientThrows() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp")
+        fakeClient.throwOnUnsubscribe = true
+        assertFalse(manager.unsubscribe("home/temp"))
+    }
+
+    @Test
+    fun testUnsubscribeDoesNotCrashWhenClientThrows() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp")
+        fakeClient.throwOnUnsubscribe = true
+        manager.unsubscribe("home/temp")
+        // no exception = pass
+    }
+
+    @Test
+    fun testSubscriptionsAreClearedOnDisconnect() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp")
+        manager.disconnect()
+        assertTrue(manager.activeSubscriptions.isEmpty())
+    }
+
+    @Test
+    fun testSubscribeAfterDisconnectSucceedsAgain() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp")
+        manager.disconnect()
+        // Re-create manager with same fakeClient to simulate reconnection.
+        manager = MqttManager(FakeMqttClientFactory(fakeClient))
+        fakeClient.connected = true
+        fakeClient.subscribeCalled = false
+        manager.subscribe(defaultConfig, "home/temp")
+        assertTrue(fakeClient.subscribeCalled)
+    }
+
+    @Test
+    fun testDuplicateSubscribeWithDifferentQosDoesNotResubscribe() {
+        fakeClient.connected = true
+        manager.subscribe(defaultConfig, "home/temp", qos = 0)
+        fakeClient.subscribeCalled = false
+        manager.subscribe(defaultConfig, "home/temp", qos = 2)
+        assertFalse(fakeClient.subscribeCalled)
+    }
+
+    @Test
+    fun testFailedSubscribeDoesNotAddToActiveSubscriptions() {
+        fakeClient.connected = true
+        fakeClient.throwOnSubscribe = true
+        manager.subscribe(defaultConfig, "home/temp")
+        assertTrue(manager.activeSubscriptions.isEmpty())
+    }
+
     // --- buildMessage() ---
 
     @Test
@@ -475,6 +693,27 @@ class MqttManagerTest {
             lastPayload = String(message.payload)
             lastQos = message.qos
             lastRetained = message.isRetained
+        }
+
+        var throwOnSubscribe = false
+        var throwOnUnsubscribe = false
+        var subscribeCalled = false
+        var unsubscribeCalled = false
+        var lastSubscribedTopic: String? = null
+        var lastSubscribedQos: Int = -1
+        var lastUnsubscribedTopic: String? = null
+
+        override fun subscribe(topic: String, qos: Int) {
+            if (throwOnSubscribe) throw org.eclipse.paho.client.mqttv3.MqttException(0)
+            subscribeCalled = true
+            lastSubscribedTopic = topic
+            lastSubscribedQos = qos
+        }
+
+        override fun unsubscribe(topic: String) {
+            if (throwOnUnsubscribe) throw org.eclipse.paho.client.mqttv3.MqttException(0)
+            unsubscribeCalled = true
+            lastUnsubscribedTopic = topic
         }
     }
 }

--- a/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttManagerTest.kt
+++ b/catroid/src/test/java/org/catrobat/catroid/test/mqtt/MqttManagerTest.kt
@@ -29,6 +29,7 @@ import org.catrobat.catroid.devices.mqtt.MqttConnectionConfig
 import org.catrobat.catroid.devices.mqtt.MqttManager
 import org.eclipse.paho.client.mqttv3.MqttCallback
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions
+import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -256,6 +257,168 @@ class MqttManagerTest {
         // no exception = pass
     }
 
+    // --- publish() ---
+
+    @Test
+    fun testPublishReturnsTrueWhenConnectedAndTopicValid() {
+        fakeClient.connected = true
+        assertTrue(manager.publish(defaultConfig, "home/temp", "22"))
+    }
+
+    @Test
+    fun testPublishCallsClientPublish() {
+        fakeClient.connected = true
+        manager.publish(defaultConfig, "home/temp", "22")
+        assertTrue(fakeClient.publishCalled)
+    }
+
+    @Test
+    fun testPublishSendsCorrectTopicAndPayload() {
+        fakeClient.connected = true
+        manager.publish(defaultConfig, "home/temp", "42")
+        assertEquals("home/temp", fakeClient.lastTopic)
+        assertEquals("42", fakeClient.lastPayload)
+    }
+
+    @Test
+    fun testPublishSetsQosAndRetained() {
+        fakeClient.connected = true
+        manager.publish(defaultConfig, "home/temp", "on", qos = 2, retained = true)
+        assertEquals(2, fakeClient.lastQos)
+        assertTrue(fakeClient.lastRetained)
+    }
+
+    @Test
+    fun testPublishTriggersLazyConnectWhenDisconnected() {
+        fakeClient.connected = false
+        manager.publish(defaultConfig, "home/temp", "22")
+        assertTrue(fakeClient.connectCalled)
+    }
+
+    @Test
+    fun testPublishReturnsTrueAfterLazyConnect() {
+        fakeClient.connected = false
+        assertTrue(manager.publish(defaultConfig, "home/temp", "22"))
+    }
+
+    @Test
+    fun testPublishReturnsFalseWhenLazyConnectFails() {
+        fakeClient.connected = false
+        fakeClient.throwOnConnect = true
+        assertFalse(manager.publish(defaultConfig, "home/temp", "22"))
+    }
+
+    @Test
+    fun testPublishReturnsFalseForBlankTopic() {
+        fakeClient.connected = true
+        assertFalse(manager.publish(defaultConfig, "   ", "22"))
+    }
+
+    @Test
+    fun testPublishDoesNotCallClientForBlankTopic() {
+        fakeClient.connected = true
+        manager.publish(defaultConfig, "   ", "22")
+        assertFalse(fakeClient.publishCalled)
+    }
+
+    @Test
+    fun testPublishReturnsFalseForTopicWithHashWildcard() {
+        fakeClient.connected = true
+        assertFalse(manager.publish(defaultConfig, "home/#", "22"))
+    }
+
+    @Test
+    fun testPublishReturnsFalseForTopicWithPlusWildcard() {
+        fakeClient.connected = true
+        assertFalse(manager.publish(defaultConfig, "home/+/temp", "22"))
+    }
+
+    @Test
+    fun testPublishReturnsFalseForInvalidQos() {
+        fakeClient.connected = true
+        assertFalse(manager.publish(defaultConfig, "home/temp", "22", qos = 3))
+    }
+
+    @Test
+    fun testPublishReturnsFalseWhenClientThrows() {
+        fakeClient.connected = true
+        fakeClient.throwOnPublish = true
+        assertFalse(manager.publish(defaultConfig, "home/temp", "22"))
+    }
+
+    @Test
+    fun testPublishDoesNotCrashWhenClientThrows() {
+        fakeClient.connected = true
+        fakeClient.throwOnPublish = true
+        manager.publish(defaultConfig, "home/temp", "22")
+        // no exception = pass
+    }
+
+    @Test
+    fun testPublishWithEmptyPayloadReturnsTrue() {
+        fakeClient.connected = true
+        assertTrue(manager.publish(defaultConfig, "home/temp", ""))
+    }
+
+    @Test
+    fun testPublishWithQosZeroReturnsTrue() {
+        fakeClient.connected = true
+        assertTrue(manager.publish(defaultConfig, "home/temp", "22", qos = 0))
+    }
+
+    @Test
+    fun testPublishWithQosOneReturnsTrue() {
+        fakeClient.connected = true
+        assertTrue(manager.publish(defaultConfig, "home/temp", "22", qos = 1))
+    }
+
+    @Test
+    fun testPublishWithQosTwoReturnsTrue() {
+        fakeClient.connected = true
+        assertTrue(manager.publish(defaultConfig, "home/temp", "22", qos = 2))
+    }
+
+    @Test
+    fun testPublishWithRetainedFalseSetsRetainedFalse() {
+        fakeClient.connected = true
+        manager.publish(defaultConfig, "home/temp", "22", retained = false)
+        assertFalse(fakeClient.lastRetained)
+    }
+
+    @Test
+    fun testPublishWhenAlreadyConnectedDoesNotReconnect() {
+        manager.connect(defaultConfig)
+        fakeClient.connectCalled = false
+        manager.publish(defaultConfig, "home/temp", "22")
+        assertFalse(fakeClient.connectCalled)
+    }
+
+    @Test
+    fun testPublishDoesNotCallClientWhenLazyConnectFails() {
+        fakeClient.connected = false
+        fakeClient.throwOnConnect = true
+        manager.publish(defaultConfig, "home/temp", "22")
+        assertFalse(fakeClient.publishCalled)
+    }
+
+    // --- buildMessage() ---
+
+    @Test
+    fun testBuildMessageSetsPayload() {
+        val msg = manager.buildMessage("hello", 1, false)
+        assertEquals("hello", String(msg.payload))
+    }
+
+    @Test
+    fun testBuildMessageSetsQos() {
+        assertEquals(1, manager.buildMessage("hello", 1, false).qos)
+    }
+
+    @Test
+    fun testBuildMessageSetsRetained() {
+        assertTrue(manager.buildMessage("hello", 0, true).isRetained)
+    }
+
     // --- FakeMqttClientFactory ---
 
     private class FakeMqttClientFactory(private val client: FakeMqttClient) : MqttClientFactory {
@@ -275,6 +438,12 @@ class MqttManagerTest {
         var closeCalled = false
         var callbackSet = false
         var throwOnConnect = false
+        var throwOnPublish = false
+        var publishCalled = false
+        var lastTopic: String? = null
+        var lastPayload: String? = null
+        var lastQos: Int = -1
+        var lastRetained: Boolean = false
         var lastConnectOptions: MqttConnectOptions? = null
 
         override val isConnected get() = connected
@@ -297,6 +466,15 @@ class MqttManagerTest {
 
         override fun setCallback(callback: MqttCallback) {
             callbackSet = true
+        }
+
+        override fun publish(topic: String, message: MqttMessage) {
+            if (throwOnPublish) throw org.eclipse.paho.client.mqttv3.MqttException(0)
+            publishCalled = true
+            lastTopic = topic
+            lastPayload = String(message.payload)
+            lastQos = message.qos
+            lastRetained = message.isRetained
         }
     }
 }


### PR DESCRIPTION
## Summary

Extends `MqttManager` to support subscribing to and unsubscribing from MQTT topics.

**Dependency notice:** this PR builds on [CATROID-1673](https://catrobat.atlassian.net/browse/CATROID-1673) ([#5225](https://github.com/Catrobat/Catroid/pull/5225)), which is not merged yet, so that commit is included here to keep the branch buildable on its own. **Please merge [#5225](https://github.com/Catrobat/Catroid/pull/5225) first**; this branch will then be rebased and the commit will drop out by itself.

The branch previously also carried the dependency, settings and connection lifecycle commits. Those have since been merged ([#5220](https://github.com/Catrobat/Catroid/pull/5220), [#5222](https://github.com/Catrobat/Catroid/pull/5222)), so the branch has been rebased onto `develop` and they are gone. Two commits remain.

This ticket is scoped to **subscription management only**. Handling the messages that arrive on a subscribed topic is a separate ticket.

## CATROID-1674 — Subscribe implementation

### Changes

- Added `subscribe(topic, qos)` and `unsubscribe(topic)` to `MqttClientInterface` and implemented both in `PahoMqttClient`
- `MqttManager.subscribe()` validates the topic is not blank and the QoS is in range 0–2. Unlike publish, the `#` and `+` wildcards are accepted here, since they are only legal in subscriptions
- Active subscriptions are tracked in a `Map<String, Int>` of topic to QoS, exposed read-only as `activeSubscriptions`, and cleared on `disconnect()`
- A duplicate subscribe returns `true` without calling the client again
- Lazy-connects before subscribing when no connection is active
- `subscribeFromContext()` convenience wrapper for the brick layer
- `unsubscribe()` is idempotent and returns `true` when the topic was never subscribed
- A failed subscribe does not record the topic, so the tracked state never claims a subscription the broker did not accept
- Failures are logged and returned as `false` rather than thrown

### Tests

29 new tests:

- Subscribe succeeds and reaches the client with the correct topic and QoS
- Wildcard topics accepted (`#` and `+`)
- Blank topic rejected, and the client is not called
- QoS 0 and 2 accepted; out-of-range QoS rejected
- Duplicate subscribe returns `true` without re-calling the client, including with a different QoS
- Lazy connect triggered when disconnected, and subscribe fails cleanly when that connect fails
- Client exception returns `false` without crashing
- A failed subscribe is not added to the tracked subscriptions
- Unsubscribe succeeds with the correct topic and removes it from the tracked set
- Unsubscribe on a topic that was never subscribed returns `true` without calling the client
- Blank topic rejected on unsubscribe; client exception returns `false` without crashing
- Subscriptions cleared on `disconnect()`, and subscribing works again afterwards

Full suite: 4709 tests, 0 failures.

### A note on the rebase

Two existing tests were updated. `MqttManager` now takes an `MqttClientFactory` instead of a client instance, following the change made during the CATROID-1671 review, so tests that assumed an injected client have to connect first. Without that, `testSubscribeAfterDisconnectSucceedsAgain` did not compile.

The conflict in `disconnect()` was resolved in favour of the version on `develop`, which guards on `mqttClient == null` inside a `synchronized` block rather than on `!isConnected`, with `subscriptions.clear()` added into its `finally`. The null guard is the safer of the two, since it still cleans up when the connection has dropped but the client object is alive.

## Acceptance criteria

- [x] `subscribe()` and `unsubscribe()` API added to `MqttManager`
- [x] Both methods added to `MqttClientInterface` and `PahoMqttClient`
- [x] Wildcard topics supported for subscriptions
- [x] Active subscriptions tracked and cleared on disconnect
- [x] Lazy connection established automatically if none exists
- [x] Configurable QoS per subscription
- [x] Failures logged without crashing
- [x] Unit tests covering the success paths, the validation rejections and the failure modes
- [x] All existing and new tests pass

## Your Checklist

- [x] Include the name of the Jira ticket in the PR's title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project's coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits' message style matches the [project's guideline](https://github.com/Catrobat/Catroid/wiki/Branch-and-Commit-Message-Guidelines)
- [x] Stick to the project's gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

[CATROID-1674]: https://catrobat.atlassian.net/browse/CATROID-1674


[CATROID-1673]: https://catrobat.atlassian.net/browse/CATROID-1673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ